### PR TITLE
Use app logo for guest profile and topic loading

### DIFF
--- a/app-expo/features/profile/components/ProfileHeader.tsx
+++ b/app-expo/features/profile/components/ProfileHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { View, Text, TouchableOpacity, Image, StyleSheet, LayoutChangeEvent } from "react-native";
+import AppLogo from "@/assets/images/icon.png";
 import { LinearGradient } from "expo-linear-gradient";
 import { ArrowLeft, Settings, Share, Pencil as Edit3, MessageCircle } from "lucide-react-native";
 import { Card } from "@/components/Card";
@@ -79,7 +80,7 @@ export function ProfileHeader({
 				<Card style={styles.card} pointerEvents="box-none">
 					{/* Avatar and Stats */}
 					<View style={[styles.profileHeader]} pointerEvents="none">
-						<Image source={{ uri: profile.avatar }} style={styles.avatar} />
+						<Image source={isGuest ? AppLogo : { uri: profile.avatar }} style={styles.avatar} />
 
 						{!isGuest && (
 							<View style={styles.statsContainer}>

--- a/app-expo/features/topics/components/TopicsLoading.tsx
+++ b/app-expo/features/topics/components/TopicsLoading.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { View, Text, StyleSheet, SafeAreaView, ActivityIndicator } from "react-native";
+import { View, Text, StyleSheet, SafeAreaView, ActivityIndicator, Image } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
-import { Sparkles } from "lucide-react-native";
+import AppLogo from "@/assets/images/icon.png";
 import i18n from "@/lib/i18n";
 
 // Loading indicator while topics are being fetched
@@ -10,7 +10,7 @@ export const TopicsLoading = () => (
 		<SafeAreaView style={styles.loadingContent}>
 			<View style={styles.loadingCard}>
 				<View style={styles.loadingIconContainer}>
-					<Sparkles size={32} color="#5EA2FF" />
+					<Image source={AppLogo} style={styles.loadingIcon} />
 				</View>
 				<ActivityIndicator size="large" color="#5EA2FF" style={styles.loadingSpinner} />
 				<Text style={styles.loadingTitle}>{i18n.t("Topics.Loading.title")}</Text>
@@ -45,6 +45,10 @@ const styles = StyleSheet.create({
 	},
 	loadingIconContainer: {
 		marginBottom: 16,
+	},
+	loadingIcon: {
+		width: 32,
+		height: 32,
 	},
 	loadingSpinner: {
 		marginBottom: 24,


### PR DESCRIPTION
## Summary
- Show app logo instead of default avatar for guest profiles
- Replace sparkles icon with app logo while topics load

## Testing
- `pnpm --filter app-expo lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm --filter app-expo test -- --watchAll=false` *(fails: jest: not found)*
- `pnpm --filter app-expo typecheck` *(fails: missing modules and implicit any type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4d121748832b941e7442ba8b3dfd