### PR TITLE
#933 fix: 検索・地図・レビュー画面の現在地/クリア/ヘルプアイコンにアクセシブル名が無くタップ領域も不足している不具合を修正

### DIFF
--- a/app-expo/app/[locale]/(tabs)/map.tsx
+++ b/app-expo/app/[locale]/(tabs)/map.tsx
@@ -262,7 +262,13 @@ export default function MapScreen() {
 					onClear={() => setSearchQuery("")}
 					placeholder={i18n.t("Map.placeholders.searchRestaurants")}
 					renderInputRight={
-						<TouchableOpacity style={styles.currentLocationButton} onPress={handleCurrentLocation}>
+						<TouchableOpacity
+							style={styles.currentLocationButton}
+							onPress={handleCurrentLocation}
+							hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+							accessibilityRole="button"
+							accessibilityLabel={i18n.t("Map.accessibility.useCurrentLocation")}
+							testID="map-current-location-button">
 							<Navigation size={20} color="#F05537" />
 						</TouchableOpacity>
 					}

--- a/app-expo/app/[locale]/(tabs)/review/selectRestaurant.tsx
+++ b/app-expo/app/[locale]/(tabs)/review/selectRestaurant.tsx
@@ -471,7 +471,13 @@ export default function SelectRestaurantScreen() {
 						onClear={() => setSearchQuery("")}
 						placeholder={i18n.t("Map.placeholders.searchRestaurantsForReview")}
 						renderInputRight={
-							<TouchableOpacity style={styles.currentLocationButton} onPress={handleCurrentLocation}>
+							<TouchableOpacity
+								style={styles.currentLocationButton}
+								onPress={handleCurrentLocation}
+								hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+								accessibilityRole="button"
+								accessibilityLabel={i18n.t("Map.accessibility.useCurrentLocation")}
+								testID="review-select-restaurant-current-location-button">
 								<Navigation size={20} color="#000000" />
 							</TouchableOpacity>
 						}

--- a/app-expo/app/[locale]/(tabs)/search/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/index.tsx
@@ -337,7 +337,13 @@ export default function SearchScreen() {
 				<Text style={styles.headerTitle}>{i18n.t("Search.headerTitle")}</Text>
 				{/* #642 【設計】ヘルプアイコンからチュートリアルを再表示 */}
 				{isJapanese && (
-					<TouchableOpacity style={styles.helpButton} onPress={handleOpenTutorial}>
+					<TouchableOpacity
+						style={styles.helpButton}
+						onPress={handleOpenTutorial}
+						hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+						accessibilityRole="button"
+						accessibilityLabel={i18n.t("Search.accessibility.showTutorial")}
+						testID="search-help-button">
 						<HelpCircle size={24} color="#6B7280" />
 					</TouchableOpacity>
 				)}
@@ -366,7 +372,13 @@ export default function SearchScreen() {
 							placeholder={i18n.t("Search.placeholders.enterLocation")}
 							autoClearOnFocus={locationQuery === i18n.t("Search.currentLocation")}
 							renderInputRight={
-								<TouchableOpacity style={styles.currentLocationButton} onPress={handleUseCurrentLocation}>
+								<TouchableOpacity
+									style={styles.currentLocationButton}
+									onPress={handleUseCurrentLocation}
+									hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+									accessibilityRole="button"
+									accessibilityLabel={i18n.t("Search.accessibility.useCurrentLocation")}
+									testID="search-current-location-button">
 									<Navigation size={20} color="#000000" />
 								</TouchableOpacity>
 							}

--- a/app-expo/components/LocationAutocomplete.tsx
+++ b/app-expo/components/LocationAutocomplete.tsx
@@ -194,6 +194,7 @@ export function LocationAutocomplete({
 					<TouchableOpacity
 						style={styles.clearButton}
 						onPress={handleClear}
+						hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
 						accessibilityRole="button"
 						accessibilityLabel={i18n.t("Search.accessibility.clearLocation")}
 						testID={`${testID}-clear`}>

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -123,6 +123,8 @@
 		"accessibility": {
 			"locationInputHint": "أدخل موقعًا للبحث عن المطاعم",
 			"clearLocation": "مسح الموقع",
+			"useCurrentLocation": "استخدام الموقع الحالي",
+			"showTutorial": "عرض كيفية الاستخدام",
 			"selectLocation": "اختر هذا الموقع"
 		},
 		"loading": "جارٍ البحث...",
@@ -489,6 +491,7 @@
 			"dishCategoryNoResults": "لم يتم العثور على فئات أطباق مطابقة",
 			"dishCategoryInputHint": "أدخل فئة الطبق للبحث",
 			"clearDishCategory": "مسح فئة الطبق",
+			"useCurrentLocation": "استخدام الموقع الحالي",
 			"selectDishCategory": "اختر فئة الطبق هذه"
 		},
 		"errors": {

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -123,6 +123,8 @@
 		"accessibility": {
 			"locationInputHint": "Enter a location to search for restaurants",
 			"clearLocation": "Clear location",
+			"useCurrentLocation": "Use current location",
+			"showTutorial": "View how to use",
 			"selectLocation": "Select this location"
 		},
 		"loading": "Searching...",
@@ -489,6 +491,7 @@
 			"dishCategoryNoResults": "No matching dish categories found",
 			"dishCategoryInputHint": "Enter a dish category to search",
 			"clearDishCategory": "Clear dish category",
+			"useCurrentLocation": "Use current location",
 			"selectDishCategory": "Select this dish category"
 		},
 		"errors": {

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -123,6 +123,8 @@
 		"accessibility": {
 			"locationInputHint": "Introduce una ubicación para buscar restaurantes",
 			"clearLocation": "Borrar ubicación",
+			"useCurrentLocation": "Usar ubicación actual",
+			"showTutorial": "Ver cómo usar",
 			"selectLocation": "Seleccionar esta ubicación"
 		},
 		"loading": "Buscando...",
@@ -489,6 +491,7 @@
 			"dishCategoryNoResults": "No se encontraron categorías de platos coincidentes",
 			"dishCategoryInputHint": "Introduce una categoría de plato para buscar",
 			"clearDishCategory": "Borrar categoría de plato",
+			"useCurrentLocation": "Usar ubicación actual",
 			"selectDishCategory": "Seleccionar esta categoría de plato"
 		},
 		"errors": {

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -123,6 +123,8 @@
 		"accessibility": {
 			"locationInputHint": "Saisissez un lieu pour rechercher des restaurants",
 			"clearLocation": "Effacer le lieu",
+			"useCurrentLocation": "Utiliser la position actuelle",
+			"showTutorial": "Voir le mode d'emploi",
 			"selectLocation": "Sélectionner ce lieu"
 		},
 		"loading": "Recherche...",
@@ -489,6 +491,7 @@
 			"dishCategoryNoResults": "Aucune catégorie de plat correspondante trouvée",
 			"dishCategoryInputHint": "Saisissez une catégorie de plat pour rechercher",
 			"clearDishCategory": "Effacer la catégorie de plat",
+			"useCurrentLocation": "Utiliser la position actuelle",
 			"selectDishCategory": "Sélectionner cette catégorie de plat"
 		},
 		"errors": {

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -123,6 +123,8 @@
 		"accessibility": {
 			"locationInputHint": "रेस्टोरेंट खोजने के लिए स्थान दर्ज करें",
 			"clearLocation": "स्थान साफ़ करें",
+			"useCurrentLocation": "वर्तमान स्थान का उपयोग करें",
+			"showTutorial": "उपयोग कैसे करें देखें",
 			"selectLocation": "इस स्थान को चुनें"
 		},
 		"loading": "खोज जारी...",
@@ -490,6 +492,7 @@
 			"dishCategoryNoResults": "No matching dish categories found",
 			"dishCategoryInputHint": "खोजने के लिए डिश श्रेणी दर्ज करें",
 			"clearDishCategory": "डिश श्रेणी साफ़ करें",
+			"useCurrentLocation": "वर्तमान स्थान का उपयोग करें",
 			"selectDishCategory": "इस डिश श्रेणी को चुनें"
 		},
 		"errors": {

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -123,6 +123,8 @@
 		"accessibility": {
 			"locationInputHint": "レストランを検索する場所を入力してください",
 			"clearLocation": "場所をクリア",
+			"useCurrentLocation": "現在地を使う",
+			"showTutorial": "使い方を見る",
 			"selectLocation": "この場所を選択"
 		},
 		"loading": "検索中...",
@@ -489,6 +491,7 @@
 			"dishCategoryNoResults": "一致する料理カテゴリが見つかりませんでした",
 			"dishCategoryInputHint": "料理カテゴリを入力して検索してください",
 			"clearDishCategory": "料理カテゴリをクリア",
+			"useCurrentLocation": "現在地を使う",
 			"selectDishCategory": "この料理カテゴリを選択"
 		},
 		"errors": {

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -123,6 +123,8 @@
 		"accessibility": {
 			"locationInputHint": "레스토랑을 검색할 위치를 입력하세요",
 			"clearLocation": "위치 지우기",
+			"useCurrentLocation": "현재 위치 사용",
+			"showTutorial": "사용법 보기",
 			"selectLocation": "이 위치 선택"
 		},
 		"loading": "검색 중...",
@@ -489,6 +491,7 @@
 			"dishCategoryNoResults": "일치하는 요리 카테고리를 찾을 수 없습니다",
 			"dishCategoryInputHint": "검색할 음식 카테고리를 입력하세요",
 			"clearDishCategory": "음식 카테고리 지우기",
+			"useCurrentLocation": "현재 위치 사용",
 			"selectDishCategory": "이 음식 카테고리 선택"
 		},
 		"errors": {

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -123,6 +123,8 @@
 		"accessibility": {
 			"locationInputHint": "输入地点以搜索餐厅",
 			"clearLocation": "清除位置",
+			"useCurrentLocation": "使用当前位置",
+			"showTutorial": "查看使用方法",
 			"selectLocation": "选择此位置"
 		},
 		"loading": "搜索中...",
@@ -489,6 +491,7 @@
 			"dishCategoryNoResults": "未找到匹配的菜品类别",
 			"dishCategoryInputHint": "输入菜品类别以搜索",
 			"clearDishCategory": "清除菜品类别",
+			"useCurrentLocation": "使用当前位置",
 			"selectDishCategory": "选择此菜品类别"
 		},
 		"errors": {


### PR DESCRIPTION
## 概要

close #933 (UX-005, UX-012)

検索画面・地図画面・レビュー用店舗選択画面の現在地ボタンとヘルプアイコンに `accessibilityLabel`/`accessibilityRole`/`testID` が一切無く、スクリーンリーダー利用者が機能を判別できなかった不具合を修正。クリアボタンにタップ領域拡張(hitSlop)を追加。

## 変更内容

- `search/index.tsx` / `map.tsx` / `review/selectRestaurant.tsx`: 現在地ボタンに `accessibilityRole="button"` + `accessibilityLabel`(「現在地を使う」) + `testID` + `hitSlop(8px)` を付与
- `search/index.tsx`: ヘルプアイコンに `accessibilityLabel`(「使い方を見る」) + `testID` + `hitSlop` を付与
- `LocationAutocomplete.tsx`: クリアボタンに `hitSlop(8px)` を追加(既存 padding:12 と合わせて実効タップ領域 56×56px 相当に拡大、隣接する現在地ボタンとの誤タップリスクを低減)
- i18n: `Search.accessibility.useCurrentLocation`/`showTutorial`、`Map.accessibility.useCurrentLocation` を8言語に追加

現在地取得の許可状態変化を `announceForAccessibility` で通知する対応(設計doc記載)は、現在地取得ロジック自体を扱う #932 側にまとめます(本チケットはラベル/タップ領域のみ)。

## 動作確認

Playwright + 実際の dev API で検索画面を表示し確認。

```
current location button found: true
bounding box: { x: 320, y: 110, width: 53, height: 52 }
help button found: true
clear button found (should be null when empty): false
```

実効タップ領域が 44×44px を上回ることを確認。

スクリーンショット: `tmp/933-地点入力の右端アイコンa11yとタップ領域/1-search-screen.png`（tmp/ は gitignore 対象のためリポジトリには含めていません）— レイアウトに変化が無いことを確認。

## 確認項目

- [x] `pnpm --filter app-expo typecheck` 通過
- [x] Playwright + 実データで aria-label/タップ領域を確認
- [x] 8言語 locale ファイルへのキー追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)