### PR TITLE
feat: pass location to search result map

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/result.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/result.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { View, Text, StyleSheet, TouchableOpacity, Platform } from "react-native";
 import { X } from "lucide-react-native";
 import { useLocalSearchParams } from "expo-router";
@@ -9,9 +9,19 @@ import { useHaptics } from "@/hooks/useHaptics";
 import { useLogger } from "@/hooks/useLogger";
 
 export default function ResultScreen() {
-	const { topicId } = useLocalSearchParams<{ topicId: string }>();
-	const { lightImpact } = useHaptics();
-	const { logFrontendEvent } = useLogger();
+        const { topicId, location } = useLocalSearchParams<{ topicId: string; location?: string }>();
+        const initialLocation = useMemo(() => {
+                if (typeof location === "string") {
+                        try {
+                                return JSON.parse(location) as { latitude: number; longitude: number };
+                        } catch {
+                                return undefined;
+                        }
+                }
+                return undefined;
+        }, [location]);
+        const { lightImpact } = useHaptics();
+        const { logFrontendEvent } = useLogger();
 
 	const { currentIndex, showCompletionModal, dishesPromise, handleIndexChange, handleClose, handleReturnToCards } =
 		useSearchResult(topicId as string);
@@ -49,10 +59,14 @@ export default function ResultScreen() {
 			</View>
 
 			{/* Feed Content */}
-			{/* <FoodContentFeed items={dishes} onIndexChange={handleIndexChange} /> */}
-			<FoodContentMap itemsPromise={dishesPromise} onIndexChange={handleIndexChange} />
-		</LinearGradient>
-	);
+                        {/* <FoodContentFeed items={dishes} onIndexChange={handleIndexChange} /> */}
+                        <FoodContentMap
+                                itemsPromise={dishesPromise}
+                                onIndexChange={handleIndexChange}
+                                initialLocation={initialLocation}
+                        />
+                </LinearGradient>
+        );
 }
 
 const styles = StyleSheet.create({

--- a/app-expo/app/[locale]/(tabs)/search/topics.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/topics.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { ThumbsUp, X } from "lucide-react-native";
 import { router, useLocalSearchParams } from "expo-router";
@@ -21,7 +21,17 @@ import { useLocale } from "@/hooks/useLocale";
 
 export default function TopicsScreen() {
 	const locale = useLocale();
-	const { searchParams } = useLocalSearchParams<{ searchParams: string }>();
+        const { searchParams } = useLocalSearchParams<{ searchParams: string }>();
+        const params = useMemo(() => {
+                if (searchParams) {
+                        try {
+                                return JSON.parse(searchParams) as SearchParams;
+                        } catch {
+                                return null;
+                        }
+                }
+                return null;
+        }, [searchParams]);
 	const [currentIndex, setCurrentIndex] = useState(0);
 	const carouselRef = useRef<any>(null);
 	const setDishes = useDishMediaEntriesStore((state) => state.setDishePromises);
@@ -36,30 +46,28 @@ export default function TopicsScreen() {
 		confirmHideCard,
 	} = useHideTopic(topics, hideTopic, showSnackbar);
 
-	useEffect(() => {
-		if (searchParams) {
-			try {
-				const params: SearchParams = JSON.parse(searchParams);
-				searchTopics(params).catch(() => {
-					showSnackbar(i18n.t("Topics.errors.fetchFailed"));
-				});
-			} catch (error) {
-				showSnackbar(i18n.t("Topics.errors.invalidSearchParams"));
-				router.back();
-			}
-		}
-	}, [searchParams]);
+        useEffect(() => {
+                if (params) {
+                        searchTopics(params).catch(() => {
+                                showSnackbar(i18n.t("Topics.errors.fetchFailed"));
+                        });
+                } else {
+                        showSnackbar(i18n.t("Topics.errors.invalidSearchParams"));
+                        router.back();
+                }
+        }, [params, searchTopics, showSnackbar]);
 
-	const handleViewDetails = (topic: Topic) => {
-		setDishes(topic.categoryId, topic.dishItemsPromise);
-		router.push({
-			pathname: "/[locale]/(tabs)/search/result",
-			params: {
-				locale,
-				topicId: topic.categoryId,
-			},
-		});
-	};
+        const handleViewDetails = (topic: Topic) => {
+                setDishes(topic.categoryId, topic.dishItemsPromise);
+                router.push({
+                        pathname: "/[locale]/(tabs)/search/result",
+                        params: {
+                                locale,
+                                topicId: topic.categoryId,
+                                ...(params && { location: JSON.stringify(params.location) }),
+                        },
+                });
+        };
 
 	const handleBack = () => {
 		router.back();

--- a/app-expo/components/FoodContentMap.tsx
+++ b/app-expo/components/FoodContentMap.tsx
@@ -15,12 +15,16 @@ const CAROUSEL_HEIGHT = height * 0.8;
 const PARALLAX_SCALE = 0.85;
 
 interface FoodContentMapProps {
-	itemsPromise: Promise<DishMediaEntry[]>;
-	initialIndex?: number;
-	onIndexChange?: (index: number) => void;
+        itemsPromise: Promise<DishMediaEntry[]>;
+        initialIndex?: number;
+        onIndexChange?: (index: number) => void;
+        initialLocation?: {
+                latitude: number;
+                longitude: number;
+        };
 }
 
-export default function FoodContentMap({ itemsPromise, initialIndex = 0, onIndexChange }: FoodContentMapProps) {
+export default function FoodContentMap({ itemsPromise, initialIndex = 0, onIndexChange, initialLocation }: FoodContentMapProps) {
 	const [currentIndex, setCurrentIndex] = useState(initialIndex);
 	const carouselRef = useRef<any>(null);
 	const mapRef = useRef<any>(null);
@@ -36,15 +40,15 @@ export default function FoodContentMap({ itemsPromise, initialIndex = 0, onIndex
 		});
 	}, [itemsPromise]);
 
-	const getMapRegion = useCallback((): Region => {
-		if (coordinates.length === 0) {
-			return {
-				latitude: 35.6762, // TODO searchParams を引き継ぐ
-				longitude: 139.6503,
-				latitudeDelta: 0.01,
-				longitudeDelta: 0.01,
-			};
-		}
+        const getMapRegion = useCallback((): Region => {
+                if (coordinates.length === 0) {
+                        return {
+                                latitude: initialLocation?.latitude ?? 35.6762,
+                                longitude: initialLocation?.longitude ?? 139.6503,
+                                latitudeDelta: 0.01,
+                                longitudeDelta: 0.01,
+                        };
+                }
 
 		// マップのアスペクト比
 		const aspectRatio = width / height;
@@ -76,7 +80,7 @@ export default function FoodContentMap({ itemsPromise, initialIndex = 0, onIndex
 			latitudeDelta: latDelta,
 			longitudeDelta: lngDelta,
 		};
-	}, [coordinates]);
+        }, [coordinates, initialLocation]);
 
 	useEffect(() => {
 		// 初期位置設定


### PR DESCRIPTION
## Summary
- add optional `initialLocation` to `FoodContentMap` and center map accordingly
- thread search `location` through Topics and Result screens

## Testing
- `pnpm --filter app-expo lint` *(fails: ESLint couldn't find an eslint.config)*
- `pnpm --filter app-expo typecheck` *(fails: Cannot find module '@shared/api/v1/res')*
- `pnpm --filter app-expo test -- --watchAll=false` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf195ff38c832b858948c81ecbe1ff