### PR TITLE
Use context-specific processing messages and add localized keys

### DIFF
--- a/app-expo/app/[locale]/auth/callback.tsx
+++ b/app-expo/app/[locale]/auth/callback.tsx
@@ -135,7 +135,7 @@ export default function AuthCallbackScreen() {
 	return (
 		<View style={styles.container}>
 			<ActivityIndicator size="large" color="#F05537" />
-			<Text style={styles.text}>{i18n.t("Common.processing")}</Text>
+			<Text style={styles.text}>{i18n.t("auth.callback_processing")}</Text>
 
 			{/* Conflict Warning Dialog */}
 			<ConflictModal>

--- a/app-expo/features/dishMedia/components/DishMediaContent.tsx
+++ b/app-expo/features/dishMedia/components/DishMediaContent.tsx
@@ -278,7 +278,7 @@ export default function DishMediaContent({
 			{isProcessing && (
 				<View style={styles.processingOverlay}>
 					<ActivityIndicator size="large" color="#fff" />
-					<Text style={styles.processingText}>{i18n.t("Common.processing")}</Text>
+					<Text style={styles.processingText}>{i18n.t("DishMediaContent.processing")}</Text>
 				</View>
 			)}
 

--- a/app-expo/features/profile/components/OtpModal.tsx
+++ b/app-expo/features/profile/components/OtpModal.tsx
@@ -207,7 +207,7 @@ export function OtpModal({ onClose, phone }: OtpModalProps) {
 					{/* Resend Button */}
 					<TouchableOpacity onPress={handleResend} disabled={isResending || isLoading} style={styles.resendButton}>
 						<Text style={[styles.resendText, (isResending || isLoading) && styles.resendTextDisabled]}>
-							{isResending ? i18n.t("Common.processing") : i18n.t("auth.otp_send_again")}
+							{isResending ? i18n.t("auth.otp_resending") : i18n.t("auth.otp_send_again")}
 						</Text>
 					</TouchableOpacity>
 				</View>

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -9,7 +9,6 @@
 		"post": "نشر",
 		"postReview": "نشر مراجعة",
 		"retry": "إعادة المحاولة",
-		"processing": "معالجة...",
 		"error": "حدث خطأ. يُرجى المحاولة مرة أخرى.",
 		"success": "نجح",
 		"linkCopied": "تم نسخ الرابط إلى الحافظة",
@@ -222,6 +221,7 @@
 		"buttons": {
 			"viewRestaurant": "عرض المطعم"
 		},
+		"processing": "جارٍ معالجة الوسائط...",
 		"info": {
 			"walkFromShibuya": "على بُعد 13 دقيقة سيرًا من محطة شيبويا"
 		},
@@ -504,6 +504,7 @@
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
 		"otp_title": "أدخل الرمز",
+		"otp_resending": "جارٍ إعادة إرسال الرمز...",
 		"otp_send_again": "إعادة إرسال الرمز",
 		"otp_enter_all_digits": "يرجى إدخال الأرقام الستة كاملة",
 		"login_success": "تم تسجيل الدخول بنجاح!",
@@ -515,6 +516,7 @@
 		"conflict_dialog_message": "هذا الحساب مرتبط بالفعل بمستخدم آخر. إذا قمت بالتبديل، لن يتم نقل البيانات التي تم إنشاؤها كضيف. هل تريد التبديل إلى الحساب الموجود؟",
 		"conflict_dialog_switch": "تبديل",
 		"conflict_dialog_cancel": "إلغاء",
+		"callback_processing": "جارٍ إكمال تسجيل الدخول...",
 		"consent_login_prefix": "بالمتابعة، فإنك توافق على ",
 		"consent_login_terms": "شروط الخدمة",
 		"consent_login_and": " و",

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -9,7 +9,6 @@
 		"post": "Post",
 		"postReview": "Post review",
 		"retry": "Retry",
-		"processing": "Processing...",
 		"error": "An error occurred. Please try again.",
 		"success": "Success",
 		"linkCopied": "Link copied to clipboard",
@@ -222,6 +221,7 @@
 		"buttons": {
 			"viewRestaurant": "View restaurant"
 		},
+		"processing": "Processing media...",
 		"errors": {
 			"mapOpenFailed": "Could not open map application",
 			"mediaUnavailable": "This media is currently unavailable."
@@ -504,6 +504,7 @@
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
 		"otp_title": "Enter Code",
+		"otp_resending": "Resending code...",
 		"otp_send_again": "Resend Code",
 		"otp_enter_all_digits": "Please enter all 6 digits",
 		"login_success": "Successfully logged in!",
@@ -515,6 +516,7 @@
 		"conflict_dialog_message": "This account is already linked to another user. If you switch, data created as a guest will not be transferred. Do you want to switch to the existing account?",
 		"conflict_dialog_switch": "Switch",
 		"conflict_dialog_cancel": "Cancel",
+		"callback_processing": "Completing sign-in...",
 		"consent_login_prefix": "By continuing, you agree to our ",
 		"consent_login_terms": "Terms of Service",
 		"consent_login_and": " and ",

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -9,7 +9,6 @@
 		"post": "Publicar",
 		"postReview": "Publicar reseña",
 		"retry": "Reintentar",
-		"processing": "Procesando...",
 		"error": "Se produjo un error. Vuelve a intentarlo.",
 		"success": "Éxito",
 		"linkCopied": "Enlace copiado al portapapeles",
@@ -222,6 +221,7 @@
 		"buttons": {
 			"viewRestaurant": "Ver restaurante"
 		},
+		"processing": "Procesando el contenido...",
 		"errors": {
 			"mapOpenFailed": "No se pudo abrir la aplicación de mapas",
 			"mediaUnavailable": "Este contenido no está disponible actualmente."
@@ -504,6 +504,7 @@
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
 		"otp_title": "Introducir Código",
+		"otp_resending": "Reenviando el código...",
 		"otp_send_again": "Reenviar Código",
 		"otp_enter_all_digits": "Por favor ingresa los 6 dígitos",
 		"login_success": "¡Inicio de sesión exitoso!",
@@ -515,6 +516,7 @@
 		"conflict_dialog_message": "Esta cuenta ya está vinculada a otro usuario. Si cambias, los datos creados como invitado no se transferirán. ¿Deseas cambiar a la cuenta existente?",
 		"conflict_dialog_switch": "Cambiar",
 		"conflict_dialog_cancel": "Cancelar",
+		"callback_processing": "Completando el inicio de sesión...",
 		"consent_login_prefix": "Al continuar, aceptas nuestros ",
 		"consent_login_terms": "Términos de Servicio",
 		"consent_login_and": " y ",

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -9,7 +9,6 @@
 		"post": "Publier",
 		"postReview": "Publier un avis",
 		"retry": "Réessayer",
-		"processing": "Traitement...",
 		"error": "Une erreur s'est produite. Veuillez réessayer.",
 		"success": "Succès",
 		"linkCopied": "Lien copié dans le presse-papiers",
@@ -222,6 +221,7 @@
 		"buttons": {
 			"viewRestaurant": "Voir le restaurant"
 		},
+		"processing": "Traitement du média...",
 		"errors": {
 			"mapOpenFailed": "Impossible d'ouvrir l'application de carte",
 			"mediaUnavailable": "Ce contenu n'est actuellement pas disponible."
@@ -504,6 +504,7 @@
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
 		"otp_title": "Entrer le code",
+		"otp_resending": "Renvoi du code...",
 		"otp_send_again": "Renvoyer le code",
 		"otp_enter_all_digits": "Veuillez saisir les 6 chiffres",
 		"login_success": "Connexion réussie !",
@@ -515,6 +516,7 @@
 		"conflict_dialog_message": "Ce compte est déjà lié à un autre utilisateur. Si vous changez, les données créées en tant qu'invité ne seront pas transférées. Voulez-vous passer au compte existant?",
 		"conflict_dialog_switch": "Changer",
 		"conflict_dialog_cancel": "Annuler",
+		"callback_processing": "Finalisation de la connexion...",
 		"consent_login_prefix": "En continuant, vous acceptez nos ",
 		"consent_login_terms": "Conditions d'utilisation",
 		"consent_login_and": " et ",

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -9,7 +9,6 @@
 		"post": "पोस्ट करें",
 		"postReview": "समीक्षा पोस्ट करें",
 		"retry": "पुनः प्रयास करें",
-		"processing": "प्रसंस्करण...",
 		"error": "एक त्रुटि हुई है। कृपया पुनः प्रयास करें।",
 		"success": "सफलता",
 		"linkCopied": "लिंक क्लिपबोर्ड पर कॉपी किया गया",
@@ -222,6 +221,7 @@
 		"buttons": {
 			"viewRestaurant": "रेस्टोरेंट देखें"
 		},
+		"processing": "मीडिया प्रोसेस किया जा रहा है...",
 		"info": {
 			"walkFromShibuya": "शिबुया स्टेशन से 13 मिनट की पैदल दूरी"
 		},
@@ -505,6 +505,7 @@
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
 		"otp_title": "कोड दर्ज करें",
+		"otp_resending": "कोड दोबारा भेजा जा रहा है...",
 		"otp_send_again": "कोड पुनः भेजें",
 		"otp_enter_all_digits": "कृपया सभी 6 अंक दर्ज करें",
 		"login_success": "सफलतापूर्वक लॉग इन हो गया!",
@@ -516,6 +517,7 @@
 		"conflict_dialog_message": "यह खाता पहले से ही किसी अन्य उपयोगकर्ता से जुड़ा हुआ है। यदि आप स्विच करते हैं, तो अतिथि के रूप में बनाया गया डेटा स्थानांतरित नहीं होगा। क्या आप मौजूदा खाते पर स्विच करना चाहते हैं?",
 		"conflict_dialog_switch": "स्विच करें",
 		"conflict_dialog_cancel": "रद्द करें",
+		"callback_processing": "साइन-इन पूरा किया जा रहा है...",
 		"consent_login_prefix": "जारी रखकर, आप हमारी ",
 		"consent_login_terms": "सेवा की शर्तें",
 		"consent_login_and": " और ",

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -9,7 +9,6 @@
 		"post": "投稿",
 		"postReview": "レビューを投稿する",
 		"retry": "再試行",
-		"processing": "処理中...",
 		"error": "エラーが発生しました。もう一度お試しください。",
 		"success": "成功",
 		"linkCopied": "リンクをクリップボードにコピーしました",
@@ -222,6 +221,7 @@
 		"buttons": {
 			"viewRestaurant": "店を見る"
 		},
+		"processing": "メディアを処理中...",
 		"errors": {
 			"mapOpenFailed": "地図アプリを開けませんでした",
 			"mediaUnavailable": "このメディアは現在ご利用いただけません。"
@@ -504,6 +504,7 @@
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
 		"otp_title": "コードを入力",
+		"otp_resending": "コードを再送信中...",
 		"otp_send_again": "コードを再送",
 		"otp_enter_all_digits": "6桁すべてを入力してください",
 		"login_success": "ログインに成功しました！",
@@ -515,6 +516,7 @@
 		"conflict_dialog_message": "対象のアカウントは既に別ユーザーに紐づいています。切り替えるとゲストで作成したデータは引き継がれません。既存アカウントに切り替えますか？",
 		"conflict_dialog_switch": "切り替える",
 		"conflict_dialog_cancel": "キャンセル",
+		"callback_processing": "ログイン処理中...",
 		"consent_login_prefix": "このまま続行すると、",
 		"consent_login_terms": "利用規約",
 		"consent_login_and": " と ",

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -9,7 +9,6 @@
 		"post": "게시",
 		"postReview": "리뷰 게시하기",
 		"retry": "재시도",
-		"processing": "처리 중...",
 		"error": "오류가 발생했습니다. 다시 시도해 주세요.",
 		"success": "성공",
 		"linkCopied": "링크가 클립보드에 복사되었습니다",
@@ -222,6 +221,7 @@
 		"buttons": {
 			"viewRestaurant": "가게 보기"
 		},
+		"processing": "미디어 처리 중...",
 		"info": {
 			"walkFromShibuya": "시부야역에서 도보 13분"
 		},
@@ -504,6 +504,7 @@
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
 		"otp_title": "코드 입력",
+		"otp_resending": "인증 코드를 다시 전송 중...",
 		"otp_send_again": "코드 재전송",
 		"otp_enter_all_digits": "6자리 모두 입력해 주세요",
 		"login_success": "성공적으로 로그인되었습니다!",
@@ -515,6 +516,7 @@
 		"conflict_dialog_message": "이 계정은 이미 다른 사용자에게 연결되어 있습니다. 전환하면 게스트로 생성된 데이터는 전송되지 않습니다. 기존 계정으로 전환하시겠습니까?",
 		"conflict_dialog_switch": "전환",
 		"conflict_dialog_cancel": "취소",
+		"callback_processing": "로그인 완료 중...",
 		"consent_login_prefix": "계속 진행하면 ",
 		"consent_login_terms": "이용약관",
 		"consent_login_and": " 및 ",

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -9,7 +9,6 @@
 		"post": "发布",
 		"postReview": "发布评论",
 		"retry": "重试",
-		"processing": "处理中...",
 		"error": "发生错误。请重试。",
 		"success": "成功",
 		"linkCopied": "链接已复制到剪贴板",
@@ -222,6 +221,7 @@
 		"buttons": {
 			"viewRestaurant": "查看餐厅"
 		},
+		"processing": "正在处理媒体...",
 		"errors": {
 			"mapOpenFailed": "无法打开地图应用",
 			"mediaUnavailable": "该内容当前不可用。"
@@ -504,6 +504,7 @@
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
 		"otp_title": "输入验证码",
+		"otp_resending": "正在重新发送验证码...",
 		"otp_send_again": "重新发送验证码",
 		"otp_enter_all_digits": "请输入全部6位数字",
 		"login_success": "登录成功！",
@@ -515,6 +516,7 @@
 		"conflict_dialog_message": "此账户已链接到另一个用户。如果您切换，作为访客创建的数据将不会被转移。您要切换到现有账户吗？",
 		"conflict_dialog_switch": "切换",
 		"conflict_dialog_cancel": "取消",
+		"callback_processing": "正在完成登录...",
 		"consent_login_prefix": "继续即表示您同意我们的",
 		"consent_login_terms": "服务条款",
 		"consent_login_and": "和",


### PR DESCRIPTION
### Motivation
- Replace a generic `Common.processing` message with context-specific copy for better UX in auth callback, media overlay, and OTP resend flows.
- Introduce dedicated translation keys to allow different wording per context and per locale.
- Keep the Common namespace focused on generic UI labels instead of contextual process messages.

### Description
- Updated UI to use new keys: replaced `i18n.t("Common.processing")` with `i18n.t("auth.callback_processing")` in `app-expo/app/[locale]/auth/callback.tsx`, `i18n.t("DishMediaContent.processing")` in `app-expo/features/dishMedia/components/DishMediaContent.tsx`, and `i18n.t("auth.otp_resending")` in `app-expo/features/profile/components/OtpModal.tsx`.
- Added locale entries for the new keys across supported locales (`ar-SA`, `en-US`, `es-ES`, `fr-FR`, `hi-IN`, `ja-JP`, `ko-KR`, `zh-CN`) including `DishMediaContent.processing`, `auth.otp_resending`, and `auth.callback_processing` with translated copy.
- Removed the generic `Common.processing` string in the updated locale files to avoid ambiguous usage.
- Committed changes with message `Update processing messages for auth and media` and verified replacements via search.

### Testing
- No automated test suite was run for this change.
- Ran quick verification commands such as `rg` to confirm that previous `Common.processing` usages were replaced and that new keys exist in `app-expo/locales/*` (search results matched expected files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971321e45a4832b92c7d97bab280c29)