### PR TITLE
#827 fix: 検索結果0件時にGoogleマップで開く導線を追加

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/result.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/result.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useMemo } from "react";
-import { View, StyleSheet, TouchableOpacity, Platform } from "react-native";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { View, StyleSheet, TouchableOpacity, Platform, Linking } from "react-native";
 import { X, Share2 } from "lucide-react-native";
 import { router, useLocalSearchParams } from "expo-router";
 import DishMediaMap from "@/features/dishMedia/components/DishMediaMap";
@@ -16,14 +16,24 @@ import {
 import { shallow } from "zustand/shallow";
 import { RestaurantLoading } from "@/features/dishMedia/components/RestaurantLoading";
 import { useDishMediaActions } from "@/features/dishMedia/hooks/useDishMediaActions";
+import { useDialog } from "@/contexts/DialogProvider";
+import i18n from "@/lib/i18n";
+import { useLocale } from "@/hooks/useLocale";
 
 const idType = "dish_media" as const;
+
 export default function ResultScreen() {
 	// #633 【設計】topicId ではなく entriesKey を使用（Topics/SavedTopics 共通化）
-	const { entriesKey, location } = useLocalSearchParams<{ entriesKey: string; location?: string }>();
+	const { entriesKey, location, category } = useLocalSearchParams<{
+		entriesKey: string;
+		location?: string;
+		category?: string;
+	}>();
 	const { lightImpact } = useHaptics();
 	const { logFrontendEvent } = useLogger();
 	const { shareRestaurant } = useDishMediaActions({ source: "search_result_screen" });
+	const { showDialog } = useDialog();
+	const { locale } = useLocale();
 
 	// #633 【防御】entriesKey が undefined の場合は戻る（クラッシュ防止）
 	useEffect(() => {
@@ -41,7 +51,7 @@ export default function ResultScreen() {
 		(state: DishMediaEntriesStore) => selectIdsByKey(entriesKey || "", idType)(state),
 		[entriesKey, idType],
 	);
-	const { isLoading } = useDishMediaEntriesStore(selector, shallow);
+	const { ids, isLoading } = useDishMediaEntriesStore(selector, shallow);
 	const initialLocation = useMemo(() => {
 		if (typeof location === "string") {
 			try {
@@ -69,6 +79,100 @@ export default function ResultScreen() {
 			},
 		});
 	}, [entriesKey, logFrontendEvent]);
+
+	useEffect(() => {
+		// #827 【設計】0件確定後の退避導線は、取得元ではなく検索結果画面の責務として扱う。
+		if (!entriesKey || isLoading || ids.length > 0 || !initialLocation || !category) return;
+
+		const buildGoogleMapsSearchUrl = (
+			category: string,
+			location: {
+				latitude: number;
+				longitude: number;
+			},
+			options?: {
+				zoom?: number;
+				hl?: string;
+			},
+		) => {
+			const zoom = options?.zoom ?? 14;
+			const lat = Number(location.latitude.toFixed(7));
+			const lng = Number(location.longitude.toFixed(7));
+			const encodedCategory = encodeURIComponent(category);
+
+			const url = new URL(`https://www.google.com/maps/search/${encodedCategory}/@${lat},${lng},${zoom}z`);
+
+			if (options?.hl) {
+				url.searchParams.set("hl", options.hl);
+			}
+
+			return url.toString();
+		};
+
+		// #827 【設計】アプリ側の検索カテゴリと表示言語に寄せ、Google Maps 側で同じ意図の検索を開く。
+		const url = buildGoogleMapsSearchUrl(category, initialLocation, {
+			hl: locale.split("-")[0],
+		});
+
+		logFrontendEvent({
+			event_name: "google_maps_fallback_dialog_shown",
+			error_level: "warn",
+			payload: {
+				entriesKey,
+				category,
+				latitude: initialLocation.latitude,
+				longitude: initialLocation.longitude,
+			},
+		});
+
+		showDialog(i18n.t("Search.googleMapsFallback.message"), {
+			okLabel: i18n.t("Search.googleMapsFallback.confirm"),
+			cancelLabel: i18n.t("Search.googleMapsFallback.cancel"),
+			onConfirm: async () => {
+				try {
+					await Linking.openURL(url);
+					logFrontendEvent({
+						event_name: "google_maps_fallback_opened",
+						error_level: "log",
+						payload: {
+							entriesKey,
+							category,
+							latitude: initialLocation.latitude,
+							longitude: initialLocation.longitude,
+						},
+					});
+				} catch (error) {
+					logFrontendEvent({
+						event_name: "google_maps_fallback_open_failed",
+						error_level: "error",
+						payload: {
+							entriesKey,
+							category,
+							error_message: error instanceof Error ? error.message : String(error),
+						},
+					});
+				}
+			},
+			onHide: (reason) => {
+				if (reason !== "confirm") {
+					logFrontendEvent({
+						event_name: "google_maps_fallback_dismissed",
+						error_level: "log",
+						payload: {
+							entriesKey,
+							category,
+							reason,
+						},
+					});
+				}
+			},
+		});
+
+
+		// #827 【設計】表示できる店舗がない場合、料理候補画面へ戻す。
+		// iOS で、react-native-paper の Portal.Host が transparentModal より下にあるため、この位置。
+		handleClose();
+	}, [category, entriesKey, ids.length, initialLocation, isLoading, logFrontendEvent, showDialog, locale, handleClose]);
 
 	const handleCloseWithHaptic = () => {
 		lightImpact();

--- a/app-expo/app/[locale]/(tabs)/search/topics.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/topics.tsx
@@ -112,6 +112,8 @@ export default function TopicsScreen() {
 					locale,
 					entriesKey, // #633 【設計】topicId ではなく entriesKey を渡す
 					...(params && { location: JSON.stringify(params.location) }),
+					// #827 【設計】0件時のGoogle Maps検索はresult画面で判断するため、表示中カテゴリを渡す。
+					category: topic.category,
 				},
 			});
 			// #633 【設計】分析基盤互換のため移行期間は topicId と entriesKey を併記

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -63,6 +63,11 @@
 			"noSceneSelected": "يرجى اختيار مشهد",
 			"searchFailed": "فشل البحث"
 		},
+		"googleMapsFallback": {
+			"message": "بيانات المطاعم محدودة في هذه المنطقة. هل تريد فتحها في خرائط Google؟",
+			"confirm": "فتح خرائط Google",
+			"cancel": "إغلاق"
+		},
 		"sections": {
 			"location": "أين تبحث؟",
 			"time": "ما الوقت؟",

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -63,6 +63,11 @@
 			"noSceneSelected": "Please select a scene",
 			"searchFailed": "Search failed"
 		},
+		"googleMapsFallback": {
+			"message": "Restaurant data is limited in this area. Open it in Google Maps?",
+			"confirm": "Open Google Maps",
+			"cancel": "Close"
+		},
 		"sections": {
 			"location": "Where to search?",
 			"time": "What time?",

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -63,6 +63,11 @@
 			"noSceneSelected": "Seleccione una escena",
 			"searchFailed": "La búsqueda falló"
 		},
+		"googleMapsFallback": {
+			"message": "Hay pocos datos de restaurantes en esta zona. ¿Abrir en Google Maps?",
+			"confirm": "Abrir Google Maps",
+			"cancel": "Cerrar"
+		},
 		"sections": {
 			"location": "¿Dónde buscar?",
 			"time": "¿En qué horario?",

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -63,6 +63,11 @@
 			"noSceneSelected": "Veuillez sélectionner une scène",
 			"searchFailed": "La recherche a échoué"
 		},
+		"googleMapsFallback": {
+			"message": "Les données de restaurants sont limitées dans cette zone. Ouvrir dans Google Maps ?",
+			"confirm": "Ouvrir Google Maps",
+			"cancel": "Fermer"
+		},
 		"sections": {
 			"location": "Où chercher ?",
 			"time": "À quelle heure ?",

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -63,6 +63,11 @@
 			"noSceneSelected": "कृपया एक दृश्य चुनें",
 			"searchFailed": "खोज विफल हुई"
 		},
+		"googleMapsFallback": {
+			"message": "इस क्षेत्र में रेस्तरां डेटा कम है। Google Maps में खोलें?",
+			"confirm": "Google Maps खोलें",
+			"cancel": "बंद करें"
+		},
 		"sections": {
 			"location": "कहां खोजें?",
 			"time": "कौन सा समय?",

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -63,6 +63,11 @@
 			"noSceneSelected": "シーンを選択してください",
 			"searchFailed": "検索に失敗しました"
 		},
+		"googleMapsFallback": {
+			"message": "このエリアの店舗データが不足しています。Google マップで表示しますか？",
+			"confirm": "Google マップで開く",
+			"cancel": "閉じる"
+		},
 		"sections": {
 			"location": "どのあたりで探す？",
 			"time": "時間帯は？",

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -63,6 +63,11 @@
 			"noSceneSelected": "장면을 선택해 주세요",
 			"searchFailed": "검색에 실패했습니다"
 		},
+		"googleMapsFallback": {
+			"message": "이 지역의 매장 데이터가 부족합니다. Google 지도에서 표시할까요?",
+			"confirm": "Google 지도 열기",
+			"cancel": "닫기"
+		},
 		"sections": {
 			"location": "어디에서 찾을까요?",
 			"time": "시간대는?",

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -63,6 +63,11 @@
 			"noSceneSelected": "请选择场景",
 			"searchFailed": "搜索失败"
 		},
+		"googleMapsFallback": {
+			"message": "该区域的餐厅数据不足。要在 Google 地图中打开吗？",
+			"confirm": "打开 Google 地图",
+			"cancel": "关闭"
+		},
 		"sections": {
 			"location": "在哪里搜索？",
 			"time": "什么时间？",


### PR DESCRIPTION
店舗データ取得後に結果が0件のままになるとユーザーが次の行動を取れないため、検索結果画面でGoogleマップ表示ダイアログを出す

result.tsxでRestaurantLoading終了後の0件を検知し、topics.tsxからカテゴリ名を渡してGoogleマップ検索URLを開く