### PR TITLE
Add ReviewHeader component and replace duplicated headers in review screens

### DIFF
--- a/app-expo/app/[locale]/(tabs)/review/restaurant/[restaurantId].tsx
+++ b/app-expo/app/[locale]/(tabs)/review/restaurant/[restaurantId].tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { View, StyleSheet, ActivityIndicator, TouchableOpacity, Text } from "react-native";
+import { View, StyleSheet, ActivityIndicator, Text } from "react-native";
 import { useLocalSearchParams, router } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { ChevronLeft } from "lucide-react-native";
 import { SelectedRestaurantDetails } from "@/features/review/components/SelectedRestaurantDetails";
 import { useRestaurantStore, type RestaurantEntry } from "@/features/review/stores/useRestaurantStore";
 import { useAPICall } from "@/hooks/useAPICall";
@@ -11,6 +10,7 @@ import { useSnackbar } from "@/contexts/SnackbarProvider";
 import { useLogger } from "@/hooks/useLogger";
 import type { GetRestaurantByIdResponse } from "@shared/api/v1/res";
 import i18n from "@/lib/i18n";
+import { ReviewHeader } from "@/features/review/components/ReviewHeader";
 
 /*
  * レビュー投稿画面から遷移するレストラン詳細画面
@@ -91,18 +91,13 @@ export default function RestaurantDetailScreen() {
 	if (isLoading && !restaurant) {
 		return (
 			<SafeAreaView edges={["top"]} style={styles.container}>
-				<View style={styles.headerContainer}>
-					<TouchableOpacity
-						style={styles.backButton}
-						onPress={() => {
-							lightImpact();
-							router.back();
-						}}>
-						<ChevronLeft size={24} color="#1A1A1A" />
-					</TouchableOpacity>
-					<Text style={styles.headerTitle}>{i18n.t("Review.restaurantDetail.title")}</Text>
-					<View style={styles.headerRightSpacer} />
-				</View>
+				<ReviewHeader
+					title={i18n.t("Review.restaurantDetail.title")}
+					onPressBack={() => {
+						lightImpact();
+						router.back();
+					}}
+				/>
 				<View style={styles.loadingContainer}>
 					<ActivityIndicator size="large" color="#5EA2FF" />
 				</View>
@@ -114,18 +109,13 @@ export default function RestaurantDetailScreen() {
 	if (error && !restaurant) {
 		return (
 			<SafeAreaView edges={["top"]} style={styles.container}>
-				<View style={styles.headerContainer}>
-					<TouchableOpacity
-						style={styles.backButton}
-						onPress={() => {
-							lightImpact();
-							router.back();
-						}}>
-						<ChevronLeft size={24} color="#1A1A1A" />
-					</TouchableOpacity>
-					<Text style={styles.headerTitle}>{i18n.t("Review.restaurantDetail.title")}</Text>
-					<View style={styles.headerRightSpacer} />
-				</View>
+				<ReviewHeader
+					title={i18n.t("Review.restaurantDetail.title")}
+					onPressBack={() => {
+						lightImpact();
+						router.back();
+					}}
+				/>
 				<View style={styles.errorContainer}>
 					<Text style={styles.errorText}>{i18n.t("Common.errors.notFound")}</Text>
 				</View>
@@ -139,18 +129,13 @@ export default function RestaurantDetailScreen() {
 
 	return (
 		<SafeAreaView edges={["top"]} style={styles.container}>
-			<View style={styles.headerContainer}>
-				<TouchableOpacity
-					style={styles.backButton}
-					onPress={() => {
-						lightImpact();
-						router.back();
-					}}>
-					<ChevronLeft size={24} color="#1A1A1A" />
-				</TouchableOpacity>
-				<Text style={styles.headerTitle}>{i18n.t("Review.restaurantDetail.title")}</Text>
-				<View style={styles.headerRightSpacer} />
-			</View>
+			<ReviewHeader
+				title={i18n.t("Review.restaurantDetail.title")}
+				onPressBack={() => {
+					lightImpact();
+					router.back();
+				}}
+			/>
 
 			<SelectedRestaurantDetails restaurantEntry={restaurant} />
 		</SafeAreaView>
@@ -161,30 +146,6 @@ const styles = StyleSheet.create({
 	container: {
 		flex: 1,
 		backgroundColor: "#FFFFFF",
-	},
-	headerContainer: {
-		backgroundColor: "#FFFFFF",
-		paddingVertical: 16,
-		paddingHorizontal: 16,
-		borderBottomWidth: 1,
-		borderBottomColor: "#E5E7EB",
-		flexDirection: "row",
-		alignItems: "center",
-		justifyContent: "space-between",
-	},
-	backButton: {
-		padding: 4,
-		marginRight: 8,
-	},
-	headerTitle: {
-		fontSize: 18,
-		fontWeight: "700",
-		color: "#1A1A1A",
-		textAlign: "center",
-		flex: 1,
-	},
-	headerRightSpacer: {
-		width: 32,
 	},
 	loadingContainer: {
 		flex: 1,

--- a/app-expo/app/[locale]/(tabs)/review/restaurant/[restaurantId]/review-from-media/[dishMediaId].tsx
+++ b/app-expo/app/[locale]/(tabs)/review/restaurant/[restaurantId]/review-from-media/[dishMediaId].tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { View, StyleSheet, ActivityIndicator, TouchableOpacity, Text } from "react-native";
+import { View, StyleSheet, ActivityIndicator, Text } from "react-native";
 import { useLocalSearchParams, router } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { ChevronLeft } from "lucide-react-native";
 import { ReviewForm } from "@/features/map/components/ReviewForm";
 import { useRestaurantStore, type RestaurantEntry } from "@/features/review/stores/useRestaurantStore";
 import {
@@ -17,6 +16,7 @@ import { useLogger } from "@/hooks/useLogger";
 import type { GetRestaurantByIdResponse, QueryDishMediaByIdsResponse } from "@shared/api/v1/res";
 import i18n from "@/lib/i18n";
 import { QueryDishMediaByIdsDto } from "@shared/api/v1/dto";
+import { ReviewHeader } from "@/features/review/components/ReviewHeader";
 
 export default function ReviewFromMediaScreen() {
 	const { restaurantId, dishMediaId } = useLocalSearchParams<{ restaurantId: string; dishMediaId: string }>();
@@ -108,18 +108,13 @@ export default function ReviewFromMediaScreen() {
 	if (isLoading) {
 		return (
 			<SafeAreaView edges={["top"]} style={styles.container}>
-				<View style={styles.headerContainer}>
-					<TouchableOpacity
-						style={styles.backButton}
-						onPress={() => {
-							lightImpact();
-							router.back();
-						}}>
-						<ChevronLeft size={24} color="#1A1A1A" />
-					</TouchableOpacity>
-					<Text style={styles.headerTitle}>{i18n.t("Review.title")}</Text>
-					<View style={styles.headerRightSpacer} />
-				</View>
+				<ReviewHeader
+					title={i18n.t("Review.title")}
+					onPressBack={() => {
+						lightImpact();
+						router.back();
+					}}
+				/>
 				<View style={styles.loadingContainer}>
 					<ActivityIndicator size="large" color="#5EA2FF" />
 				</View>
@@ -131,18 +126,13 @@ export default function ReviewFromMediaScreen() {
 	if (error || !restaurantEntry || !dishMedia) {
 		return (
 			<SafeAreaView edges={["top"]} style={styles.container}>
-				<View style={styles.headerContainer}>
-					<TouchableOpacity
-						style={styles.backButton}
-						onPress={() => {
-							lightImpact();
-							router.back();
-						}}>
-						<ChevronLeft size={24} color="#1A1A1A" />
-					</TouchableOpacity>
-					<Text style={styles.headerTitle}>{i18n.t("Review.title")}</Text>
-					<View style={styles.headerRightSpacer} />
-				</View>
+				<ReviewHeader
+					title={i18n.t("Review.title")}
+					onPressBack={() => {
+						lightImpact();
+						router.back();
+					}}
+				/>
 				<View style={styles.errorContainer}>
 					<Text style={styles.errorText}>{i18n.t("Common.errors.notFound")}</Text>
 				</View>
@@ -152,20 +142,13 @@ export default function ReviewFromMediaScreen() {
 
 	return (
 		<SafeAreaView edges={["top", "bottom"]} style={styles.container}>
-			<View style={styles.headerContainer}>
-				<TouchableOpacity
-					style={styles.backButton}
-					onPress={() => {
-						lightImpact();
-						router.back();
-					}}>
-					<ChevronLeft size={24} color="#1A1A1A" />
-				</TouchableOpacity>
-				<Text style={styles.headerTitle} numberOfLines={1} ellipsizeMode="tail">
-					{restaurantEntry.restaurant.name}
-				</Text>
-				<View style={styles.headerRightSpacer} />
-			</View>
+			<ReviewHeader
+				title={restaurantEntry.restaurant.name}
+				onPressBack={() => {
+					lightImpact();
+					router.back();
+				}}
+			/>
 
 			{/* #644 【設計】ReviewForm を既存メディア利用モード（prefilledMedia）で表示 */}
 			<ReviewForm
@@ -181,30 +164,6 @@ const styles = StyleSheet.create({
 	container: {
 		flex: 1,
 		backgroundColor: "#FFFFFF",
-	},
-	headerContainer: {
-		backgroundColor: "#FFFFFF",
-		paddingVertical: 16,
-		paddingHorizontal: 16,
-		borderBottomWidth: 1,
-		borderBottomColor: "#E5E7EB",
-		flexDirection: "row",
-		alignItems: "center",
-		justifyContent: "space-between",
-	},
-	backButton: {
-		padding: 4,
-		marginRight: 8,
-	},
-	headerTitle: {
-		fontSize: 18,
-		fontWeight: "700",
-		color: "#1A1A1A",
-		textAlign: "center",
-		flex: 1,
-	},
-	headerRightSpacer: {
-		width: 32,
 	},
 	loadingContainer: {
 		flex: 1,

--- a/app-expo/app/[locale]/(tabs)/review/restaurant/[restaurantId]/review.tsx
+++ b/app-expo/app/[locale]/(tabs)/review/restaurant/[restaurantId]/review.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { View, StyleSheet, ActivityIndicator, TouchableOpacity, Text } from "react-native";
+import { View, StyleSheet, ActivityIndicator, Text } from "react-native";
 import { useLocalSearchParams, router } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { ChevronLeft } from "lucide-react-native";
 import { ReviewForm } from "@/features/map/components/ReviewForm";
 import { useRestaurantStore, type RestaurantEntry } from "@/features/review/stores/useRestaurantStore";
 import { useAPICall } from "@/hooks/useAPICall";
@@ -11,6 +10,7 @@ import { useSnackbar } from "@/contexts/SnackbarProvider";
 import { useLogger } from "@/hooks/useLogger";
 import type { GetRestaurantByIdResponse } from "@shared/api/v1/res";
 import i18n from "@/lib/i18n";
+import { ReviewHeader } from "@/features/review/components/ReviewHeader";
 
 export default function ReviewScreen() {
 	const { restaurantId } = useLocalSearchParams<{ restaurantId: string }>();
@@ -85,18 +85,13 @@ export default function ReviewScreen() {
 	if (isLoading && !restaurant) {
 		return (
 			<SafeAreaView edges={["top"]} style={styles.container}>
-				<View style={styles.headerContainer}>
-					<TouchableOpacity
-						style={styles.backButton}
-						onPress={() => {
-							lightImpact();
-							router.back();
-						}}>
-						<ChevronLeft size={24} color="#1A1A1A" />
-					</TouchableOpacity>
-					<Text style={styles.headerTitle}>{i18n.t("Review.title")}</Text>
-					<View style={styles.headerRightSpacer} />
-				</View>
+				<ReviewHeader
+					title={i18n.t("Review.title")}
+					onPressBack={() => {
+						lightImpact();
+						router.back();
+					}}
+				/>
 				<View style={styles.loadingContainer}>
 					<ActivityIndicator size="large" color="#5EA2FF" />
 				</View>
@@ -108,18 +103,13 @@ export default function ReviewScreen() {
 	if (error && !restaurant) {
 		return (
 			<SafeAreaView edges={["top"]} style={styles.container}>
-				<View style={styles.headerContainer}>
-					<TouchableOpacity
-						style={styles.backButton}
-						onPress={() => {
-							lightImpact();
-							router.back();
-						}}>
-						<ChevronLeft size={24} color="#1A1A1A" />
-					</TouchableOpacity>
-					<Text style={styles.headerTitle}>{i18n.t("Review.title")}</Text>
-					<View style={styles.headerRightSpacer} />
-				</View>
+				<ReviewHeader
+					title={i18n.t("Review.title")}
+					onPressBack={() => {
+						lightImpact();
+						router.back();
+					}}
+				/>
 				<View style={styles.errorContainer}>
 					<Text style={styles.errorText}>{i18n.t("Common.errors.notFound")}</Text>
 				</View>
@@ -133,18 +123,13 @@ export default function ReviewScreen() {
 
 	return (
 		<SafeAreaView edges={["top", "bottom"]} style={styles.container}>
-			<View style={styles.headerContainer}>
-				<TouchableOpacity
-					style={styles.backButton}
-					onPress={() => {
-						lightImpact();
-						router.back();
-					}}>
-					<ChevronLeft size={24} color="#1A1A1A" />
-				</TouchableOpacity>
-				<Text style={styles.headerTitle}>{i18n.t("Review.title")}</Text>
-				<View style={styles.headerRightSpacer} />
-			</View>
+			<ReviewHeader
+				title={i18n.t("Review.title")}
+				onPressBack={() => {
+					lightImpact();
+					router.back();
+				}}
+			/>
 
 			{/* #644 【設計】ReviewForm をメディア選択ありモードで表示 */}
 			<ReviewForm restaurant={restaurant.restaurant} onCancel={() => router.back()} />
@@ -156,30 +141,6 @@ const styles = StyleSheet.create({
 	container: {
 		flex: 1,
 		backgroundColor: "#FFFFFF",
-	},
-	headerContainer: {
-		backgroundColor: "#FFFFFF",
-		paddingVertical: 16,
-		paddingHorizontal: 16,
-		borderBottomWidth: 1,
-		borderBottomColor: "#E5E7EB",
-		flexDirection: "row",
-		alignItems: "center",
-		justifyContent: "space-between",
-	},
-	backButton: {
-		padding: 4,
-		marginRight: 8,
-	},
-	headerTitle: {
-		fontSize: 18,
-		fontWeight: "700",
-		color: "#1A1A1A",
-		textAlign: "center",
-		flex: 1,
-	},
-	headerRightSpacer: {
-		width: 32,
 	},
 	loadingContainer: {
 		flex: 1,

--- a/app-expo/app/[locale]/(tabs)/review/selectRestaurant.tsx
+++ b/app-expo/app/[locale]/(tabs)/review/selectRestaurant.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
-import { View, StyleSheet, TouchableOpacity, ActivityIndicator, Text, Dimensions } from "react-native";
-import { Navigation, ChevronLeft, RotateCw } from "lucide-react-native";
+import { View, StyleSheet, TouchableOpacity, ActivityIndicator } from "react-native";
+import { Navigation, RotateCw } from "lucide-react-native";
 import MapView, { Region } from "@/components/MapView";
 import type { PoiClickEvent } from "react-native-maps";
 import { useLocationSearch } from "@/hooks/useLocationSearch";
@@ -26,6 +26,7 @@ import { SavedRestaurantsSheet, SavedRestaurantsSheetHandle } from "@/features/r
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { useRestaurantStore } from "@/features/review/stores/useRestaurantStore";
 import { useLocale } from "@/hooks/useLocale";
+import { ReviewHeader } from "@/features/review/components/ReviewHeader";
 
 type SavedRestaurant = QueryMeSavedRestaurantsResponse["data"][number];
 
@@ -354,18 +355,14 @@ export default function SelectRestaurantScreen() {
 		<MarkerBitmapRendererProvider>
 			<SafeAreaView edges={["top"]} style={styles.container}>
 				{/* #644 【設計】画面タイトル with 戻るボタン */}
-				<View style={styles.headerContainer}>
-					<TouchableOpacity
-						style={styles.backButton}
-						onPress={() => {
-							lightImpact();
-							router.back();
-						}}>
-						<ChevronLeft size={24} color="#1A1A1A" />
-					</TouchableOpacity>
-					<Text style={styles.headerTitle}>{i18n.t("Review.selectRestaurant.title")}</Text>
-					<View style={styles.headerRightSpacer} />
-				</View>
+				<ReviewHeader
+					title={i18n.t("Review.selectRestaurant.title")}
+					onPressBack={() => {
+						lightImpact();
+						router.back();
+					}}
+					containerStyle={styles.headerContainer}
+				/>
 
 				{/* Map */}
 				<MapView
@@ -458,20 +455,6 @@ const styles = StyleSheet.create({
 		flexDirection: "row",
 		alignItems: "center",
 		justifyContent: "space-between",
-	},
-	backButton: {
-		padding: 4,
-		marginRight: 8,
-	},
-	headerTitle: {
-		fontSize: 18,
-		fontWeight: "700",
-		color: "#1A1A1A",
-		textAlign: "center",
-		flex: 1,
-	},
-	headerRightSpacer: {
-		width: 32,
 	},
 	map: {
 		flex: 1,

--- a/app-expo/features/review/components/ReviewHeader.tsx
+++ b/app-expo/features/review/components/ReviewHeader.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import type { ReactNode } from "react";
+import { View, Text, TouchableOpacity, StyleSheet, type StyleProp, type TextStyle, type ViewStyle } from "react-native";
+import { ChevronLeft } from "lucide-react-native";
+
+export type ReviewHeaderProps = {
+	/** 表示するタイトル（i18n 済み文字列） */
+	title: string;
+	/** 戻るボタン押下時のハンドラ（画面側で router.back() や haptics を制御） */
+	onPressBack: () => void;
+	/** 右側に任意のコンテンツ（例: スキップボタン、閉じるアイコン）を挿入したい場合 */
+	rightContent?: ReactNode;
+	/** ヘッダー全体の追加スタイル（absolute で重ねたい画面などで使用） */
+	containerStyle?: StyleProp<ViewStyle>;
+	/** タイトルの追加スタイル（必要であれば） */
+	titleStyle?: StyleProp<TextStyle>;
+};
+
+export function ReviewHeader({
+	title,
+	onPressBack,
+	rightContent,
+	containerStyle,
+	titleStyle,
+}: ReviewHeaderProps) {
+	return (
+		<View style={[styles.container, containerStyle]}>
+			<TouchableOpacity
+				style={styles.backButton}
+				onPress={onPressBack}
+				accessibilityRole="button"
+				accessibilityLabel="戻る"
+				hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+				<ChevronLeft size={24} color="#1A1A1A" />
+			</TouchableOpacity>
+
+			<Text style={[styles.title, titleStyle]} numberOfLines={1} ellipsizeMode="tail">
+				{title}
+			</Text>
+
+			<View style={styles.rightContainer}>{rightContent ?? <View style={styles.rightSpacer} />}</View>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		backgroundColor: "#FFFFFF",
+		paddingVertical: 16,
+		paddingHorizontal: 16,
+		borderBottomWidth: 1,
+		borderBottomColor: "#E5E7EB",
+		zIndex: 100,
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "space-between",
+	},
+	backButton: {
+		padding: 4,
+		marginRight: 8,
+	},
+	title: {
+		fontSize: 18,
+		fontWeight: "700",
+		color: "#1A1A1A",
+		textAlign: "center",
+		flex: 1,
+	},
+	rightContainer: {
+		minWidth: 32,
+		alignItems: "flex-end",
+		justifyContent: "center",
+	},
+	rightSpacer: {
+		width: 32,
+	},
+});


### PR DESCRIPTION
### Motivation
- Consolidate duplicated header UI (back button + centered title + right spacer) used across review screens to reduce copy-paste and centralize style and accessibility fixes.
- Keep navigation/haptics logic in screens and make the header a presentational component to simplify future changes and maintain behavior.

### Description
- Add `ReviewHeader` component at `app-expo/features/review/components/ReviewHeader.tsx` with props `title`, `onPressBack`, optional `rightContent`, `containerStyle`, and `titleStyle` and accessibility defaults (`accessibilityRole`, `accessibilityLabel`, `hitSlop`).
- Replace duplicated header blocks in the four review screens `selectRestaurant.tsx`, `restaurant/[restaurantId].tsx`, `restaurant/[restaurantId]/review.tsx`, and `restaurant/[restaurantId]/review-from-media/[dishMediaId].tsx` with the new `ReviewHeader` usage.
- Move positioning responsibility to screens by allowing `containerStyle` (the `SelectRestaurant` screen continues to pass its absolute-positioned `styles.headerContainer`).
- Remove per-screen header style entries (back button, title, right spacer) where they were replaced by the shared component.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969386bbe34832b8e496e0c38ed6869)