### PR TITLE
#952 fix: 地点サジェストの同名候補(渋谷駅など)の重複をサーバー側deduplicationで解消

### DIFF
--- a/api/src/v1/locations/locations.service.spec.ts
+++ b/api/src/v1/locations/locations.service.spec.ts
@@ -393,4 +393,132 @@ describe('LocationsService', () => {
       expect(result.address).toContain('locality:Oita City');
     });
   });
+
+  describe('autocompleteLocations', () => {
+    const mockQuery = {
+      q: '渋谷駅',
+      languageCode: 'ja',
+      sessionToken: 'test-session-token',
+    };
+
+    /** Autocomplete (New) の suggestion 形式でモック候補を作る */
+    const buildSuggestion = (
+      placeId: string,
+      mainText: string,
+      secondaryText: string,
+      types: string[],
+    ) => ({
+      placePrediction: {
+        placeId,
+        text: { text: `${mainText}、${secondaryText}` },
+        structuredFormat: {
+          mainText: { text: mainText },
+          secondaryText: { text: secondaryText },
+        },
+        types,
+      },
+    });
+
+    it('should dedupe same-name candidates keeping the establishment one', async () => {
+      // #952 【テスト】渋谷駅が「駅(establishment)」と「番地レベル(geocode)」で重複するケース。
+      // 関連度順では番地レベルが後だが、establishment が優先されて1件に畳まれること。
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion('place-station', '渋谷駅', '日本、東京都渋谷区', [
+            'train_station',
+            'transit_station',
+            'point_of_interest',
+            'establishment',
+          ]),
+          buildSuggestion(
+            'place-address',
+            '渋谷駅',
+            '日本、東京都渋谷区２丁目２４',
+            ['geocode'],
+          ),
+          buildSuggestion(
+            'place-mark-city',
+            'マークシティ',
+            '日本、東京都渋谷区',
+            ['shopping_mall', 'establishment'],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].place_id).toBe('place-station');
+      expect(result[1].place_id).toBe('place-mark-city');
+    });
+
+    it('should prefer the establishment even when the address-level candidate comes first', async () => {
+      // #952 【テスト】関連度順で番地レベルが先頭に来ても、駅(establishment)が残ること。
+      // 返却順は先勝ちの位置(先頭)を維持する。
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion(
+            'place-address',
+            '渋谷駅',
+            '日本、東京都渋谷区２丁目２４',
+            ['geocode'],
+          ),
+          buildSuggestion('place-station', '渋谷駅', '日本、東京都渋谷区', [
+            'train_station',
+            'establishment',
+          ]),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].place_id).toBe('place-station');
+    });
+
+    it('should keep distinct names untouched', async () => {
+      // #952 【テスト】「渋谷駅」と「渋谷駅前」は別地点なので dedup 対象外であること
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion('place-station', '渋谷駅', '日本、東京都渋谷区', [
+            'train_station',
+            'establishment',
+          ]),
+          buildSuggestion('place-square', '渋谷駅前', '日本、東京都渋谷区', [
+            'point_of_interest',
+            'establishment',
+          ]),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should dedupe full-width/half-width and spacing variants of the same name', async () => {
+      // #952 【テスト】NFKC 正規化 + 空白除去により表記ゆれの同名も1件に畳まれること
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion(
+            'place-1',
+            'ＡＢＣマート 渋谷',
+            '日本、東京都渋谷区',
+            ['establishment'],
+          ),
+          buildSuggestion(
+            'place-2',
+            'ABCマート渋谷',
+            '日本、東京都渋谷区２丁目',
+            ['geocode'],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].place_id).toBe('place-1');
+    });
+  });
 });

--- a/api/src/v1/locations/locations.service.ts
+++ b/api/src/v1/locations/locations.service.ts
@@ -554,10 +554,66 @@ export class LocationsService {
         return [];
       }
 
-      return places;
+      // #952 【設計】Google は同じ場所を粒度違いで複数返すことがある
+      // (例: 渋谷駅 →「日本、東京都渋谷区」の transit_station と
+      //  「日本、東京都渋谷区２丁目２４」の番地レベル geocode の2件)。
+      // ユーザーにとって同名候補の粒度差は意味を持たず単なる重複に見えるため、
+      // ここで同名候補を1件に畳む。全クライアントに効かせるためサーバー側で行う。
+      return this.dedupeAutocompletePlaces(places);
     } catch (error) {
       throw error;
     }
+  }
+
+  /**
+   * #952 【設計】Autocomplete 候補の同名重複を除去する。
+   *
+   * ルール:
+   * 1. mainText を正規化(NFKC + 空白除去)したものをグループキーにする。
+   *    「渋谷駅」と「渋谷駅前」のような別地点は別キーになり残る。
+   * 2. 同名グループ内では `establishment` を types に持つ候補(実在施設としての
+   *    prediction)を優先する。番地レベルの重複(street_address / premise /
+   *    純粋な geocode)は establishment を持たないため、これで自然に落ちる。
+   * 3. 優先度が同じ候補同士は Google の関連度順(配列順)で先勝ち。
+   * 4. 返却順は元の関連度順を維持する(グループの初出位置)。
+   *
+   * なお Autocomplete (New) は最大5件固定で追加取得手段がないため、
+   * dedup により件数は減りうる(通常は0〜1件)。同名重複が並ぶより
+   * 少なくてもクリーンな候補の方が選びやすい、という判断を優先している。
+   */
+  private dedupeAutocompletePlaces(
+    places: AutocompleteLocationsResponse,
+  ): AutocompleteLocationsResponse {
+    const normalizeKey = (mainText: string): string =>
+      mainText.normalize('NFKC').replace(/\s+/g, '');
+
+    const isEstablishment = (place: { types: string[] }): boolean =>
+      place.types.includes('establishment');
+
+    const bestByKey = new Map<
+      string,
+      { place: AutocompleteLocationsResponse[number]; firstIndex: number }
+    >();
+
+    places.forEach((place, index) => {
+      const key = normalizeKey(place.mainText);
+      const existing = bestByKey.get(key);
+
+      if (!existing) {
+        bestByKey.set(key, { place, firstIndex: index });
+        return;
+      }
+
+      // 既存より優先すべきは「後から来た establishment vs 既存の非 establishment」のみ。
+      // それ以外(同格)は関連度順の先勝ちを維持する。
+      if (isEstablishment(place) && !isEstablishment(existing.place)) {
+        bestByKey.set(key, { place, firstIndex: existing.firstIndex });
+      }
+    });
+
+    return [...bestByKey.values()]
+      .sort((a, b) => a.firstIndex - b.firstIndex)
+      .map((entry) => entry.place);
   }
 
   /**


### PR DESCRIPTION
## 概要
close #952

Google Places Autocomplete (New) は同じ場所を粒度違いで複数返すことがある(例: 渋谷駅が「日本、東京都渋谷区」の transit_station と「日本、東京都渋谷区２丁目２４」の番地レベル geocode の2件)。ユーザーには単なる重複に見え、どちらを選べばよいか迷わせていた。

**レビュー指摘を受けた作り直し**: 当初の種別バッジ実装(駅/空港/住所のテキストバッジ)は「本質は重複除去」との指摘により全て破棄し、サーバー側 dedup に差し替えた(force push 済み)。UI 変更なし。

## 変更内容
- `api/src/v1/locations/locations.service.ts`: `autocompleteLocations` に `dedupeAutocompletePlaces` を追加
  - `mainText` の NFKC 正規化+空白除去をグループキーに同名候補を1件に畳む
  - 同名グループ内は `establishment` を types に持つ候補(実在施設)を優先。番地レベルの重複(street_address / premise / 純粋な geocode)は establishment を持たないため自然に落ちる
  - 同格同士は Google の関連度順で先勝ち、返却順は初出位置を維持
  - 「渋谷駅」と「渋谷駅前」のような別地点は別キーとして残る
- `locations.service.spec.ts`: dedup の単体テスト4ケース追加

## 候補数への影響(レビューでの懸念に対する回答)
Autocomplete (New) は最大5件固定で追加取得手段がないため、dedup により件数は減りうる(通常0〜1件)。全候補が同名に畳まれる極端なケース(番地まで入力した場合など)は1件になるが、それはむしろ正解の1件。重複が並ぶより少なくてもクリーンな候補の方が選びやすい、という判断。

## テスト
- `npx jest src/v1/locations/locations.service.spec.ts`: 15件全pass(新規4件含む)
- `npx tsc --noEmit`(api): エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)