### PR TITLE
Translate docs to Japanese

### DIFF
--- a/docs/CDN_SIGNED_COOKIE_IMPLEMENTATION.md
+++ b/docs/CDN_SIGNED_COOKIE_IMPLEMENTATION.md
@@ -1,368 +1,369 @@
-# CDN Signed Cookie Implementation for Video Media
+# 動画メディア向けCDN署名付きCookie実装
 
-## Overview
+## 概要
 
-This implementation adds CDN signed cookie authentication for video media playback. Videos are served via HLS (HTTP Live Streaming) which requires multiple file requests (master.m3u8 → segment playlists → .ts segments). CDN signed cookies provide path-based authentication that covers all files under a specific URL prefix, unlike single-file signed URLs.
+この実装では、動画の再生にCDN署名付きCookieによる認証を追加した。動画はHLS（HTTP Live Streaming）で配信され、`master.m3u8` → セグメントプレイリスト → `.ts` セグメントと複数のファイルへアクセスする必要がある。単一ファイルだけを保護する署名付きURLとは異なり、CDN署名付きCookieは特定のURLプレフィックス配下のファイルをまとめて保護できる。
 
-## Architecture
+## アーキテクチャ
 
-### Components
+### 構成要素
 
-1. **Environment Configuration** (`api/src/core/config/env.ts`)
-   - `CDN_HOST`: CDN domain (e.g., `cdn.example.com`)
-   - `CDN_KEY_NAME`: Key name for signing
-   - `CDN_KEY_SECRET_B64`: Base64-encoded secret key
-   - `CDN_SIGNED_COOKIE_TTL_SECONDS`: Cookie TTL (default: 600 seconds / 10 minutes)
+1. **環境変数設定** (`api/src/core/config/env.ts`)
+   - `CDN_HOST`: CDNドメイン（例: `cdn.example.com`）
+   - `CDN_KEY_NAME`: 署名に使用するキー名
+   - `CDN_KEY_SECRET_B64`: Base64エンコードした秘密鍵
+   - `CDN_SIGNED_COOKIE_TTL_SECONDS`: CookieのTTL（デフォルト600秒/10分）
 
-2. **Cookie Generation** (`api/src/core/storage/storage.service.ts`)
-   - `generateCdnSignedCookies()`: Generates Cloud CDN signed cookies
-   - Uses HMAC-SHA1 signature with Base64 URL-safe encoding
-   - Cookie format: `URLPrefix=<url>&Expires=<timestamp>&KeyName=<key>&Signature=<sig>`
-   - Cookie attributes: `Domain`, `Path`, `Max-Age`, `HttpOnly`, `Secure`, `SameSite=None`
+2. **Cookie生成** (`api/src/core/storage/storage.service.ts`)
+   - `generateCdnSignedCookies()`: Cloud CDNの署名付きCookieを生成
+   - HMAC-SHA1署名とBase64 URLセーフエンコードを使用
+   - Cookie値の形式: `URLPrefix=<url>&Expires=<timestamp>&KeyName=<key>&Signature=<sig>`
+   - Cookie属性: `Domain`, `Path`, `Max-Age`, `HttpOnly`, `Secure`, `SameSite=None`
 
-3. **Media URL Generation** (`api/src/v1/dish-media/dish-media.service.ts`)
-   - `fetchDishMediaEntryItems()`: Detects video media and generates CDN URLs
-   - For videos: `https://{CDN_HOST}/{env}/transcoded/dish_media/media_path/{recordId}/master.m3u8`
-   - For images: Uses existing GCS signed URL logic
-   - Returns both data and optional CDN cookies
+3. **メディアURL生成** (`api/src/v1/dish-media/dish-media.service.ts`)
+   - `fetchDishMediaEntryItems()`: 動画メディアを検出し、CDNのURLを生成
+   - 動画の場合: `https://{CDN_HOST}/{env}/transcoded/dish_media/media_path/{recordId}/master.m3u8`
+   - 画像の場合: 従来通りGCSの署名付きURLを使用
+   - データ本体に加えて必要に応じてCDN Cookieを返却
 
-4. **Controller Integration**
-   - `UsersController`: Sets cookies for saved/liked dish media endpoints
-   - `DishMediaController`: Sets cookies for search and query endpoints
-   - `RestaurantsController`: Sets cookies for restaurant dish media endpoint
-   - Uses NestJS `@Res({ passthrough: true })` to set `Set-Cookie` headers
+4. **コントローラーへの組み込み**
+   - `UsersController`: 保存済み/いいね済みのディッシュメディアAPIでCookieを設定
+   - `DishMediaController`: 検索およびID指定取得のエンドポイントでCookieを設定
+   - `RestaurantsController`: 店舗のディッシュメディア取得でCookieを設定
+  
+   - NestJSの`@Res({ passthrough: true })`で`Set-Cookie`ヘッダーを付与
 
-## Cookie Format
+## Cookieの形式
 
-### Cookie Structure
+### Cookie構造
 
-The cookie name is `Cloud-CDN-Cookie` and the value contains colon-separated fields:
+Cookie名は`Cloud-CDN-Cookie`で、値はコロン区切りのフィールドで構成される。
 
 ```
 Cloud-CDN-Cookie=URLPrefix=<url>:Expires=<timestamp>:KeyName=<key>:Signature=<sig>; Domain=<cdn-host>; Path=<path>; Max-Age=<ttl>; HttpOnly; Secure; SameSite=None
 ```
 
-Note: The signature is computed over the URL parameter format (`URLPrefix=<url>&Expires=<timestamp>&KeyName=<key>`), but the cookie value uses colon separators.
+※署名は`URLPrefix=<url>&Expires=<timestamp>&KeyName=<key>`というアンパサンド区切りの文字列を対象に計算するが、Cookie値はコロン区切りで表現する。
 
-### Example
+### 例
 
 ```
 Cloud-CDN-Cookie=URLPrefix=https://cdn.example.com/prod/transcoded/dish_media/media_path/abc123/:Expires=1760483243:KeyName=my-key:Signature=BnNrXpMt4ul7kQciSaqt1dUOoG4=; Domain=cdn.example.com; Path=/prod/transcoded/dish_media/media_path/abc123/; Max-Age=600; HttpOnly; Secure; SameSite=None
 ```
 
-### Cookie Attributes
+### Cookie属性
 
-- **Domain**: `cdn.example.com` - Scoped to CDN domain
-- **Path**: `/{env}/transcoded/dish_media/media_path/{recordId}/` - Scoped to specific video directory
-- **Max-Age**: `600` - Cookie expires after TTL (default 10 minutes)
-- **HttpOnly**: Prevents JavaScript access for security
-- **Secure**: Requires HTTPS
-- **SameSite=None**: Allows cross-site requests (required for cross-origin video playback)
+- **Domain**: `cdn.example.com`（CDNドメインに限定）
+- **Path**: `/{env}/transcoded/dish_media/media_path/{recordId}/`（個別動画のディレクトリに限定）
+- **Max-Age**: `600`（デフォルトTTLは10分）
+- **HttpOnly**: JavaScriptからのアクセスを遮断
+- **Secure**: HTTPS通信のみで送信
+- **SameSite=None**: クロスサイト動画再生に必要
 
-## URL Path Structure
+## URLパス構造
 
-### Video Files
+### 動画ファイル
 
 ```
 https://cdn.example.com/{env}/transcoded/dish_media/media_path/{recordId}/
-├── master.m3u8          # Master playlist (returned as mediaUrl)
-├── 720p.m3u8            # Resolution variant playlist
-├── 480p.m3u8            # Resolution variant playlist
+├── master.m3u8          # master.m3u8はAPIレスポンスのmediaUrlとして返却
+├── 720p.m3u8            # 解像度別プレイリスト
+├── 480p.m3u8            # 解像度別プレイリスト
 └── segments/
-    ├── 720p_00001.ts    # Video segments
+    ├── 720p_00001.ts    # 動画セグメント
     ├── 720p_00002.ts
     └── ...
 ```
 
-### Cookie Scope
+### Cookieのスコープ
 
-The cookie's `Path` attribute is set to the directory path, allowing access to:
+`Path`属性をディレクトリパスに設定することで、以下のファイルへアクセスできる。
 
 - `master.m3u8`
-- All variant playlists (e.g., `720p.m3u8`)
-- All video segments under the path
+- すべての解像度プレイリスト（例: `720p.m3u8`）
+- パス配下のすべての動画セグメント
 
-## API Endpoints
+## APIエンドポイント
 
-### Endpoints That Set Cookies
+### Cookieを設定するエンドポイント
 
-All endpoints that return dish media with videos will set signed cookies:
+動画を含むディッシュメディアを返すエンドポイントでは、署名付きCookieをレスポンスに含める。
 
 1. **GET /v1/users/me/saved-dish-media**
-   - Returns saved dish media
-   - Sets cookies for each video in the response
+   - 保存済みディッシュメディアを返却
+   - レスポンスの動画ごとにCookieを設定
 
 2. **GET /v1/users/me/liked-dish-media**
-   - Returns liked dish media
-   - Sets cookies for each video in the response
+   - いいね済みディッシュメディアを返却
+   - レスポンスの動画ごとにCookieを設定
 
 3. **GET /v1/users/:id/dish-reviews**
-   - Returns dish reviews with media
-   - Sets cookies for each video in the response
+   - ユーザーのレビューとメディアを返却
+   - レスポンスの動画ごとにCookieを設定
 
 4. **GET /v1/dish-media?ids=...**
-   - Returns dish media by IDs
-   - Sets cookies for each video in the response
+   - ID指定でディッシュメディアを取得
+   - レスポンスの動画ごとにCookieを設定
 
 5. **GET /v1/dish-media/search**
-   - Returns search results
-   - Sets cookies for each video in the response
+   - ディッシュメディア検索結果を返却
+   - レスポンスの動画ごとにCookieを設定
 
 6. **GET /v1/restaurants/:id/dish-media**
-   - Returns restaurant's dish media
-   - Sets cookies for each video in the response
+   - 店舗のディッシュメディアを返却
+   - レスポンスの動画ごとにCookieを設定
 
-### Response Behavior
+### レスポンスの挙動
 
-- Multiple `Set-Cookie` headers are returned (one per video record)
-- Cookies are only set when CDN configuration is present
-- Falls back to GCS signed URLs if CDN is not configured
-- DTO only contains `mediaUrl` (CDN URL); cookies are in headers only
+- `Set-Cookie`ヘッダーを複数返却（1動画につき1Cookie）
+- CDN設定が存在する場合にのみCookieを設定
+- CDNが未設定の場合はGCS署名付きURLにフォールバック
+- DTOには`mediaUrl`（CDN URL）のみを含め、Cookieはヘッダーで提供
 
-## Security Considerations
+## セキュリティの考慮事項
 
-### Cookie Attributes
+### Cookie属性
 
-- **HttpOnly**: Prevents XSS attacks by making cookies inaccessible to JavaScript
-- **Secure**: Ensures cookies are only sent over HTTPS
-- **SameSite=None**: Required for cross-origin video playback, but requires `Secure`
+- **HttpOnly**: XSS対策のためJavaScriptからアクセス不可
+- **Secure**: HTTPS通信でのみ送信
+- **SameSite=None**: クロスオリジン再生に必要。設定時は`Secure`が必須
 
-### TTL Strategy
+### TTL戦略
 
-- Default TTL: 10 minutes (600 seconds)
-- Short TTL limits exposure window
-- Client must re-fetch media list to refresh cookies
-- Natural expiration eliminates need for explicit revocation
+- デフォルトTTL: 10分（600秒）
+- 短時間TTLで漏えいリスクを最小化
+- クライアントはCookie更新のためにメディア一覧を再取得する必要がある
+- 自然失効により明示的な失効処理は不要
 
-### Signature Security
+### 署名の安全性
 
-- Uses HMAC-SHA1 with secret key
-- Signature covers: URLPrefix + Expires + KeyName
-- Base64 URL-safe encoding (+/= → -/\_)
-- Invalid signatures result in 403 responses from CDN
+- HMAC-SHA1と秘密鍵を使用
+- 署名対象: `URLPrefix + Expires + KeyName`
+- Base64のURLセーフ変換（`+`/`=`→`-`/`_`）
+- 署名が不正な場合、CDNが403を返却
 
-### Path Scoping
+### パスの分離
 
-- Each cookie is scoped to specific `recordId` path
-- Users can only access videos they have permissions to view
-- Path-based isolation prevents cross-record access
+- Cookieは各`recordId`のパス単位でスコープを設定
+- ユーザーは権限のある動画にのみアクセス可能
+- パスベースの制限により他レコードへのアクセスを防止
 
-## Configuration
+## 設定
 
-### Development Environment
+### 開発環境
 
-```bash
-# .env in api/ directory
+```
+# api/ ディレクトリの .env
 CDN_HOST=cdn.example.com
 CDN_KEY_NAME=dev-signing-key
 CDN_KEY_SECRET_B64=<base64-encoded-secret>
 CDN_SIGNED_COOKIE_TTL_SECONDS=600
 ```
 
-### Production Environment
+### 本番環境
 
-Set via environment variables in deployment:
+デプロイ時の環境変数として設定する。
 
-- Google Cloud Run secrets
-- GitHub Actions workflow variables
-- Configured per environment (dev/staging/prod)
+- Google Cloud Runのシークレット
+- GitHub Actionsのワークフローバリアブル
+- 環境（dev/staging/prod）ごとに設定
 
-## Client Integration
+## クライアント統合
 
-### Web (React/Next.js)
+### Web（React / Next.js）
 
 ```typescript
-// Fetch with credentials to receive cookies
+// Cookieを受け取るためにcredentialsをinclude
 const response = await fetch("/v1/users/me/saved-dish-media", {
-	credentials: "include",
+        credentials: "include",
 });
 
 const data = await response.json();
 
-// Use mediaUrl directly with HLS player
+// HLSプレイヤーでmediaUrlをそのまま利用
 data.items.forEach((item) => {
-	if (item.dish_media.media_type === "video") {
-		// Browser automatically sends cookies with HLS requests
-		player.src = item.dish_media.mediaUrl;
-	}
+        if (item.dish_media.media_type === "video") {
+                // ブラウザがHLSリクエスト時にCookieを自動送信
+                player.src = item.dish_media.mediaUrl;
+        }
 });
 ```
 
-### Mobile (React Native with expo-av)
+### モバイル（React Native + expo-av）
 
 ```typescript
-// Fetch with credentials to receive cookies
+// Cookieを受け取るためにcredentialsをinclude
 const response = await fetch('/v1/users/me/saved-dish-media', {
   credentials: 'include'
 });
 
 const data = await response.json();
 
-// Use mediaUrl directly with Video component
+// expo-avのVideoコンポーネントで再生
 data.items.forEach(item => {
   if (item.dish_media.media_type === 'video') {
-    // expo-av automatically sends cookies
+    // expo-avが自動的にCookieを送信
     <Video source={{ uri: item.dish_media.mediaUrl }} />
   }
 });
 ```
 
-## CDN Configuration
+## CDNの設定
 
-### Cloud CDN Setup
+### Cloud CDNの準備
 
-1. Create signing key:
+1. 署名鍵の生成:
 
 ```bash
-# Generate key
+# 秘密鍵を生成
 openssl rand -base64 32 > cdn-signing-key.txt
 
-# Store key in Secret Manager
+# Secret Managerに保存
 gcloud secrets create cdn-signing-key \
   --data-file=cdn-signing-key.txt
 ```
 
-2. Configure Cloud CDN with signed cookies:
+2. Cloud CDNを署名付きURL/Cookie対応で設定:
 
 ```bash
-# Enable signed URL/cookie support
+# 署名付きURL/署名付きCookieを有効化
 gcloud compute backend-services update BACKEND_SERVICE \
   --signed-url-cache-max-age=600s
 ```
 
-3. Add key to environment:
+3. 環境変数へ登録:
 
 ```bash
-# Set environment variables
+# 環境変数を設定
 export CDN_HOST=cdn.example.com
 export CDN_KEY_NAME=primary-key
 export CDN_KEY_SECRET_B64=$(cat cdn-signing-key.txt)
 ```
 
-## Testing
+## テスト
 
-### Manual Testing
+### 手動テスト
 
-1. Start API server with CDN configuration
-2. Fetch a media endpoint (e.g., `/v1/users/me/saved-dish-media`)
-3. Verify `Set-Cookie` headers in response for video items
-4. Verify cookie attributes (Domain, Path, HttpOnly, Secure, SameSite)
-5. Use cookie to access `mediaUrl` and verify video plays
-6. Wait for TTL expiration and verify 403 response
+1. CDN設定を有効にした状態でAPIサーバーを起動
+2. `/v1/users/me/saved-dish-media` などのエンドポイントを叩く
+3. レスポンスヘッダーに動画用`Set-Cookie`が含まれることを確認
+4. Domain / Path / HttpOnly / Secure / SameSiteなどの属性を検証
+5. `mediaUrl`へアクセスして動画が再生できることを確認
+6. TTLを過ぎた後にアクセスし403になることを確認
 
-### Cookie Verification Script
+### Cookie検証スクリプト
 
-Create a test script to verify cookie generation:
+Cookie生成を検証するスクリプト例:
 
 ```javascript
 const crypto = require("crypto");
 
 const env = {
-	CDN_HOST: "cdn.example.com",
-	CDN_KEY_NAME: "test-key",
-	CDN_KEY_SECRET_B64: Buffer.from("test-secret").toString("base64"),
-	CDN_SIGNED_COOKIE_TTL_SECONDS: 600,
+        CDN_HOST: "cdn.example.com",
+        CDN_KEY_NAME: "test-key",
+        CDN_KEY_SECRET_B64: Buffer.from("test-secret").toString("base64"),
+        CDN_SIGNED_COOKIE_TTL_SECONDS: 600,
 };
 
 function generateCdnSignedCookies(urlPrefix, recordId) {
-	const keySecret = Buffer.from(env.CDN_KEY_SECRET_B64, "base64");
-	const expires = Math.floor(Date.now() / 1000) + env.CDN_SIGNED_COOKIE_TTL_SECONDS;
+        const keySecret = Buffer.from(env.CDN_KEY_SECRET_B64, "base64");
+        const expires = Math.floor(Date.now() / 1000) + env.CDN_SIGNED_COOKIE_TTL_SECONDS;
 
-	// Create signature - note this uses & separators
-	const toSign = `URLPrefix=${urlPrefix}&Expires=${expires}&KeyName=${env.CDN_KEY_NAME}`;
-	const signature = crypto
-		.createHmac("sha1", keySecret)
-		.update(toSign)
-		.digest("base64")
-		.replace(/\+/g, "-")
-		.replace(/\//g, "_");
+        // 署名は&区切りの文字列に対して生成
+        const toSign = `URLPrefix=${urlPrefix}&Expires=${expires}&KeyName=${env.CDN_KEY_NAME}`;
+        const signature = crypto
+                .createHmac("sha1", keySecret)
+                .update(toSign)
+                .digest("base64")
+                .replace(/\+/g, "-")
+                .replace(/\//g, "_");
 
-	const urlObj = new URL(urlPrefix);
-	const cookiePath = urlObj.pathname;
+        const urlObj = new URL(urlPrefix);
+        const cookiePath = urlObj.pathname;
 
-	// Cookie value uses : separators
-	return [
-		`Cloud-CDN-Cookie=URLPrefix=${urlPrefix}:Expires=${expires}:KeyName=${env.CDN_KEY_NAME}:Signature=${signature}; Domain=${env.CDN_HOST}; Path=${cookiePath}; Max-Age=${env.CDN_SIGNED_COOKIE_TTL_SECONDS}; HttpOnly; Secure; SameSite=None`,
-	];
+        // Cookie値は:区切りで表現
+        return [
+                `Cloud-CDN-Cookie=URLPrefix=${urlPrefix}:Expires=${expires}:KeyName=${env.CDN_KEY_NAME}:Signature=${signature}; Domain=${env.CDN_HOST}; Path=${cookiePath}; Max-Age=${env.CDN_SIGNED_COOKIE_TTL_SECONDS}; HttpOnly; Secure; SameSite=None`,
+        ];
 }
 
-// Test cookie generation
+// テスト実行
 const testRecordId = "123e4567-e89b-12d3-a456-426614174000";
 const testUrl = `https://cdn.example.com/prod/transcoded/dish_media/media_path/${testRecordId}/`;
 const cookies = generateCdnSignedCookies(testUrl, testRecordId);
 console.log(cookies);
 ```
 
-## Monitoring
+## 監視
 
-### Key Metrics
+### 重要なメトリクス
 
-- Cookie generation success/failure rate
-- Cookie validation failures (403s from CDN)
-- TTL expiration patterns
-- Cookie count per request
+- Cookie生成の成功/失敗率
+- CDNから返却される403（署名エラー）
+- TTLの有効期限パターン
+- 1リクエストあたりのCookie発行数
 
-### Logging
+### ログ
 
-All cookie operations are logged via `AppLoggerService`:
+すべてのCookie関連処理は`AppLoggerService`で記録される。
 
-- `CdnSignedCookiesGenerated`: Successful generation
-- `CdnConfigMissing`: Missing CDN configuration
-- `CdnSignedCookieError`: Generation errors
+- `CdnSignedCookiesGenerated`: 生成に成功
+- `CdnConfigMissing`: CDN設定が不足している
+- `CdnSignedCookieError`: 生成中にエラー発生
 
-### Example Log Entry
+### ログ例
 
 ```json
 {
-	"event": "CdnSignedCookiesGenerated",
-	"context": "generateCdnSignedCookies",
-	"data": {
-		"urlPrefix": "https://cdn.example.com/prod/transcoded/dish_media/media_path/abc123/",
-		"recordId": "abc123",
-		"expires": "2025-10-14T23:17:23.000Z",
-		"cookieCount": 1
-	}
+        "event": "CdnSignedCookiesGenerated",
+        "context": "generateCdnSignedCookies",
+        "data": {
+                "urlPrefix": "https://cdn.example.com/prod/transcoded/dish_media/media_path/abc123/",
+                "recordId": "abc123",
+                "expires": "2025-10-14T23:17:23.000Z",
+                "cookieCount": 1
+        }
 }
 ```
 
-## Troubleshooting
+## トラブルシューティング
 
-### Issue: No cookies in response
+### 課題: レスポンスにCookieが含まれない
 
-- Verify CDN environment variables are set
-- Check logs for `CdnConfigMissing` warnings
-- Confirm media items have `media_type=video`
+- CDN関連の環境変数が設定されているか確認
+- ログに`CdnConfigMissing`が出力されていないか確認
+- レスポンスのメディアが`media_type=video`になっているか確認
 
-### Issue: 403 responses from CDN
+### 課題: CDNから403が返る
 
-- Verify cookie signature is correct
-- Check cookie hasn't expired (TTL)
-- Verify CDN is configured with correct signing key
-- Confirm CDN domain matches cookie Domain attribute
+- Cookieの署名が正しいか検証
+- CookieのTTLが切れていないか確認
+- CDNに正しい署名鍵が設定されているか確認
+- CookieのDomainがCDNドメインと一致しているか確認
 
-### Issue: Cookies not sent by client
+### 課題: クライアントがCookieを送信しない
 
-- Verify `credentials: 'include'` in fetch requests
-- Check cookie attributes (Secure requires HTTPS)
-- Verify cookie Domain matches request domain
-- Check SameSite=None is supported by client
+- fetch時に`credentials: 'include'`が指定されているか確認
+- Cookieの属性（特にSecure）が要件を満たしているか確認
+- CookieのDomainがリクエストドメインと一致しているか確認
+- SameSite=Noneをサポートしていないクライアントでないか確認
 
-### Issue: Multiple cookies for same recordId
+### 課題: 同じrecordIdでCookieが複数発行される
 
-- Expected behavior for pagination
-- Each page fetch generates new cookies
-- Old cookies expire naturally via TTL
-- Consider explicit deletion if needed: `Max-Age=0`
+- ページネーション時は想定される挙動
+- リスト取得ごとに新しいCookieが生成される
+- 古いCookieはTTLで自然に失効
+- 必要であれば`Max-Age=0`のCookieで明示的に削除
 
-## Future Enhancements
+## 今後の拡張
 
-1. **Proactive Cookie Refresh**: Client-side renewal before expiration
-2. **Batch Optimization**: Reduce cookie count via shared paths
-3. **Analytics**: Track cookie usage and expiration patterns
-4. **Rate Limiting**: Limit cookie generation per user/IP
-5. **Monitoring Dashboard**: Visualize cookie metrics
+1. **Cookieの事前更新**: 有効期限前にクライアント側で更新する仕組み
+2. **バッチ最適化**: Cookie数を減らすためのパス共有
+3. **分析基盤**: Cookie利用状況や期限切れを可視化
+4. **レート制限**: ユーザー/IPごとのCookie発行回数を制限
+5. **モニタリングダッシュボード**: メトリクスの可視化
 
-## References
+## 参考資料
 
 - [Cloud CDN Signed Cookies Documentation](https://cloud.google.com/cdn/docs/using-signed-cookies)
 - [HTTP Cookie Specification (RFC 6265)](https://tools.ietf.org/html/rfc6265)

--- a/docs/DISH_CATEGORY_AUTOCOMPLETE_IMPLEMENTATION.md
+++ b/docs/DISH_CATEGORY_AUTOCOMPLETE_IMPLEMENTATION.md
@@ -1,142 +1,142 @@
-# DishCategoryAutocomplete Implementation Summary
+# DishCategoryAutocomplete 実装サマリー
 
-## Overview
+## 概要
 
-This document summarizes the implementation of the DishCategoryAutocomplete feature that allows users to search and select dish categories when posting reviews, with automatic category variant creation when no match is found.
+本ドキュメントは、レビュー投稿時に料理カテゴリを検索・選択できるようにし、一致する候補が存在しない場合はカテゴリバリアントを自動で作成する DishCategoryAutocomplete 機能の実装内容をまとめたものである。
 
-## Implementation Date
+## 実装日
 
 2025-10-10
 
-## Components Implemented
+## 実装コンポーネント
 
-### 1. `useDishCategorySearch` Hook (`app-expo/hooks/useDishCategorySearch.ts`)
+### 1. `useDishCategorySearch` フック (`app-expo/hooks/useDishCategorySearch.ts`)
 
-A custom React hook that manages dish category search and variant creation:
+料理カテゴリの検索とバリアント作成を管理するカスタム React フック。
 
-**Features:**
+**主な機能:**
 
-- Debounced search (300ms) with minimum 3 characters
-- AbortController support for request cancellation
-- GET `/v1/dish-category-variants?q&lang` for autocomplete
-- POST `/v1/dish-category-variants` for creating new variants
-- Loading state management
-- Comprehensive error logging
+- 300ms のデバウンスと最小3文字条件での検索
+- リクエストキャンセルに対応する AbortController
+- オートコンプリート用の GET `/v1/dish-category-variants?q&lang`
+- 新規バリアント作成用の POST `/v1/dish-category-variants`
+- ローディング状態の管理
+- 詳細なエラーログ
 
-**Key Functions:**
+**主要メソッド:**
 
-- `searchDishCategories(query: string)` - Searches for matching dish categories
-- `createDishCategoryVariant(name: string)` - Creates a new dish category variant
+- `searchDishCategories(query: string)` — 一致する料理カテゴリの検索
+- `createDishCategoryVariant(name: string)` — 新しい料理カテゴリバリアントの作成
 
-### 2. `DishCategoryAutocomplete` Component (`app-expo/components/DishCategoryAutocomplete.tsx`)
+### 2. `DishCategoryAutocomplete` コンポーネント (`app-expo/components/DishCategoryAutocomplete.tsx`)
 
-A reusable autocomplete component based on `LocationAutocomplete`:
+`LocationAutocomplete` をベースにした再利用可能なオートコンプリートコンポーネント。
 
-**Features:**
+**主な機能:**
 
-- Text input with real-time suggestions
-- Clear button functionality
-- Loading indicator during search
-- Accessible with screen reader announcements
-- Keyboard-friendly navigation
-- Consistent styling with existing components
+- テキスト入力とリアルタイムのサジェスト表示
+- クリアボタンの実装
+- 検索中のローディングインジケーター
+- スクリーンリーダー向けアナウンス対応
+- キーボード操作に配慮したナビゲーション
+- 既存コンポーネントと統一したスタイリング
 
-**Props:**
+**プロパティ:**
 
-- `value: string` - Current input value
-- `onChangeText: (text: string) => void` - Text change handler
-- `onSelectSuggestion: (suggestion) => void` - Suggestion selection handler
-- `onClear?: () => void` - Clear button handler
-- `placeholder?: string` - Input placeholder
-- `renderInputRight?: React.ReactNode` - Optional right-side element
-- `autofocus?: boolean` - Auto-focus on mount
-- `testID?: string` - Testing identifier
+- `value: string` — 現在の入力値
+- `onChangeText: (text: string) => void` — 入力変更時のハンドラー
+- `onSelectSuggestion: (suggestion) => void` — サジェスト選択時のハンドラー
+- `onClear?: () => void` — クリアボタン押下時のハンドラー
+- `placeholder?: string` — プレースホルダー
+- `renderInputRight?: React.ReactNode` — 右側に表示する任意要素
+- `autofocus?: boolean` — マウント時に自動フォーカスするか
+- `testID?: string` — テスト用ID
 
-### 3. ReviewForm Integration (`app-expo/features/map/components/ReviewForm.tsx`)
+### 3. ReviewForm への統合 (`app-expo/features/map/components/ReviewForm.tsx`)
 
-**Changes:**
+**変更点:**
 
-- Added `DishCategoryAutocomplete` component to the form
-- State management for `dishCategoryName` and `dishCategoryId`
-- Suggestion selection updates `dishCategoryId`
-- Form submission logic:
-  - If category is selected (has `dishCategoryId`), use it directly
-  - If category name entered but not selected, POST to create variant first
-  - Display inline error if variant creation fails
-  - Continue with review submission after successful variant creation
+- フォームに `DishCategoryAutocomplete` コンポーネントを追加
+- `dishCategoryName` と `dishCategoryId` の状態管理を実装
+- サジェスト選択時に `dishCategoryId` を更新
+- フォーム送信時のロジック:
+  - カテゴリが選択済み（`dishCategoryId` が存在）ならそのまま利用
+  - 名前のみ入力され選択されていない場合は POST でバリアントを作成
+  - バリアント作成に失敗した場合はインラインエラーを表示
+  - 成功時はレビュー投稿処理を継続
 
-**Error Handling:**
+**エラーハンドリング:**
 
-- Inline error messages below the autocomplete input
-- Accessible error announcements (`accessibilityLiveRegion="polite"`)
-- Focus returns to input on error
-- Processing state prevents multiple submissions
+- オートコンプリート入力の直下にインラインエラーを表示
+- `accessibilityLiveRegion="polite"` でスクリーンリーダー通知
+- エラー時は入力欄へフォーカスを戻す
+- 処理中フラグで多重送信を防止
 
-## Internationalization (i18n)
+## 国際化（i18n）
 
-Added strings to all 8 locale files (en-US, ja-JP, ar-SA, es-ES, fr-FR, hi-IN, ko-KR, zh-CN):
+全8言語（en-US, ja-JP, ar-SA, es-ES, fr-FR, hi-IN, ko-KR, zh-CN）へ翻訳文字列を追加。
 
-**Map Section Additions:**
+**Map セクションの追加内容:**
 
 ```json
 {
-	"Map": {
-		"inputs": {
-			"dishCategory": "料理カテゴリ / Dish Category"
-		},
-		"placeholders": {
-			"enterDishCategory": "料理カテゴリを入力 (例: ラーメン、寿司)"
-		},
-		"noResultsFound": "結果が見つかりませんでした",
-		"accessibility": {
-			"dishCategoryInputFocused": "料理カテゴリ入力がフォーカスされました",
-			"dishCategorySelected": "{{category}}を選択しました",
-			"dishCategorySearching": "料理カテゴリを検索中",
-			"dishCategorySuggestionsFound": "{{count}}件の候補が見つかりました",
-			"dishCategoryNoResults": "一致する料理カテゴリが見つかりませんでした"
-		},
-		"errors": {
-			"dishCategoryCreateFailed": "料理カテゴリの作成に失敗しました",
-			"dishCategoryNotFound": "料理カテゴリが見つかりません",
-			"dishCategoryInvalidInput": "無効な料理カテゴリ名です"
-		}
-	}
+        "Map": {
+                "inputs": {
+                        "dishCategory": "料理カテゴリ / Dish Category"
+                },
+                "placeholders": {
+                        "enterDishCategory": "料理カテゴリを入力 (例: ラーメン、寿司)"
+                },
+                "noResultsFound": "結果が見つかりませんでした",
+                "accessibility": {
+                        "dishCategoryInputFocused": "料理カテゴリ入力がフォーカスされました",
+                        "dishCategorySelected": "{{category}}を選択しました",
+                        "dishCategorySearching": "料理カテゴリを検索中",
+                        "dishCategorySuggestionsFound": "{{count}}件の候補が見つかりました",
+                        "dishCategoryNoResults": "一致する料理カテゴリが見つかりませんでした"
+                },
+                "errors": {
+                        "dishCategoryCreateFailed": "料理カテゴリの作成に失敗しました",
+                        "dishCategoryNotFound": "料理カテゴリが見つかりません",
+                        "dishCategoryInvalidInput": "無効な料理カテゴリ名です"
+                }
+        }
 }
 ```
 
-## API Integration
+## API連携
 
 ### GET `/v1/dish-category-variants`
 
-**Request:**
+**リクエスト:**
 
 ```typescript
 {
-  q: string,      // Search query (minimum 3 characters)
-  lang: string    // Language code (e.g., "ja", "en")
+  q: string,      // 検索クエリ（最低3文字）
+  lang: string    // 言語コード（例: "ja", "en"）
 }
 ```
 
-**Response:**
+**レスポンス:**
 
 ```typescript
 Array<{
-	dishCategoryId: string;
-	label: string;
+        dishCategoryId: string;
+        label: string;
 }>;
 ```
 
 ### POST `/v1/dish-category-variants`
 
-**Request:**
+**リクエスト:**
 
 ```typescript
 {
-	name: string; // Dish category name to create
+        name: string; // 新しく作成する料理カテゴリ名
 }
 ```
 
-**Response:**
+**レスポンス:**
 
 ```typescript
 {
@@ -145,120 +145,119 @@ Array<{
 }
 ```
 
-**Error Handling:**
+**エラーハンドリング:**
 
-- 404: No matching dish category found (variant creation failed)
-- 422/400: Validation errors
-- 429: Rate limiting
-- 5xx: Server errors
+- 404: 一致する料理カテゴリが存在せずバリアント作成に失敗
+- 422/400: バリデーションエラー
+- 429: レートリミット
+- 5xx: サーバーエラー
 
-All errors display inline below the autocomplete input with appropriate error messages.
+すべてのエラーはオートコンプリート入力欄の下に適切なメッセージをインライン表示する。
 
-## UX Flow
+## UXフロー
 
-1. **User Types in Autocomplete:**
-   - After 300ms debounce, searches for matching categories (min 3 chars)
-   - Shows loading indicator during search
-   - Displays suggestions in dropdown
-   - Announces results count to screen readers
+1. **ユーザーがオートコンプリートへ入力**
+   - 300ms デバウンス後に（3文字以上で）検索
+   - 検索中インジケーターを表示
+   - ドロップダウンに候補を表示
+   - 検索結果件数をスクリーンリーダーへ通知
 
-2. **User Selects Suggestion:**
-   - Sets `dishCategoryId` and `dishCategoryName`
-   - Closes suggestion dropdown
-   - Announces selection to screen readers
+2. **候補を選択**
+   - `dishCategoryId` と `dishCategoryName` を設定
+   - サジェストを閉じる
+   - 選択内容をスクリーンリーダーへ通知
 
-3. **User Types but Doesn't Select:**
-   - Form submission attempts to create variant via POST
-   - On success: Uses returned `dishCategoryId` for review
-   - On failure: Shows inline error, returns focus to input
+3. **入力のみで選択しなかった場合**
+   - フォーム送信時に POST でバリアント作成を試行
+   - 成功時: 返却された `dishCategoryId` を使用してレビューを送信
+   - 失敗時: インラインエラーを表示しフォーカスを入力欄へ戻す
 
-4. **Clear Button:**
-   - Clears input text and selected category
-   - Returns focus to input
+4. **クリアボタン**
+   - 入力値と選択済みカテゴリを初期化
+   - フォーカスを入力欄へ戻す
 
-## Accessibility Features
+## アクセシビリティ対応
 
-- **Screen Reader Announcements:**
-  - Input focus state
-  - Search progress
-  - Results count
-  - Selection confirmation
-  - Error messages
+- **スクリーンリーダーアナウンス**
+  - 入力フォーカス
+  - 検索進行状況
+  - 結果件数
+  - 候補選択
+  - エラーメッセージ
 
-- **Keyboard Navigation:**
-  - Tab to navigate between fields
-  - Arrow keys for suggestion selection (native behavior)
-  - Enter to select suggestion
-  - Escape to close suggestions
+- **キーボード操作**
+  - Tab でフィールド間を移動
+  - 矢印キーで候補を移動（ネイティブの挙動を利用）
+  - Enter で候補を確定
+  - Escape で候補一覧を閉じる
 
-- **Live Regions:**
-  - Error messages use `accessibilityLiveRegion="polite"`
-  - Status changes announced without interrupting user
+- **ライブリージョン**
+  - エラーメッセージは `accessibilityLiveRegion="polite"` を利用し、ユーザー操作を妨げずに通知
 
-## Code Quality
+## コード品質
 
-- **TypeScript:** Full type safety with shared DTOs and response types
-- **Comments:** Japanese comments throughout for consistency with codebase
-- **Formatting:** Prettier-compliant formatting
-- **Testing:** TypeScript compilation and build verification passed
-- **Patterns:** Follows existing LocationAutocomplete implementation patterns
+- **TypeScript**: 共有DTOとレスポンスタイプを用いた型安全な実装
+- **コメント**: 既存コードベースに合わせ日本語コメントを追加
+- **フォーマット**: Prettierのスタイルに準拠
+- **テスト**: TypeScriptコンパイルおよびビルドを通過済み
+- **設計**: 既存の LocationAutocomplete のパターンに沿って実装
 
-## Future Enhancements
+## 今後の拡張案
 
-1. **Idempotency Key Support:**
-   - Currently removed due to useAPICall hook limitations
-   - Can be added when backend implements idempotency key handling
+1. **Idempotency Key 対応**
+   - 現状は `useAPICall` フックの制約で未対応
+   - バックエンドがidempotency keyをサポートした時点で導入予定
 
-2. **Enhanced Error Handling:**
-   - Retry logic for network failures
-   - Offline support with cached categories
+2. **エラーハンドリング強化**
+   - ネットワーク失敗時のリトライ
+   - オフライン時のカテゴリキャッシュ
 
-3. **Performance:**
-   - Category results caching
-   - Recent selections persistence
+3. **パフォーマンス改善**
+   - 検索結果のキャッシュ
+   - 最近使用したカテゴリの保持
 
-4. **Additional Features:**
-   - Category suggestions based on restaurant type
-   - Popular categories quick-select
+4. **追加機能**
+   - 店舗種別に応じた候補表示
+   - 人気カテゴリのクイックセレクト
 
-## Testing Recommendations
+## テスト推奨事項
 
-1. **Manual Testing:**
-   - Type 3+ characters and verify suggestions appear
-   - Select a suggestion and verify it's stored
-   - Submit form with selected category
-   - Submit form with typed but unselected category
-   - Verify error handling for POST failures
-   - Test clear button functionality
-   - Test accessibility with screen reader
+1. **手動テスト**
+   - 3文字以上入力した際に候補が表示されること
+   - 候補を選択すると値が保持されること
+   - 選択済みカテゴリでフォーム送信が成功すること
+   - 入力のみで送信した場合にバリアントが作成されること
+   - POST 失敗時にエラーが表示されること
+   - クリアボタンが正しく動作すること
+   - スクリーンリーダーでのアナウンスを確認すること
 
-2. **Automated Testing:**
-   - Unit tests for `useDishCategorySearch` hook
-   - Component tests for `DishCategoryAutocomplete`
-   - Integration tests for ReviewForm submission flow
+2. **自動テスト**
+   - `useDishCategorySearch` フックのユニットテスト
+   - `DishCategoryAutocomplete` コンポーネントのテスト
+   - ReviewForm の統合テスト（送信フロー）
 
-## Files Changed
+## 変更ファイル
 
-**New Files:**
+**新規ファイル:**
 
-- `app-expo/hooks/useDishCategorySearch.ts` (152 lines)
-- `app-expo/components/DishCategoryAutocomplete.tsx` (330 lines)
+- `app-expo/hooks/useDishCategorySearch.ts`（152行）
+- `app-expo/components/DishCategoryAutocomplete.tsx`（330行）
 
-**Modified Files:**
+**既存ファイルの変更:**
 
-- `app-expo/features/map/components/ReviewForm.tsx` (added 60+ lines)
-- `app-expo/locales/*.json` (8 files, added i18n strings)
+- `app-expo/features/map/components/ReviewForm.tsx`（約60行追加）
+- `app-expo/locales/*.json`（8ファイルにi18n文字列を追加）
 
-**Total Lines Added:** ~600 lines of code and configuration
+**総追加行数:** 約600行
 
-## Dependencies
+## 依存関係
 
-No new dependencies added. Uses existing packages:
+新規パッケージの追加はなし。既存の以下のパッケージを利用。
 
-- React Native core components
-- `lucide-react-native` for icons (ChefHat)
-- Existing custom hooks (useAPICall, useLocale, useLogger, useHaptics)
+- React Native コアコンポーネント
+- アイコン用の `lucide-react-native`
+- 既存のカスタムフック（useAPICall, useLocale, useLogger, useHaptics）
 
-## Conclusion
+## まとめ
 
-The DishCategoryAutocomplete feature is fully implemented and integrated into the ReviewForm. It follows established patterns from LocationAutocomplete, provides excellent accessibility support, and includes comprehensive error handling. The implementation is production-ready and has passed all type checking and build validation.
+DishCategoryAutocomplete 機能は ReviewForm に統合済みで、LocationAutocomplete の実装パターンを踏襲しつつ高いアクセシビリティと手厚いエラーハンドリングを実現している。TypeScript の型チェックとビルドも完了しており、本番投入可能な状態である。

--- a/docs/FEATURE_IMAGE_RESIZE_SUMMARY.md
+++ b/docs/FEATURE_IMAGE_RESIZE_SUMMARY.md
@@ -1,34 +1,34 @@
-# Image Resize Feature - Implementation Complete ✅
+# 画像リサイズ機能 - 実装完了 ✅
 
-## Summary
+## サマリー
 
-Successfully implemented on-demand image resizing for `dish_media` thumbnails to optimize loading performance in saved/liked item lists.
+保存済み・いいね済み一覧の読み込み性能を向上させるため、`dish_media` のサムネイルに対してオンデマンドの画像リサイズ機能を実装した。
 
-## Problem Solved
+## 解決した課題
 
-**Before:**
+**導入前:**
 
-- Original full-size images (several MB) served directly for thumbnails
-- Extremely slow loading on mobile devices (4G connections)
-- Poor UX with delayed rendering and high data consumption
+- サムネイル表示でも元のフルサイズ画像（数MB）がそのまま配信されていた
+- モバイル（特に4G回線）での読み込みが非常に遅い
+- レンダリング遅延とデータ消費量の増大によるUX悪化
 
-**After:**
+**導入後:**
 
-- Optimized WebP images (256px thumbnails, 1024px detail view)
-- 60-80% file size reduction
-- 3-5x faster loading on mobile
-- Smooth list scrolling and rendering
+- WebP形式で最適化された画像（サムネイル256px、詳細表示1024px）を提供
+- ファイルサイズを60〜80%削減
+- モバイルでの読み込み速度が3〜5倍向上
+- リスト表示とスクロールが滑らかに
 
-## Implementation Approach
+## 実装アプローチ
 
-### MVP: On-Demand Generation
+### MVP: オンデマンド生成
 
-1. **First Request**: Returns original image immediately, queues resize in background
-2. **Background Processing**: Non-blocking resize job (2-5 seconds)
-3. **Subsequent Requests**: Returns optimized WebP images
-4. **Graceful Degradation**: Falls back to original on any error
+1. **初回リクエスト**: いったんオリジナル画像のURLを返却し、バックグラウンドでリサイズ処理をキューに登録
+2. **バックグラウンド処理**: ノンブロッキングでリサイズジョブを実行（2〜5秒程度）
+3. **2回目以降のリクエスト**: 最適化済みWebP画像のURLを返却
+4. **フォールバック**: エラー発生時はオリジナル画像を返す
 
-### Architecture
+### アーキテクチャ
 
 ```
 Client Request
@@ -54,82 +54,82 @@ Check if resized image exists in GCS
          Next request returns resized URL ✅
 ```
 
-## Key Features
+## 主な特徴
 
-### Technical Specifications
+### 技術仕様
 
-- **Library**: Sharp 0.34.4 (high-performance Node.js)
-- **Format**: WebP (optimized for iOS/Android)
-- **Aspect Ratio**: 9:16 (vertical portrait)
-- **Crop Mode**: `cover` with `attention` (smart cropping)
-- **Quality**: 85
-- **Sizes**: 256px (list), 1024px (detail)
+- **利用ライブラリ**: Sharp 0.34.4（高性能なNode.js画像処理）
+- **出力フォーマット**: WebP（iOS/Android向けに最適化）
+- **アスペクト比**: 9:16（縦長ポートレート）
+- **トリミングモード**: `cover` + `attention`（注目領域を優先）
+- **品質**: 85
+- **生成サイズ**: 256px（一覧）、1024px（詳細）
 
-### Path Naming Convention
+### パス命名規則
 
 ```
 ${env}/resized-image/${table}/${column}/${recordId}/${size}.webp
 ```
 
-Example:
+例:
 
 ```
 development/resized-image/dish_media/thumbnail_path/abc-123-uuid/256.webp
 ```
 
-### Cache Configuration
+### キャッシュ設定
 
 ```
 Cache-Control: public, max-age=31536000, immutable
 ```
 
-- Content-addressed by UUID (safe to cache forever)
-- CDN-friendly
-- 1-year max-age
+- UUIDベースでコンテンツアドレス化されているため、永続キャッシュが安全
+- CDNフレンドリー
+- 最大1年のキャッシュ
 
-### Safety Features
+### 安全性
 
-- ✅ Idempotent (safe to call multiple times)
-- ✅ Race-condition safe (file existence check)
-- ✅ Error recovery (fallback to original)
-- ✅ Non-blocking (async processing)
-- ✅ Security validated (OIDC guard, input validation)
+- ✅ 何度呼んでも同じ結果（冪等性）
+- ✅ ファイル存在チェックでレースコンディションを防止
+- ✅ エラー時はオリジナルにフォールバック
+- ✅ 非同期処理でAPIレスポンスに影響なし
+- ✅ OIDCガードと入力バリデーションでセキュリティ確保
 
-## Files Created
+## 作成したファイル
 
-### Core Implementation
+### コア実装
 
 ```
 api/src/internal/resize-image/
-├── resize-image.controller.ts    # POST /internal/resize-image endpoint
-├── resize-image.service.ts       # Resize logic with Sharp
-├── resize-image.module.ts        # NestJS module
-├── resize-image.dto.ts           # Request validation
-├── resize-image.interface.ts     # TypeScript interfaces
-├── README.md                      # Module documentation
-└── validate.ts                    # Validation script
+├── resize-image.controller.ts    # POST /internal/resize-image エンドポイント
+├── resize-image.service.ts       # Sharpによるリサイズ処理
+├── resize-image.module.ts        # NestJSモジュール
+├── resize-image.dto.ts           # リクエストバリデーション
+├── resize-image.interface.ts     # TypeScriptインターフェース
+├── README.md                     # モジュールのドキュメント
+└── validate.ts                   # バリデーションスクリプト
 ```
 
-### Documentation
+### ドキュメント
 
 ```
 docs/
-└── IMAGE_RESIZE_IMPLEMENTATION.md  # Complete implementation guide
+└── IMAGE_RESIZE_IMPLEMENTATION.md  # 詳細な実装ガイド
 ```
 
-### Modified Files
+### 変更したファイル
 
 ```
-api/src/internal/internal.module.ts           # Register ResizeImageModule
-api/src/core/storage/storage.service.ts       # Add getOrQueueResizedSignedUrl()
-api/src/core/storage/storage.types.ts         # Add interfaces
-api/src/v1/dish-media/dish-media.service.ts  # Use resized URLs
-api/package.json                               # Add sharp dependency
+api/src/internal/internal.module.ts           # ResizeImageModuleを登録
+api/src/core/storage/storage.service.ts       # getOrQueueResizedSignedUrl() を追加
+api/src/core/storage/storage.types.ts         # インターフェースを追加
+api/src/v1/dish-media/dish-media.service.ts  # リサイズ済みURLを利用
+api/package.json                               # sharp 依存関係を追加
 ```
 
-## Validation Results
+## バリデーション結果
 
-All automated validation tests pass:
+すべての自動テストに成功。
 
 ```bash
 $ npx ts-node src/internal/resize-image/validate.ts
@@ -144,7 +144,7 @@ $ npx ts-node src/internal/resize-image/validate.ts
 ✅ All validation tests passed!
 ```
 
-Build and typecheck status:
+ビルドと型チェックの結果:
 
 ```bash
 $ pnpm typecheck && pnpm build
@@ -153,160 +153,159 @@ $ pnpm typecheck && pnpm build
 ✅ Code formatting: PASS
 ```
 
-## Manual Testing Guide
+## 手動テストガイド
 
-### 1. Start API Server
+### 1. APIサーバーを起動
 
 ```bash
 cd api && pnpm dev
 ```
 
-### 2. Test First Request
+### 2. 初回リクエストを確認
 
 ```bash
 curl http://localhost:3000/v1/dish-media?ids=<dish-media-id>
 ```
 
-**Expected**: Returns original image URLs, queues resize jobs
+**期待値**: オリジナル画像のURLを返し、バックグラウンドでリサイズジョブをキューに投入
 
-### 3. Wait for Processing
+### 3. 処理完了を待機
 
-Wait 2-5 seconds for background resize to complete
+バックグラウンドリサイズが完了するまで約2〜5秒待つ
 
-### 4. Test Second Request
+### 4. 再リクエスト
 
 ```bash
 curl http://localhost:3000/v1/dish-media?ids=<dish-media-id>
 ```
 
-**Expected**: Returns resized WebP URLs
+**期待値**: リサイズ済みWebP画像のURLを返却
 
-### 5. Verify in GCS
+### 5. GCSを確認
 
-Check bucket path: `development/resized-image/dish_media/`
+バケット `development/resized-image/dish_media/` を確認
 
-**Expected**: WebP files with proper naming and ~60-80% size reduction
+**期待値**: 適切なファイル名でWebPが保存され、サイズが60〜80%削減されている
 
-## Performance Impact
+## パフォーマンスへの影響
 
-### Expected Improvements
+### 期待される改善効果
 
-| Metric            | Before | After     | Improvement            |
-| ----------------- | ------ | --------- | ---------------------- |
-| File Size         | 2-5 MB | 400KB-1MB | 60-80% reduction       |
-| Loading Time (4G) | 10-20s | 2-4s      | 3-5x faster            |
-| Data Usage        | High   | Low       | 60-80% reduction       |
-| UX                | Poor   | Smooth    | Significantly improved |
+| 指標              | 導入前 | 導入後     | 改善度                  |
+| ----------------- | ------ | ---------- | ----------------------- |
+| ファイルサイズ     | 2-5 MB | 400KB-1MB  | 60-80%削減              |
+| 読み込み時間 (4G) | 10-20s | 2-4s       | 3-5倍高速化             |
+| データ使用量       | 高い   | 低い       | 60-80%削減              |
+| UX                | 悪い   | 良い       | 大幅に改善              |
 
-### Request Flow
+### リクエストフロー
 
-| Request | Image Served | Processing   | Response Time            |
-| ------- | ------------ | ------------ | ------------------------ |
-| First   | Original     | Queued async | Normal                   |
-| Second+ | Resized WebP | Complete     | Normal + faster download |
+| リクエスト | 返却される画像 | バックグラウンド処理 | レスポンス時間             |
+| ---------- | -------------- | -------------------- | -------------------------- |
+| 初回       | オリジナル     | 非同期でキュー投入    | 従来と同等                 |
+| 2回目以降  | リサイズ済み   | 完了済み              | 従来 + ダウンロード高速化 |
 
-## Monitoring
+## 監視
 
-### Key Log Events
+### 主要なログイベント
 
-- `ResizeImageStarted`: Resize job initiated
-- `ResizeImageCompleted`: Resize successful
-- `ResizedImageExists`: Serving existing resized image
-- `ResizedImageNotFound`: Queueing new resize job
-- `ResizeQueueError`: Queue failed (non-critical, fallback works)
+- `ResizeImageStarted`: リサイズジョブ開始
+- `ResizeImageCompleted`: リサイズ完了
+- `ResizedImageExists`: 既存のリサイズ済み画像を利用
+- `ResizedImageNotFound`: 新しいリサイズジョブをキューに投入
+- `ResizeQueueError`: キュー登録失敗（非致命的、フォールバックあり）
 
-All events are structured JSON logs compatible with Cloud Logging.
+いずれもCloud Loggingで扱いやすい構造化JSONログ。
 
-## Security
+## セキュリティ
 
-✅ OIDC guard protects internal endpoint
-✅ Only `dish_media` table supported
-✅ Only `media_path` and `thumbnail_path` columns supported
-✅ Input validation with class-validator
-✅ No user input in file paths (database UUIDs only)
-✅ Signed URLs expire after 24 hours
+- ✅ 内部エンドポイントはOIDCガードで保護
+- ✅ 対応テーブルは `dish_media` のみ
+- ✅ 対応カラムは `media_path` / `thumbnail_path` のみ
+- ✅ ファイルパスにユーザー入力は使用せず、DBのUUIDを利用
+- ✅ 署名付きURLの有効期限は24時間
 
-## Future Enhancements
+## 今後の拡張
 
-### Phase 2: Cloud Functions Trigger
+### フェーズ2: Cloud Functionsトリガー
 
-- Automatic resize on image upload
-- Eliminates first-request delay
-- Pregenerate all sizes
-- Fully automated workflow
+- 画像アップロード時に自動リサイズ
+- 初回リクエストの遅延を解消
+- すべてのサイズを事前生成
+- 完全自動化
 
-### Phase 3: CDN Integration
+### フェーズ3: CDN統合
 
-- Media CDN with signed URLs
-- Global edge caching
-- Format negotiation (WebP/AVIF/JPEG)
-- Further performance gains
+- メディアCDNと署名付きURLを導入
+- グローバルエッジキャッシュ
+- フォーマットネゴシエーション（WebP/AVIF/JPEG）
+- さらなる性能向上
 
-### Phase 4: Advanced Features
+### フェーズ4: 高度な機能
 
-- Dynamic size generation
-- Art direction (face detection)
-- Progressive loading (LQIP)
-- Responsive srcsets
+- 動的なサイズ生成
+- アートディレクション（顔検出など）
+- LQIPによる段階的ロード
+- レスポンシブなsrcset対応
 
-## Migration Path
+## マイグレーションパス
 
-Current implementation is designed for seamless evolution:
+現行実装は段階的な進化を想定。
 
-**MVP (Current)** → **Cloud Functions** → **CDN** → **Advanced**
+**MVP（現状）** → **Cloud Functions** → **CDN** → **高度化**
 
-No breaking changes required at any stage.
+どの段階でも破壊的変更は不要。
 
-## Impact Assessment
+## 影響評価
 
-### User Experience
+### ユーザー体験
 
-✅ Significantly faster loading
-✅ Lower data usage
-✅ Smoother scrolling
-✅ Better mobile experience
+- ✅ 読み込み速度が大幅に向上
+- ✅ データ通信量を削減
+- ✅ スクロールが滑らかに
+- ✅ モバイルでの使い勝手が向上
 
-### Technical
+### 技術面
 
-✅ No breaking changes
-✅ Backward compatible
-✅ Production-ready
-✅ Well-documented
-✅ Maintainable
+- ✅ 破壊的変更なし
+- ✅ 後方互換性を維持
+- ✅ 本番投入可能
+- ✅ ドキュメント完備
+- ✅ 保守しやすい構成
 
-### Business
+### ビジネス面
 
-✅ Improved UX → higher engagement
-✅ Lower costs (reduced bandwidth)
-✅ Competitive advantage (performance)
-✅ Scalable foundation
+- ✅ UX改善によるエンゲージメント向上
+- ✅ 帯域コストの削減
+- ✅ パフォーマンス面での差別化
+- ✅ 将来的な拡張に耐えうる基盤
 
-## Conclusion
+## まとめ
 
-The on-demand image resize feature is **complete and ready for deployment**. It provides immediate performance improvements while maintaining backward compatibility and a clear path for future enhancements.
+オンデマンド画像リサイズ機能は **実装完了かつデプロイ準備済み**。即時の性能改善をもたらしつつ、後方互換性と将来拡張の余地を両立している。
 
-### Deployment Checklist
+### デプロイチェックリスト
 
-- [x] Code implementation complete
-- [x] TypeScript compilation passes
-- [x] Build succeeds
-- [x] Validation tests pass
-- [x] Documentation complete
-- [x] Error handling verified
-- [x] Security validated
-- [ ] Manual integration testing (requires live environment)
-- [ ] Performance monitoring setup
-- [ ] Production deployment
+- [x] コード実装完了
+- [x] TypeScriptコンパイル成功
+- [x] ビルド成功
+- [x] バリデーションスクリプト通過
+- [x] ドキュメント整備
+- [x] エラーハンドリング検証
+- [x] セキュリティ確認
+- [ ] 本番環境での統合テスト
+- [ ] パフォーマンス監視の設定
+- [ ] 本番デプロイ
 
-### Next Steps
+### 次のアクション
 
-1. **Integration Testing**: Test with real dish_media records
-2. **Performance Monitoring**: Track resize durations and success rates
-3. **User Feedback**: Monitor load times and user experience
-4. **Iterate**: Plan Phase 2 (Cloud Functions) based on data
+1. **統合テスト**: 実際の `dish_media` レコードで挙動を確認
+2. **パフォーマンス監視**: リサイズ時間と成功率のトラッキングを開始
+3. **ユーザーフィードバック**: 読み込み体験の変化を収集
+4. **改善サイクル**: データに基づきフェーズ2（Cloud Functions）を計画
 
 ---
 
-**Implementation Date**: 2024
-**Status**: ✅ Complete and Validated
-**Documentation**: See `docs/IMAGE_RESIZE_IMPLEMENTATION.md` and `api/src/internal/resize-image/README.md`
+**実装時期**: 2024年  
+**ステータス**: ✅ 実装済み / 検証済み  
+**参照ドキュメント**: `docs/IMAGE_RESIZE_IMPLEMENTATION.md`, `api/src/internal/resize-image/README.md`

--- a/docs/IMAGE_RESIZE_IMPLEMENTATION.md
+++ b/docs/IMAGE_RESIZE_IMPLEMENTATION.md
@@ -1,276 +1,270 @@
-# On-Demand Image Resize Implementation
+# オンデマンド画像リサイズ実装
 
-This document describes the on-demand image resizing feature implementation for optimizing dish media loading performance.
+本ドキュメントでは、ディッシュメディアの読み込み性能を最適化するために導入したオンデマンド画像リサイズ機能について説明する。
 
-## Overview
+## 概要
 
-The on-demand image resize feature addresses the performance issue where original full-size images (several MB) were being served for thumbnails in saved/liked item lists, causing extremely slow initial rendering on mobile devices, especially over 4G connections.
+保存済み・いいね済みリストでサムネイルとしてフルサイズ画像（数MB）が配信されていたため、特に4G回線のモバイルで初期描画が著しく遅いという課題を解決する。
 
-## Problem Statement
+## 課題
 
-- **Before**: `dish_media` thumbnails served original full-size images directly from GCS
-- **Impact**: Multi-MB images caused slow loading on mobile (4G networks)
-- **User Experience**: Poor UX with delayed list rendering and high data consumption
+- **従来**: `dish_media` のサムネイルがGCSからフルサイズ画像を直接配信
+- **影響**: 数MBの画像がモバイル（4G）での読み込みを大幅に遅延
+- **ユーザー体験**: リスト描画の遅延とデータ通信量の増加によるUX悪化
 
-## Solution: On-Demand Resize (MVP Approach)
+## 解決策: オンデマンドリサイズ（MVPアプローチ）
 
-### Architecture
+### アーキテクチャ
 
-The implementation uses an on-demand generation approach with async background processing:
+オンデマンド生成と非同期バックグラウンド処理を組み合わせた構成。
 
-1. **First Request**: Returns original image URL immediately, queues resize job in background
-2. **Subsequent Requests**: Returns optimized resized WebP image
-3. **Idempotency**: Multiple requests for same image don't trigger duplicate processing
+1. **初回リクエスト**: まずはオリジナル画像の署名付きURLを返却し、バックグラウンドでリサイズジョブをキューに投入
+2. **2回目以降のリクエスト**: リサイズ済みWebP画像のURLを返却
+3. **冪等性**: 同じ画像への複数リクエストでも重複処理を行わない
 
-### Key Components
+### 主なコンポーネント
 
-#### 1. Resize Endpoint (`/internal/resize-image`)
+#### 1. リサイズ用エンドポイント (`/internal/resize-image`)
 
-New internal endpoint for processing resize requests:
+リサイズ処理を受け付ける内部エンドポイント。
 
-- **Controller**: `api/src/internal/resize-image/resize-image.controller.ts`
-- **Service**: `api/src/internal/resize-image/resize-image.service.ts`
-- **Protected**: OIDC guard (Cloud Tasks authentication)
-- **Request Body**:
+- **コントローラー**: `api/src/internal/resize-image/resize-image.controller.ts`
+- **サービス**: `api/src/internal/resize-image/resize-image.service.ts`
+- **保護**: OIDCガード（Cloud Tasks認証）
+- **リクエストボディ例**:
   ```json
   {
-  	"table": "dish_media",
-  	"column": "thumbnail_path",
-  	"recordId": "uuid",
-  	"size": 256
+        "table": "dish_media",
+        "column": "thumbnail_path",
+        "recordId": "uuid",
+        "size": 256
   }
   ```
 
-#### 2. Storage Service Extensions
+#### 2. StorageService の拡張
 
-Added new methods to `StorageService`:
+`StorageService` に以下のメソッドを追加。
 
-- **`getOrQueueResizedSignedUrl()`**: Main method for getting optimized image URLs
-  - Checks if resized image exists in GCS
-  - Returns resized URL if available
-  - Queues async resize and returns original URL if not ready
-  - Graceful error handling with fallback to original
+- **`getOrQueueResizedSignedUrl()`**: 最適化済み画像URLの取得
+  - GCSにリサイズ済みファイルが存在するかチェック
+  - あればそのURLを返却
+  - なければ非同期リサイズをキューに投入しオリジナルURLを返却
+  - エラー時はフォールバックでオリジナルURLを返す
 
-- **`fileExists()`**: Helper to check file existence in GCS
+- **`fileExists()`**: GCS上のファイル存在チェック
 
-- **`queueResizeJob()`**: Fire-and-forget async resize request
-  - Short timeout (2s localhost, 5s production)
-  - Non-blocking, doesn't affect API response time
+- **`queueResizeJob()`**: 非同期リサイズリクエストを送信
+  - タイムアウトはローカル2秒/本番5秒
+  - Fire-and-forgetでAPIレスポンスには影響しない
 
-#### 3. DishMediaService Integration
+#### 3. DishMediaService との統合
 
-Modified `fetchDishMediaEntryItems()` to use resized images:
+`fetchDishMediaEntryItems()` をリサイズ済み画像に対応させた。
 
 ```typescript
-// Detail view (1024px)
+// 詳細表示用（1024px）
 const mediaUrl = await this.storage.getOrQueueResizedSignedUrl(
-	{ table: "dish_media", column: "media_path", recordId: rec.dish_media.id, size: 1024 },
-	rec.dish_media.media_path,
+        { table: "dish_media", column: "media_path", recordId: rec.dish_media.id, size: 1024 },
+        rec.dish_media.media_path,
 );
 
-// List view thumbnails (256px)
+// サムネイル（256px）
 const thumbnailImageUrl = await this.storage.getOrQueueResizedSignedUrl(
-	{ table: "dish_media", column: "thumbnail_path", recordId: rec.dish_media.id, size: 256 },
-	rec.dish_media.thumbnail_path,
+        { table: "dish_media", column: "thumbnail_path", recordId: rec.dish_media.id, size: 256 },
+        rec.dish_media.thumbnail_path,
 );
 ```
 
-## Technical Specifications
+## 技術仕様
 
-### Image Processing
+### 画像処理
 
-- **Library**: Sharp (high-performance Node.js image processing)
-- **Output Format**: WebP (iOS/Android optimized, smaller file sizes)
-- **Aspect Ratio**: 9:16 (vertical portrait)
-- **Crop Method**: `fit: 'cover', position: 'attention'` (smart cropping)
-- **Quality**: 85 (balance between size and quality)
+- **ライブラリ**: Sharp（高性能なNode.js画像処理）
+- **出力フォーマット**: WebP（iOS/Androidで高い圧縮率）
+- **アスペクト比**: 9:16（縦長）
+- **トリミング方法**: `fit: 'cover', position: 'attention'`（注目領域を優先）
+- **品質**: 85（サイズと画質のバランス）
 
-### Supported Sizes
+### 対応サイズ
 
-| Size   | Use Case    | Dimensions         |
-| ------ | ----------- | ------------------ |
-| 256px  | List view   | 256 × 455 (9:16)   |
-| 1024px | Detail view | 1024 × 1820 (9:16) |
+| サイズ | 用途       | 実寸法             |
+| ------ | ---------- | ------------------ |
+| 256px  | リスト表示 | 256 × 455 (9:16)   |
+| 1024px | 詳細表示   | 1024 × 1820 (9:16) |
 
-### Path Naming Convention
+### パス命名規則
 
-Resized images follow a consistent naming pattern:
+リサイズ済みファイルは以下のパターンで保存。
 
 ```
 ${env}/resized-image/${table}/${column}/${recordId}/${size}.webp
 ```
 
-**Example**:
+**例:**
 
 ```
 development/resized-image/dish_media/thumbnail_path/5f482536-4aab-4deb-8ab8-f6f36259d4d9/256.webp
 ```
 
-### Cache Configuration
+### キャッシュ設定
 
-All resized images include optimal cache headers:
+すべてのリサイズ済み画像に最適なキャッシュヘッダーを付与。
 
 ```
 Cache-Control: public, max-age=31536000, immutable
 ```
 
-- **public**: CDN cacheable
-- **max-age=31536000**: Cache for 1 year
-- **immutable**: Never revalidate (content-addressed by UUID)
+- **public**: CDNでキャッシュ可能
+- **max-age=31536000**: 1年間キャッシュ
+- **immutable**: UUIDベースのため再検証不要
 
-## Performance Impact
+## パフォーマンスインパクト
 
-### Expected Improvements
+### 期待される改善
 
-- **File Size Reduction**: 60-80% smaller than originals
-- **Loading Time**: 3-5x faster on 4G connections
-- **Data Usage**: Significant reduction for mobile users
-- **UX**: Much smoother list scrolling and rendering
+- **ファイルサイズ**: 60〜80%削減
+- **読み込み時間**: 4G環境で3〜5倍高速化
+- **データ使用量**: モバイル通信量を大幅削減
+- **UX**: リスト描画とスクロールが滑らかに
 
-### First vs. Subsequent Requests
+### 初回と2回目以降の挙動
 
-| Request Type | Image Served | Processing   | Response Time            |
-| ------------ | ------------ | ------------ | ------------------------ |
-| First        | Original     | Queued async | Normal (unchanged)       |
-| Subsequent   | Resized WebP | Already done | Normal + faster download |
+| リクエスト | 提供する画像 | バックグラウンド処理 | レスポンス時間             |
+| ---------- | ------------ | -------------------- | -------------------------- |
+| 初回       | オリジナル   | 非同期でジョブ登録   | 従来と同等                 |
+| 2回目以降  | リサイズ済み | すでに完了           | 従来 + ダウンロード高速化 |
 
-## Implementation Details
+## 実装詳細
 
-### Idempotency & Race Conditions
+### 冪等性とレースコンディション対策
 
-- File existence check before processing
-- `overwriteIfExists: false` in uploads
-- Multiple concurrent requests are safe
-- No duplicate processing
+- 処理前にファイル存在をチェック
+- アップロード時に `overwriteIfExists: false` を指定
+- 同時アクセスがあっても安全
+- 重複リサイズを防止
 
-### Error Handling
+### エラーハンドリング
 
-Graceful degradation at every level:
+各レイヤーで段階的にフォールバック。
 
-1. **GCS Check Fails**: Falls back to original image
-2. **Resize Job Fails**: Logs warning, serves original
-3. **Queue Fails**: Logs warning, serves original
-4. **Download Fails**: Returns error to resize endpoint
+1. **GCS存在チェックに失敗**: オリジナル画像を返却
+2. **リサイズジョブ失敗**: ログを出しオリジナルを返却
+3. **キュー投入失敗**: 警告ログのみ、オリジナルを返却
+4. **ダウンロード失敗**: リサイズエンドポイントでエラーを返す
 
-All errors are logged but don't break the user experience.
+ユーザー体験を損なわないよう、すべてのエラーでフォールバックが用意されている。
 
-### Security
+### セキュリティ
 
-- OIDC guard protects internal endpoint
-- Only `dish_media` table supported (validated)
-- Only `media_path` and `thumbnail_path` columns supported (validated)
-- No user input in file paths (uses database UUIDs)
-- Signed URLs expire after 24 hours
+- 内部エンドポイントはOIDCガードで保護
+- 対応テーブルは `dish_media` に限定（バリデーションあり）
+- 対応カラムは `media_path` / `thumbnail_path` に限定（バリデーションあり）
+- ファイルパスはDBのUUIDを利用し、ユーザー入力を含めない
+- 署名付きURLの有効期限は24時間
 
-## Database Changes
+## データベースの変更
 
-**None required** - This is a pure backend optimization that:
+**不要** — 既存の `dish_media.thumbnail_path` と `media_path` をそのまま利用。リサイズ済み画像はGCSに保存し、API契約にも影響しない。
 
-- Works with existing `dish_media.thumbnail_path` and `media_path` columns
-- Stores resized images in GCS (not database)
-- Transparent to existing API contracts
+## テスト
 
-## Testing
+### 手動テスト手順
 
-### Manual Testing Steps
-
-1. Start API server:
+1. APIサーバーを起動
 
    ```bash
    cd api && pnpm dev
    ```
 
-2. Request dish media (first time):
+2. ディッシュメディアを初回取得
 
    ```bash
    curl http://localhost:3000/v1/dish-media?ids=<dish-media-id>
    ```
 
-   - Returns original image URLs
-   - Resize jobs queued in background
+   - オリジナル画像のURLが返る
+   - バックグラウンドでリサイズジョブがキューに登録される
 
-3. Wait 2-5 seconds for resize completion
+3. 2〜5秒待機
 
-4. Request again:
+4. 再度リクエスト
 
    ```bash
    curl http://localhost:3000/v1/dish-media?ids=<dish-media-id>
    ```
 
-   - Returns resized WebP URLs
+   - リサイズ済みWebPのURLが返る
 
-5. Verify in GCS:
-   - Check `development/resized-image/` path
-   - Confirm WebP files with correct naming
+5. GCSを確認
+   - `development/resized-image/` 配下をチェック
+   - 正しい命名とWebPファイルを確認
 
-## Monitoring & Observability
+### 監視・可観測性
 
-### Key Log Events
+| イベント                      | レベル | 内容                                 |
+| ---------------------------- | ------ | ------------------------------------ |
+| `ResizeImageStarted`         | DEBUG  | リサイズジョブの開始                 |
+| `ResizeImageCompleted`       | LOG    | リサイズ完了                         |
+| `ResizeImageAlreadyExists`   | DEBUG  | 既にリサイズ済みであることを検出     |
+| `ResizedImageExists`         | DEBUG  | 既存のリサイズ済み画像を利用         |
+| `ResizedImageNotFound`       | DEBUG  | 新しいリサイズジョブをキューに登録   |
+| `ResizeQueueError`           | WARN   | キュー登録失敗（フォールバックあり） |
+| `ResizeImageError`           | ERROR  | 致命的なリサイズ失敗                 |
 
-| Event                      | Level | Description                       |
-| -------------------------- | ----- | --------------------------------- |
-| `ResizeImageStarted`       | DEBUG | Resize job initiated              |
-| `ResizeImageCompleted`     | LOG   | Resize successful                 |
-| `ResizeImageAlreadyExists` | DEBUG | Idempotency hit                   |
-| `ResizedImageExists`       | DEBUG | Serving existing resized image    |
-| `ResizedImageNotFound`     | DEBUG | Queueing new resize job           |
-| `ResizeQueueError`         | WARN  | Async queue failed (non-critical) |
-| `ResizeImageError`         | ERROR | Critical resize failure           |
+## 今後の拡張（MVP以降）
 
-## Future Enhancements (Post-MVP)
+### 1. Cloud Functions トリガー
 
-### 1. Cloud Functions Trigger
+- `dish_media` 作成時に自動リサイズ
+- 初回リクエストの遅延を解消
+- 必要なサイズを事前生成
+- 完全自動化を実現
 
-- Automatic resize on `dish_media` creation
-- Eliminates first-request delay
-- Pregenerate all required sizes
-- Fully automated workflow
+### 2. 追加サイズ
 
-### 2. Additional Sizes
+- **384px**: 高DPIデバイス向け中間サイズ
+- **512px**: 詳細表示の代替サイズ
+- デバイスDPIに応じたサイズ選択
 
-- **384px**: Medium size for high-DPI devices
-- **512px**: Alternative detail view
-- Device DPI-aware size selection
+### 3. CDN統合
 
-### 3. CDN Integration
+- メディアCDNと署名付きURL
+- グローバルエッジキャッシュ
+- クライアントごとのフォーマット選択（WebP/AVIF/JPEG）
+- さらなる性能改善
 
-- Media CDN with signed URLs
-- Global edge caching
-- Automatic format selection (WebP/AVIF/JPEG based on client)
-- Further performance improvements
+### 4. 高度な最適化
 
-### 4. Advanced Features
+- 画面サイズに応じた動的生成
+- 顔検出によるトリミング
+- LQIPによる段階的ローディング
+- レスポンシブ画像（srcset）対応
 
-- Dynamic size generation based on viewport
-- Art direction cropping (face detection)
-- Progressive image loading (LQIP)
-- Responsive image srcsets
+## マイグレーションパス
 
-## Migration Path
+### 現在のMVP
 
-### Current Implementation (MVP)
+- ✅ 内部エンドポイントによるオンデマンド生成
+- ✅ Fire-and-forget の非同期処理
+- ✅ 冪等でレースコンディションに強い
+- ✅ フォールバックを備えた安全な実装
 
-✅ On-demand generation via internal endpoint
-✅ Fire-and-forget async processing
-✅ Idempotent and race-condition safe
-✅ Graceful degradation
+### 将来的な姿
 
-### Future State
+- 🔲 アップロード時にCloud Functionsで自動リサイズ
+- 🔲 事前生成による高速化
+- 🔲 CDNによるグローバル配信
+- 🔲 高度な最適化機能
 
-🔲 Cloud Functions trigger on upload
-🔲 Automatic pre-generation
-🔲 CDN integration
-🔲 Advanced optimization
+現行実装は将来の拡張と互換性があり、破壊的変更なく移行できる。
 
-**Seamless transition**: MVP implementation is compatible with future enhancements. No breaking changes required.
+## 追加した依存関係
 
-## Dependencies Added
+- **sharp**: ^0.34.4（画像処理用）
 
-- **sharp**: ^0.34.4 (image processing)
+## 変更ファイル
 
-## Files Modified
-
-### New Files
+### 新規作成
 
 - `api/src/internal/resize-image/resize-image.controller.ts`
 - `api/src/internal/resize-image/resize-image.service.ts`
@@ -279,37 +273,37 @@ All errors are logged but don't break the user experience.
 - `api/src/internal/resize-image/resize-image.interface.ts`
 - `api/src/internal/resize-image/README.md`
 
-### Modified Files
+### 変更した既存ファイル
 
-- `api/src/internal/internal.module.ts` (added ResizeImageModule)
-- `api/src/core/storage/storage.service.ts` (added new methods)
-- `api/src/core/storage/storage.types.ts` (added new interfaces)
-- `api/src/v1/dish-media/dish-media.service.ts` (use resized URLs)
-- `api/package.json` (added sharp dependency)
+- `api/src/internal/internal.module.ts`（ResizeImageModule を追加）
+- `api/src/core/storage/storage.service.ts`（新メソッドを追加）
+- `api/src/core/storage/storage.types.ts`（新インターフェースを追加）
+- `api/src/v1/dish-media/dish-media.service.ts`（リサイズ済みURLを使用）
+- `api/package.json`（sharp 依存関係を追加）
 
-## Documentation
+## ドキュメント
 
-Detailed module documentation available at:
+詳細なモジュールドキュメントは以下を参照。
 
 - [`api/src/internal/resize-image/README.md`](api/src/internal/resize-image/README.md)
 
-## Validation
+## バリデーション
 
-✅ TypeScript compilation passes
-✅ Project build succeeds
-✅ Code formatting applied
-✅ No breaking changes to existing APIs
-✅ Backward compatible
-✅ Error handling tested
+- ✅ TypeScriptコンパイルが成功
+- ✅ プロジェクトのビルドが成功
+- ✅ フォーマッターを適用済み
+- ✅ 既存APIとの互換性を維持
+- ✅ 後方互換性を担保
+- ✅ エラーハンドリングをテスト済み
 
-## Impact Summary
+## 影響まとめ
 
-This implementation provides significant performance improvements for mobile users while maintaining backward compatibility and graceful degradation. The MVP approach allows immediate deployment with a clear path to future enhancements.
+この実装により、モバイル利用時のパフォーマンスが大幅に改善されつつ、後方互換性とフォールバックが確保される。段階的な拡張にも耐えうる設計となっている。
 
-**Key Benefits**:
+**主な利点:**
 
-- ✅ Faster loading times (3-5x improvement expected)
-- ✅ Reduced data usage (60-80% smaller files)
-- ✅ Better mobile UX
-- ✅ No breaking changes
-- ✅ Future-proof architecture
+- ✅ 読み込み速度が3〜5倍向上
+- ✅ ファイルサイズを60〜80%削減
+- ✅ モバイルUXが向上
+- ✅ 破壊的変更なし
+- ✅ 将来拡張を見据えたアーキテクチャ

--- a/docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/IMPLEMENTATION_SUMMARY.md
@@ -1,73 +1,73 @@
-# Google Places Currency Mapping Implementation
+# Google Places 通貨マッピング実装
 
-This implementation adds support for storing Google Places `address_components` and `plus_code` data in the `restaurants` table and provides client-side currency code determination functionality.
+この実装では、`restaurants` テーブルに Google Places の `address_components` と `plus_code` を保存し、クライアント側で通貨コードを判定できるようにした。
 
-## Database Changes
+## データベースの変更
 
-### Schema Updates
+### スキーマ更新
 
-- Added `address_components` (jsonb) column to `restaurants` table
-- Added `plus_code` (jsonb) column to `restaurants` table
-- Updated Supabase database types to include new fields
-- Updated Prisma converters to handle the new fields
+- `restaurants` テーブルに `address_components`（jsonb）列を追加
+- `restaurants` テーブルに `plus_code`（jsonb）列を追加
+- Supabase のデータ型を新フィールドに対応
+- Prisma 変換処理を更新し、新フィールドを取り扱い可能に
 
-## API Changes
+## APIの変更
 
-### Google Places Integration
+### Google Places 連携
 
-- Modified field mask in `locations.service.ts` to include `places.addressComponents`
-- Updated `bulkImportFromGoogle` in `dishes.service.ts` to capture and store:
+- `locations.service.ts` のフィールドマスクに `places.addressComponents` を追加
+- `dishes.service.ts` の `bulkImportFromGoogle` を更新し以下を保存:
   - `place.addressComponents` → `restaurant.address_components`
   - `place.plusCode` → `restaurant.plus_code`
 
-## Client-Side Currency Mapping
+## クライアント側の通貨マッピング
 
-### Core Library (`app-expo/lib/googlePlaces.ts`)
+### コアライブラリ (`app-expo/lib/googlePlaces.ts`)
 
-Provides comprehensive currency mapping functionality:
+以下の通貨マッピング機能を提供。
 
-- **`extractCountryCode(addressComponents)`** - Extracts ISO-2 country code from Google Places address components
-- **`getCurrencyCodeFromCountry(countryCode)`** - Maps country code to ISO-4217 currency code
-- **`getCurrencyCodeFromAddressComponents(addressComponents)`** - Main function for currency determination
-- **`getCurrencyCodeFromRestaurant(restaurant)`** - Convenience function for restaurant objects
+- **`extractCountryCode(addressComponents)`** — Google Placesのaddress componentsからISO2国コードを抽出
+- **`getCurrencyCodeFromCountry(countryCode)`** — 国コードからISO 4217通貨コードを取得
+- **`getCurrencyCodeFromAddressComponents(addressComponents)`** — address componentsから通貨コードを判定するメイン関数
+- **`getCurrencyCodeFromRestaurant(restaurant)`** — レストランオブジェクトから簡易に通貨を取得するヘルパー
 
-### Supported Countries/Currencies
+### 対応国/通貨
 
-Includes mapping for 50+ countries including:
+50以上の国をサポート。
 
-- Major currencies: USD, EUR, JPY, GBP, CNY, CAD, AUD, etc.
-- Regional currencies: KRW, SGD, HKD, TWD, THB, etc.
-- European Union countries automatically mapped to EUR
-- Conservative approach: Returns `null` for unknown countries
+- 主要通貨: USD, EUR, JPY, GBP, CNY, CAD, AUD など
+- 地域通貨: KRW, SGD, HKD, TWD, THB など
+- EU加盟国は自動的にEURへマッピング
+- 未知の国コードは安全側に倒して `null` を返す
 
-### Usage Example
+### 使用例
 
 ```typescript
 import { getCurrencyCodeFromRestaurant } from "@/lib/googlePlaces";
 
 const restaurant = {
-	address_components: [{ shortText: "JP", types: ["country", "political"] }],
+        address_components: [{ shortText: "JP", types: ["country", "political"] }],
 };
 
 const currency = getCurrencyCodeFromRestaurant(restaurant);
 // Returns: "JPY"
 ```
 
-## Key Features
+## 主な特徴
 
-1. **Data Preservation**: Full Google Places `address_components` and `plus_code` are stored for future use
-2. **Conservative Mapping**: Only maps known countries to avoid incorrect assumptions
-3. **Type Safety**: Full TypeScript support with proper type definitions
-4. **Extensible**: Easy to add new country-currency mappings
-5. **Error Handling**: Graceful handling of missing or invalid data
+1. **データ保持**: Google Places の `address_components` と `plus_code` を完全に保存
+2. **保守的なマッピング**: 不明な国コードはマッピングしないことで誤判定を防止
+3. **型安全性**: TypeScript で型定義を提供
+4. **拡張性**: 対応国を容易に追加可能
+5. **エラーハンドリング**: 欠損や不正データでも安全に処理
 
-## Impact
+## 影響
 
-This implementation enables:
+この実装により以下が可能になる。
 
-- Consistent currency display in restaurant reviews
-- Automatic currency code determination based on restaurant location
-- Future analysis and processing of restaurant location data
-- Support for international restaurant reviews with proper currency formatting
+- レビュー表示で一貫した通貨表記を実現
+- レストラン所在地に基づく通貨コードの自動判定
+- レストラン位置情報の将来的な分析に活用可能
+- 国際的なレビューでも適切な通貨フォーマットをサポート
 
-All changes are backward compatible and maintain existing functionality while adding the new capabilities.
+すべての変更は後方互換性を維持しつつ、新機能を追加している。

--- a/docs/IMPLEMENTATION_SUMMARY_CDN_COOKIES.md
+++ b/docs/IMPLEMENTATION_SUMMARY_CDN_COOKIES.md
@@ -1,26 +1,26 @@
-# Implementation Summary: CDN Signed Cookie Authentication for Video Media
+# 実装サマリー: 動画メディア向けCDN署名付きCookie認証
 
-## Overview
+## 概要
 
-Successfully implemented CDN signed cookie authentication for video media playback in the nanitabeyo food app. This replaces single-file signed URLs with path-based cookie authentication suitable for HLS video streaming.
+nanitabeyoの動画再生において、HLS配信に適したCDN署名付きCookie認証を実装し、単一ファイルの署名付きURLをパスベース認証へ置き換えた。
 
-## Problem Solved
+## 解決した課題
 
-**Original Issue**: Video files use HLS (HTTP Live Streaming) which requires accessing multiple files:
+**元の問題:** HLS（HTTP Live Streaming）では以下のように多数のファイルへアクセスする必要がある。
 
-- `master.m3u8` (master playlist)
-- Multiple variant playlists (e.g., `720p.m3u8`, `480p.m3u8`)
-- Hundreds of `.ts` video segments
+- `master.m3u8`（マスタープレイリスト）
+- 複数の解像度別プレイリスト（例: `720p.m3u8`, `480p.m3u8`）
+- 数百件の`.ts`セグメントファイル
 
-**Previous Limitation**: Single-file GCS signed URLs only protect one file at a time, making HLS impractical.
+**従来の制約:** GCS署名付きURLは1ファイルずつしか保護できないため、HLSに向かない。
 
-**Solution**: CDN signed cookies provide path-based authentication, allowing access to all files under a specific directory path with a single cookie.
+**解決策:** CDN署名付きCookieにより、特定ディレクトリ配下のすべてのファイルに対して1枚のCookieで認証を付与。
 
-## Changes Made
+## 実施内容
 
-### 1. Environment Configuration (`api/src/core/config/env.ts`)
+### 1. 環境変数設定 (`api/src/core/config/env.ts`)
 
-Added four new optional environment variables:
+以下の4つの任意設定を追加。
 
 ```typescript
 CDN_HOST: z.string().optional(),
@@ -29,77 +29,60 @@ CDN_KEY_SECRET_B64: z.string().optional(),
 CDN_SIGNED_COOKIE_TTL_SECONDS: z.string().default('600').transform((v) => Number(v)),
 ```
 
-### 2. Storage Service (`api/src/core/storage/storage.service.ts`)
+### 2. StorageService (`api/src/core/storage/storage.service.ts`)
 
-Added new method `generateCdnSignedCookies()`:
+`generateCdnSignedCookies()` を追加。
 
-- Generates Cloud CDN signed cookies using HMAC-SHA1
-- Returns cookies with proper security attributes
-- Handles missing configuration gracefully
-- Logs all operations for debugging
+- Cloud CDNの署名付きCookieを生成（HMAC-SHA1）
+- セキュリティ属性を正しく付与
+- 設定が不足している場合は安全にフォールバック
+- すべての操作をログ出力
 
-Key implementation details:
+署名フォーマットやCookieの値は以下の通り。
 
-- Signature format: `URLPrefix=<url>&Expires=<timestamp>&KeyName=<key>`
-- Cookie format: `URLPrefix=<url>:Expires=<timestamp>:KeyName=<key>:Signature=<sig>`
-- Base64 URL-safe encoding (replaces +/ with -\_)
-- Cookie attributes: HttpOnly, Secure, SameSite=None
+- 署名文字列: `URLPrefix=<url>&Expires=<timestamp>&KeyName=<key>`
+- Cookie値: `URLPrefix=<url>:Expires=<timestamp>:KeyName=<key>:Signature=<sig>`
+- Base64はURLセーフ変換（`+`/`/`→`-`/`_`）
+- 属性: HttpOnly, Secure, SameSite=None など
 
-### 3. Dish Media Service (`api/src/v1/dish-media/dish-media.service.ts`)
+### 3. DishMediaService (`api/src/v1/dish-media/dish-media.service.ts`)
 
-Modified `fetchDishMediaEntryItems()`:
+`fetchDishMediaEntryItems()` を更新。
 
-- Detects `media_type === 'video'`
-- Generates CDN URL: `https://{CDN_HOST}/{env}/transcoded/dish_media/media_path/{recordId}/master.m3u8`
-- Collects signed cookies for all videos
-- Returns both data and optional cookies
-- Falls back to GCS signed URLs when CDN not configured
+- `media_type === 'video'` の場合にCDN URLを生成
+- URL形式: `https://{CDN_HOST}/{env}/transcoded/dish_media/media_path/{recordId}/master.m3u8`
+- 動画ごとに署名付きCookieを収集
+- 戻り値を `Promise<{ items: DishMediaEntryItem[]; cdnCookies?: string[] }>` に変更
+- CDN未設定時は従来通りGCSの署名付きURLを返却
 
-Return type changed from:
+### 4. サービス層の更新
 
-```typescript
-Promise<DishMediaEntryItem[]>;
-```
+以下のメソッドがCookie付きレスポンスに対応。
 
-To:
+- `DishMediaService.findByCriteria()`（検索）
+- `DishMediaService.findByIds()`（ID指定）
+- `UsersService.getUserDishReviews()`（ユーザーレビュー）
+- `UsersService.getMeLikedDishMedia()`（いいね済み）
+- `UsersService.getMeSavedDishMedia()`（保存済み）
+- `RestaurantsService.getRestaurantDishMedia()`（店舗メディア）
 
-```typescript
-Promise<{ items: DishMediaEntryItem[]; cdnCookies?: string[] }>;
-```
+### 5. コントローラー更新
 
-### 4. Service Layer Updates
+以下の6エンドポイントで `Set-Cookie` ヘッダーを設定。
 
-Updated all methods that call `fetchDishMediaEntryItems()`:
-
-- `DishMediaService.findByCriteria()` - Search endpoint
-- `DishMediaService.findByIds()` - Query by IDs endpoint
-- `UsersService.getUserDishReviews()` - User reviews endpoint
-- `UsersService.getMeLikedDishMedia()` - Liked media endpoint
-- `UsersService.getMeSavedDishMedia()` - Saved media endpoint
-- `RestaurantsService.getRestaurantDishMedia()` - Restaurant media endpoint
-
-All now return cookies alongside data.
-
-### 5. Controller Updates
-
-Updated six controllers to set `Set-Cookie` headers:
-
-**UsersController** (`api/src/v1/users/users.controller.ts`):
-
+**UsersController** (`api/src/v1/users/users.controller.ts`)
 - `GET /v1/users/:id/dish-reviews`
 - `GET /v1/users/me/liked-dish-media`
 - `GET /v1/users/me/saved-dish-media`
 
-**DishMediaController** (`api/src/v1/dish-media/dish-media.controller.ts`):
-
+**DishMediaController** (`api/src/v1/dish-media/dish-media.controller.ts`)
 - `GET /v1/dish-media?ids=...`
 - `GET /v1/dish-media/search`
 
-**RestaurantsController** (`api/src/v1/restaurants/restaurants.controller.ts`):
-
+**RestaurantsController** (`api/src/v1/restaurants/restaurants.controller.ts`)
 - `GET /v1/restaurants/:id/dish-media`
 
-Implementation pattern (all controllers):
+実装パターン:
 
 ```typescript
 async getEndpoint(
@@ -109,7 +92,6 @@ async getEndpoint(
 ): Promise<ResponseType> {
   const result = await this.service.getMethod(user.id, query);
 
-  // Set CDN signed cookies if present
   if (result.cdnCookies && result.cdnCookies.length > 0) {
     const existing = res.getHeader('Set-Cookie');
     const merged = [
@@ -123,43 +105,40 @@ async getEndpoint(
 }
 ```
 
-## Security Implementation
+## セキュリティ実装
 
-### Cookie Attributes
+### Cookie属性
 
-- **HttpOnly**: Prevents JavaScript access (XSS protection)
-- **Secure**: HTTPS only
-- **SameSite=None**: Allows cross-origin playback (required with Secure)
-- **Domain**: Scoped to CDN domain
-- **Path**: Scoped to specific video directory
-- **Max-Age**: Short TTL (default 10 minutes)
+- **HttpOnly**: JavaScriptからアクセス不可（XSS対策）
+- **Secure**: HTTPS通信のみ
+- **SameSite=None**: クロスオリジン再生に必要
+- **Domain**: CDNドメインに限定
+- **Path**: `/{env}/transcoded/dish_media/media_path/{recordId}/`
+- **Max-Age**: デフォルト10分（短期TTL）
 
-### Signature Security
+### 署名
 
-- HMAC-SHA1 with secret key
-- Base64 URL-safe encoding
-- Covers: URLPrefix + Expires + KeyName
-- Invalid signatures → 403 from CDN
+- HMAC-SHA1 + 秘密鍵
+- Base64 URLセーフエンコード
+- `URLPrefix + Expires + KeyName` をカバー
+- 署名が不正な場合はCDNが403を返却
 
-### Path Isolation
+### パス分離
 
-- Each cookie scoped to: `/{env}/transcoded/dish_media/media_path/{recordId}/`
-- Users can only access videos in their response
-- No cross-record access possible
+- Cookieは各 `recordId` のディレクトリに限定
+- レスポンス内の動画のみアクセス可能
+- 他レコードへのアクセスは不可
 
-## Backward Compatibility
+## 後方互換性
 
-✅ **No Breaking Changes**:
+- ✅ CDN設定は任意（未設定なら従来のGCS署名付きURLを使用）
+- ✅ 画像メディアは従来通り
+- ✅ DTO構造は変更なし（Cookieはヘッダーのみ）
+- ✅ フロントエンドの改修は後続タスクに回しても問題なし
 
-- CDN configuration is optional
-- Falls back to existing GCS signed URLs
-- Image media unchanged
-- DTO structure unchanged (cookies in headers only)
-- Frontend changes not required yet
+## テスト
 
-## Testing
-
-### Build Verification
+### ビルド確認
 
 ```bash
 cd /home/runner/work/nanitabeyo/nanitabeyo
@@ -167,7 +146,7 @@ pnpm build --filter=api
 # ✅ Build successful
 ```
 
-### TypeScript Compilation
+### TypeScriptコンパイル
 
 ```bash
 cd /home/runner/work/nanitabeyo/nanitabeyo/api
@@ -175,9 +154,7 @@ npx tsc --noEmit
 # ✅ No errors
 ```
 
-### Manual Cookie Generation Test
-
-Created and ran test script:
+### Cookie生成の手動テスト
 
 ```bash
 node /tmp/test-cdn-cookies.js
@@ -186,30 +163,28 @@ node /tmp/test-cdn-cookies.js
 # ✅ Signature format correct
 ```
 
-## Documentation
+## ドキュメント
 
-Created comprehensive documentation:
+- `CDN_SIGNED_COOKIE_IMPLEMENTATION.md` を新規作成（約10KB）
+  - アーキテクチャ概要
+  - API仕様
+  - セキュリティの考慮事項
+  - クライアント統合例
+  - CDNセットアップ手順
+  - トラブルシューティング
+  - テスト方法
 
-- `CDN_SIGNED_COOKIE_IMPLEMENTATION.md` (10KB)
-- Architecture overview
-- API endpoint documentation
-- Security considerations
-- Client integration examples
-- CDN setup guide
-- Troubleshooting guide
-- Testing procedures
+## 今後の課題（未対応）
 
-## What's NOT Included (Future Work)
+1. **フロントエンド改修**: クライアントコードは未変更（後続タスクで対応予定）
+2. **CDNインフラ構築**: CDN自体は既存の設定を想定
+3. **Cookie更新ロジック**: TTL切れの再取得は自然失効に任せる
+4. **バッチ最適化**: 現状は動画ごとにCookieを発行
+5. **可視化**: Cookieメトリクスのダッシュボードは未実装
 
-1. **Frontend Changes**: Client code not modified (documented for future)
-2. **CDN Infrastructure**: Assumes CDN already configured
-3. **Cookie Refresh Logic**: Relies on natural TTL expiration
-4. **Batch Optimization**: Each video gets separate cookie
-5. **Analytics Dashboard**: No cookie metrics visualization yet
+## 本番環境の設定
 
-## Configuration Required for Production
-
-### Environment Variables
+### 環境変数
 
 ```bash
 # Production .env
@@ -219,75 +194,69 @@ CDN_KEY_SECRET_B64=<base64-encoded-secret>
 CDN_SIGNED_COOKIE_TTL_SECONDS=600
 ```
 
-### CDN Setup (if not already done)
+### CDNセットアップ（未実施の場合）
 
-1. Configure Cloud CDN with signed URL/cookie support
-2. Generate and store signing key
-3. Set cache max age (600s recommended)
-4. Configure backend bucket
+1. 署名付きURL/Cookie対応でCloud CDNを構成
+2. 署名鍵を生成し安全に保管
+3. キャッシュのmax-ageを600秒程度に設定
+4. バックエンドバケットを設定
 
-## Acceptance Criteria Status
+## 受け入れ条件の達成状況
 
-From original issue:
+- [x] 動画メディアが `Set-Cookie` ヘッダーを返す（レコードIDごとに1枚）
+- [x] `DishMediaEntry.mediaUrl` にCDNの `master.m3u8` URLが入る
+- [x] Cookie属性（Domain/Path/Max-Age/HttpOnly/Secure/SameSite=None）が正しい
+- [x] DTOにCookie文字列を含めずヘッダーのみで返却
+- [ ] iOS/Androidの再生確認（フロント作業、ドキュメント化済み）
+- [ ] Web再生（hls.js）の確認（フロント作業、ドキュメント化済み）
+- [ ] TTL切れ後の403確認（CDN環境が必要）
 
-- [x] Video items return `Set-Cookie` headers (one per recordId)
-- [x] `DishMediaEntry.mediaUrl` contains CDN `master.m3u8` URL
-- [x] Cookie attributes correct (Domain/Path/Max-Age/HttpOnly/Secure/SameSite=None)
-- [x] DTO does not contain cookie strings (headers only)
-- [ ] iOS/Android playback with expo-av (frontend work, documented)
-- [ ] Web playback with hls.js (frontend work, documented)
-- [ ] TTL expiration results in 403 (requires CDN configuration)
+## デプロイメモ
 
-## Deployment Notes
+### 開発環境
 
-### For Development Environment
+1. `api/` 直下に `.env` を用意
+2. 必要に応じてCDN設定を追加（未設定でもGCSで動作）
+3. APIを起動: `cd api && pnpm dev`
+4. 動画を含むエンドポイントで動作確認
 
-1. Create `.env` file in `api/` directory
-2. Add CDN configuration (or leave empty for GCS fallback)
-3. Start API: `cd api && pnpm dev`
-4. Test endpoints with video media
+### 本番環境
 
-### For Production Deployment
+1. CDN設定を事前に完了させる
+2. Cloud Run等に環境変数を設定
+3. 新コードをデプロイ
+4. Cookie生成のログを監視
+5. レスポンスヘッダーに `Set-Cookie` が含まれることを確認
 
-1. Configure CDN if not already done
-2. Set environment variables in Cloud Run
-3. Deploy API with new code
-4. Monitor logs for cookie generation
-5. Verify `Set-Cookie` headers in responses
+## 監視
 
-## Monitoring
+- `CdnSignedCookiesGenerated`: 正常発行
+- `CdnConfigMissing`: 設定不足の警告
+- `CdnSignedCookieError`: 生成時のエラー
 
-All cookie operations logged:
-
-- `CdnSignedCookiesGenerated`: Success
-- `CdnConfigMissing`: Configuration warning
-- `CdnSignedCookieError`: Generation errors
-
-Example log:
+ログ例:
 
 ```json
 {
-	"event": "CdnSignedCookiesGenerated",
-	"context": "generateCdnSignedCookies",
-	"data": {
-		"urlPrefix": "https://cdn.example.com/prod/.../",
-		"recordId": "abc123",
-		"expires": "2025-10-14T23:17:23.000Z",
-		"cookieCount": 1
-	}
+        "event": "CdnSignedCookiesGenerated",
+        "context": "generateCdnSignedCookies",
+        "data": {
+                "urlPrefix": "https://cdn.example.com/prod/.../",
+                "recordId": "abc123",
+                "expires": "2025-10-14T23:17:23.000Z",
+                "cookieCount": 1
+        }
 }
 ```
 
-## Summary
+## まとめ
 
-Successfully implemented CDN signed cookie authentication for video media with:
+- ✅ 8ファイルを変更
+- ✅ 破壊的変更なし
+- ✅ ドキュメントを整備
+- ✅ ビルド/型チェック成功
+- ✅ 後方互換性あり
+- ✅ セキュリティ強化済み
+- ✅ 本番投入可能
 
-- ✅ 8 files modified
-- ✅ 0 breaking changes
-- ✅ Comprehensive documentation
-- ✅ All builds passing
-- ✅ Backward compatible
-- ✅ Security hardened
-- ✅ Production ready
-
-The implementation is minimal, focused, and ready for code review and deployment.
+最小限の変更で動画再生の認証を強化し、デプロイに必要な情報も揃っている。

--- a/docs/IMPLEMENTATION_VIDEO_ARCHITECTURE.md
+++ b/docs/IMPLEMENTATION_VIDEO_ARCHITECTURE.md
@@ -1,99 +1,98 @@
-# MVP Video Storage Architecture - Implementation Summary
+# MVP動画ストレージアーキテクチャ - 実装サマリー
 
-## Overview
+## 概要
 
-This implementation adds video upload and transcoding capabilities to the nanitabeyo food app, following the sequence diagrams specified in the issue.
+課題で提示されたシーケンス図に従い、nanitabeyo アプリに動画アップロードとトランスコード機能を追加した実装内容をまとめる。
 
-## Backend Changes
+## バックエンドの変更点
 
-### 1. DTO Updates (`shared/api/v1/dto/dish-media/create-dish-media.dto.ts`)
+### 1. DTOの更新 (`shared/api/v1/dto/dish-media/create-dish-media.dto.ts`)
 
-- Added optional `thumbnailPath` field to `CreateDishMediaDto`
-- Exported `MediaType` enum (VIDEO/IMAGE) for use across the application
+- `CreateDishMediaDto` に任意の `thumbnailPath` フィールドを追加
+- アプリ全体で利用できるように `MediaType` enum（VIDEO/IMAGE）をエクスポート
 
-### 2. Transcoder Service (`api/src/core/transcoder/`)
+### 2. トランスコーダーサービス (`api/src/core/transcoder/`)
 
-- New `TranscoderService` using Google Cloud Video Transcoder API
-- Generates HLS output with adaptive bitrate streaming:
+- Google Cloud Video Transcoder API を利用する `TranscoderService` を新規追加
+- HLS の可変ビットレート出力を生成
   - 1080p @ 8000 kbps
   - 720p @ 5000 kbps
   - 480p @ 2500 kbps
-  - Audio: AAC @ 128 kbps
-- Outputs to: `gs://<bucket>/transcoded/dish_media/media_path/<recordId>/master.m3u8`
+  - 音声: AAC @ 128 kbps
+- 出力先: `gs://<bucket>/transcoded/dish_media/media_path/<recordId>/master.m3u8`
 
-### 3. Cloud Tasks Integration (`api/src/core/cloud-tasks/cloud-tasks.service.ts`)
+### 3. Cloud Tasks 連携 (`api/src/core/cloud-tasks/cloud-tasks.service.ts`)
 
-- Added `enqueueTranscodeJob()` method
-- Sends jobs to `transcode-queue` for async processing
+- `enqueueTranscodeJob()` を追加し、`transcode-queue` へジョブを送信
 
-### 4. Internal Worker Endpoint (`api/src/internal/transcode/`)
+### 4. 内部ワーカーエンドポイント (`api/src/internal/transcode/`)
 
-- New `/internal/transcode` endpoint protected by OIDC guard
-- Receives transcode jobs from Cloud Tasks
-- Delegates to TranscoderService to create Transcoder API jobs
+- Cloud Tasks から呼び出される `/internal/transcode` エンドポイントを追加
+- OIDCガードで保護
+- 受け取ったペイロードを TranscoderService へ渡してジョブを作成
 
-### 5. DishMedia Service Updates (`api/src/v1/dish-media/dish-media.service.ts`)
+### 5. DishMediaService の更新 (`api/src/v1/dish-media/dish-media.service.ts`)
 
-- Updated `createDishMedia()` to handle VIDEO vs IMAGE:
-  - **VIDEO**: Requires thumbnailPath, enqueues transcoding job
-  - **IMAGE**: thumbnailPath defaults to mediaPath if not provided
-- Logs transcode job enqueueing for monitoring
+- `createDishMedia()` の動画/画像処理を分岐
+  - **VIDEO**: `thumbnailPath` が必須、Cloud Tasks へトランスコードジョブを投入
+  - **IMAGE**: `thumbnailPath` が指定されていなければ `mediaPath` を流用
+- ジョブ投入状況をログ出力
 
-## Frontend Compatibility
+## フロントエンド互換性
 
-### FileUploader Component (`app-expo/features/uploads/components/FileUploader.tsx`)
+### FileUploader コンポーネント (`app-expo/features/uploads/components/FileUploader.tsx`)
 
-**No changes needed** - the component already supports the required flow:
+**変更なし**。既存機能で以下のフローを実現できる。
 
-1. Component handles single file upload with signed URL
-2. Returns `objectPath` via `onUploadComplete` callback
-3. Calling code can use it twice for video upload flow:
-   - First call: Upload video with `baseFileName: "${dishId}-media"`
-   - Second call: Upload thumbnail with `baseFileName: "${dishId}-thumbnail"`
-   - Then call: `POST /v1/dish-media` with both paths
+1. 署名付きURLを取得し、1ファイルずつアップロード
+2. `onUploadComplete` コールバックで `objectPath` を受け取る
+3. 動画フローでは以下のように利用可能
+   - 1回目: `baseFileName: "${dishId}-media"` で動画をアップロード
+   - 2回目: `baseFileName: "${dishId}-thumbnail"` でサムネイルをアップロード
+   - 最後に `POST /v1/dish-media` で両方のパスを送信
 
-## Video Upload Flow (End-to-End)
+## 動画アップロードの全体像
 
-### For Video Media:
+### 動画メディアの場合
 
 ```
 1. UI → Backend: POST /v1/user-uploads/signed-url { baseFileName: "${dishId}-media", mimeType: "video/mp4" }
 2. Backend → UI: { putUrl, objectPath: mediaPath }
-3. UI → GCS: PUT (video binary)
+3. UI → GCS: PUT (動画バイナリ)
 4. UI → Backend: POST /v1/user-uploads/signed-url { baseFileName: "${dishId}-thumbnail", mimeType: "image/jpeg" }
 5. Backend → UI: { putUrl, objectPath: thumbnailPath }
-6. UI → GCS: PUT (thumbnail binary)
+6. UI → GCS: PUT (サムネイルバイナリ)
 7. UI → Backend: POST /v1/dish-media { dishId, mediaType: "VIDEO", mediaPath, thumbnailPath }
-8. Backend: Creates dish_media record
-9. Backend → Cloud Tasks: Enqueue transcode job
+8. Backend: dish_media レコードを作成
+9. Backend → Cloud Tasks: トランスコードジョブをキューに投入
 10. Cloud Tasks → Backend: POST /internal/transcode { inputUri, outputUri, recordId }
-11. Backend → Transcoder API: Create HLS transcode job
-12. Transcoder API: Generates HLS files asynchronously
+11. Backend → Transcoder API: HLS トランスコードジョブを作成
+12. Transcoder API: 非同期でHLSファイルを生成
 ```
 
-### For Image Media:
+### 画像メディアの場合
 
 ```
 1. UI → Backend: POST /v1/user-uploads/signed-url { baseFileName: "${dishId}-media", mimeType: "image/jpeg" }
 2. Backend → UI: { putUrl, objectPath: mediaPath }
-3. UI → GCS: PUT (image binary)
+3. UI → GCS: PUT (画像バイナリ)
 4. UI → Backend: POST /v1/dish-media { dishId, mediaType: "IMAGE", mediaPath, thumbnailPath: mediaPath }
-   (thumbnailPath is required, set to same value as mediaPath for images)
-5. Backend: Creates dish_media record with thumbnailPath = mediaPath
+   (画像の場合は thumbnailPath も必須だが mediaPath と同じ値を設定)
+5. Backend: dish_media レコードを作成（thumbnailPath=mediaPath）
 ```
 
-## Environment Variables
+## 環境変数
 
-No new environment variables required. Uses existing:
+新たな環境変数は不要。既存の以下を利用。
 
-- `GCP_PROJECT`: Google Cloud project ID
-- `TASKS_LOCATION`: Cloud Tasks region (e.g., us-central1)
-- `GCS_BUCKET_NAME`: Storage bucket name
-- `CLOUD_RUN_URL`: Backend URL for Cloud Tasks callbacks
+- `GCP_PROJECT`: Google Cloud プロジェクトID
+- `TASKS_LOCATION`: Cloud Tasks のリージョン（例: us-central1）
+- `GCS_BUCKET_NAME`: ストレージバケット名
+- `CLOUD_RUN_URL`: Cloud Tasks コールバック先のAPI URL
 
-## Cloud Tasks Queue
+## Cloud Tasks キュー
 
-A new queue `transcode-queue` should be created in Google Cloud Tasks:
+`transcode-queue` を新規作成する。
 
 ```bash
 gcloud tasks queues create transcode-queue \
@@ -102,71 +101,71 @@ gcloud tasks queues create transcode-queue \
   --max-concurrent-dispatches=5
 ```
 
-## Database Schema
+## データベーススキーマ
 
-No schema changes required. Existing `dish_media` table fields used:
+新たなスキーマ変更は不要。既存の `dish_media` テーブルを利用。
 
-- `media_path`: Original video URI or image URI
-- `thumbnail_path`: Thumbnail image URI
-- `media_type`: 'IMAGE' or 'VIDEO'
+- `media_path`: 元動画または画像のURI
+- `thumbnail_path`: サムネイル画像のURI
+- `media_type`: 'IMAGE' または 'VIDEO'
 
-Future enhancement could add:
+将来的な拡張案としては以下が考えられる。
 
-- `transcode_status`: PENDING, PROCESSING, READY, FAILED
-- `hls_master_path`: Path to master.m3u8 file
+- `transcode_status`: PENDING / PROCESSING / READY / FAILED
+- `hls_master_path`: `master.m3u8` のパス
 
-## Testing
+## テスト
 
-### Manual Testing Steps:
+### 手動テスト手順
 
-1. **Setup**:
+1. **準備**
 
    ```bash
    cd api
-   # Create .env with all required variables
+   # 必要な環境変数を含む .env を作成
    pnpm dev
    ```
 
-2. **Test Image Upload**:
-   - Upload image via FileUploader
-   - Call POST /v1/dish-media with mediaType: IMAGE
-   - Verify record created with thumbnailPath = mediaPath
+2. **画像アップロードの確認**
+   - FileUploader で画像をアップロード
+   - `mediaType: IMAGE` で `POST /v1/dish-media`
+   - thumbnailPath が mediaPath と同じ値で保存されることを確認
 
-3. **Test Video Upload** (requires GCS and Transcoder API access):
-   - Upload video via FileUploader
-   - Upload thumbnail via FileUploader
-   - Call POST /v1/dish-media with mediaType: VIDEO and both paths
-   - Verify record created
-   - Check Cloud Tasks console for transcode job
-   - Check Transcoder API console for job execution
+3. **動画アップロードの確認**（GCSとTranscoder APIのアクセスが必要）
+   - FileUploader で動画をアップロード
+   - FileUploader でサムネイルをアップロード
+   - `mediaType: VIDEO` と両方のパスで `POST /v1/dish-media`
+   - レコードが作成されることを確認
+   - Cloud Tasks コンソールでジョブ投入を確認
+   - Transcoder API コンソールでジョブ実行を確認
 
-### Build Validation:
+### ビルド確認
 
 ```bash
-pnpm build      # ✅ Passes
-pnpm typecheck  # ✅ Passes
+pnpm build      # ✅ 成功
+pnpm typecheck  # ✅ 成功
 ```
 
-## Future Enhancements
+## 今後の拡張
 
-1. **Status Updates via Pub/Sub**:
-   - Subscribe to Transcoder job completion notifications
-   - Update dish_media.transcode_status when job completes
+1. **Pub/Sub を用いたステータス更新**
+   - Transcoder の完了通知を購読
+   - dish_media.transcode_status を更新
 
-2. **CDN Integration**:
-   - Add signed URL generation for HLS playback
-   - Integrate with Cloud CDN for better performance
+2. **CDN統合**
+   - HLS再生用の署名付きURL生成
+   - Cloud CDN 統合によるパフォーマンス向上
 
-3. **Progress Tracking**:
-   - Real-time transcode progress updates to UI
-   - Webhook endpoint for Transcoder notifications
+3. **進捗トラッキング**
+   - トランスコードの進捗をリアルタイムでUIに表示
+   - Transcoder通知のWebhookエンドポイントを追加
 
-4. **Error Handling**:
-   - Retry logic for failed transcode jobs
-   - User notifications on transcode failure
+4. **エラーハンドリング強化**
+   - 失敗したジョブのリトライ
+   - 失敗時のユーザー通知
 
-## References
+## 参考資料
 
-- Issue: 【課題】MVP の動画保存アーキテクチャ
+- 課題: 【課題】MVP の動画保存アーキテクチャ
 - Google Cloud Video Transcoder API: https://cloud.google.com/transcoder/docs
-- HLS Specification: https://datatracker.ietf.org/doc/html/rfc8216
+- HLS 仕様: https://datatracker.ietf.org/doc/html/rfc8216

--- a/docs/MAINTENANCE_SYSTEM.md
+++ b/docs/MAINTENANCE_SYSTEM.md
@@ -1,150 +1,148 @@
-# Maintenance / Forced Update Control System
+# メンテナンス / 強制アップデート制御システム
 
-This document describes the maintenance and forced update control system implemented for the nanitabeyo app. The system uses GCS configuration to control maintenance mode and app version requirements globally across all APIs.
+このドキュメントでは、GCSの設定ファイルを利用して nanitabeyo アプリ全体のメンテナンスモードおよびアプリの最低サポートバージョンを制御する仕組みを説明する。
 
-## Overview
+## 概要
 
-The system consists of two main components:
+システムは以下の2要素で構成される。
 
-1. **Backend**: Global guard that checks maintenance status and app version requirements
-2. **Frontend**: Health check and error handling for maintenance/version scenarios
+1. **バックエンド**: メンテナンス状態とアプリバージョンを判定するグローバルガード
+2. **フロントエンド**: ヘルスチェックとエラーハンドリングでメンテナンス/バージョン警告を表示
 
-## Backend Implementation
+## バックエンド実装
 
 ### MaintenanceGuard
 
-Located in `api/src/core/guards/maintenance.guard.ts`, this global guard:
+`api/src/core/guards/maintenance.guard.ts` に配置されたグローバルガードで、以下を行う。
 
-- Checks `is_maintenance` and `minimum_supported_version` from GCS configuration
-- Returns HTTP 503 for maintenance mode
-- Returns HTTP 426 for unsupported app versions
-- Allows requests without `X-App-Version` header to pass through
-- Excludes essential paths like `/metrics` from checks
-- Gracefully falls back if GCS configuration is unavailable
+- GCS設定から `is_maintenance` と `minimum_supported_version` を取得
+- メンテナンス中はHTTP 503を返す
+- 最低バージョン未満の場合はHTTP 426を返す
+- `X-App-Version` ヘッダーがないリクエストは許可
+- `/metrics` など重要なパスは除外
+- GCS設定が取得できない場合はフェイルオープンで処理を継続
 
-### Health Endpoint
+### ヘルスチェックエンドポイント
 
-A new `/health` endpoint provides:
+`/health` エンドポイントを新設。
 
-- Lightweight health status check
-- Subject to maintenance/version guard (not exempted)
-- Returns 200 in normal conditions
-- Returns 503/426 when maintenance/version conditions are triggered
+- 軽量なヘルスチェックを提供
+- MaintenanceGuard のチェック対象（例外ではない）
+- 通常時は200を返す
+- メンテナンス/バージョン条件で503/426を返す
 
-### Configuration Cache
+### 設定キャッシュ
 
-The `RemoteConfigService` now includes:
+`RemoteConfigService` にキャッシュ機構を追加。
 
-- 5-minute TTL caching for performance
-- Reduced GCS API calls
-- Automatic cache invalidation
+- TTLは5分
+- GCS API呼び出しを削減
+- 自動的にキャッシュを無効化
 
-## Frontend Implementation
+## フロントエンド実装
 
-### Health Check Hook
+### ヘルスチェックフック
 
-`app-expo/hooks/useHealthCheck.ts` provides:
+`app-expo/hooks/useHealthCheck.ts` が担当。
 
-- Async health check on app startup
-- Non-blocking UI rendering
-- Automatic 503/426 error handling
-- Proper dialog management
+- アプリ起動時に非同期でヘルスチェック
+- UI描画をブロックしない
+- HTTP 503/426 を検出してダイアログを表示
+- ダイアログ状態を適切に管理
 
-### Enhanced API Error Handling
+### APIエラーハンドリング強化
 
-`app-expo/hooks/useAPICall.ts` now handles:
+`app-expo/hooks/useAPICall.ts` の機能。
 
-- HTTP 503: Shows maintenance dialog
-- HTTP 426: Shows forced update dialog with store redirect
-- Backward compatibility with existing 403 error handling
+- HTTP 503: メンテナンスダイアログを表示
+- HTTP 426: 強制アップデートダイアログとストア遷移
+- 既存の403エラーとの互換性を維持
 
-### Integration
+### 統合ポイント
 
-The health check is integrated into the app startup flow via:
+ヘルスチェックは `HealthCheckInitializer` コンポーネント経由でアプリ起動時に実行。
 
-- `HealthCheckInitializer` component
-- Added to app layout without blocking UI
-- Runs after providers are initialized
+- プロバイダー初期化後に実行
+- UIをブロックしない
 
-## Configuration
+## 設定
 
-### GCS Configuration Values
+### GCS構成値
 
-The system reads these values from GCS static master configuration:
+静的マスターデータから以下を読み取る。
 
 ```json
 {
   "is_maintenance": "true" | "false",
-  "minimum_supported_version": "1.0.0" // SemVer format
+  "minimum_supported_version": "1.0.0" // SemVer形式
 }
 ```
 
-### Environment Variables
+### 環境変数
 
-Required environment variables for API:
+APIで必要な環境変数。
 
-- `GCS_BUCKET_NAME`: GCS bucket for static master files
-- `GCS_STATIC_MASTER_DIR_PATH`: Directory path in GCS bucket
+- `GCS_BUCKET_NAME`: 静的マスターファイルを格納するバケット
+- `GCS_STATIC_MASTER_DIR_PATH`: バケット内のディレクトリパス
 
-## Testing the System
+## テスト手順
 
-### 1. Test Maintenance Mode
+### 1. メンテナンスモード
 
-1. Set GCS config: `is_maintenance: "true"`
-2. Make any API call with `X-App-Version` header
-3. Expect HTTP 503 response
-4. Frontend should show maintenance dialog
+1. GCS設定の `is_maintenance` を `"true"` にする
+2. `X-App-Version` ヘッダー付きでAPIを呼び出す
+3. HTTP 503 が返ることを確認
+4. フロントエンドでメンテナンスダイアログが表示されることを確認
 
-### 2. Test Version Control
+### 2. バージョン制御
 
-1. Set GCS config: `minimum_supported_version: "2.0.0"`
-2. Make API call with `X-App-Version: "1.5.0"`
-3. Expect HTTP 426 response
-4. Frontend should show update dialog with store redirect
+1. GCS設定の `minimum_supported_version` を `"2.0.0"` にする
+2. `X-App-Version: "1.5.0"` でAPIを呼び出す
+3. HTTP 426 が返ることを確認
+4. フロントエンドでアップデートダイアログが表示され、ストアへ遷移できることを確認
 
-### 3. Test Health Endpoint
+### 3. ヘルスエンドポイント
 
 ```bash
-# Normal operation
+# 通常
 curl -H "X-App-Version: 2.0.0" http://localhost:3000/health
-# Expected: 200 OK
+# 期待: 200 OK
 
-# Maintenance mode (when is_maintenance: "true")
+# メンテナンス中（is_maintenance: "true"）
 curl -H "X-App-Version: 2.0.0" http://localhost:3000/health
-# Expected: 503 Service Unavailable
+# 期待: 503 Service Unavailable
 
-# Unsupported version (when minimum_supported_version > X-App-Version)
+# 最低バージョン未満（minimum_supported_version > X-App-Version）
 curl -H "X-App-Version: 1.0.0" http://localhost:3000/health
-# Expected: 426 Upgrade Required
+# 期待: 426 Upgrade Required
 
-# No version header (should pass through)
+# バージョンヘッダーなし（許可される）
 curl http://localhost:3000/health
-# Expected: 200 OK (guard allows through)
+# 期待: 200 OK
 ```
 
-### 4. Test Graceful Fallback
+### 4. フェイルオープンの確認
 
-1. Temporarily break GCS access or config format
-2. API should continue working (allows all requests)
-3. Check console for warning messages
+1. GCSアクセスや設定フォーマットを意図的に壊す
+2. APIが引き続き動作し、警告ログのみ出力されることを確認
 
-## Monitoring and Operations
+## 監視と運用
 
-### Allowed Paths
+### 除外パス
 
-These paths bypass maintenance/version checks:
+メンテナンス/バージョンチェックを除外するパス。
 
-- `/metrics` - For monitoring and health checks
+- `/metrics` — 監視用
 
-### Cache Behavior
+### キャッシュ動作
 
-- Configuration is cached for 5 minutes
-- Cache invalidation happens automatically
-- Failed config loads trigger graceful fallback
+- 設定は5分間キャッシュ
+- キャッシュは自動で更新
+- 設定取得に失敗した場合もフェイルオープン
 
-### Error Response Format
+### エラーレスポンス形式
 
-All maintenance/version errors follow the standard API response format:
+すべてのエラーは標準APIレスポンス形式。
 
 ```typescript
 {
@@ -155,37 +153,37 @@ All maintenance/version errors follow the standard API response format:
 }
 ```
 
-## Localization
+## ローカライゼーション
 
-All required error messages are available in all supported locales:
+必要な文言は全サポート言語に翻訳済み。
 
-- `Error.maintenanceMessage`: Maintenance mode message
-- `Error.unsupportedVersion`: Version upgrade required message
-- `Common.goStore`: Store redirect button text
-- `Common.ok`: Dialog confirmation button
+- `Error.maintenanceMessage`: メンテナンス中のメッセージ
+- `Error.unsupportedVersion`: アップデート要求メッセージ
+- `Common.goStore`: ストア遷移ボタン
+- `Common.ok`: ダイアログの確定ボタン
 
-## Development Guidelines
+## 開発ガイドライン
 
-### Adding New Exempted Paths
+### 除外パスの追加
 
-To add paths that should bypass maintenance/version checks:
+メンテナンス/バージョンチェックから除外したいパスを追加する。
 
 ```typescript
-// In MaintenanceGuard
+// MaintenanceGuard 内
 private readonly allowedPaths = ['/metrics', '/new-exempted-path'];
 ```
 
-### Customizing Cache TTL
+### キャッシュTTLの変更
 
-To modify the configuration cache duration:
+キャッシュ期間を変更する。
 
 ```typescript
-// In RemoteConfigService
-private readonly CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+// RemoteConfigService 内
+private readonly CACHE_TTL_MS = 10 * 60 * 1000; // 10分
 ```
 
-### Adding New Configuration Values
+### 新しい設定値の追加
 
-1. Update `shared/remoteConfig/remoteConfig.schema.ts`
-2. Update GCS static master data
-3. Use via `RemoteConfigService.getRemoteConfigValue()`
+1. `shared/remoteConfig/remoteConfig.schema.ts` を更新
+2. GCS静的マスターを更新
+3. `RemoteConfigService.getRemoteConfigValue()` から取得

--- a/docs/VIDEO_ARCHITECTURE_SUMMARY.md
+++ b/docs/VIDEO_ARCHITECTURE_SUMMARY.md
@@ -1,81 +1,81 @@
-# Video Upload Architecture - Quick Reference
+# 動画アップロードアーキテクチャ - クイックリファレンス
 
-## What Was Implemented
+## 実装内容
 
-This PR implements the MVP video upload and transcoding architecture as specified in issue 【課題】MVP の動画保存アーキテクチャ.
+このPRでは、課題「【課題】MVP の動画保存アーキテクチャ」で求められたMVPレベルの動画アップロード／トランスコード構成を実装した。
 
-## Key Changes
+## 主な変更点
 
-### 1. DTO Enhancement
+### 1. DTOの拡張
 
-- **File**: `shared/api/v1/dto/dish-media/create-dish-media.dto.ts`
-- Added optional `thumbnailPath` field
-- Exported `MediaType` enum (VIDEO/IMAGE)
+- **対象ファイル**: `shared/api/v1/dto/dish-media/create-dish-media.dto.ts`
+- 任意の `thumbnailPath` フィールドを追加
+- `MediaType` enum（VIDEO/IMAGE）をエクスポート
 
-### 2. Video Transcoding Service
+### 2. 動画トランスコードサービス
 
-- **Directory**: `api/src/core/transcoder/`
-- HLS transcoding with 3 quality levels (1080p, 720p, 480p)
-- Google Cloud Video Transcoder API integration
-- Output: `gs://<bucket>/transcoded/dish_media/media_path/<recordId>/master.m3u8`
+- **ディレクトリ**: `api/src/core/transcoder/`
+- 1080p / 720p / 480p の3品質でHLSを出力
+- Google Cloud Video Transcoder API を統合
+- 出力パス: `gs://<bucket>/transcoded/dish_media/media_path/<recordId>/master.m3u8`
 
-### 3. Cloud Tasks Integration
+### 3. Cloud Tasks との連携
 
-- **File**: `api/src/core/cloud-tasks/cloud-tasks.service.ts`
-- New method: `enqueueTranscodeJob()`
-- Queue: `transcode-queue`
+- **ファイル**: `api/src/core/cloud-tasks/cloud-tasks.service.ts`
+- `enqueueTranscodeJob()` を追加
+- キュー名: `transcode-queue`
 
-### 4. Worker Endpoint
+### 4. ワーカーエンドポイント
 
-- **Directory**: `api/src/internal/transcode/`
-- Endpoint: `POST /internal/transcode`
-- Protected by OIDC guard for Cloud Tasks
+- **ディレクトリ**: `api/src/internal/transcode/`
+- エンドポイント: `POST /internal/transcode`
+- Cloud Tasks 用のOIDCガードで保護
 
-### 5. Business Logic Update
+### 5. ビジネスロジックの更新
 
-- **File**: `api/src/v1/dish-media/dish-media.service.ts`
-- Video: Requires thumbnailPath, enqueues transcoding
-- Image: thumbnailPath defaults to mediaPath
+- **ファイル**: `api/src/v1/dish-media/dish-media.service.ts`
+- 動画: `thumbnailPath` が必須、トランスコードをキューに投入
+- 画像: `thumbnailPath` に `mediaPath` を流用
 
-## Usage Example
+## 使用例
 
-### Frontend - Video Upload
+### フロントエンド - 動画アップロード
 
 ```typescript
-// 1. Upload video
+// 1. 動画をアップロード
 const videoPath = await uploadFile(videoFile, `${dishId}-media`);
 
-// 2. Upload thumbnail
+// 2. サムネイルをアップロード
 const thumbnailPath = await uploadFile(thumbnailFile, `${dishId}-thumbnail`);
 
-// 3. Create dish media
+// 3. dish media を作成
 await createDishMedia({
-	dishId,
-	mediaType: "VIDEO",
-	mediaPath: videoPath,
-	thumbnailPath: thumbnailPath,
+        dishId,
+        mediaType: "VIDEO",
+        mediaPath: videoPath,
+        thumbnailPath: thumbnailPath,
 });
-// Backend automatically enqueues transcoding job
+// バックエンドが自動でトランスコードをキューに投入
 ```
 
-### Frontend - Image Upload
+### フロントエンド - 画像アップロード
 
 ```typescript
-// 1. Upload image
+// 1. 画像をアップロード
 const imagePath = await uploadFile(imageFile, `${dishId}-media`);
 
-// 2. Create dish media (thumbnailPath is required, use same path as media)
+// 2. dish media を作成（thumbnailPath も必須なので同じ値をセット）
 await createDishMedia({
-	dishId,
-	mediaType: "IMAGE",
-	mediaPath: imagePath,
-	thumbnailPath: imagePath, // Required: set to same value as mediaPath
+        dishId,
+        mediaType: "IMAGE",
+        mediaPath: imagePath,
+        thumbnailPath: imagePath, // 必須: mediaPath と同じ値を設定
 });
 ```
 
-## Infrastructure Setup
+## インフラ設定
 
-### Create Cloud Tasks Queue
+### Cloud Tasks キュー作成
 
 ```bash
 gcloud tasks queues create transcode-queue \
@@ -84,32 +84,32 @@ gcloud tasks queues create transcode-queue \
   --max-concurrent-dispatches=5
 ```
 
-### Enable APIs
+### 必要なAPIの有効化
 
 ```bash
 gcloud services enable videotranscoder.googleapis.com
 gcloud services enable cloudtasks.googleapis.com
 ```
 
-## Testing
+## テスト
 
-### Build & Typecheck (Passing ✅)
+### ビルド / 型チェック（✅ 通過済み）
 
 ```bash
-pnpm build      # All packages compile successfully
-pnpm typecheck  # No type errors
-pnpm format     # Code formatted
+pnpm build      # すべてのパッケージがコンパイルに成功
+pnpm typecheck  # 型エラーなし
+pnpm format     # コードを整形
 ```
 
-### Manual Testing
+### 手動テスト
 
-1. Start API server: `cd api && pnpm dev`
-2. Test image upload flow (should work immediately)
-3. Test video upload flow (requires GCS and Transcoder API access)
+1. APIサーバーを起動: `cd api && pnpm dev`
+2. 画像アップロードフローを確認（即時動作）
+3. 動画アップロードフローを確認（GCSとTranscoder APIのアクセスが必要）
 
-## Architecture Diagrams
+## アーキテクチャ図
 
-### Video Upload Flow
+### 動画アップロードフロー
 
 ```
 ┌─────────┐                  ┌─────────┐                  ┌──────────┐
@@ -124,7 +124,7 @@ pnpm format     # Code formatted
      ├─────────────────────────────────────────────────────────>│
      │                            │                            │
      │ 4. Get signed URL (thumb)  │                            │
-     ├───────────────────────────>│                            │
+     ├──────────────────────────>│                            │
      │ 5. Return signed URL        │                            │
      │<───────────────────────────┤                            │
      │ 6. Upload thumbnail binary  │                            │
@@ -143,7 +143,7 @@ pnpm format     # Code formatted
      │<───────────────────────────┤                            │
      │                            │                            │
 
-     Later (async):
+     後続（非同期）:
 
      ┌─────────────┐              ┌────────────┐
      │ Cloud Tasks │              │ Transcoder │
@@ -158,7 +158,7 @@ pnpm format     # Code formatted
             │               │           ├────────────────────>│
 ```
 
-### Image Upload Flow
+### 画像アップロードフロー
 
 ```
 ┌─────────┐                  ┌─────────┐                  ┌──────────┐
@@ -183,42 +183,42 @@ pnpm format     # Code formatted
      │<───────────────────────────┤                            │
 ```
 
-## Files Changed
+## 変更ファイル
 
-### New Files
+### 新規ファイル
 
-- `api/src/core/transcoder/transcoder.service.ts` - Transcoder API client
-- `api/src/core/transcoder/transcoder.module.ts` - Module definition
-- `api/src/internal/transcode/transcode.controller.ts` - Worker endpoint
-- `api/src/internal/transcode/transcode.service.ts` - Worker logic
-- `api/src/internal/transcode/transcode.module.ts` - Module definition
-- `api/src/internal/transcode/transcode.dto.ts` - DTO for worker
-- `api/src/internal/transcode/transcode-job.interface.ts` - Job payload interface
-- `IMPLEMENTATION_VIDEO_ARCHITECTURE.md` - Detailed documentation
+- `api/src/core/transcoder/transcoder.service.ts` — Transcoder API クライアント
+- `api/src/core/transcoder/transcoder.module.ts` — モジュール定義
+- `api/src/internal/transcode/transcode.controller.ts` — ワーカーエンドポイント
+- `api/src/internal/transcode/transcode.service.ts` — トランスコードロジック
+- `api/src/internal/transcode/transcode.module.ts` — モジュール定義
+- `api/src/internal/transcode/transcode.dto.ts` — ワーカー用DTO
+- `api/src/internal/transcode/transcode-job.interface.ts` — ジョブのペイロード定義
+- `IMPLEMENTATION_VIDEO_ARCHITECTURE.md` — 詳細ドキュメント
 
-### Modified Files
+### 変更した既存ファイル
 
-- `shared/api/v1/dto/dish-media/create-dish-media.dto.ts` - Added thumbnailPath
-- `shared/api/v1/dto/index.ts` - Export MediaType enum
-- `api/src/v1/dish-media/dish-media.service.ts` - Video/image logic
-- `api/src/v1/dish-media/dish-media.module.ts` - Added dependencies
-- `api/src/core/cloud-tasks/cloud-tasks.service.ts` - Added transcode queue
-- `api/src/core/core.module.ts` - Added TranscoderModule
-- `api/src/internal/internal.module.ts` - Added TranscodeModule
-- `api/package.json` - Added @google-cloud/video-transcoder
+- `shared/api/v1/dto/dish-media/create-dish-media.dto.ts` — `thumbnailPath` を追加
+- `shared/api/v1/dto/index.ts` — `MediaType` enum をエクスポート
+- `api/src/v1/dish-media/dish-media.service.ts` — 動画/画像ロジックを更新
+- `api/src/v1/dish-media/dish-media.module.ts` — 依存モジュールを追加
+- `api/src/core/cloud-tasks/cloud-tasks.service.ts` — トランスコードキューを追加
+- `api/src/core/core.module.ts` — TranscoderModule を追加
+- `api/src/internal/internal.module.ts` — TranscodeModule を追加
+- `api/package.json` — `@google-cloud/video-transcoder` を追加
 
-## Next Steps
+## 次のステップ
 
-1. **Deploy**: Push to production and create Cloud Tasks queue
-2. **Monitor**: Set up logging/alerting for transcode jobs
-3. **Optimize**: Consider Pub/Sub for status updates
-4. **Enhance**: Add retry logic and error notifications
+1. **デプロイ**: 本番環境へ反映し、Cloud Tasks キューを作成
+2. **監視**: トランスコードジョブのログ／アラートを設定
+3. **最適化**: ステータス更新にPub/Sub利用を検討
+4. **拡張**: リトライやエラー通知を追加
 
-## Questions?
+## 疑問点がある場合
 
-See `IMPLEMENTATION_VIDEO_ARCHITECTURE.md` for full documentation including:
+詳細な情報は `IMPLEMENTATION_VIDEO_ARCHITECTURE.md` を参照。
 
-- Detailed API specifications
-- Environment configuration
-- Testing strategies
-- Future enhancements
+- API仕様
+- 環境変数
+- テスト戦略
+- 将来の拡張案

--- a/docs/mobile/share-and-links.md
+++ b/docs/mobile/share-and-links.md
@@ -1,189 +1,190 @@
-# Share Functionality with Universal Links / App Links
+# 共有機能（ユニバーサルリンク / アプリリンク対応）
 
-This document describes the implementation of the Share functionality with Universal Links (iOS) and App Links (Android) support for the nanitabeyo food app.
+このドキュメントでは、nanitabeyo フードアプリの共有機能における iOS のユニバーサルリンクと Android のアプリリンク実装について説明する。
 
-## Overview
+## 概要
 
-The share functionality allows users to share content from the app with URLs that:
+共有機能は以下を満たすURLを生成する。
 
-- Open in web browsers as a fallback
-- Open in the app when it's installed on the device (via Universal Links/App Links)
-- Support all platforms: iOS, Android, and Web
+- Webブラウザで開いた場合はフォールバック表示
+- 対応アプリがインストールされている端末ではアプリを起動（ユニバーサルリンク／アプリリンク）
+- iOS、Android、Webの全プラットフォームをサポート
 
-## Implementation
+## 実装
 
-### 1. Core Share Functionality
+### 1. 共有機能のコア処理
 
-**File**: `app-expo/lib/share.ts`
+**ファイル**: `app-expo/lib/share.ts`
 
-- `generateShareUrl(pathname)`: Generates shareable URLs based on current pathname
-- `handleShare(url, title, onSuccess, onError)`: Platform-specific sharing logic
-  - **Web**: Uses Web Share API if available, falls back to clipboard
-  - **iOS/Android**: Uses native sharing, falls back to clipboard
+- `generateShareUrl(pathname)`: 現在のパスから共有URLを生成
+- `handleShare(url, title, onSuccess, onError)`: プラットフォーム別の共有処理
+  - **Web**: Web Share API を優先し、未対応ブラウザではクリップボードにコピー
+  - **iOS/Android**: ネイティブ共有ダイアログを使用し、失敗時はクリップボードにコピー
 
-### 2. Environment Variables
+### 2. 環境変数
 
-Add these environment variables to your deployment:
+デプロイ時に以下の環境変数を設定。
 
 ```bash
 EXPO_PUBLIC_WEB_BASE_URL=https://your-domain.com
 ```
 
-**Files updated**:
+**更新したファイル:**
 
-- `app-expo/app.config.ts`: Added environment variables to `extra` section
-- `app-expo/constants/Env.ts`: Added `WEB_BASE_URL` and `LINK_HOST` constants
+- `app-expo/app.config.ts`: `extra` セクションに環境変数を追加
+- `app-expo/constants/Env.ts`: `WEB_BASE_URL` と `LINK_HOST` を追加
 
-### 3. App Configuration
+### 3. アプリ設定
 
-**File**: `app-expo/app.config.ts`
+**ファイル**: `app-expo/app.config.ts`
 
-**Changes**:
+**変更点:**
 
-- `scheme`: Changed from "myapp" to "nanitabeyo"
-- `ios.associatedDomains`: Added for Universal Links
-- `android.intentFilters`: Added for App Links
+- `scheme` を `"myapp"` から `"nanitabeyo"` に変更
+- `ios.associatedDomains` にユニバーサルリンク設定を追加
+- `android.intentFilters` にアプリリンク設定を追加
 
-### 4. Universal Links / App Links Files
+### 4. ユニバーサルリンク / アプリリンク用ファイル
 
-**iOS Universal Links**:
+**iOS（ユニバーサルリンク）:**
 
-- **File**: `app-expo/public/apple-app-site-association`
-- **Deployment**: Must be served at `https://your-domain.com/apple-app-site-association`
+- **ファイル**: `app-expo/public/apple-app-site-association`
+- **配置**: `https://your-domain.com/apple-app-site-association` で公開
 - **Content-Type**: `application/json`
-- **Note**: Replace `TEAMID.com.nanitabeyo` with your actual Team ID + Bundle ID
+- **注意**: `TEAMID.com.nanitabeyo` を実際のチームID＋Bundle IDに置き換える
 
-**Android App Links**:
+**Android（アプリリンク）:**
 
-- **File**: `app-expo/public/.well-known/assetlinks.json`
-- **Deployment**: Must be served at `https://your-domain.com/.well-known/assetlinks.json`
-- **Note**: Replace the SHA256 fingerprint with your app's actual certificate fingerprint
+- **ファイル**: `app-expo/public/.well-known/assetlinks.json`
+- **配置**: `https://your-domain.com/.well-known/assetlinks.json`
+- **注意**: SHA256フィンガープリントを実アプリの証明書に置き換える
 
-### 5. FoodContentScreen Integration
+### 5. FoodContentScreen への組み込み
 
-**File**: `app-expo/components/FoodContentScreen.tsx`
+**ファイル**: `app-expo/components/FoodContentScreen.tsx`
 
-**Changes**:
+**変更内容:**
 
-- Added imports for share functionality
-- Added `handleSharePress()` function with comprehensive logging
-- Connected Share button to the new handler
-- Added pathname detection using `usePathname()`
+- 共有機能のインポートを追加
+- 共有ボタン用の `handleSharePress()` と詳細ログを追加
+- Shareボタンから新しいハンドラーを呼び出すように更新
+- `usePathname()` を用いてパスを取得
 
-### 6. Translations
+### 6. 翻訳
 
-**Files**: `app-expo/locales/en-US.json`, `app-expo/locales/ja-JP.json`
+**ファイル**: `app-expo/locales/en-US.json`, `app-expo/locales/ja-JP.json`
 
-Added `FoodContentScreen.share.title` for share dialog titles.
+`FoodContentScreen.share.title` を追加（共有ダイアログのタイトルに使用）。
 
-## Setup Instructions
+## セットアップ手順
 
-### 1. Environment Variables
+### 1. 環境変数
 
-Set these in your deployment environment:
+環境ごとに以下を設定。
 
 ```bash
-# Example for production
+# 本番
 EXPO_PUBLIC_WEB_BASE_URL=https://nanitabeyo.com
 
-# Example for staging
+# ステージング
 EXPO_PUBLIC_WEB_BASE_URL=https://staging.nanitabeyo.com
 ```
 
-### 2. Deploy Universal Links / App Links Files
+### 2. ユニバーサルリンク / アプリリンクファイルの配信
 
-Deploy the following files to your web server:
+以下のファイルをWebサーバーに配置。
 
 - `apple-app-site-association` → `https://your-domain.com/apple-app-site-association`
 - `assetlinks.json` → `https://your-domain.com/.well-known/assetlinks.json`
 
-**Important**:
+**重要事項:**
 
-- Serve `apple-app-site-association` with `Content-Type: application/json`
-- No file extension for the AASA file
-- Update the Team ID and SHA256 fingerprints with your actual values
+- `apple-app-site-association` は `application/json` で配信
+- AASAファイルに拡張子は不要
+- Team IDやSHA256フィンガープリントを実際の値に置き換える
 
-### 3. Update Certificate Information
+### 3. 証明書情報の更新
 
-**For iOS (AASA file)**:
-Replace `TEAMID` in `apple-app-site-association` with your Apple Developer Team ID.
+**iOS（AASAファイル）:**
+`apple-app-site-association` 内の `TEAMID` を自社のApple Developer Team IDに置き換える。
 
-**For Android (assetlinks.json)**:
-Replace the SHA256 fingerprint with your app's certificate fingerprint:
+**Android（assetlinks.json）:**
+アプリの証明書フィンガープリントを設定。
 
 ```bash
-# Get SHA256 fingerprint for debug build
+# デバッグビルドのSHA256フィンガープリント取得
 keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
 
-# Get SHA256 fingerprint for release build
+# リリースビルドのSHA256フィンガープリント取得
 keytool -list -v -keystore /path/to/your/release.keystore -alias your-alias
 ```
 
-## Verification
+## 検証方法
 
-### iOS Universal Links
+### iOS ユニバーサルリンク
 
-1. **AASA Validator**: Use Apple's validator (search for "Apple App Site Association validator")
-2. **Device Testing**:
-   - Install the app on a physical device
-   - Open Safari and navigate to `https://your-domain.com/en/spot/123`
-   - Should show an app banner or automatically open the app
+1. **AASAバリデータ**: Appleが提供するバリデータを使用
+2. **実機テスト**:
+   - 端末にアプリをインストール
+   - Safariで `https://your-domain.com/en/spot/123` を開く
+   - アプリバナーが表示されるか、直接アプリが起動することを確認
 
-### Android App Links
+### Android アプリリンク
 
-1. **Google Validator**: Use [Google's Digital Asset Links validator](https://developers.google.com/digital-asset-links/tools/generator)
-2. **adb Testing**:
+1. **Googleバリデータ**: [Digital Asset Links ツール](https://developers.google.com/digital-asset-links/tools/generator)
+2. **adbテスト**:
+
    ```bash
    adb shell pm verify-app-links com.nanitabeyo
    ```
 
-### Web Testing
+### Webテスト
 
-1. **Chrome/Edge**: Should show native share dialog
-2. **Firefox/Safari**: Should copy to clipboard with notification
+1. **Chrome/Edge**: ネイティブの共有ダイアログが表示されることを確認
+2. **Firefox/Safari**: 共有内容がクリップボードにコピーされ、通知が表示されることを確認
 
-## Troubleshooting
+## トラブルシューティング
 
-### Universal Links Not Working
+### ユニバーサルリンクが動作しない
 
-1. **AASA file issues**:
-   - Ensure it's served with `Content-Type: application/json`
-   - No redirects in the URL path
-   - Check Team ID and Bundle ID are correct
+1. **AASAファイルの問題**:
+   - `Content-Type` が `application/json` になっているか
+   - リダイレクトが挟まっていないか
+   - Team ID / Bundle ID が正しいか
 
-2. **Caching**: Apple caches AASA files aggressively
-   - Wait several hours after deployment
-   - Or deploy to a new path and update the domain
+2. **キャッシュ**: Apple はAASAファイルを長期間キャッシュする
+   - 反映まで数時間待つ
+   - ドメインを変える、またはパスを変更する方法も検討
 
-### App Links Not Working
+### アプリリンクが動作しない
 
-1. **Digital Asset Links issues**:
-   - Verify SHA256 fingerprint is correct
-   - Check package name matches exactly
-   - Ensure assetlinks.json is properly formatted
+1. **Digital Asset Links の問題**:
+   - SHA256フィンガープリントが正しいか
+   - パッケージ名が完全一致しているか
+   - `assetlinks.json` のフォーマットが正しいか
 
-2. **Intent Filter issues**:
-   - Verify the host matches your domain exactly
-   - Check autoVerify is set to true
+2. **インテントフィルターの問題**:
+   - `host` がドメインと一致しているか
+   - `autoVerify` が true になっているか
 
-### Share Functionality Issues
+### 共有機能の問題
 
-1. **URL generation**:
-   - Check environment variables are set correctly
-   - Verify pathname is being captured correctly
+1. **URL生成**:
+   - 環境変数が正しく設定されているか
+   - `pathname` が期待通りに取得できているか
 
-2. **Platform-specific**:
-   - iOS/Android: Ensure expo-sharing is properly installed
-   - Web: Check browser support for Web Share API
+2. **プラットフォーム別の注意点**:
+   - iOS/Android: `expo-sharing` が正しくインストールされているか
+   - Web: ブラウザが Web Share API に対応しているか
 
-## Supported URL Patterns
+## サポートしているURLパターン
 
-The current implementation supports these URL patterns:
+現状は以下のパターンに対応。
 
-- `/[locale]/spot/[id]` - Individual dish/spot pages
-- `/[locale]/restaurant/[id]` - Restaurant pages
-- `/[locale]/profile/[id]` - User profile pages
-- `/[locale]/topic/[id]` - Topic pages
-- `/` - Root page
+- `/[locale]/spot/[id]` — 個別スポットページ
+- `/[locale]/restaurant/[id]` — レストランページ
+- `/[locale]/profile/[id]` — ユーザープロフィール
+- `/[locale]/topic/[id]` — トピックページ
+- `/` — ルートページ
 
-Add more patterns to the AASA and assetlinks.json files as needed.
+必要に応じてAASA／assetlinks.jsonにパターンを追加する。

--- a/docs/mobile/store-redirect.md
+++ b/docs/mobile/store-redirect.md
@@ -1,39 +1,37 @@
-# Store Smart Link `/store`
+# ストア誘導用スマートリンク `/store`
 
-This document describes the smart link route that funnels users to the
-appropriate destination when visiting `https://food-scroll.web.app/store`.
+このドキュメントでは、`https://food-scroll.web.app/store` にアクセスしたユーザーを適切な遷移先へ誘導するスマートリンクルートについて説明する。
 
-## Behaviour
+## 挙動
 
-| Platform                            | Result                                                                                                      |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **iOS/Android (app installed)**     | Attempts to open the app via Universal/App Links. When rendered in the app it immediately navigates to `/`. |
-| **iOS/Android (app not installed)** | After trying to open the app, redirects to the App Store or Google Play after ~800 ms.                      |
-| **Desktop browsers**                | Redirects to `https://food-scroll.web.app/`.                                                                |
+| プラットフォーム                     | 結果                                       |
+| ------------------------------------ | ------------------------------------------ |
+| **iOS/Android（アプリインストール済）** | ユニバーサルリンク／アプリリンクでアプリを開き、アプリ内では即座に `/` に遷移 |
+| **iOS/Android（アプリ未インストール）** | アプリ起動を試みた後、約800ms後に App Store または Google Play へリダイレクト |
+| **デスクトップブラウザ**              | `https://food-scroll.web.app/` へリダイレクト |
 
-The implementation also tries the custom scheme `nanitabeyo:/` on iOS as a
-fallback.
+iOSではフォールバックとしてカスタムスキーム `nanitabeyo:/` も試行する。
 
-## Verification Steps
+## 検証手順
 
-1. **Mobile with app installed**
-   - Open `https://food-scroll.web.app/store` from a message or browser.
-   - The app should launch and display the home screen (`/`).
-2. **Mobile without app installed**
-   - Open the same URL.
-   - After a short pause you should be redirected to the respective store.
-3. **Desktop**
-   - Open the URL in a desktop browser.
-   - You should immediately be redirected to `https://food-scroll.web.app/`.
+1. **アプリがインストールされたモバイル端末**
+   - `https://food-scroll.web.app/store` をメッセージやブラウザから開く
+   - アプリが起動し、ホーム画面（`/`）が表示されることを確認
 
-## Configuration
+2. **アプリ未インストールのモバイル端末**
+   - 同じURLを開く
+   - 短い待機の後、各ストアへリダイレクトされることを確認
 
-The following environment variables are used:
+3. **デスクトップブラウザ**
+   - デスクトップでURLを開く
+   - 即座に `https://food-scroll.web.app/` へリダイレクトされることを確認
+
+## 設定
+
+以下の環境変数を使用する。
 
 - `EXPO_PUBLIC_WEB_BASE_URL`
 - `EXPO_PUBLIC_APP_STORE_URL`
 - `EXPO_PUBLIC_PLAY_STORE_URL`
 
-Universal Links (iOS) and App Links (Android) must also be configured for the
-`food-scroll.web.app` domain. A custom scheme `nanitabeyo` is used as a fallback
-on iOS.
+ユニバーサルリンク（iOS）とアプリリンク（Android）は `food-scroll.web.app` ドメインで設定する。iOS向けには `nanitabeyo` カスタムスキームをフォールバックとして利用する。


### PR DESCRIPTION
## Summary
- translate documentation under `docs/` from English to Japanese so content matches project language
- update mobile documentation pages (`share-and-links`, `store-redirect`) to Japanese for consistency

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68fa4fd90944832bb14e994c4f8e28b7