### PR TITLE
reactions テーブルのスキーマ・インデックス最適化（UUID化、プロフィール取得・集計・targetId検索対応）

### DIFF
--- a/infra/supabase/migrations/20250803T0101_create_reactions.sql
+++ b/infra/supabase/migrations/20250803T0101_create_reactions.sql
@@ -2,7 +2,7 @@
 
 -- テーブル定義
 CREATE TABLE reactions (
-    id TEXT PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID NOT NULL,
     target_type TEXT NOT NULL,
     target_id TEXT NOT NULL,
@@ -10,24 +10,32 @@ CREATE TABLE reactions (
     meta JSONB,
     created_at TIMESTAMPTZ NOT NULL,
     created_version TEXT NOT NULL,
-    lock_no INTEGER NOT NULL
+    lock_no INTEGER NOT NULL,
+    UNIQUE (user_id, target_type, target_id, action_type)
 );
 
 -- インデックス
-CREATE INDEX idx_reactions_target_id ON reactions(target_id);
+CREATE INDEX idx_reactions_profile_cursor
+  ON reactions (user_id, target_type, action_type, created_at DESC, id);
+
+CREATE INDEX idx_reactions_agg
+  ON reactions (target_type, action_type, target_id);
+
+CREATE INDEX idx_reactions_user_target_id
+  ON reactions (user_id, target_id);
 
 -- コメント（テーブル）
-COMMENT ON TABLE reactions IS 'ユーザーによるリアクション（例：いいね、やり直しなど）を記録するテーブル';
+COMMENT ON TABLE reactions IS 'ユーザーのリアクションを記録（例：like, bookmark, hide）';
 
 -- コメント（カラム）
-COMMENT ON COLUMN reactions.id IS 'リアクションの一意なID（UUID）';
-COMMENT ON COLUMN reactions.user_id IS 'リアクションをしたユーザーのID（匿名可）';
-COMMENT ON COLUMN reactions.target_type IS 'リアクション対象のテーブル（例：spot, spot_guide）';
-COMMENT ON COLUMN reactions.target_id IS '対象となるスポットやガイドのID';
-COMMENT ON COLUMN reactions.action_type IS '実行されたアクションの種類（例：like, bookmark）';
-COMMENT ON COLUMN reactions.meta IS 'メタ情報を格納するJSONBフィールド（例：hideReason等）';
+COMMENT ON COLUMN reactions.id IS 'リアクションID';
+COMMENT ON COLUMN reactions.user_id IS 'リアクションしたユーザーのID';
+COMMENT ON COLUMN reactions.target_type IS 'リアクション対象の種類（例：dish_reviews, dish_media）';
+COMMENT ON COLUMN reactions.target_id IS 'リアクション対象のID';
+COMMENT ON COLUMN reactions.action_type IS 'リアクションの種類（例：like, bookmark, hide）';
+COMMENT ON COLUMN reactions.meta IS '追加情報（例：hideReason など）';
 COMMENT ON COLUMN reactions.created_at IS 'リアクション作成日時';
-COMMENT ON COLUMN reactions.created_version IS '実行時のアプリバージョン（バグ分析用途）';
+COMMENT ON COLUMN reactions.created_version IS 'アプリバージョン';
 COMMENT ON COLUMN reactions.lock_no IS '楽観ロック用バージョン番号';
 
 -- RLS 有効化


### PR DESCRIPTION
## Summary
- convert reactions.id to UUID and enforce uniqueness on user/target/action
- add indices for profile cursor paging, aggregation, and user-specific target lookups
- refresh table and column comments for app terminology

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config for app-expo)*
- `pnpm typecheck` *(fails: missing modules in app-expo and api)*

------
https://chatgpt.com/codex/tasks/task_e_68b2bbf1f1f4832ba9f67945613d552c