### PR TITLE
【DB】Prisma 7の接続プール設定をpg.Poolへ明示する

### DIFF
--- a/api/src/core/config/env.ts
+++ b/api/src/core/config/env.ts
@@ -14,6 +14,26 @@ const envSchema = z.object({
   CORS_ORIGIN: z.string(),
   DATABASE_URL: z.string(),
   DB_SCHEMA: z.string(),
+  // #904 【設計】Prisma 7 driver adapterではPool設定をDATABASE_URLではなくpg.Poolへ渡す
+  DB_POOL_MAX: z.coerce.number().int().min(1).max(10).default(1),
+  DB_POOL_CONNECTION_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(1_000)
+    .max(60_000)
+    .default(10_000),
+  DB_POOL_IDLE_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(1_000)
+    .max(300_000)
+    .default(30_000),
+  DB_POOL_MAX_LIFETIME_SECONDS: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(3_600)
+    .default(0),
   SUPABASE_JWT_SECRET: z.string(),
   GOOGLE_PLACE_API_KEY: z.string(),
   GCS_BUCKET_NAME: z.string(),

--- a/api/src/prisma/middlewares/metrics.middleware.ts
+++ b/api/src/prisma/middlewares/metrics.middleware.ts
@@ -1,7 +1,9 @@
 import { PrismaClient } from '../../../../shared/prisma/client';
 import { performance } from 'node:perf_hooks';
+import type { Pool, PoolClient } from 'pg';
 import {
   Counter,
+  Gauge,
   Histogram,
   Registry,
   collectDefaultMetrics,
@@ -43,6 +45,133 @@ const queryLatency =
     buckets: [5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000],
     registers: [registry],
   });
+
+// #904 【設計】Prisma 7 adapter-pgの実効Pool状態と接続取得待ち時間をNodeドライバ側で計測する
+const poolTotalConnections =
+  (registry.getSingleMetric('pg_pool_total_connections') as Gauge<string>) ??
+  new Gauge({
+    name: 'pg_pool_total_connections',
+    help: 'Total number of PostgreSQL clients in the pool',
+    registers: [registry],
+  });
+
+const poolIdleConnections =
+  (registry.getSingleMetric('pg_pool_idle_connections') as Gauge<string>) ??
+  new Gauge({
+    name: 'pg_pool_idle_connections',
+    help: 'Number of idle PostgreSQL clients in the pool',
+    registers: [registry],
+  });
+
+const poolWaitingRequests =
+  (registry.getSingleMetric('pg_pool_waiting_requests') as Gauge<string>) ??
+  new Gauge({
+    name: 'pg_pool_waiting_requests',
+    help: 'Number of requests waiting for a PostgreSQL client',
+    registers: [registry],
+  });
+
+const poolConnectionErrors =
+  (registry.getSingleMetric(
+    'pg_pool_connection_errors_total',
+  ) as Counter<string>) ??
+  new Counter({
+    name: 'pg_pool_connection_errors_total',
+    help: 'Total number of PostgreSQL pool connection errors',
+    labelNames: ['source'] as const,
+    registers: [registry],
+  });
+
+const poolAcquireLatency =
+  (registry.getSingleMetric(
+    'pg_pool_acquire_duration_milliseconds',
+  ) as Histogram<string>) ??
+  new Histogram({
+    name: 'pg_pool_acquire_duration_milliseconds',
+    help: 'PostgreSQL pool client acquisition duration in milliseconds',
+    labelNames: ['status'] as const,
+    buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1_000, 5_000, 10_000],
+    registers: [registry],
+  });
+
+const instrumentedPools: WeakSet<Pool> =
+  (global as any).__PG_POOL_METRICS_INSTRUMENTED__ ?? new WeakSet<Pool>();
+(global as any).__PG_POOL_METRICS_INSTRUMENTED__ = instrumentedPools;
+
+type PoolConnectCallback = (
+  error: Error | undefined,
+  client: PoolClient | undefined,
+  done: (release?: any) => void,
+) => void;
+
+function updatePoolStateMetrics(pool: Pool): void {
+  poolTotalConnections.set(pool.totalCount);
+  poolIdleConnections.set(pool.idleCount);
+  poolWaitingRequests.set(pool.waitingCount);
+}
+
+/**
+ * pg.Pool の状態と接続取得待ち時間を既存の Prometheus registry へ登録する。
+ *
+ * @param pool 計測対象の pg.Pool
+ * @returns 計測処理を追加した同一の pg.Pool
+ * @remarks 副作用として connect をラップし、Poolイベントリスナーを追加する。
+ * 失敗時は元の接続エラーを変更せず、呼び出し元へそのまま返す。
+ */
+export function withPoolMetrics<TPool extends Pool>(pool: TPool): TPool {
+  if (instrumentedPools.has(pool)) {
+    return pool;
+  }
+  instrumentedPools.add(pool);
+  updatePoolStateMetrics(pool);
+
+  const originalConnect = pool.connect.bind(pool) as Pool['connect'];
+  pool.connect = ((callback?: PoolConnectCallback) => {
+    const startedAt = performance.now();
+
+    const observeAcquire = (status: 'success' | 'error') => {
+      poolAcquireLatency
+        .labels(status)
+        .observe(performance.now() - startedAt);
+      updatePoolStateMetrics(pool);
+    };
+
+    if (callback) {
+      originalConnect((error, client, done) => {
+        const status = error ? 'error' : 'success';
+        if (error) {
+          poolConnectionErrors.labels('acquire').inc();
+        }
+        observeAcquire(status);
+        callback(error, client, done);
+      });
+      return;
+    }
+
+    return originalConnect().then(
+      (client) => {
+        observeAcquire('success');
+        return client;
+      },
+      (error) => {
+        poolConnectionErrors.labels('acquire').inc();
+        observeAcquire('error');
+        throw error;
+      },
+    );
+  }) as Pool['connect'];
+
+  pool.on('connect', () => updatePoolStateMetrics(pool));
+  pool.on('acquire', () => updatePoolStateMetrics(pool));
+  pool.on('release', () => updatePoolStateMetrics(pool));
+  pool.on('remove', () => updatePoolStateMetrics(pool));
+  pool.on('error', () => {
+    poolConnectionErrors.labels('idle').inc();
+    updatePoolStateMetrics(pool);
+  });
+
+  return pool;
+}
 
 /* ------------------------ Prisma Client Extension ---------------------- */
 /**

--- a/api/src/prisma/middlewares/metrics.middleware.ts
+++ b/api/src/prisma/middlewares/metrics.middleware.ts
@@ -163,7 +163,8 @@ export function withPoolMetrics<TPool extends Pool>(pool: TPool): TPool {
 
   pool.on('connect', () => updatePoolStateMetrics(pool));
   pool.on('acquire', () => updatePoolStateMetrics(pool));
-  pool.on('release', () => updatePoolStateMetrics(pool));
+  // #904 【バグ】releaseイベント時点ではidleキュー反映前のため、完了後の状態を次のイベントループで計測する
+  pool.on('release', () => setImmediate(() => updatePoolStateMetrics(pool)));
   pool.on('remove', () => updatePoolStateMetrics(pool));
   pool.on('error', () => {
     poolConnectionErrors.labels('idle').inc();

--- a/api/src/prisma/prisma.service.ts
+++ b/api/src/prisma/prisma.service.ts
@@ -7,7 +7,7 @@ import {
 import { PrismaClient, Prisma } from '../../../shared/prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
-import { withMetrics } from './middlewares/metrics.middleware';
+import { withMetrics, withPoolMetrics } from './middlewares/metrics.middleware';
 import { env } from 'src/core/config/env';
 
 // グローバルなシングルトンインスタンスを作成
@@ -40,12 +40,50 @@ export class PrismaService implements OnModuleInit, OnModuleDestroy {
     url.searchParams.delete('sslmode');
     const connectionString = url.toString();
 
-    const pool = new Pool({
-      connectionString,
-      ssl: {
-        rejectUnauthorized: false,
-      },
+    // #904 【設計】Prisma 7 driver adapterの接続上限と待機時間はpg.Pool側で明示管理する
+    const pool = withPoolMetrics(
+      new Pool({
+        connectionString,
+        ssl: {
+          rejectUnauthorized: false,
+        },
+        max: env.DB_POOL_MAX,
+        connectionTimeoutMillis: env.DB_POOL_CONNECTION_TIMEOUT_MS,
+        idleTimeoutMillis: env.DB_POOL_IDLE_TIMEOUT_MS,
+        maxLifetimeSeconds: env.DB_POOL_MAX_LIFETIME_SECONDS,
+      }),
+    );
+
+    // #904 【バグ】idle clientのerror未捕捉によるプロセス終了を防ぎ、Pool状態を構造化ログへ残す
+    pool.on('error', (error) => {
+      this.logger.error(
+        JSON.stringify({
+          severity: 'ERROR',
+          type: 'pg_pool',
+          message: 'Unexpected error on idle PostgreSQL client',
+          error: error.message,
+          total_count: pool.totalCount,
+          idle_count: pool.idleCount,
+          waiting_count: pool.waitingCount,
+          timestamp: new Date().toISOString(),
+        }),
+        error.stack,
+      );
     });
+
+    this.logger.log(
+      JSON.stringify({
+        severity: 'INFO',
+        type: 'pg_pool_config',
+        message: 'PostgreSQL pool configured',
+        max: env.DB_POOL_MAX,
+        connection_timeout_ms: env.DB_POOL_CONNECTION_TIMEOUT_MS,
+        idle_timeout_ms: env.DB_POOL_IDLE_TIMEOUT_MS,
+        max_lifetime_seconds: env.DB_POOL_MAX_LIFETIME_SECONDS,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+
     const adapter = new PrismaPg(pool);
     const base = new PrismaClient({
       adapter,

--- a/docs/database-connection-pool.md
+++ b/docs/database-connection-pool.md
@@ -1,0 +1,59 @@
+# PostgreSQL 接続プール設定
+
+## 背景
+
+Prisma ORM 7 で `@prisma/adapter-pg` を使用する場合、接続プールは Prisma の内蔵Poolではなく `pg.Pool` が管理する。
+
+`DATABASE_URL` に残っている次の旧Prisma向けパラメータは、`pg.Pool` の接続数・待機時間設定として扱わない。
+
+- `connection_limit`
+- `pool_timeout`
+- `pgbouncer`
+
+Issue #904 の初回対応ではURLパラメータを削除せず、接続方式も Supavisor session mode（5432）のままとする。URLの整理や transaction mode（6543）への切り替えは、prepared statementなどの互換性を別途確認してから実施する。
+
+## 実効設定
+
+API起動時に `api/src/core/config/env.ts` で検証し、`api/src/prisma/prisma.service.ts` から `pg.Pool` へ明示的に渡す。
+
+| 環境変数 | 初期値 | 許容範囲 | `pg.Pool` 設定 |
+| --- | ---: | ---: | --- |
+| `DB_POOL_MAX` | `1` | `1`〜`10` | `max` |
+| `DB_POOL_CONNECTION_TIMEOUT_MS` | `10000` | `1000`〜`60000` | `connectionTimeoutMillis` |
+| `DB_POOL_IDLE_TIMEOUT_MS` | `30000` | `1000`〜`300000` | `idleTimeoutMillis` |
+| `DB_POOL_MAX_LIFETIME_SECONDS` | `0` | `0`〜`3600` | `maxLifetimeSeconds` |
+
+`DB_POOL_MAX_LIFETIME_SECONDS=0` は接続寿命による強制ローテーションを無効にする。変更する場合は、接続再生成の頻度とレイテンシを本番メトリクスで確認する。
+
+## Cloud Runの最大接続数
+
+Issue #898 の調査時点ではCloud Runの最大インスタンス数は8、DB上限は60接続だった。
+
+初期値では理論最大接続数は次のとおり。
+
+```text
+8 instances × DB_POOL_MAX 1 = 8 connections
+```
+
+`DB_POOL_MAX` を変更するときは、アプリ以外の予約接続とSupabase内部サービスの利用枠を差し引き、全インスタンス合計がDB上限を超えないことを確認する。
+
+## 観測項目
+
+既存のPrometheusレジストリへ次のメトリクスを登録する。
+
+- `pg_pool_total_connections`
+- `pg_pool_idle_connections`
+- `pg_pool_waiting_requests`
+- `pg_pool_connection_errors_total{source="acquire"|"idle"}`
+- `pg_pool_acquire_duration_milliseconds{status="success"|"error"}`
+
+DBクエリ時間は既存の `prisma_query_duration_milliseconds` で計測する。
+
+idle clientのエラーは `pool.on('error')` で捕捉し、接続数と待機数を含む `pg_pool` 構造化ログとしてCloud Loggingへ出力する。起動時には実効設定を `pg_pool_config` ログへ出力する。
+
+## 調整手順
+
+1. まず `DB_POOL_MAX=1` でエラー率、APIレイテンシ、接続取得待ち時間、`waiting_requests` を確認する。
+2. 待機が継続し、DB側に十分な接続余力がある場合のみ `DB_POOL_MAX` を段階的に増やす。
+3. 変更後はCloud Runの最大インスタンス数を掛けた理論最大接続数を再計算する。
+4. 接続エラーやレイテンシが悪化した場合は直前の値へ戻す。


### PR DESCRIPTION
Closes #904

## 概要

Prisma ORM 7 / `@prisma/adapter-pg` 移行後の実効接続プールを `pg.Pool` 側で明示管理し、Cloud Runスケール時の接続数を制御できるようにします。

## 変更内容

- `DB_POOL_MAX`、接続タイムアウト、idleタイムアウト、最大接続寿命を環境変数として追加
- `pg.Pool` へ各設定を明示的に適用
- 初期値を `DB_POOL_MAX=1` とし、Cloud Run最大8インスタンス時の理論最大を8接続に制限
- `pool.on('error')` でidle clientエラーを捕捉し、Pool状態を構造化ログへ出力
- Pool状態・接続取得待ち時間・接続エラーを既存Prometheusレジストリへ追加
- DATABASE_URLの旧Prisma向けパラメータを初回変更では削除しない方針と調整手順をドキュメント化

## 追加した設定

| 環境変数 | 初期値 | `pg.Pool` |
| --- | ---: | --- |
| `DB_POOL_MAX` | `1` | `max` |
| `DB_POOL_CONNECTION_TIMEOUT_MS` | `10000` | `connectionTimeoutMillis` |
| `DB_POOL_IDLE_TIMEOUT_MS` | `30000` | `idleTimeoutMillis` |
| `DB_POOL_MAX_LIFETIME_SECONDS` | `0` | `maxLifetimeSeconds` |

## 追加した観測項目

- `pg_pool_total_connections`
- `pg_pool_idle_connections`
- `pg_pool_waiting_requests`
- `pg_pool_connection_errors_total`
- `pg_pool_acquire_duration_milliseconds`
- 起動時の `pg_pool_config` 構造化ログ
- idle clientエラー時の `pg_pool` 構造化ログ

既存の `prisma_query_duration_milliseconds` でDBクエリ時間も継続して観測します。

## 確認

- 変更部分はTypeScript 5.8の最小スタブ環境で型検証済み
- リポジトリ全体の `pnpm typecheck` / `pnpm build` は、実行環境から依存関係を取得できないため未実施
- 本番でのエラー率・レイテンシ・Pool待機状況はデプロイ後に確認が必要

## リスクとロールバック

`DB_POOL_MAX=1` によりDB接続数を抑える一方、1コンテナ内の同時DB利用が増えると接続待ち時間が増える可能性があります。`waiting_requests` と接続取得時間を確認し、DB側に余力がある場合のみ段階的に増やします。悪化時は環境変数を直前の値へ戻します。

## スクショ不要の理由

APIのDB接続設定・メトリクス・ドキュメントのみの変更で、画面表示には影響しないためです。