### PR TITLE
#941 fix: グループ投票で全員が未投票のとき全候補が「1位」と表示される不具合を修正

### DIFF
--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCandidateCard.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCandidateCard.tsx
@@ -13,6 +13,7 @@ import i18n from "@/lib/i18n";
 type Props = {
 	candidate: DishCategoryGroupVoteCandidate;
 	isHost: boolean;
+	hasVotes: boolean;
 	isDishMediaLoading: boolean;
 	onPressCandidate: (candidate: DishCategoryGroupVoteCandidate) => void;
 	onPressDishMedia: (candidate: DishCategoryGroupVoteCandidate) => void;
@@ -22,6 +23,7 @@ type Props = {
 export function DishCategoryGroupVoteCandidateCard({
 	candidate,
 	isHost,
+	hasVotes,
 	isDishMediaLoading,
 	onPressCandidate,
 	onPressDishMedia,
@@ -33,7 +35,12 @@ export function DishCategoryGroupVoteCandidateCard({
 		<Pressable style={styles.card} onPress={() => onPressCandidate(candidate)}>
 			<Image source={{ uri: candidate.imageUrl }} style={styles.image} contentFit="cover" />
 			<View style={styles.rankBadge}>
-				<Text style={styles.rankText}>{candidate.rank ? `${candidate.rank}位` : "-"}</Text>
+				{/* #941 【仕様】総投票数0はBEが全候補同率rank(=1)で返すため、UI側で「未投票」に統一する */}
+				<Text style={styles.rankText} numberOfLines={1}>
+					{hasVotes && candidate.rank
+						? i18n.t("DishCategoryGroupVotes.rankLabel", { rank: candidate.rank })
+						: i18n.t("DishCategoryGroupVotes.unvoted")}
+				</Text>
 			</View>
 			<View style={styles.info}>
 				<Text style={styles.title} numberOfLines={1}>
@@ -101,9 +108,11 @@ const styles = StyleSheet.create({
 		backgroundColor: "#E5E7EB",
 	},
 	rankBadge: {
-		width: 38,
+		// #941 「未投票」など可変長ラベルが入るため固定 width から minWidth+padding に変更
+		minWidth: 38,
 		height: 38,
 		borderRadius: 19,
+		paddingHorizontal: 6,
 		alignItems: "center",
 		justifyContent: "center",
 		backgroundColor: "#F05537",

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCandidateDetailModal.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCandidateDetailModal.tsx
@@ -14,6 +14,7 @@ import i18n from "@/lib/i18n";
 type Props = {
 	candidate: DishCategoryGroupVoteCandidate;
 	isHost: boolean;
+	hasVotes: boolean;
 	isDishMediaLoading: boolean;
 	onPressDishMedia: (candidate: DishCategoryGroupVoteCandidate) => void;
 	onDeleteCandidate: (candidate: DishCategoryGroupVoteCandidate) => void;
@@ -22,6 +23,7 @@ type Props = {
 export function DishCategoryGroupVoteCandidateDetailModal({
 	candidate,
 	isHost,
+	hasVotes,
 	isDishMediaLoading,
 	onPressDishMedia,
 	onDeleteCandidate,
@@ -36,7 +38,12 @@ export function DishCategoryGroupVoteCandidateDetailModal({
 				<View style={styles.hero}>
 					<Image source={{ uri: candidate.imageUrl }} style={styles.image} contentFit="cover" />
 					<View style={styles.rankBadge}>
-						<Text style={styles.rankText}>{candidate.rank ? `${candidate.rank}位` : "-"}</Text>
+						{/* #941 【仕様】総投票数0はBEが全候補同率rank(=1)で返すため、UI側で「未投票」に統一する */}
+						<Text style={styles.rankText}>
+							{hasVotes && candidate.rank
+								? i18n.t("DishCategoryGroupVotes.rankLabel", { rank: candidate.rank })
+								: i18n.t("DishCategoryGroupVotes.unvoted")}
+						</Text>
 					</View>
 				</View>
 				<Text style={styles.title}>{candidate.displayName}</Text>

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCandidateList.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCandidateList.tsx
@@ -11,6 +11,7 @@ import { DishCategoryGroupVoteCandidateCard } from "./DishCategoryGroupVoteCandi
 type Props = {
 	candidates: DishCategoryGroupVoteCandidate[];
 	isHost: boolean;
+	hasVotes: boolean;
 	loadingCandidateId: string | null;
 	onPressCandidate: (candidate: DishCategoryGroupVoteCandidate) => void;
 	onPressDishMedia: (candidate: DishCategoryGroupVoteCandidate) => void;
@@ -20,21 +21,17 @@ type Props = {
 export function DishCategoryGroupVoteCandidateList({
 	candidates,
 	isHost,
+	hasVotes,
 	loadingCandidateId,
 	onPressCandidate,
 	onPressDishMedia,
 	onDeleteCandidate,
 }: Props) {
-	// rank は同率を保持するため、同順位内だけ displayOrder で表示順を安定させる。
-	// rank が返らない古いレスポンスでも末尾で displayOrder 順に並べる。
+	// #856 【仕様】表示順は投票結果で並び替えず、候補作成時の displayOrder を維持する
+	// (順位はバッジのみで示す)。rank によるソートは行わない。
 	const visibleCandidates = candidates
 		.filter((candidate) => candidate.deletedAt === null)
-		.sort((a, b) => {
-			const rankA = a.rank ?? Number.MAX_SAFE_INTEGER;
-			const rankB = b.rank ?? Number.MAX_SAFE_INTEGER;
-			if (rankA !== rankB) return rankA - rankB;
-			return a.displayOrder - b.displayOrder;
-		});
+		.sort((a, b) => a.displayOrder - b.displayOrder);
 
 	return (
 		<View style={styles.container}>
@@ -43,6 +40,7 @@ export function DishCategoryGroupVoteCandidateList({
 					key={candidate.id}
 					candidate={candidate}
 					isHost={isHost}
+					hasVotes={hasVotes}
 					isDishMediaLoading={loadingCandidateId === candidate.id}
 					onPressCandidate={onPressCandidate}
 					onPressDishMedia={onPressDishMedia}

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.tsx
@@ -181,6 +181,10 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 		);
 	}
 
+	// #941 【仕様】全候補の総投票数が 0 のときは BE が返す rank(=同スコアで全員1位) を
+	// そのまま表示せず「未投票」に統一する。総投票数はここでのみ判定し、rank の算出ロジック(BE)は変更しない。
+	const hasVotes = detail.candidates.some((candidate) => candidate.likeCount > 0 || candidate.dislikeCount > 0);
+
 	return (
 		<SafeAreaView style={styles.safeArea} edges={[]}>
 			<SearchHeader title={i18n.t("DishCategoryGroupVotes.resultTitle")} onPressBack={() => router.back()} />
@@ -230,6 +234,7 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 				<DishCategoryGroupVoteCandidateList
 					candidates={detail.candidates}
 					isHost={detail.session.isHost}
+					hasVotes={hasVotes}
 					loadingCandidateId={loadingCandidateId}
 					onPressCandidate={handlePressCandidate}
 					onPressDishMedia={handleOpenCandidateDishMedia}
@@ -242,6 +247,7 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 					<DishCategoryGroupVoteCandidateDetailModal
 						candidate={selectedCandidate}
 						isHost={detail.session.isHost}
+						hasVotes={hasVotes}
 						isDishMediaLoading={loadingCandidateId === selectedCandidate.id}
 						onPressDishMedia={handleOpenCandidateDishMedia}
 						onDeleteCandidate={handleDeleteCandidate}

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -47,6 +47,8 @@
 		"copyShareLink": "نسخ رابط المشاركة",
 		"voteCta": "تصويت",
 		"candidatesTitle": "الخيارات",
+		"rankLabel": "المركز {{rank}}",
+		"unvoted": "لم يتم التصويت",
 		"commentsTitle": "التعليقات",
 		"viewRestaurants": "عرض المطاعم",
 		"loadingRestaurants": "جارٍ البحث",

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -47,6 +47,8 @@
 		"copyShareLink": "Copy share link",
 		"voteCta": "Vote",
 		"candidatesTitle": "Choices",
+		"rankLabel": "#{{rank}}",
+		"unvoted": "Not voted yet",
 		"commentsTitle": "Comments",
 		"viewRestaurants": "View restaurants",
 		"loadingRestaurants": "Searching",

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -47,6 +47,8 @@
 		"copyShareLink": "Copiar enlace",
 		"voteCta": "Votar",
 		"candidatesTitle": "Opciones",
+		"rankLabel": "N.º {{rank}}",
+		"unvoted": "Sin votos",
 		"commentsTitle": "Comentarios",
 		"viewRestaurants": "Ver restaurantes",
 		"loadingRestaurants": "Buscando",

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -47,6 +47,8 @@
 		"copyShareLink": "Copier le lien",
 		"voteCta": "Voter",
 		"candidatesTitle": "Choix",
+		"rankLabel": "N° {{rank}}",
+		"unvoted": "Pas encore voté",
 		"commentsTitle": "Commentaires",
 		"viewRestaurants": "Voir les restaurants",
 		"loadingRestaurants": "Recherche",

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -47,6 +47,8 @@
 		"copyShareLink": "शेयर लिंक कॉपी करें",
 		"voteCta": "वोट करें",
 		"candidatesTitle": "विकल्प",
+		"rankLabel": "स्थान {{rank}}",
+		"unvoted": "अभी तक वोट नहीं",
 		"commentsTitle": "टिप्पणियाँ",
 		"viewRestaurants": "रेस्तरां देखें",
 		"loadingRestaurants": "खोज रहे हैं",

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -47,6 +47,8 @@
 		"copyShareLink": "共有リンクをコピー",
 		"voteCta": "投票する",
 		"candidatesTitle": "候補",
+		"rankLabel": "{{rank}}位",
+		"unvoted": "未投票",
 		"commentsTitle": "コメント",
 		"viewRestaurants": "店を見る",
 		"loadingRestaurants": "検索中",

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -47,6 +47,8 @@
 		"copyShareLink": "공유 링크 복사",
 		"voteCta": "투표하기",
 		"candidatesTitle": "후보",
+		"rankLabel": "{{rank}}위",
+		"unvoted": "미투표",
 		"commentsTitle": "댓글",
 		"viewRestaurants": "가게 보기",
 		"loadingRestaurants": "검색 중",

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -47,6 +47,8 @@
 		"copyShareLink": "复制分享链接",
 		"voteCta": "投票",
 		"candidatesTitle": "选项",
+		"rankLabel": "第{{rank}}名",
+		"unvoted": "未投票",
 		"commentsTitle": "评论",
 		"viewRestaurants": "查看餐厅",
 		"loadingRestaurants": "搜索中",


### PR DESCRIPTION
## 概要

close #941

グループ投票の結果画面で、参加者・投票がまだ0件のセッションを開くと全候補が「1位」と表示されていた不具合を修正。

## 原因

BE (`dish-category-group-votes.assembler.ts` の `buildRanks`) は総投票数が0のときも全候補を同スコア (likeCount=0, dislikeCount=0) として扱い `rank=1` を返す。これは「同スコアは同順位」という仕様通りの挙動であり、rank算出ロジック自体は変更していない。

「未投票と分かるように表示する」のはUI都合の判断のため、**FEのみ**で対応（設計議論の結果、BEには手を入れない方針）。

## 変更内容

- `DishCategoryGroupVoteResultScreen.tsx`: セッション全体の投票有無 (`hasVotes`) を算出し、CandidateList/CandidateDetailModal に伝播
- `DishCategoryGroupVoteCandidateCard.tsx` / `DishCategoryGroupVoteCandidateDetailModal.tsx`: `hasVotes=false` のときは rank を無視して「未投票」バッジを表示。バッジ幅を固定→可変(minWidth+padding)に変更し可変長ラベルに対応
- `DishCategoryGroupVoteCandidateList.tsx`: 表示順ソートを rank基準からdisplayOrder基準に変更(#856 仕様「表示順は投票結果で並び替えない」に合わせて修正)
- 「○位」のハードコード文言を i18n化 (`DishCategoryGroupVotes.rankLabel` / `.unvoted`、8言語追加)

## 動作確認

Playwright + 実際の dev API (`api-development.nanitabeyo.net`) を使い、候補3件のグループ投票セッションを作成して実機フローで確認。スクリーンショットは `tmp/941-投票結果の順位表示修正/` に保存（tmp/ は gitignore 対象のためリポジトリには含めていません）。

- `1-before-votes.png`: 投票0件時、全候補が「未投票」バッジで表示される
- `2-after-votes.png`: 投票後、ラーメン=1位(1いいね)、焼き鳥・ハンバーガー=2位(同率タイ、BEのタイ判定ロジック通り)

## 確認項目

- [x] `pnpm --filter app-expo typecheck` 通過
- [x] Playwright で実データ確認(投票前/投票後)
- [x] 8言語 locale ファイルへのキー追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)