### PR TITLE
feat(app): use platform-specific splash icons

### DIFF
--- a/app-expo/app.config.ts
+++ b/app-expo/app.config.ts
@@ -76,15 +76,20 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 	},
 	plugins: [
 		"expo-router",
-		[
-			"expo-splash-screen",
-			{
-				image: "./assets/images/splash-icon.png",
-				enableFullScreenImage_legacy: true,
-				resizeMode: "cover",
-				backgroundColor: "#ffffff",
-			},
-		],
+                [
+                        "expo-splash-screen",
+                        {
+                                backgroundColor: "#ffffff",
+                                ios: {
+                                        image: "./assets/images/splash-icon.png",
+                                        resizeMode: "cover",
+                                        enableFullScreenImage_legacy: true,
+                                },
+                                android: {
+                                        image: "./assets/images/icon.png",
+                                },
+                        },
+                ],
 		[
 			"expo-camera",
 			{


### PR DESCRIPTION
## Summary
- use a platform-specific splash icon configuration
- show `splash-icon.png` on iOS and `icon.png` on Android

## Testing
- `pnpm --filter app-expo lint` *(fails: ESLint couldn't find eslint.config.js)*
- `pnpm --filter app-expo typecheck` *(fails: Cannot find module '@shared/api/v1/res' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b2bc38fca8832bac15b54686acfe5c