### PR TITLE
#897 fix: 推薦APIの空応答と認証切れで検索が失敗する問題を修正

### DIFF
--- a/api/src/v1/dish-categories/query-dish-category-recommendations.dto.spec.ts
+++ b/api/src/v1/dish-categories/query-dish-category-recommendations.dto.spec.ts
@@ -1,0 +1,43 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { QueryDishCategoryRecommendationsDto } from '@shared/v1/dto/dish-categories/query-dish-category-recommendations.dto';
+
+const createDto = (
+  overrides: Partial<QueryDishCategoryRecommendationsDto> = {},
+): QueryDishCategoryRecommendationsDto =>
+  Object.assign(new QueryDishCategoryRecommendationsDto(), {
+    address: 'country:JP, locality:Tokyo',
+    languageTag: 'ja-JP',
+    localLanguageCode: 'ja',
+    ...overrides,
+  });
+
+describe('QueryDishCategoryRecommendationsDto', () => {
+  it.each(['ja', 'en-AU', 'zh-Hans', 'zh-Hant-TW'])(
+    'accepts languageTag %s emitted by the client locale provider',
+    async (languageTag) => {
+      const errors = await validate(createDto({ languageTag }));
+
+      expect(errors).toHaveLength(0);
+    },
+  );
+
+  it.each(['ja', 'zh-Hant', 'zh-Hant-TW'])(
+    'accepts localLanguageCode %s emitted by reverse geocoding',
+    async (localLanguageCode) => {
+      const errors = await validate(createDto({ localLanguageCode }));
+
+      expect(errors).toHaveLength(0);
+    },
+  );
+
+  it('rejects a malformed language tag', async () => {
+    const errors = await validate(createDto({ languageTag: 'not_a_locale' }));
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ property: 'languageTag' }),
+      ]),
+    );
+  });
+});

--- a/api/src/v1/dish-category-group-votes/create-dish-category-group-vote.dto.spec.ts
+++ b/api/src/v1/dish-category-group-votes/create-dish-category-group-vote.dto.spec.ts
@@ -1,0 +1,35 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { CreateDishCategoryGroupVoteCandidateDto } from '@shared/v1/dto/dish-category-group-votes/create-dish-category-group-vote.dto';
+
+describe('CreateDishCategoryGroupVoteCandidateDto', () => {
+  it('accepts an empty tagline when recommendations have no localized reason', async () => {
+    const dto = Object.assign(new CreateDishCategoryGroupVoteCandidateDto(), {
+      dishCategoryId: 'Q282',
+      displayName: 'Wine',
+      tagline: '',
+      imageUrl: 'https://example.com/wine.jpg',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('still rejects a non-string tagline', async () => {
+    const dto = Object.assign(new CreateDishCategoryGroupVoteCandidateDto(), {
+      dishCategoryId: 'Q282',
+      displayName: 'Wine',
+      tagline: null,
+      imageUrl: 'https://example.com/wine.jpg',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ property: 'tagline' }),
+      ]),
+    );
+  });
+});

--- a/app-expo/app/[locale]/(tabs)/search/topics.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/topics.tsx
@@ -98,6 +98,7 @@ export default function TopicsScreen() {
 	useEffect(() => {
 		if (params) {
 			searchTopics(params, { pinnedTopic }).catch(() => {
+				// useTopicSearch は再試行と状態管理を担当し、画面側が最終失敗をSnackbarで可視化する。
 				showSnackbar(i18n.t("Topics.errors.fetchFailed"));
 			});
 		} else {

--- a/app-expo/contexts/AuthProvider.tsx
+++ b/app-expo/contexts/AuthProvider.tsx
@@ -16,6 +16,7 @@ import { useCdnCookieStore } from "@/stores/useCdnCookieStore";
 type AuthContextType = {
 	user: User | null;
 	getSession: () => Session | null;
+	refreshSession: () => Promise<Session | null>;
 	loading: boolean;
 	loginWithEmail: (email: string, password: string) => Promise<void>;
 	logout: (options?: SignOut) => Promise<void>;
@@ -44,6 +45,23 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 	const { locale } = useLocale();
 	const sessionRef = useRef<Session | null>(null);
 	const getSession = useCallback(() => sessionRef.current, []);
+	/**
+	 * 401 を受けたリクエストが、新しい access token で即時再試行できるようにする。
+	 * Supabase の自動更新は後続リクエストには効くが、既に失敗した通信は再送しないため、
+	 * 更新済み Session を呼び出し元へ返しつつ、同期参照する sessionRef も先に更新する。
+	 */
+	const refreshSession = useCallback(async (): Promise<Session | null> => {
+		const { data, error } = await supabase.auth.refreshSession();
+		if (error) throw error;
+
+		const refreshedSession = data.session;
+		if (refreshedSession) {
+			sessionRef.current = refreshedSession;
+			setUser(refreshedSession.user);
+		}
+
+		return refreshedSession;
+	}, []);
 
 	useEffect(() => {
 		/**
@@ -372,6 +390,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 		() => ({
 			user,
 			getSession,
+			refreshSession,
 			loading,
 			loginWithEmail,
 			signUpWithEmail,
@@ -385,6 +404,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 		[
 			user,
 			getSession,
+			refreshSession,
 			loading,
 			loginWithEmail,
 			signUpWithEmail,

--- a/app-expo/features/topics/hooks/useTopicSearch.ts
+++ b/app-expo/features/topics/hooks/useTopicSearch.ts
@@ -35,23 +35,42 @@ export const useTopicSearch = () => {
 			const remoteConfig = getRemoteConfig();
 			const searchResultTopicsNumber = parseInt(remoteConfig?.v1_search_result_dish_categories_number!, 10);
 
-			const topicsResponse = await callBackend<
-				QueryDishCategoryRecommendationsDto,
-				QueryDishCategoryRecommendationsResponse
-			>("v1/dish-categories/recommendations", {
-				method: "GET",
-				requestPayload: {
-					address: params.address,
-					timeSlot: params.timeSlot,
-					scene: params.scene,
-					taste: params.taste,
-					budgetIntent: deriveBudgetIntentFromPriceLevels(params.priceLevels),
-					diningPace: params.diningPace,
-					coreIngredient: params.coreIngredient,
-					languageTag: locale,
-					localLanguageCode: params.localLanguageCode,
-				},
-			});
+			const fetchRecommendations = () =>
+				callBackend<QueryDishCategoryRecommendationsDto, QueryDishCategoryRecommendationsResponse>(
+					"v1/dish-categories/recommendations",
+					{
+						method: "GET",
+						requestPayload: {
+							address: params.address,
+							timeSlot: params.timeSlot,
+							scene: params.scene,
+							taste: params.taste,
+							budgetIntent: deriveBudgetIntentFromPriceLevels(params.priceLevels),
+							diningPace: params.diningPace,
+							coreIngredient: params.coreIngredient,
+							languageTag: locale,
+							localLanguageCode: params.localLanguageCode,
+						},
+					},
+				);
+
+			let topicsResponse = await fetchRecommendations();
+			// #897 バックエンドは外部推薦のフォールバックまで失敗した場合、成功応答の空配列を返す。
+			// 空配列だけを一時失敗として扱い、別操作を要求せず500ms後に一度だけ再検索する。
+			if (topicsResponse.length === 0) {
+				logFrontendEvent({
+					event_name: "dish_category_recommendations_empty_retry",
+					error_level: "warn",
+					payload: {},
+				});
+				await new Promise((resolve) => setTimeout(resolve, 500));
+				topicsResponse = await fetchRecommendations();
+			}
+
+			if (topicsResponse.length === 0) {
+				// hookは表示手段を持たない。呼び出し元へ伝播し、Topics画面のSnackbarで通知する。
+				throw new Error(i18n.t("Topics.errors.fetchFailed"));
+			}
 
 			let topicsResponseWithCategoryIds: QueryDishCategoryRecommendationsResponse = topicsResponse
 				.slice(0, searchResultTopicsNumber)
@@ -81,8 +100,8 @@ export const useTopicSearch = () => {
 									...topic,
 									category:
 										createDishCategoryVariantResponse.labels &&
-										typeof createDishCategoryVariantResponse.labels === "object" &&
-										params.localLanguageCode in createDishCategoryVariantResponse.labels
+											typeof createDishCategoryVariantResponse.labels === "object" &&
+											params.localLanguageCode in createDishCategoryVariantResponse.labels
 											? (createDishCategoryVariantResponse.labels as Record<string, string>)[params.localLanguageCode]
 											: topic.category,
 									categoryId: createDishCategoryVariantResponse.id,
@@ -108,7 +127,7 @@ export const useTopicSearch = () => {
 
 			return topicsResponseWithCategoryIds.map((topic) => createTopic(topic));
 		},
-		[callBackend, createTopic, locale],
+		[callBackend, createTopic, locale, logFrontendEvent],
 	);
 
 	// #633 【設計】料理メディアの取得処理（オンデマンド実行用に export）

--- a/app-expo/hooks/useAPICall.ts
+++ b/app-expo/hooks/useAPICall.ts
@@ -16,13 +16,13 @@ import { fetchWithAuth } from "@/lib/fetchWithAuth";
 export type ApiError = {
 	/** クライアント側で使う大まかな分類コード */
 	code:
-		| "maintenance_mode"
-		| "unsupported_version"
-		| "forbidden"
-		| "http_error"
-		| "api_error"
-		| "invalid_response"
-		| "network_error";
+	| "maintenance_mode"
+	| "unsupported_version"
+	| "forbidden"
+	| "http_error"
+	| "api_error"
+	| "invalid_response"
+	| "network_error";
 
 	/** HTTP ステータス。ネットワークエラー等の場合は undefined or 0 */
 	status?: number;
@@ -58,7 +58,7 @@ export type ApiError = {
 export const useAPICall = () => {
 	const { logFrontendEvent } = useLogger();
 	const { showDialog } = useDialog();
-	const { getSession } = useAuth();
+	const { getSession, refreshSession } = useAuth();
 
 	/**
 	 * 指定されたエンドポイントに対して API を呼び出す関数
@@ -83,7 +83,7 @@ export const useAPICall = () => {
 			},
 		): Promise<R> => {
 			// 🔐 認証トークンの有無をチェック
-			const accessToken = getSession()?.access_token;
+			let accessToken = getSession()?.access_token;
 			if (!accessToken) {
 				throw new Error("User is not authenticated: Supabase access_token is missing.");
 			}
@@ -101,22 +101,88 @@ export const useAPICall = () => {
 				},
 			});
 
-			// #525 【設計】fetchWithAuth のネットワークエラーを ApiError 形式に正規化
-			let response: Response;
-			let endpoint: string;
-			try {
-				const result = await fetchWithAuth(
-					endpointName,
-					{
-						method,
-						requestPayload,
-						isMultipart,
-					},
-					accessToken,
-				);
-				response = result.response;
-				endpoint = result.endpoint;
-			} catch (networkError) {
+			// #897 リトライ上限は初回を含め2回に固定する。401・GETの一時障害が重なっても
+			// API呼び出し単位で無制限に再送せず、最終失敗は従来どおり下の共通処理へ渡す。
+			let response: Response | undefined;
+			let endpoint = endpointName;
+			let networkError: unknown;
+
+			for (let attempt = 0; attempt < 2; attempt++) {
+				response = undefined;
+				try {
+					const result = await fetchWithAuth(
+						endpointName,
+						{
+							method,
+							requestPayload,
+							isMultipart,
+						},
+						accessToken,
+					);
+					response = result.response;
+					endpoint = result.endpoint;
+					networkError = undefined;
+				} catch (error) {
+					networkError = error;
+					// 通信到達が不明なPOST等は重複作成を避ける。副作用のないGETだけを再送する。
+					if (method === "GET" && attempt === 0) {
+						logFrontendEvent({
+							event_name: "api_call_retry",
+							error_level: "warn",
+							payload: { endpoint: endpointName, method, reason: "network_error" },
+						});
+						await new Promise((resolve) => setTimeout(resolve, 500));
+						continue;
+					}
+					break;
+				}
+
+				// 自動refreshだけでは失敗済みリクエストは復旧しないため、新tokenで1回だけ再送する。
+				// 401は認証段階で拒否された応答なので、POSTを含めても処理の二重実行にはならない。
+				if (response.status === 401 && attempt === 0) {
+					try {
+						const refreshedSession = await refreshSession();
+						if (!refreshedSession?.access_token) break;
+						accessToken = refreshedSession.access_token;
+						logFrontendEvent({
+							event_name: "api_call_retry",
+							error_level: "warn",
+							payload: { endpoint: endpointName, method, reason: "session_refreshed_after_401" },
+						});
+						continue;
+					} catch (error) {
+						logFrontendEvent({
+							event_name: "api_call_session_refresh_failed",
+							error_level: "error",
+							payload: {
+								endpoint: endpointName,
+								error: error instanceof Error ? error.message : String(error),
+							},
+						});
+						break;
+					}
+				}
+
+				// 503は一時的な過負荷でも返る。GETに限定し、Retry-Afterを最大5秒まで尊重する。
+				if (response.status === 503 && method === "GET" && attempt === 0) {
+					const retryAfterHeader = response.headers.get("retry-after");
+					const retryAfterSeconds = retryAfterHeader === null ? Number.NaN : Number(retryAfterHeader);
+					const retryDelayMs = Number.isFinite(retryAfterSeconds)
+						? Math.min(Math.max(retryAfterSeconds * 1000, 0), 5000)
+						: 500;
+					logFrontendEvent({
+						event_name: "api_call_retry",
+						error_level: "warn",
+						payload: { endpoint: endpointName, method, reason: "service_unavailable", retryDelayMs },
+					});
+					await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+					continue;
+				}
+
+				break;
+			}
+
+			if (!response) {
 				logFrontendEvent({
 					event_name: "api_call_error",
 					error_level: "error",
@@ -288,7 +354,7 @@ export const useAPICall = () => {
 			// data のみを返す
 			return json.data;
 		},
-		[logFrontendEvent, getSession, showDialog],
+		[logFrontendEvent, getSession, refreshSession, showDialog],
 	);
 
 	return { callBackend };

--- a/shared/api/v1/dto/dish-categories/query-dish-category-recommendations.dto.ts
+++ b/shared/api/v1/dto/dish-categories/query-dish-category-recommendations.dto.ts
@@ -1,6 +1,10 @@
 import { IsArray, IsOptional, IsString, Matches } from "class-validator";
 import { Transform } from "class-transformer";
 
+// Expo の locale は script subtag を含むことがある。検索開始前に正当な
+// `zh-Hans` / `zh-Hant-TW` 等を ValidationError にしない範囲で受け入れる。
+const BCP47_LANGUAGE_TAG_PATTERN = /^[A-Za-z]{2,3}(?:-[A-Za-z]{4})?(?:-(?:[A-Za-z]{2}|\d{3}))?$/;
+
 // 共通の正規化: undefined / null / 空文字 / "undefined" / "null" を undefined にする
 const normalizeOptionalString = () =>
 	Transform(({ value }) => {
@@ -103,16 +107,16 @@ export class QueryDishCategoryRecommendationsDto {
 	/** 言語タグ (IETF BCP 47準拠, 例: en-US, ja-JP, fr-CA) */
 	/** TopicTitle や Reason の翻訳に使用される */
 	@IsString()
-	@Matches(/^[a-z]{2,3}(-[A-Z]{2})?$/, {
+	@Matches(BCP47_LANGUAGE_TAG_PATTERN, {
 		message: "languageTag must follow IETF BCP 47 format (e.g., en-US, ja-JP, fr-CA)",
 	})
 	languageTag!: string;
 
-	/** 現地言語コード (例: ka, ja, en) */
+	/** 現地言語タグ (例: ka, ja, zh-Hant) */
 	/** res.category の現地言語名取得に利用し後続の Google Maps TextSearch に渡される */
 	@IsString()
-	@Matches(/^[a-z]{2,3}$/, {
-		message: "localLanguageCode must be a 2-3 character language code (e.g., en, ja, ka)",
+	@Matches(BCP47_LANGUAGE_TAG_PATTERN, {
+		message: "localLanguageCode must follow IETF BCP 47 format (e.g., en, ja, zh-Hant)",
 	})
 	localLanguageCode!: string;
 }

--- a/shared/api/v1/dto/dish-category-group-votes/create-dish-category-group-vote.dto.ts
+++ b/shared/api/v1/dto/dish-category-group-votes/create-dish-category-group-vote.dto.ts
@@ -63,9 +63,13 @@ export class CreateDishCategoryGroupVoteCandidateDto {
 	@IsNotEmpty()
 	displayName!: string;
 
-	/** 投票作成時点で固定する候補サブタイトル */
+	/**
+	 * 投票作成時点で固定する候補サブタイトル。
+	 *
+	 * 推薦APIは要求言語の localized text がない場合も候補自体は返し、reason を
+	 * 空文字にする。その候補を投票から脱落させないため、文字列であることだけを保証する。
+	 */
 	@IsString()
-	@IsNotEmpty()
 	tagline!: string;
 
 	/** 投票作成時点で固定する画像URL */


### PR DESCRIPTION
推薦の空配列を一時失敗として1回再検索し、401時のセッション更新とGETの一時障害再試行を追加。
正当な言語タグの検証復元と、localized text欠落時の空tagline受理をDTOへ反映。