### PR TITLE
Add localized video unavailable error message

### DIFF
--- a/app-expo/features/dishMedia/components/DishMediaContent.tsx
+++ b/app-expo/features/dishMedia/components/DishMediaContent.tsx
@@ -112,11 +112,13 @@ export default function DishMediaContent({
 						</View>
 					)}
 					{/* #511 【設計】エラーオーバーレイ */}
-					{showErrorOverlay && (
-						<View style={styles.errorOverlay}>
-							<Text style={styles.errorText}>{i18n.t("Common.error")}</Text>
-						</View>
-					)}
+                                        {showErrorOverlay && (
+                                                <View style={styles.errorOverlay}>
+                                                        <Text style={styles.errorText}>
+                                                                {i18n.t("DishMediaContent.errors.videoUnavailable")}
+                                                        </Text>
+                                                </View>
+                                        )}
 				</>
 			) : (
 				<Image

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -176,10 +176,11 @@
 		"info": {
 			"walkFromShibuya": "على بُعد 13 دقيقة سيرًا من محطة شيبويا"
 		},
-		"errors": {
-			"mapOpenFailed": "تعذر فتح تطبيق الخرائط"
-		}
-	},
+                "errors": {
+                        "mapOpenFailed": "تعذر فتح تطبيق الخرائط",
+                        "videoUnavailable": "هذا الفيديو غير متاح حالياً."
+                }
+        },
 	"ImageCardGrid": {
 		"openItemDetails": "فتح تفاصيل العنصر"
 	},

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -173,9 +173,10 @@
 		"buttons": {
 			"viewRestaurant": "View restaurant"
 		},
-		"errors": {
-			"mapOpenFailed": "Could not open map application"
-		},
+  "errors": {
+    "mapOpenFailed": "Could not open map application",
+    "videoUnavailable": "This video is currently unavailable."
+  },
 		"info": {
 			"walkFromShibuya": "13 min walk from Shibuya Station"
 		}

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -173,9 +173,10 @@
 		"buttons": {
 			"viewRestaurant": "Ver restaurante"
 		},
-		"errors": {
-			"mapOpenFailed": "No se pudo abrir la aplicación de mapas"
-		},
+                "errors": {
+                        "mapOpenFailed": "No se pudo abrir la aplicación de mapas",
+                        "videoUnavailable": "Este video no está disponible actualmente."
+                },
 		"info": {
 			"walkFromShibuya": "A 13 min a pie de la estación de Shibuya"
 		}

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -173,9 +173,10 @@
 		"buttons": {
 			"viewRestaurant": "Voir le restaurant"
 		},
-		"errors": {
-			"mapOpenFailed": "Impossible d'ouvrir l'application de carte"
-		},
+                "errors": {
+                        "mapOpenFailed": "Impossible d'ouvrir l'application de carte",
+                        "videoUnavailable": "Cette vidéo n'est actuellement pas disponible."
+                },
 		"info": {
 			"walkFromShibuya": "À 13 min à pied de la gare de Shibuya"
 		}

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -173,13 +173,14 @@
 		"buttons": {
 			"viewRestaurant": "रेस्टोरेंट देखें"
 		},
-		"info": {
-			"walkFromShibuya": "शिबुया स्टेशन से 13 मिनट की पैदल दूरी"
-		},
-		"errors": {
-			"mapOpenFailed": "मानचित्र ऐप नहीं खोल सका"
-		}
-	},
+                "info": {
+                        "walkFromShibuya": "शिबुया स्टेशन से 13 मिनट की पैदल दूरी"
+                },
+                "errors": {
+                        "mapOpenFailed": "मानचित्र ऐप नहीं खोल सका",
+                        "videoUnavailable": "यह वीडियो अभी उपलब्ध नहीं है।"
+                }
+        },
 	"ImageCardGrid": {
 		"openItemDetails": "आइटम विवरण खोलें"
 	},

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -173,9 +173,10 @@
 		"buttons": {
 			"viewRestaurant": "店を見る"
 		},
-		"errors": {
-			"mapOpenFailed": "地図アプリを開けませんでした"
-		},
+  "errors": {
+    "mapOpenFailed": "地図アプリを開けませんでした",
+    "videoUnavailable": "この動画は現在ご利用いただけません。"
+  },
 		"info": {
 			"walkFromShibuya": "渋谷駅から徒歩13分"
 		}

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -173,13 +173,14 @@
 		"buttons": {
 			"viewRestaurant": "가게 보기"
 		},
-		"info": {
-			"walkFromShibuya": "시부야역에서 도보 13분"
-		},
-		"errors": {
-			"mapOpenFailed": "지도 앱을 열 수 없습니다"
-		}
-	},
+                "info": {
+                        "walkFromShibuya": "시부야역에서 도보 13분"
+                },
+                "errors": {
+                        "mapOpenFailed": "지도 앱을 열 수 없습니다",
+                        "videoUnavailable": "이 동영상은 현재 이용하실 수 없습니다."
+                }
+        },
 	"ImageCardGrid": {
 		"openItemDetails": "항목 세부정보 열기"
 	},

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -173,9 +173,10 @@
 		"buttons": {
 			"viewRestaurant": "查看餐厅"
 		},
-		"errors": {
-			"mapOpenFailed": "无法打开地图应用"
-		},
+                "errors": {
+                        "mapOpenFailed": "无法打开地图应用",
+                        "videoUnavailable": "该视频当前不可用。"
+                },
 		"info": {
 			"walkFromShibuya": "距离涩谷站步行13分钟"
 		}


### PR DESCRIPTION
## Summary
- replace the DishMediaContent video error overlay with the new videoUnavailable i18n key
- add DishMediaContent.errors.videoUnavailable translations across all locale files

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e4172e324832b9662de2ed071123e)