### PR TITLE
feat: store app version in CLS for review likes

### DIFF
--- a/api/src/core/cls/cls.constants.ts
+++ b/api/src/core/cls/cls.constants.ts
@@ -2,3 +2,4 @@ export const CLS_KEY_REQUEST_ID = 'reqId';
 export const CLS_KEY_USER_ID = 'userId';
 export const CLS_KEY_API_LOG_BUFFER = 'apiLogBuffer';
 export const CLS_KEY_BE_LOG_BUFFER = 'beLogBuffer';
+export const CLS_KEY_APP_VERSION = 'appVersion';

--- a/api/src/core/guards/maintenance.guard.spec.ts
+++ b/api/src/core/guards/maintenance.guard.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ExecutionContext, HttpException, HttpStatus } from '@nestjs/common';
 import { MaintenanceGuard } from './maintenance.guard';
 import { RemoteConfigService } from '../remote-config/remote-config.service';
+import { ClsService } from 'nestjs-cls';
 
 // Mock request object
 const createMockRequest = (
@@ -29,6 +30,7 @@ describe('MaintenanceGuard', () => {
     const mockRemoteConfigService = {
       getRemoteConfigValue: jest.fn(),
     };
+    const mockClsService = { set: jest.fn() } as unknown as ClsService;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -36,6 +38,10 @@ describe('MaintenanceGuard', () => {
         {
           provide: RemoteConfigService,
           useValue: mockRemoteConfigService,
+        },
+        {
+          provide: ClsService,
+          useValue: mockClsService,
         },
       ],
     }).compile();

--- a/api/src/core/guards/maintenance.guard.ts
+++ b/api/src/core/guards/maintenance.guard.ts
@@ -9,6 +9,8 @@ import {
 import { Request } from 'express';
 import { RemoteConfigService } from '../remote-config/remote-config.service';
 import { isVersionGreaterOrEqual } from '../utils/version.util';
+import { ClsService } from 'nestjs-cls';
+import { CLS_KEY_APP_VERSION } from '../cls/cls.constants';
 
 /**
  * 🔒 メンテナンス・バージョン制御ガード
@@ -24,7 +26,10 @@ export class MaintenanceGuard implements CanActivate {
   /** 許可するパス（メンテナンス・バージョンチェックを行わない） */
   private readonly allowedPaths = ['/metrics'];
 
-  constructor(private readonly remoteConfigService: RemoteConfigService) {}
+  constructor(
+    private readonly remoteConfigService: RemoteConfigService,
+    private readonly cls: ClsService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
@@ -62,6 +67,7 @@ export class MaintenanceGuard implements CanActivate {
       // バージョンチェック（X-App-Version未送信時はスキップ）
       const appVersion = request.headers['x-app-version'] as string;
       if (appVersion) {
+        this.cls.set(CLS_KEY_APP_VERSION, appVersion);
         if (!isVersionGreaterOrEqual(appVersion, minimumVersionStr)) {
           throw new HttpException(
             {

--- a/api/src/v1/dish-reviews/dish-reviews.repository.ts
+++ b/api/src/v1/dish-reviews/dish-reviews.repository.ts
@@ -6,13 +6,18 @@
 //
 
 import { Injectable } from '@nestjs/common';
+import { ClsService } from 'nestjs-cls';
+import { CLS_KEY_APP_VERSION } from '../../core/cls/cls.constants';
 import { Prisma } from '../../../../shared/prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateDishReviewDto } from '@shared/v1/dto';
 
 @Injectable()
 export class DishReviewsRepository {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cls: ClsService,
+  ) {}
 
   /**
    * 料理が存在するかチェック
@@ -80,6 +85,8 @@ export class DishReviewsRepository {
     // Generate a unique ID for the reaction
     const reactionId = `${userId}_${reviewId}_like_${Date.now()}`;
 
+    const appVersion = this.cls.get<string>(CLS_KEY_APP_VERSION) ?? 'unknown';
+
     return this.prisma.prisma.reactions.create({
       data: {
         id: reactionId,
@@ -88,7 +95,7 @@ export class DishReviewsRepository {
         target_id: reviewId,
         action_type: 'like',
         created_at: new Date(),
-        created_version: '1.0.0', // TODO: 実際のバージョンを取得
+        created_version: appVersion,
         lock_no: 0,
       },
     });


### PR DESCRIPTION
## Summary
- use NestJS CLS to read app version when liking a review
- capture app version from request in maintenance guard
- expose CLS app version key

## Testing
- `pnpm --filter api test` *(fails: Invalid environment variables. Please check your .env file or runtime environment.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf178d5340832ba79232be1b83cfce