### PR TITLE
fix #785: iOS スケルトンローディングが終わらないバグを修正

### DIFF
--- a/app-expo/app/[locale]/contribution-tasks/dish-copy-survey.tsx
+++ b/app-expo/app/[locale]/contribution-tasks/dish-copy-survey.tsx
@@ -20,7 +20,7 @@ import { Image } from "expo-image";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { HelpCircle, CheckCircle2, Circle } from "lucide-react-native";
 import Carousel from "react-native-reanimated-carousel";
-import * as Crypto from "expo-crypto";
+import { generateUUID } from "@/lib/uuid";
 
 import { useBlurModal } from "@/features/blurModal/hooks/useBlurModal";
 import { useSnackbar } from "@/contexts/SnackbarProvider";
@@ -171,7 +171,7 @@ export default function DishCopySurveyPage() {
 	const [dishes, setDishes] = useState<DishData[]>([]);
 
 	// セッション情報
-	const [sessionId] = useState(() => Crypto.randomUUID());
+	const [sessionId] = useState(() => generateUUID());
 	const [startedAt] = useState(() => new Date().toISOString());
 
 	// 回答管理

--- a/app-expo/app/[locale]/contribution-tasks/dish-ranking-summary.tsx
+++ b/app-expo/app/[locale]/contribution-tasks/dish-ranking-summary.tsx
@@ -24,7 +24,7 @@ import {
 import { Image } from "expo-image";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { HelpCircle, ChevronDown, MessageCircle } from "lucide-react-native";
-import * as Crypto from "expo-crypto";
+import { generateUUID } from "@/lib/uuid";
 
 import { useBlurModal } from "@/features/blurModal/hooks/useBlurModal";
 import { useSnackbar } from "@/contexts/SnackbarProvider";
@@ -121,7 +121,7 @@ export default function DishRankingSummaryScreen() {
 	} | null>(null);
 
 	/* ---- Session tracking ---- */
-	const sessionId = useMemo(() => Crypto.randomUUID(), []);
+	const sessionId = useMemo(() => generateUUID(), []);
 	const startedAt = useMemo(() => new Date().toISOString(), []);
 
 	/* ---- BlurModal ---- */

--- a/app-expo/features/dishMedia/components/DishMediaFeed.tsx
+++ b/app-expo/features/dishMedia/components/DishMediaFeed.tsx
@@ -15,7 +15,7 @@ import { StyleSheet, FlatList, ViewToken, View, ListRenderItemInfo } from "react
 import DishMediaContent from "./DishMediaContent";
 import { useHaptics } from "@/hooks/useHaptics";
 import { useLogger } from "@/hooks/useLogger";
-import * as Crypto from "expo-crypto";
+import { generateUUID } from "@/lib/uuid";
 import {
 	DishMediaEntriesStore,
 	NormalizedDishMediaEntry,
@@ -94,7 +94,7 @@ export default function DishMediaFeed({
 	const { logFrontendEvent } = useLogger();
 
 	// 一意なセッションID（DishMediaContent へ伝搬）
-	const sessionId = useRef(Crypto.randomUUID());
+	const sessionId = useRef(generateUUID());
 
 	// --- ライフサイクルログ（初回） ------------------------------
 	useEffect(() => {

--- a/app-expo/features/dishMedia/components/DishMediaMap.tsx
+++ b/app-expo/features/dishMedia/components/DishMediaMap.tsx
@@ -6,7 +6,7 @@ import DishMediaContent from "./DishMediaContent";
 import { AvatarBubbleMarker } from "@/features/mapMarkers";
 import { useHaptics } from "@/hooks/useHaptics";
 import { useLogger } from "@/hooks/useLogger";
-import * as Crypto from "expo-crypto";
+import { generateUUID } from "@/lib/uuid";
 import Animated, { useSharedValue, useAnimatedStyle, withSpring } from "react-native-reanimated";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import {
@@ -102,7 +102,7 @@ export default function DishMediaMap({
 	const { logFrontendEvent } = useLogger();
 
 	// 一意なセッションID（DishMediaContent へ伝搬）
-	const sessionId = useRef(Crypto.randomUUID());
+	const sessionId = useRef(generateUUID());
 
 	// #605 【設計】Carousel の上下移動量（0 = Expanded, MAX_TRANSLATE_Y = Collapsed）
 	const MAX_TRANSLATE_Y = height * (EXPANDED_RATIO - COLLAPSED_RATIO);

--- a/app-expo/features/dishMedia/hooks/useMediaTracking.ts
+++ b/app-expo/features/dishMedia/hooks/useMediaTracking.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { AppState } from "react-native";
-import * as Crypto from "expo-crypto";
+import { generateUUID } from "@/lib/uuid";
 import { useAPICall } from "@/hooks/useAPICall";
 import { useLogger } from "@/hooks/useLogger";
 import { getRemoteConfig } from "@/lib/remoteConfig";
@@ -43,7 +43,7 @@ export const useMediaTracking = ({ isActive, sessionId, source, dishMedia }: Use
 				});
 
 			// 新しいインプレッションを作成
-			const id = Crypto.randomUUID();
+			const id = generateUUID();
 			impressionId.current = id;
 			watchStartTime.current = new Date();
 			watchMs.current = 0;

--- a/app-expo/features/mapMarkers/components/AvatarBubbleMarker.tsx
+++ b/app-expo/features/mapMarkers/components/AvatarBubbleMarker.tsx
@@ -92,6 +92,7 @@ export function AvatarBubbleMarker({
 						source={uri ? { uri } : undefined}
 						contentFit="cover"
 						transition={100}
+						cachePolicy="memory-disk" // #785 DishMediaContent と同一ポリシーにすることで iOS SDWebImage のパイプライン競合を防止
 					/>
 				</View>
 

--- a/app-expo/hooks/useImageLoadWithRetry.ts
+++ b/app-expo/hooks/useImageLoadWithRetry.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 
-type LoadState = "loading" | "loaded" | "error";
+// #785 ローディングが終わらない不具合に対応するため追加（"idle" 状態追加）
+type LoadState = "idle" | "loading" | "loaded" | "error";
 
 interface UseImageLoadWithRetryOptions {
 	uri: string | undefined;
@@ -35,7 +36,8 @@ export const useImageLoadWithRetry = ({
 	onErrorCountChange,
 	onGiveUp,
 }: UseImageLoadWithRetryOptions) => {
-	const [loadState, setLoadState] = useState<LoadState>("loading");
+	// #785 初期値を "loading" から "idle" に変更（メモリキャッシュヒット時にイベントが発火しなくてもスケルトンが残らないよう）
+	const [loadState, setLoadState] = useState<LoadState>("idle");
 	const [errorCount, setErrorCount] = useState(0);
 	const [isRetrying, setIsRetrying] = useState(false);
 	const [reloadToken, setReloadToken] = useState(0);
@@ -44,6 +46,9 @@ export const useImageLoadWithRetry = ({
 
 	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const prevSourceKeyRef = useRef<string | undefined>(undefined);
+	// #785 ローディングが終わらない不具合に対応するため追加
+	// 初回マウント済みフラグ（マウント後のURI変更のみリセットするため）
+	const isMountedRef = useRef(false);
 
 	// uri + cacheBustingKey をまとめた “ソースキー”
 	const sourceKey = useMemo(() => {
@@ -163,16 +168,22 @@ export const useImageLoadWithRetry = ({
 	);
 
 	// uri 変更時に状態をリセット
+	// #785 初回マウント時はスキップ（onDisplay/onLoad が useEffect より先に発火すると "loaded" → "idle" の逆戻りが起きるため）
 	useEffect(() => {
 		if (prevSourceKeyRef.current !== sourceKey) {
 			prevSourceKeyRef.current = sourceKey;
-			setErrorCount(0);
-			setLastErrorMessage(undefined); // #715 【設計】エラーメッセージもリセット
-			setIsRetrying(false);
-			setReloadToken(0);
-			setLoadState("loading"); // #715 【設計】新しい URI では loading 状態から開始
-			clearTimer();
+
+			if (isMountedRef.current) {
+				// URI が実際に変わった場合のみリセット（初回マウント時はスキップ）
+				setErrorCount(0);
+				setLastErrorMessage(undefined);
+				setIsRetrying(false);
+				setReloadToken(0);
+				setLoadState("idle"); // #785 "loading" ではなく "idle" にリセット
+				clearTimer();
+			}
 		}
+		isMountedRef.current = true;
 	}, [sourceKey, clearTimer]);
 
 	const hasGivenUp = errorCount > maxAutoRetry;

--- a/app-expo/lib/reactions.ts
+++ b/app-expo/lib/reactions.ts
@@ -1,4 +1,4 @@
-import * as Crypto from "expo-crypto";
+import { generateUUID } from "./uuid";
 import { supabase } from "./supabase";
 import { Env } from "@/constants/Env";
 import type { DeepNonNullable } from "@shared/utils/types";
@@ -19,7 +19,7 @@ export const insertReaction = async ({
 	if (!userId) throw new Error("No authenticated user");
 
 	const { error } = await supabase.from("reactions").insert({
-		id: Crypto.randomUUID(),
+		id: generateUUID(),
 		user_id: userId,
 		target_type,
 		target_id,

--- a/app-expo/lib/uuid.ts
+++ b/app-expo/lib/uuid.ts
@@ -1,0 +1,5 @@
+import * as Crypto from "expo-crypto";
+
+export function generateUUID(): string {
+	return Crypto.randomUUID();
+}

--- a/app-expo/lib/uuid.web.ts
+++ b/app-expo/lib/uuid.web.ts
@@ -1,0 +1,20 @@
+// web 版: crypto.randomUUID() が使えない環境（HTTP等）向けにフォールバックを提供
+export function generateUUID(): string {
+	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+		return crypto.randomUUID();
+	}
+	// RFC 4122 v4 UUID via getRandomValues（より広くサポートされている）
+	const bytes = new Uint8Array(16);
+	crypto.getRandomValues(bytes);
+	bytes[6] = (bytes[6] & 0x0f) | 0x40;
+	bytes[8] = (bytes[8] & 0x3f) | 0x80;
+	return [
+		bytes.slice(0, 4),
+		bytes.slice(4, 6),
+		bytes.slice(6, 8),
+		bytes.slice(8, 10),
+		bytes.slice(10, 16),
+	]
+		.map((seg) => Array.from(seg).map((b) => b.toString(16).padStart(2, "0")).join(""))
+		.join("-");
+}


### PR DESCRIPTION
【原因】
iOS では expo-image が SDWebImage を使用しており、同一 URL を異なる cachePolicy で複数コンポーネントがロードすると別パイプラインが生成される。
後からロードしたコンポーネントに onLoad/onLoadEnd が届かず、
loadState が "loading" のまま永続しスケルトンが消えない。

【修正 1】useImageLoadWithRetry.ts
- LoadState に "idle" を追加し、初期値・URI変更時リセットを "idle" に変更 → メモリキャッシュヒット時（イベント不発）でもスケルトンが表示されない
- isMountedRef ガードを追加 → 初回マウント時に onLoad が useEffect より先に発火しても "loaded" → "idle" へ逆戻りしない

【修正 2】AvatarBubbleMarker.tsx
- cachePolicy="memory-disk" を明示 → DishMediaContent と同一ポリシーに統一し iOS パイプライン競合を解消 → お店提案カードのスケルトンが終わらない問題を修正