### PR TITLE
#895 fix: Google Mapsフォールバックの案内とダイアログ表示を明確化

### DIFF
--- a/app-expo/contexts/DialogProvider.tsx
+++ b/app-expo/contexts/DialogProvider.tsx
@@ -9,7 +9,7 @@ import React, {
 	useState,
 	type ReactNode,
 } from "react";
-import { BackHandler, Platform, ScrollView, View } from "react-native";
+import { BackHandler, Platform, ScrollView, StyleSheet, View } from "react-native";
 import { Portal, Dialog, Button, Paragraph, Text, TextInput, HelperText } from "react-native-paper";
 
 /**
@@ -830,11 +830,12 @@ export const DialogProvider = ({ children }: { children: ReactNode }) => {
 			<Portal>
 				<Dialog
 					visible={visible}
+					style={styles.dialog}
 					/**
 					 * onDismiss は「呼ばれる」ので、許可しない場合は handleDismiss 内で弾く（6）
 					 */
 					onDismiss={handleDismiss}>
-					{!!cur?.title && <Dialog.Title>{cur.title}</Dialog.Title>}
+					{!!cur?.title && <Dialog.Title style={styles.title}>{cur.title}</Dialog.Title>}
 
 					<Dialog.Content>
 						<View accessible accessibilityLabel={a11yLabel}>
@@ -844,7 +845,7 @@ export const DialogProvider = ({ children }: { children: ReactNode }) => {
 								contentContainerStyle={{ paddingBottom: 4 }}
 								// confirm中でもスクロールは許可
 							>
-								<Paragraph>{cur?.message ?? ""}</Paragraph>
+								<Paragraph style={styles.message}>{cur?.message ?? ""}</Paragraph>
 
 								{/* prompt UI（2） */}
 								{cur?.kind === "prompt" && (
@@ -875,7 +876,7 @@ export const DialogProvider = ({ children }: { children: ReactNode }) => {
 						</View>
 					</Dialog.Content>
 
-					<Dialog.Actions>
+					<Dialog.Actions style={styles.actions}>
 						{renderedActions.map((a) => {
 							const isOk = a.key === "ok";
 							const isCancel = a.key === "cancel";
@@ -908,7 +909,12 @@ export const DialogProvider = ({ children }: { children: ReactNode }) => {
 							return (
 								<Button
 									key={a.key}
-									mode={a.mode ?? "text"}
+									mode={isOk || isCancel ? "contained" : (a.mode ?? "text")}
+									buttonColor={isOk ? "#F05537" : isCancel ? "#F8F9FA" : undefined}
+									textColor={isOk ? "#FFFFFF" : isCancel ? "#6B7280" : undefined}
+									style={isOk || isCancel ? styles.actionButton : undefined}
+									contentStyle={isOk || isCancel ? styles.actionButtonContent : undefined}
+									labelStyle={[styles.actionButtonLabel, isOk && styles.confirmButtonLabel]}
 									onPress={onPress}
 									disabled={disabled}
 									accessibilityLabel={a.accessibilityLabel}
@@ -930,6 +936,44 @@ export const DialogProvider = ({ children }: { children: ReactNode }) => {
 		</DialogContext.Provider>
 	);
 };
+
+const styles = StyleSheet.create({
+	dialog: {
+		backgroundColor: "#FFFFFF",
+		borderRadius: 20,
+	},
+	title: {
+		fontSize: 20,
+		fontWeight: "700",
+		color: "#1C1B1F",
+		letterSpacing: -0.3,
+	},
+	message: {
+		fontSize: 16,
+		fontWeight: "500",
+		lineHeight: 24,
+		color: "#49454F",
+	},
+	actions: {
+		gap: 4,
+		paddingHorizontal: 24,
+		paddingBottom: 20,
+	},
+	actionButton: {
+		borderRadius: 16,
+	},
+	actionButtonContent: {
+		minHeight: 48,
+		paddingHorizontal: 8,
+	},
+	actionButtonLabel: {
+		fontSize: 16,
+		fontWeight: "600",
+	},
+	confirmButtonLabel: {
+		fontWeight: "700",
+	},
+});
 
 /** useDialog フック */
 export const useDialog = (): DialogContextType => {

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -97,7 +97,7 @@
 			"searchFailed": "فشل البحث"
 		},
 		"googleMapsFallback": {
-			"message": "بيانات المطاعم محدودة في هذه المنطقة. هل تريد فتحها في خرائط Google؟",
+			"message": "يمكنك الاطلاع على المطاعم التي تطابق شروطك على خرائط Google.",
 			"confirm": "فتح خرائط Google",
 			"cancel": "إغلاق"
 		},

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -97,7 +97,7 @@
 			"searchFailed": "Search failed"
 		},
 		"googleMapsFallback": {
-			"message": "Restaurant data is limited in this area. Open it in Google Maps?",
+			"message": "You can view restaurants matching your criteria on Google Maps.",
 			"confirm": "Open Google Maps",
 			"cancel": "Close"
 		},

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -97,7 +97,7 @@
 			"searchFailed": "La búsqueda falló"
 		},
 		"googleMapsFallback": {
-			"message": "Hay pocos datos de restaurantes en esta zona. ¿Abrir en Google Maps?",
+			"message": "Puedes consultar en Google Maps los restaurantes que cumplen tus criterios.",
 			"confirm": "Abrir Google Maps",
 			"cancel": "Cerrar"
 		},

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -97,7 +97,7 @@
 			"searchFailed": "La recherche a échoué"
 		},
 		"googleMapsFallback": {
-			"message": "Les données de restaurants sont limitées dans cette zone. Ouvrir dans Google Maps ?",
+			"message": "Vous pouvez consulter sur Google Maps les restaurants correspondant à vos critères.",
 			"confirm": "Ouvrir Google Maps",
 			"cancel": "Fermer"
 		},

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -97,7 +97,7 @@
 			"searchFailed": "खोज विफल हुई"
 		},
 		"googleMapsFallback": {
-			"message": "इस क्षेत्र में रेस्तरां डेटा कम है। Google Maps में खोलें?",
+			"message": "आप अपनी शर्तों से मेल खाने वाले रेस्तरां Google Maps पर देख सकते हैं।",
 			"confirm": "Google Maps खोलें",
 			"cancel": "बंद करें"
 		},

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -97,7 +97,7 @@
 			"searchFailed": "検索に失敗しました"
 		},
 		"googleMapsFallback": {
-			"message": "このエリアの店舗データが不足しています。Google マップで表示しますか？",
+			"message": "条件に合うお店を Googleマップ上でご確認頂けます。",
 			"confirm": "Google マップで開く",
 			"cancel": "閉じる"
 		},

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -97,7 +97,7 @@
 			"searchFailed": "검색에 실패했습니다"
 		},
 		"googleMapsFallback": {
-			"message": "이 지역의 매장 데이터가 부족합니다. Google 지도에서 표시할까요?",
+			"message": "조건에 맞는 음식점을 Google 지도에서 확인할 수 있습니다.",
 			"confirm": "Google 지도 열기",
 			"cancel": "닫기"
 		},

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -97,7 +97,7 @@
 			"searchFailed": "搜索失败"
 		},
 		"googleMapsFallback": {
-			"message": "该区域的餐厅数据不足。要在 Google 地图中打开吗？",
+			"message": "您可以在 Google 地图上查看符合条件的餐厅。",
 			"confirm": "打开 Google 地图",
 			"cancel": "关闭"
 		},


### PR DESCRIPTION
検索結果がない際の継続導線が伝わらず、閉じると何もできないように見える問題を修正。

DialogProviderのフォント・配色・ボタンをBlockTopicBlurModalに合わせ、googleMapsFallback.messageを全8言語で変更。