### PR TITLE
feat: add default title and description translations

### DIFF
--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -9,9 +9,11 @@
 		"post": "نشر",
 		"processing": "معالجة...",
 		"error": "خطأ",
-		"success": "نجح",
-		"daysRemaining": "متبقي {{count}} يومًا",
-		"timeAgo": {
+                "success": "نجح",
+                "defaultTitle": "CraveCatch - Find your dish",
+                "defaultDesc": "ما عليك سوى إخبار التطبيق بما تشعر به، وسيقترح لك ذكاؤنا الاصطناعي الأطباق التي قد تشتهيها. ثم تصفح صور الطعام الحقيقية والمراجعات لاختيار المطعم الذي يبدو مناسبًا على الفور.",
+                "daysRemaining": "متبقي {{count}} يومًا",
+                "timeAgo": {
 			"seconds": "منذ {{count}} ثانية",
 			"minutes": "منذ {{count}} دقيقة",
 			"hours": "منذ {{count}} ساعة",

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -9,9 +9,11 @@
 		"post": "Post",
 		"processing": "Processing...",
 		"error": "Error",
-		"success": "Success",
-		"daysRemaining": "Remaining {{count}} days",
-		"timeAgo": {
+                "success": "Success",
+                "defaultTitle": "CraveCatch - Find your dish",
+                "defaultDesc": "Simply tell the app how you feel, and our AI will suggest dishes you'll likely crave. Then browse real food photos and reviews to instantly pick a restaurant that feels right.",
+                "daysRemaining": "Remaining {{count}} days",
+                "timeAgo": {
 			"seconds": "{{count}} seconds ago",
 			"minutes": "{{count}} minutes ago",
 			"hours": "{{count}} hours ago",

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -9,9 +9,11 @@
 		"post": "Publicar",
 		"processing": "Procesando...",
 		"error": "Error",
-		"success": "Éxito",
-		"daysRemaining": "Quedan {{count}} días",
-		"timeAgo": {
+                "success": "Éxito",
+                "defaultTitle": "CraveCatch - Find your dish",
+                "defaultDesc": "Simplemente dile a la app cómo te sientes y nuestra IA te sugerirá los platos que probablemente se te antojen. Luego, explora fotos reales de comida y reseñas para elegir al instante el restaurante que te parezca adecuado.",
+                "daysRemaining": "Quedan {{count}} días",
+                "timeAgo": {
 			"seconds": "hace {{count}} segundos",
 			"minutes": "hace {{count}} minutos",
 			"hours": "hace {{count}} horas",

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -9,9 +9,11 @@
 		"post": "Publier",
 		"processing": "Traitement...",
 		"error": "Erreur",
-		"success": "Succès",
-		"daysRemaining": "Il reste {{count}} jours",
-		"timeAgo": {
+                "success": "Succès",
+                "defaultTitle": "CraveCatch - Find your dish",
+                "defaultDesc": "Indique simplement à l’application ce que vous ressentez, et notre IA vous proposera des plats que vous aurez probablement envie de déguster. Parcourez ensuite de vraies photos de plats et des avis pour choisir instantanément le restaurant qui vous convient.",
+                "daysRemaining": "Il reste {{count}} jours",
+                "timeAgo": {
 			"seconds": "il y a {{count}} secondes",
 			"minutes": "il y a {{count}} minutes",
 			"hours": "il y a {{count}} heures",

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -9,9 +9,11 @@
 		"post": "पोस्ट करें",
 		"processing": "प्रसंस्करण...",
 		"error": "त्रुटि",
-		"success": "सफलता",
-		"daysRemaining": "{{count}} दिन शेष",
-		"timeAgo": {
+                "success": "सफलता",
+                "defaultTitle": "CraveCatch - Find your dish",
+                "defaultDesc": "बस ऐप को बताएं कि आप कैसा महसूस कर रहे हैं और हमारी AI आपको वे व्यंजन सुझाएगी जिन्हें आप शायद पसंद करेंगे। फिर असली भोजन की तस्वीरें और समीक्षाएँ देखकर तुरंत वह रेस्तरां चुनें जो आपको सही लगे।",
+                "daysRemaining": "{{count}} दिन शेष",
+                "timeAgo": {
 			"seconds": "{{count}} सेकंड पहले",
 			"minutes": "{{count}} मिनट पहले",
 			"hours": "{{count}} घंटे पहले",

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -9,9 +9,11 @@
 		"post": "投稿",
 		"processing": "処理中...",
 		"error": "エラー",
-		"success": "成功",
-		"daysRemaining": "残り{{count}}日",
-		"timeAgo": {
+                "success": "成功",
+                "defaultTitle": "なに食べよ",
+                "defaultDesc": "あなたの気分を入力すると、AIが「これ食べたいでしょ！」という料理を提案してくれます。提案された料理写真やレビューを見ながら、直感的にお店を選べます。",
+                "daysRemaining": "残り{{count}}日",
+                "timeAgo": {
 			"seconds": "{{count}}秒前",
 			"minutes": "{{count}}分前",
 			"hours": "{{count}}時間前",

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -9,9 +9,11 @@
 		"post": "게시",
 		"processing": "처리 중...",
 		"error": "오류",
-		"success": "성공",
-		"daysRemaining": "남은 {{count}}일",
-		"timeAgo": {
+                "success": "성공",
+                "defaultTitle": "CraveCatch - Find your dish",
+                "defaultDesc": "앱에 지금 기분을 말하면 AI가 당신이 먹고 싶어 할 만한 요리를 추천해 줍니다. 그런 다음 실제 음식 사진과 리뷰를 보며 마음에 드는 식당을 바로 선택하세요.",
+                "daysRemaining": "남은 {{count}}일",
+                "timeAgo": {
 			"seconds": "{{count}}초 전",
 			"minutes": "{{count}}분 전",
 			"hours": "{{count}}시간 전",

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -9,9 +9,11 @@
 		"post": "发布",
 		"processing": "处理中...",
 		"error": "错误",
-		"success": "成功",
-		"daysRemaining": "剩余{{count}}天",
-		"timeAgo": {
+                "success": "成功",
+                "defaultTitle": "CraveCatch - Find your dish",
+                "defaultDesc": "只需告诉应用你的心情，我们的 AI 就会推荐你可能想吃的菜。然后浏览真实的美食照片和评论，立即选择一个合适的餐厅。",
+                "daysRemaining": "剩余{{count}}天",
+                "timeAgo": {
 			"seconds": "{{count}}秒前",
 			"minutes": "{{count}}分钟前",
 			"hours": "{{count}}小时前",


### PR DESCRIPTION
## Summary
- localize default app title and description across all supported languages

## Testing
- `pnpm --filter app-expo lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b22b6e44832ba93f8ddd29974047