### PR TITLE
Align ReviewForm media error dialog with AuthCallback design

### DIFF
--- a/app-expo/features/map/components/ReviewForm.tsx
+++ b/app-expo/features/map/components/ReviewForm.tsx
@@ -527,24 +527,24 @@ export function ReviewForm({
 	}, [onCancel]);
 
 	// Error state
-        if (mediaState.status === "error") {
-                return (
-                        <View style={styles.centeredContainer}>
-                                <Card style={styles.errorCard}>
-                                        <Text style={styles.errorTitle}>{i18n.t("Map.media.mediaSelectionFailed")}</Text>
-                                        <Text style={styles.errorMessage}>{mediaState.error}</Text>
-                                        <View style={styles.errorButtons}>
-                                                <TouchableOpacity style={styles.secondaryButton} onPress={handleCancel}>
-                                                        <Text style={styles.secondaryButtonText}>{i18n.t("Common.close")}</Text>
-                                                </TouchableOpacity>
-                                                <TouchableOpacity style={styles.primaryButton} onPress={handleRetry}>
-                                                        <Text style={styles.primaryButtonText}>{i18n.t("Common.retry")}</Text>
-                                                </TouchableOpacity>
-                                        </View>
-                                </Card>
-                        </View>
-                );
-        }
+	if (mediaState.status === "error") {
+		return (
+			<View style={styles.centeredContainer}>
+				<Card style={styles.errorCard}>
+					<Text style={styles.errorTitle}>{i18n.t("Map.media.mediaSelectionFailed")}</Text>
+					<Text style={styles.errorMessage}>{mediaState.error}</Text>
+					<View style={styles.errorButtons}>
+						<TouchableOpacity style={styles.secondaryButton} onPress={handleCancel}>
+							<Text style={styles.secondaryButtonText}>{i18n.t("Common.close")}</Text>
+						</TouchableOpacity>
+						<TouchableOpacity style={styles.primaryButton} onPress={handleRetry}>
+							<Text style={styles.primaryButtonText}>{i18n.t("Common.retry")}</Text>
+						</TouchableOpacity>
+					</View>
+				</Card>
+			</View>
+		);
+	}
 
 	return (
 		<SafeAreaView edges={["top"]}>
@@ -665,14 +665,13 @@ export function ReviewForm({
 }
 
 const styles = StyleSheet.create({
-        centeredContainer: {
-                flex: 1,
-                justifyContent: "center",
-                alignItems: "center",
-                backgroundColor: "#FFFFFF",
-                paddingHorizontal: 24,
-                minHeight: 400,
-        },
+	centeredContainer: {
+		flex: 1,
+		justifyContent: "center",
+		alignItems: "center",
+		paddingHorizontal: 24,
+		minHeight: 400,
+	},
 	loadingContainer: {
 		flex: 1,
 		justifyContent: "center",
@@ -683,52 +682,52 @@ const styles = StyleSheet.create({
 		fontSize: 16,
 		color: "#666",
 	},
-        errorCard: {
-                padding: 24,
-                width: "100%",
-        },
-        errorTitle: {
-                fontSize: 20,
-                fontWeight: "700",
-                color: "#1A1A1A",
-                marginBottom: 12,
-                textAlign: "center",
-        },
-        errorMessage: {
-                fontSize: 16,
-                color: "#6B7280",
-                lineHeight: 24,
-                marginBottom: 24,
-                textAlign: "center",
-        },
-        errorButtons: {
-                flexDirection: "row",
-                gap: 12,
-        },
-        primaryButton: {
-                flex: 1,
-                backgroundColor: "#5EA2FF",
-                paddingVertical: 14,
-                borderRadius: 12,
-                alignItems: "center",
-        },
-        primaryButtonText: {
-                fontSize: 16,
-                fontWeight: "600",
-                color: "#FFFFFF",
-        },
-        secondaryButton: {
-                flex: 1,
-                backgroundColor: "#F3F4F6",
-                paddingVertical: 14,
-                borderRadius: 12,
-                alignItems: "center",
-        },
-        secondaryButtonText: {
-                fontSize: 16,
-                fontWeight: "600",
-                color: "#6B7280",
-        },
+	errorCard: {
+		padding: 24,
+		width: "100%",
+	},
+	errorTitle: {
+		fontSize: 20,
+		fontWeight: "700",
+		color: "#1A1A1A",
+		marginBottom: 12,
+		textAlign: "center",
+	},
+	errorMessage: {
+		fontSize: 16,
+		color: "#6B7280",
+		lineHeight: 24,
+		marginBottom: 24,
+		textAlign: "center",
+	},
+	errorButtons: {
+		flexDirection: "row",
+		gap: 12,
+	},
+	primaryButton: {
+		flex: 1,
+		backgroundColor: "#5EA2FF",
+		paddingVertical: 14,
+		borderRadius: 12,
+		alignItems: "center",
+	},
+	primaryButtonText: {
+		fontSize: 16,
+		fontWeight: "600",
+		color: "#FFFFFF",
+	},
+	secondaryButton: {
+		flex: 1,
+		backgroundColor: "#F3F4F6",
+		paddingVertical: 14,
+		borderRadius: 12,
+		alignItems: "center",
+	},
+	secondaryButtonText: {
+		fontSize: 16,
+		fontWeight: "600",
+		color: "#6B7280",
+	},
 	inputLabel: {
 		fontSize: 16,
 		fontWeight: "600",


### PR DESCRIPTION
**タイトル**
ReviewForm のメディア選択エラー UI を AuthCallbackScreen のダイアログデザインに揃える

---

## 背景 / 課題

`ReviewForm` コンポーネント（レビュー投稿モーダル内）で、メディア選択に失敗した場合の UI は現在以下のような構成になっている。

```tsx
if (mediaState.status === "error") {
  return (
    <View style={styles.centeredContainer}>
      <Card style={styles.errorCard}>
        <Text style={styles.errorTitle}>{i18n.t("Map.media.mediaSelectionFailed")}</Text>
        <Text style={styles.errorMessage}>{mediaState.error}</Text>
        <View style={styles.errorButtons}>
          <PrimaryButton ... /> // 再試行
          <PrimaryButton ... /> // 閉じる
        </View>
      </Card>
    </View>
  );
}
```

一方、OAuth 認証コールバック画面 `AuthCallbackScreen` では、`useBlurModal` + `Card` + プライマリ / セカンダリボタンを使った、以下のようなダイアログデザインで警告を表示している。

* タイトル：`dialogTitle`
* メッセージ：`dialogMessage`
* ボタンレイアウト：`dialogButtons`
* プライマリボタン：青 (#5EA2FF) / 白字 / 太字
* セカンダリボタン：グレー背景 / グレー文字

現状、**ReviewForm のエラー UI だけトーン & マナーが異なっており、ダイアログ系 UI の一貫性がない**状態。

---

## ゴール

* `ReviewForm` の **メディア選択エラー UI（`mediaState.status === "error"`）を、`AuthCallbackScreen` のダイアログデザインに揃える**。
* ユーザー視点で、アラート / ダイアログの見た目・ボタン配置・色が統一され、迷いなく操作できる状態にする。

---

## 対象ファイル

* エラー UI を変更するコンポーネント

  * `ReviewForm`

    * （例）`app-expo/features/map/components/ReviewForm.tsx`
* 参照デザイン元コンポーネント

  * `AuthCallbackScreen`

    * `app-expo/.../AuthCallbackScreen`（auth/callback 画面）

---

## 仕様

### 1. レイアウト / コンポーネント構造

`mediaState.status === "error"` の返却 UI を、以下のような構造に揃える。

* `View`（画面中央寄せ / 白背景）

  * `Card`

    * タイトル（見出し）
    * メッセージ（説明文）
    * ボタン横並び（プライマリ / セカンダリ）

AuthCallbackScreen のスタイルと同等のレイアウトにする。

### 2. 文言・テキスト

* タイトル

  * 現行：`i18n.t("Map.media.mediaSelectionFailed")`
  * 継続利用して OK（必要に応じて文言調整可）
* メッセージ

  * 現行：`mediaState.error`（Map.media.* の i18n を使っている）
  * そのまま利用。スタイルのみ AuthCallbackScreen に合わせる。

### 3. ボタン仕様

#### 配置

* 横並び（flexDirection: "row"）
* 左：セカンダリ（「閉じる」）
* 右：プライマリ（「再試行」）

#### ラベル

* プライマリボタン（右）

  * ラベル：`i18n.t("Common.retry")`
  * onPress：`handleRetry`
* セカンダリボタン（左）

  * ラベル：`i18n.t("Common.close")`
  * onPress：`handleCancel`

#### ビジュアル

AuthCallbackScreen のダイアログボタンと同じテイストにする。

* プライマリ（右）

  * 背景色：`#5EA2FF`
  * 文字色：`#FFFFFF`
  * フォント：16, fontWeight: "600"
  * paddingVertical: ~14
  * borderRadius: 12
* セカンダリ（左）

  * 背景色：`#F3F4F6`
  * 文字色：`#6B7280`
  * フォント：16, fontWeight: "600"
  * paddingVertical: ~14
  * borderRadius: 12

実装詳細としては、下記いずれかの方針：

* A. `PrimaryButton` を使わず、AuthCallbackScreen と同じく `TouchableOpacity` + StyleSheet でボタンを定義する
* B. `PrimaryButton` コンポーネントの props でスタイルを完全に上書きして、AuthCallbackScreen と同等の見た目に寄せる

どちらか、既存のデザインシステムに合わせて選択。

### 4. スタイル（テキスト）

ReviewForm 側の `errorTitle` / `errorMessage` を、AuthCallbackScreen の `dialogTitle` / `dialogMessage` をベースに調整。

* タイトル（errorTitle）

  * fontSize: 20
  * fontWeight: "700"
  * color: "#1A1A1A"
  * marginBottom: 12
  * textAlign: "center"
* メッセージ（errorMessage）

  * fontSize: 16
  * color: "#6B7280"
  * lineHeight: 24
  * marginBottom: 24
  * textAlign: "center"

### 5. コンテナ

`styles.centeredContainer` も AuthCallbackScreen に近づける。

* flex: 1
* justifyContent: "center"
* alignItems: "center"
* backgroundColor: "#FFFFFF"
* paddingHorizontal: 24
* minHeight: 400 は残しても OK（モーダルレイアウト次第）

---

## 実装タスク（ToDo）

1. `ReviewForm` の `mediaState.status === "error"` 分岐部の JSX を、AuthCallbackScreen のダイアログ構造を参考にリファクタリングする。
2. `styles.errorCard` / `errorTitle` / `errorMessage` / `errorButtons` を、AuthCallbackScreen の `Card` / `dialogTitle` / `dialogMessage` / `dialogButtons` に揃えて修正。
3. ボタンスタイルを AuthCallbackScreen の `primaryButton` / `secondaryButton` と同等にする。
4. 必要に応じて、新しい `styles.primaryButton` / `styles.primaryButtonText` / `styles.secondaryButton` / `styles.secondaryButtonText` を ReviewForm に追加。
5. 既存の挙動（再試行・キャンセルのロジック）は変えずに、UI のみ差し替える。

---

## 受け入れ条件

1. メディア選択時に権限拒否 / キャンセル / その他エラーを発生させ、`mediaState.status === "error"` になると、
   **AuthCallbackScreen と同じトーンのダイアログ UI** で表示されること。
2. 「再試行」をタップすると、従来通りメディア再選択フロー (`handleRetry`) が走ること。
3. 「閉じる」をタップすると、従来通り `onCancel()` が呼ばれ、レビュー投稿モーダルが閉じること。
4. 既存の i18n キー（`Map.media.*` / `Common.retry` / `Common.close`）は変更せず利用されていること。
5. AuthCallbackScreen のダイアログと比較して、フォントサイズ / 色 / ボタン配置が視覚的に揃っていること。



------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b2d5bc960832ba37abcc1775b9fc3)