### PR TITLE
#533 UI 表示する timeSlots と SearchParams に齟齬あり。修正

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/index.tsx
@@ -82,7 +82,6 @@ export default function SearchScreen() {
 			{ until: 5, slot: "late_night" },
 			{ until: 10, slot: "morning" },
 			{ until: 15, slot: "lunch" },
-			{ until: 17, slot: "afternoon" },
 			{ until: 22, slot: "dinner" },
 			{ until: 24, slot: "late_night" },
 		];

--- a/app-expo/types/search.ts
+++ b/app-expo/types/search.ts
@@ -1,7 +1,7 @@
 import type { DishMediaEntry, LocationDetailsResponse } from "@shared/api/v1/res";
 
 export type SearchParams = Omit<LocationDetailsResponse, "viewport"> & {
-	timeSlot: "morning" | "lunch" | "afternoon" | "dinner" | "late_night";
+	timeSlot: "morning" | "lunch" | "dinner" | "late_night";
 	scene: "solo" | "date" | "friends" | "family" | "drinking";
 	mood?: "light" | "normal" | "heavy";
 	taste?: "sweet" | "spicy" | "healthy" | "junk" | "alcohol";


### PR DESCRIPTION
60dbcd0d7f08cf9daa4ba5f52c0238ae6ad986de
の不具合を適応。
afternoon の時間になにも選択されなかった。