### PR TITLE
#953 feat: 検索の地点入力に最近使った場所(直近5件)を追加し毎回の文字入力を不要にする

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/index.tsx
@@ -19,7 +19,7 @@ import { SearchParams } from "@/types/search";
 import type { AutocompleteLocation, LocationDetailsResponse } from "@shared/api/v1/res";
 import { useLocationSearch } from "@/hooks/useLocationSearch";
 import { useSnackbar } from "@/contexts/SnackbarProvider";
-import { LocationAutocomplete } from "@/components/LocationAutocomplete";
+import { LocationAutocomplete, type RecentLocation } from "@/components/LocationAutocomplete";
 import {
 	timeSlots,
 	sceneOptions,
@@ -40,6 +40,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { DEFAULT_SEARCH_RADIUS } from "@/features/topics/constants";
 import { TutorialBottomSheet } from "@/features/search/components/TutorialBottomSheet";
 import { useSearchTutorial } from "@/features/search/hooks/useSearchTutorial";
+import { useRecentLocations } from "@/features/search/hooks/useRecentLocations";
 import { Image } from "expo-image";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { useIsFocused } from "@react-navigation/native";
@@ -119,6 +120,10 @@ export default function SearchScreen() {
 		try {
 			const locationDetails = await getLocationDetails(prediction);
 			setLocation(locationDetails);
+			// #953 【仕様】details 取得に成功した地点だけを「最近使った場所」に保存する。
+			// viewport はスプレッドすると型上は Omit していても実行時には残ってしまうため、明示的に除く。
+			const { viewport: _viewport, ...locationWithoutViewport } = locationDetails;
+			addRecentLocation({ ...locationWithoutViewport, locationQuery: prediction.mainText });
 		} catch (error) {
 			logFrontendEvent({
 				event_name: "location_selection_failed",
@@ -128,6 +133,20 @@ export default function SearchScreen() {
 			showSnackbar(i18n.t("Search.errors.fetchLocation"));
 		}
 	};
+
+	// #953 【仕様】最近使った場所は details API を呼び直さず、保存済みの location をそのまま復元する
+	const handleSelectRecentLocation = useCallback(
+		(recent: RecentLocation) => {
+			logFrontendEvent({
+				event_name: "recent_location_selected",
+				error_level: "log",
+				payload: { locationQuery: recent.locationQuery },
+			});
+			setLocation(recent);
+			setLocationQuery(recent.locationQuery);
+		},
+		[logFrontendEvent],
+	);
 
 	const handleUseCurrentLocation = async () => {
 		lightImpact();
@@ -253,6 +272,9 @@ export default function SearchScreen() {
 		setShowAdvancedFilters(!showAdvancedFilters);
 	};
 
+	// #953 【仕様】直近5件の地点をローカル保存し、地点未入力でのフォーカス時に再選択候補として出す
+	const { recentLocations, addRecentLocation, clearRecentLocations } = useRecentLocations();
+
 	// ========== チュートリアル表示制御 ==========
 	const [showTutorial, setShowTutorial] = useState(false);
 	const { hasSeenTutorial, isLoading: isTutorialLoading, markTutorialAsSeen } = useSearchTutorial();
@@ -365,6 +387,9 @@ export default function SearchScreen() {
 							onClear={handleLocationClear}
 							placeholder={i18n.t("Search.placeholders.enterLocation")}
 							autoClearOnFocus={locationQuery === i18n.t("Search.currentLocation")}
+							recentLocations={recentLocations}
+							onSelectRecentLocation={handleSelectRecentLocation}
+							onClearRecentLocations={recentLocations.length > 0 ? clearRecentLocations : undefined}
 							renderInputRight={
 								<TouchableOpacity style={styles.currentLocationButton} onPress={handleUseCurrentLocation}>
 									<Navigation size={20} color="#000000" />

--- a/app-expo/components/LocationAutocomplete.tsx
+++ b/app-expo/components/LocationAutocomplete.tsx
@@ -5,8 +5,17 @@ import { useHaptics } from "@/hooks/useHaptics";
 import i18n from "@/lib/i18n";
 import { type AutocompleteLocation } from "@shared/api/v1/res";
 import { isFoodAndDrinkPlaceForUser } from "@shared/utils/google_places_restaurant_type";
-import { MapPin, Utensils, X } from "lucide-react-native";
+import { MapPin, Utensils, X, History, Trash2 } from "lucide-react-native";
+import type { LocationDetailsResponse } from "@shared/api/v1/res";
 import { LoadingIndicator } from "./LoadingIndicator";
+
+/**
+ * #953 【仕様】details API のレスポンスから viewport を除いたもの＋検索画面の表示用文字列。
+ * 「最近使った場所」として再選択した際に details API を呼び直さず復元できる形にする。
+ */
+export type RecentLocation = Omit<LocationDetailsResponse, "viewport"> & {
+	locationQuery: string;
+};
 
 interface LocationAutocompleteProps {
 	/** Current value of the input */
@@ -27,6 +36,12 @@ interface LocationAutocompleteProps {
 	autoClearOnFocus?: boolean;
 	/** Test ID for testing */
 	testID?: string;
+	/** #953 未入力でのフォーカス時に「最近使った場所」として提示する候補(最大5件) */
+	recentLocations?: RecentLocation[];
+	/** #953 「最近使った場所」の1件が選択されたときのハンドラ */
+	onSelectRecentLocation?: (location: RecentLocation) => void;
+	/** #953 「最近使った場所」を全件クリアするハンドラ。未指定なら消去ボタンを出さない */
+	onClearRecentLocations?: () => void;
 }
 
 // ===== Tunables (ベストプラクティス的にマジックナンバーを定数化) =====
@@ -50,6 +65,9 @@ export function LocationAutocomplete({
 	autofocus = false,
 	renderInputRight,
 	testID = "location-autocomplete",
+	recentLocations = [],
+	onSelectRecentLocation,
+	onClearRecentLocations,
 }: LocationAutocompleteProps) {
 	const [showSuggestions, setShowSuggestions] = useState(false);
 	const [isFocused, setIsFocused] = useState(false);
@@ -143,6 +161,20 @@ export function LocationAutocomplete({
 		[onSelectSuggestion, lightImpact],
 	);
 
+	// #953 【仕様】最近使った場所は details API を呼び直さず、保存済みの location をそのまま復元する
+	const handleRecentLocationPress = useCallback(
+		(recent: RecentLocation) => {
+			lightImpact();
+			onSelectRecentLocation?.(recent);
+			setIsFocused(false);
+
+			setTimeout(() => {
+				inputRef.current?.blur();
+			}, BLUR_AFTER_SELECT_DELAY_MS);
+		},
+		[onSelectRecentLocation, lightImpact],
+	);
+
 	// Handle clear button press
 	const handleClear = useCallback(() => {
 		lightImpact();
@@ -166,6 +198,9 @@ export function LocationAutocomplete({
 
 	const trimmedValueLength = value.trim().length;
 	const hasEnoughCharsForSearch = trimmedValueLength >= MIN_SEARCH_LENGTH;
+	// #953 【仕様】未入力でフォーカスしたときだけ「最近使った場所」を出す。文字入力が始まったら
+	// 通常の検索候補(showSuggestions)に切り替わるため、両者は同時に表示されない。
+	const showRecentLocations = isFocused && trimmedValueLength === 0 && recentLocations.length > 0;
 
 	return (
 		<View style={styles.container}>
@@ -202,6 +237,48 @@ export function LocationAutocomplete({
 				)}
 				{renderInputRight}
 			</View>
+
+			{/* #953 最近使った場所 */}
+			{showRecentLocations && (
+				<View style={styles.suggestionsContainer}>
+					<View style={styles.recentLocationsHeader}>
+						<Text style={styles.recentLocationsTitle}>{i18n.t("Search.recentLocations.title")}</Text>
+						{onClearRecentLocations && (
+							<TouchableOpacity
+								onPress={onClearRecentLocations}
+								hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+								accessibilityRole="button"
+								accessibilityLabel={i18n.t("Search.recentLocations.clear")}
+								testID={`${testID}-recent-locations-clear`}>
+								<Trash2 size={16} color="#9CA3AF" />
+							</TouchableOpacity>
+						)}
+					</View>
+					<ScrollView
+						keyboardShouldPersistTaps="handled"
+						showsVerticalScrollIndicator={false}
+						style={styles.suggestionsList}
+						testID={`${testID}-recent-locations`}>
+						{recentLocations.map((recent, index) => (
+							<TouchableOpacity
+								key={`${recent.location.latitude},${recent.location.longitude}`}
+								style={[styles.suggestionItem, index === recentLocations.length - 1 && styles.lastSuggestionItem]}
+								onPress={() => handleRecentLocationPress(recent)}
+								accessibilityRole="button"
+								accessibilityLabel={recent.locationQuery}
+								accessibilityHint={i18n.t("Search.accessibility.selectLocation")}
+								testID={`${testID}-recent-location-${index}`}>
+								<History size={16} color="#6B7280" />
+								<View style={styles.suggestionText}>
+									<Text style={styles.suggestionMainText} numberOfLines={1}>
+										{recent.locationQuery}
+									</Text>
+								</View>
+							</TouchableOpacity>
+						))}
+					</ScrollView>
+				</View>
+			)}
 
 			{/* Loading indicator */}
 			{isSearching && (
@@ -307,6 +384,19 @@ const styles = StyleSheet.create({
 		elevation: 4,
 	},
 	suggestionsList: {},
+	recentLocationsHeader: {
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "space-between",
+		paddingHorizontal: 20,
+		paddingTop: 14,
+		paddingBottom: 4,
+	},
+	recentLocationsTitle: {
+		fontSize: 12,
+		fontWeight: "600",
+		color: "#9CA3AF",
+	},
 	suggestionItem: {
 		flexDirection: "row",
 		alignItems: "center",

--- a/app-expo/features/search/hooks/useRecentLocations.ts
+++ b/app-expo/features/search/hooks/useRecentLocations.ts
@@ -1,0 +1,78 @@
+import { useState, useEffect, useCallback } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { LocationDetailsResponse } from "@shared/api/v1/res";
+
+const RECENT_LOCATIONS_STORAGE_KEY = "recent_locations_v1";
+const MAX_RECENT_LOCATIONS = 5;
+
+/**
+ * #953 【仕様】details API のレスポンスから viewport を除いたもの＋検索画面の表示用文字列。
+ * SearchParams が要求する location/address/localLanguageCode/locationQuery とそのまま一致する形にし、
+ * 再選択時に details API を呼び直さず SearchParams へ復元できるようにする。
+ */
+export type RecentLocation = Omit<LocationDetailsResponse, "viewport"> & {
+	locationQuery: string;
+};
+
+/**
+ * #953 【仕様】検索の起点になる地点は繰り返し使われることが多いが、毎回文字入力を要求すると
+ * 再訪時のコストが高い。端末ローカル(AsyncStorage)に直近5件を保持し、地点未入力でのフォーカス時に
+ * 候補として提示する。他端末との同期は対象外(設計議論で決定済み)。
+ */
+export function useRecentLocations() {
+	const [recentLocations, setRecentLocations] = useState<RecentLocation[]>([]);
+	const [isLoading, setIsLoading] = useState(true);
+
+	const loadRecentLocations = useCallback(async () => {
+		try {
+			const value = await AsyncStorage.getItem(RECENT_LOCATIONS_STORAGE_KEY);
+			setRecentLocations(value ? (JSON.parse(value) as RecentLocation[]) : []);
+		} catch (error) {
+			console.error("Failed to load recent locations:", error);
+			setRecentLocations([]);
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
+
+	// 新しい地点を先頭に追加する。同一地点(place_id相当の座標一致)は重複させず先頭へ移動し、
+	// 最大件数を超えた分は古い順に切り捨てる。
+	const addRecentLocation = useCallback(async (location: RecentLocation) => {
+		try {
+			setRecentLocations((current) => {
+				const deduped = current.filter(
+					(entry) =>
+						entry.location.latitude !== location.location.latitude ||
+						entry.location.longitude !== location.location.longitude,
+				);
+				const next = [location, ...deduped].slice(0, MAX_RECENT_LOCATIONS);
+				AsyncStorage.setItem(RECENT_LOCATIONS_STORAGE_KEY, JSON.stringify(next)).catch((error) => {
+					console.error("Failed to save recent locations:", error);
+				});
+				return next;
+			});
+		} catch (error) {
+			console.error("Failed to add recent location:", error);
+		}
+	}, []);
+
+	const clearRecentLocations = useCallback(async () => {
+		try {
+			await AsyncStorage.removeItem(RECENT_LOCATIONS_STORAGE_KEY);
+			setRecentLocations([]);
+		} catch (error) {
+			console.error("Failed to clear recent locations:", error);
+		}
+	}, []);
+
+	useEffect(() => {
+		loadRecentLocations();
+	}, [loadRecentLocations]);
+
+	return {
+		recentLocations,
+		isLoading,
+		addRecentLocation,
+		clearRecentLocations,
+	};
+}

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -224,6 +224,10 @@
 				"primaryCta": "استخدم الموقع الحالي",
 				"secondaryCta": "لاحقاً"
 			}
+		},
+		"recentLocations": {
+			"title": "المواقع الأخيرة",
+			"clear": "مسح المواقع الأخيرة"
 		}
 	},
 	"Topics": {

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -224,6 +224,10 @@
 				"primaryCta": "Use current location",
 				"secondaryCta": "Later"
 			}
+		},
+		"recentLocations": {
+			"title": "Recent locations",
+			"clear": "Clear recent locations"
 		}
 	},
 	"Topics": {

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -224,6 +224,10 @@
 				"primaryCta": "Usar ubicación actual",
 				"secondaryCta": "Más tarde"
 			}
+		},
+		"recentLocations": {
+			"title": "Ubicaciones recientes",
+			"clear": "Borrar ubicaciones recientes"
 		}
 	},
 	"Topics": {

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -224,6 +224,10 @@
 				"primaryCta": "Utiliser la position actuelle",
 				"secondaryCta": "Plus tard"
 			}
+		},
+		"recentLocations": {
+			"title": "Lieux récents",
+			"clear": "Effacer les lieux récents"
 		}
 	},
 	"Topics": {

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -224,6 +224,10 @@
 				"primaryCta": "वर्तमान स्थिति का उपयोग करें",
 				"secondaryCta": "बाद में"
 			}
+		},
+		"recentLocations": {
+			"title": "हाल के स्थान",
+			"clear": "हाल के स्थान साफ़ करें"
 		}
 	},
 	"Topics": {

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -224,6 +224,10 @@
 				"primaryCta": "現在地を利用する",
 				"secondaryCta": "あとで"
 			}
+		},
+		"recentLocations": {
+			"title": "最近使った場所",
+			"clear": "最近使った場所を消去"
 		}
 	},
 	"Topics": {

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -224,6 +224,10 @@
 				"primaryCta": "현재 위치 사용",
 				"secondaryCta": "나중에"
 			}
+		},
+		"recentLocations": {
+			"title": "최근 사용한 장소",
+			"clear": "최근 사용한 장소 지우기"
 		}
 	},
 	"Topics": {

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -224,6 +224,10 @@
 				"primaryCta": "使用当前位置",
 				"secondaryCta": "稍后"
 			}
+		},
+		"recentLocations": {
+			"title": "最近使用的地点",
+			"clear": "清除最近使用的地点"
 		}
 	},
 	"Topics": {


### PR DESCRIPTION
## 概要

close #953 (UX-009)

検索の起点になる地点は繰り返し使われることが多いが、検索履歴に類する機能が無く毎回文字入力が必要だった。端末ローカル(AsyncStorage)に直近5件を保持し、地点未入力でフォーカスしたときに再選択候補として提示する。

## 変更内容

- `features/search/hooks/useRecentLocations.ts`(新規): `recent_locations_v1` キーで直近5件を保存。同一座標は重複排除して先頭へ移動。端末跨ぎの同期は対象外(設計議論で決定済み)
- `LocationAutocomplete.tsx`: `recentLocations`/`onSelectRecentLocation`/`onClearRecentLocations` prop を追加。地点未入力でのフォーカス時のみ「最近使った場所」セクションを表示(文字入力中の通常サジェストとは排他)。選択時は details API を呼び直さず保存済みの `location` をそのまま復元する
- `search/index.tsx`: 地点選択成功時に `addRecentLocation` を呼び保存。最近使った場所からの選択専用ハンドラを新設。`viewport` は型上 `Omit` していてもオブジェクトスプレッドでは実行時に残ってしまうため、明示的に分割代入で除いて保存するよう修正
- i18n: `Search.recentLocations.title/clear` を8言語に追加

## 動作確認

Playwright + 実際の dev API で一連のフローを確認。

1. 「渋谷駅」を検索・選択 → `localStorage["recent_locations_v1"]` に保存されることを確認(viewportを含まない形で保存されることも確認)
2. ページリロード(次回起動を模擬)→ 地点入力にフォーカス → 「最近使った場所」に「渋谷駅」が表示される
3. 「渋谷駅」をタップ → 地点が即座に復元され、検索ボタンが有効化される(**2タップで再選択完了**、受入条件を満たす)

スクリーンショット: `tmp/953-最近使った地点/`（tmp/ は gitignore 対象のためリポジトリには含めていません）

## 確認項目

- [x] `pnpm --filter app-expo typecheck` 通過
- [x] Playwright + 実データで保存→再選択の一連のフローを確認
- [x] 8言語 locale ファイルへのキー追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)