### PR TITLE
feat: internationalize profile tab empty states

### DIFF
--- a/app-expo/app/[locale]/(tabs)/profile/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/profile/index.tsx
@@ -866,7 +866,7 @@ export default function ProfileScreen() {
 			return (
 				<View style={styles.loadingContainer}>
 					<ActivityIndicator size="large" color="#5EA2FF" />
-					<Text style={styles.loadingText}>Loading...</Text>
+					<Text style={styles.loadingText}>{i18n.t("Profile.loading")}</Text>
 				</View>
 			);
 		}
@@ -875,9 +875,9 @@ export default function ProfileScreen() {
 			return (
 				<View style={styles.emptyStateContainer}>
 					<View style={styles.emptyStateCard}>
-						<Text style={styles.emptyStateText}>Failed to load data: {tabError}</Text>
+						<Text style={styles.emptyStateText}>{i18n.t("Profile.tabError.failedToLoad", { error: tabError })}</Text>
 						<TouchableOpacity style={styles.retryButton} onPress={() => refreshData(selectedTab)}>
-							<Text style={styles.retryButtonText}>Retry</Text>
+							<Text style={styles.retryButtonText}>{i18n.t("Profile.tabError.retry")}</Text>
 						</TouchableOpacity>
 					</View>
 				</View>
@@ -888,7 +888,11 @@ export default function ProfileScreen() {
 			<View style={styles.emptyStateContainer}>
 				<View style={styles.emptyStateCard}>
 					<Text style={styles.emptyStateText}>
-						{selectedTab === "posts" ? "No posts yet" : selectedTab === "liked" ? "No liked posts" : "No saved items"}
+						{selectedTab === "posts"
+							? i18n.t("Profile.emptyState.noPosts")
+							: selectedTab === "liked"
+								? i18n.t("Profile.emptyState.noLikedPosts")
+								: i18n.t("Profile.emptyState.noSavedItems")}
 					</Text>
 				</View>
 			</View>

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -181,9 +181,17 @@
 			"million": "م",
 			"thousand": "ك"
 		},
+		"loading": "جارٍ التحميل...",
+		"tabError": {
+			"failedToLoad": "فشل تحميل البيانات: {{error}}",
+			"retry": "إعادة المحاولة"
+		},
 		"emptyState": {
 			"noDeposits": "لا توجد ودائع للحالة المحددة",
-			"noEarnings": "لا توجد أرباح للحالة المحددة"
+			"noEarnings": "لا توجد أرباح للحالة المحددة",
+			"noPosts": "لا توجد منشورات بعد",
+			"noLikedPosts": "لا توجد منشورات معجبة",
+			"noSavedItems": "لا توجد عناصر محفوظة"
 		},
 		"statusLabels": {
 			"active": "نشط",

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -181,9 +181,17 @@
 			"million": "M",
 			"thousand": "K"
 		},
+		"loading": "Loading...",
+		"tabError": {
+			"failedToLoad": "Failed to load data: {{error}}",
+			"retry": "Retry"
+		},
 		"emptyState": {
 			"noDeposits": "No deposits for the selected status",
-			"noEarnings": "No earnings for the selected status"
+			"noEarnings": "No earnings for the selected status",
+			"noPosts": "No posts yet",
+			"noLikedPosts": "No liked posts",
+			"noSavedItems": "No saved items"
 		},
 		"statusLabels": {
 			"active": "Active",

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -181,9 +181,17 @@
 			"million": "M",
 			"thousand": "K"
 		},
+		"loading": "Cargando...",
+		"tabError": {
+			"failedToLoad": "Error al cargar los datos: {{error}}",
+			"retry": "Reintentar"
+		},
 		"emptyState": {
 			"noDeposits": "No hay depósitos para el estado seleccionado",
-			"noEarnings": "No hay ganancias para el estado seleccionado"
+			"noEarnings": "No hay ganancias para el estado seleccionado",
+			"noPosts": "Aún no hay publicaciones",
+			"noLikedPosts": "No hay publicaciones con me gusta",
+			"noSavedItems": "No hay elementos guardados"
 		},
 		"statusLabels": {
 			"active": "Activo",

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -181,9 +181,17 @@
 			"million": "M",
 			"thousand": "K"
 		},
+		"loading": "Chargement...",
+		"tabError": {
+			"failedToLoad": "Échec du chargement des données : {{error}}",
+			"retry": "Réessayer"
+		},
 		"emptyState": {
 			"noDeposits": "Aucun dépôt pour le statut sélectionné",
-			"noEarnings": "Aucun revenu pour le statut sélectionné"
+			"noEarnings": "Aucun revenu pour le statut sélectionné",
+			"noPosts": "Aucune publication pour l'instant",
+			"noLikedPosts": "Aucune publication aimée",
+			"noSavedItems": "Aucun élément enregistré"
 		},
 		"statusLabels": {
 			"active": "Actif",

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -181,9 +181,17 @@
 			"million": "M",
 			"thousand": "K"
 		},
+		"loading": "लोड हो रहा है...",
+		"tabError": {
+			"failedToLoad": "डेटा लोड करने में विफल: {{error}}",
+			"retry": "पुनः प्रयास करें"
+		},
 		"emptyState": {
 			"noDeposits": "चयनित स्थिति के लिए कोई जमा नहीं",
-			"noEarnings": "चयनित स्थिति के लिए कोई आय नहीं"
+			"noEarnings": "चयनित स्थिति के लिए कोई आय नहीं",
+			"noPosts": "अभी तक कोई पोस्ट नहीं",
+			"noLikedPosts": "कोई पसंद की गई पोस्ट नहीं",
+			"noSavedItems": "कोई सहेजे गए आइटम नहीं"
 		},
 		"statusLabels": {
 			"active": "सक्रिय",

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -181,9 +181,17 @@
 			"million": "M",
 			"thousand": "K"
 		},
+		"loading": "読み込み中...",
+		"tabError": {
+			"failedToLoad": "データの読み込みに失敗しました: {{error}}",
+			"retry": "再試行"
+		},
 		"emptyState": {
 			"noDeposits": "選択したステータスの入札がありません",
-			"noEarnings": "選択したステータスの収益がありません"
+			"noEarnings": "選択したステータスの収益がありません",
+			"noPosts": "投稿はまだありません",
+			"noLikedPosts": "いいねした投稿はありません",
+			"noSavedItems": "保存されたアイテムはありません"
 		},
 		"statusLabels": {
 			"active": "アクティブ",

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -181,9 +181,17 @@
 			"million": "M",
 			"thousand": "K"
 		},
+		"loading": "로딩 중...",
+		"tabError": {
+			"failedToLoad": "데이터를 불러오지 못했습니다: {{error}}",
+			"retry": "재시도"
+		},
 		"emptyState": {
 			"noDeposits": "선택한 상태에 대한 예치금이 없습니다",
-			"noEarnings": "선택한 상태에 대한 수익이 없습니다"
+			"noEarnings": "선택한 상태에 대한 수익이 없습니다",
+			"noPosts": "게시물이 아직 없습니다",
+			"noLikedPosts": "좋아요한 게시물이 없습니다",
+			"noSavedItems": "저장된 항목이 없습니다"
 		},
 		"statusLabels": {
 			"active": "활성",

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -181,9 +181,17 @@
 			"million": "M",
 			"thousand": "K"
 		},
+		"loading": "加载中...",
+		"tabError": {
+			"failedToLoad": "加载数据失败：{{error}}",
+			"retry": "重试"
+		},
 		"emptyState": {
 			"noDeposits": "所选状态没有存款",
-			"noEarnings": "所选状态没有收益"
+			"noEarnings": "所选状态没有收益",
+			"noPosts": "暂无帖子",
+			"noLikedPosts": "暂无点赞的帖子",
+			"noSavedItems": "没有已保存的项目"
 		},
 		"statusLabels": {
 			"active": "活跃",


### PR DESCRIPTION
## Summary
- localize profile loading indicator, error state, and empty list messages
- add translations for new profile tab messages across all locales

## Testing
- `pnpm --filter app-expo lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm --filter app-expo test -- --watchAll=false` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a615cf2e40832b9311e0a0b30861c7