### PR TITLE
#837 Xcode 16を使う → App Store に提出できない

### DIFF
--- a/app-expo/eas.json
+++ b/app-expo/eas.json
@@ -8,7 +8,7 @@
 			"developmentClient": true,
 			"distribution": "internal",
 			"ios": {
-				"image": "macos-sequoia-15.5-xcode-16.4"
+				"image": "macos-sequoia-15.6-xcode-26.2"
 			}
 		},
 		"preview": {
@@ -16,7 +16,7 @@
 			"environment": "preview",
 			"channel": "preview",
 			"ios": {
-				"image": "macos-sequoia-15.5-xcode-16.4"
+				"image": "macos-sequoia-15.6-xcode-26.2"
 			}
 		},
 		"production": {
@@ -24,10 +24,10 @@
 			"environment": "production",
 			"channel": "production",
 			"ios": {
-				"image": "macos-sequoia-15.5-xcode-16.4",
+				"image": "macos-sequoia-15.6-xcode-26.2",
 				"cocoapods": "1.15.2"
 			},
-			"cache": { "key": "fix-xcode-16-2025-06-08" }
+			"cache": { "key": "fix-xcode-26-2026-06-08" }
 		}
 	},
 	"submit": {


### PR DESCRIPTION
Expo 公式の EAS infrastructure で macos-sequoia-15.6-xcode-26.2 が現在 latest / sdk-55 として載っていて、Xcode 26.2 なので App Store の「Xcode 26以上」条件を満たします。一方、問題の fmt エラーは主に Xcode 26.4 / Apple clang 21 で報告されているため、macos-tahoe-26.4-xcode-26.4 は避けるべきです。Expo docs では Xcode 26.4 image は macos-tahoe-26.4-xcode-26.4、Xcode 26.2 image は macos-sequoia-15.6-xcode-26.2 として分かれています。