### PR TITLE
Fix Card background contrast in dark mode

### DIFF
--- a/app-expo/components/Card.tsx
+++ b/app-expo/components/Card.tsx
@@ -32,8 +32,9 @@ export const Card = forwardRef<View, CardProps>(
 		ref,
 	) => {
 		/** ----- Theme-aware background ----- */
-		const colorScheme = useColorScheme();
-		const bgColor = colorScheme === "dark" ? "#1E1E1E" : "#FFFFFF";
+                const colorScheme = useColorScheme();
+                // Use a light surface even in dark mode to keep dark text readable inside cards
+                const bgColor = colorScheme === "dark" ? "#F7F3F2" : "#FFFFFF";
 
 		/** ----- Compose shadow style (iOS / Android / Web) ----- */
 		const shadowStyle: ViewStyle =


### PR DESCRIPTION
## Summary
- keep Card background light in dark mode so text remains legible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936a0fc7218832b89185bdcabf2a074)