### PR TITLE
#934 検索条件カードにネイティブなa11yセマンティクスと視覚的な選択表現を追加(UX-015)

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback } from "react";
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions, Pressable } from "react-native";
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from "react-native";
 import {
 	MapPin,
 	Search,
@@ -32,6 +32,8 @@ import {
 } from "@/features/search/constants";
 import { DistanceSlider } from "@/features/search/components/DistanceSlider";
 import { PriceLevelsMultiSelect } from "@/features/search/components/PriceLevelsMultiSelect";
+import { SelectableGridItem } from "@/features/search/components/SelectableGridItem";
+import { SelectableChip } from "@/features/search/components/SelectableChip";
 import i18n from "@/lib/i18n";
 import { useHaptics } from "@/hooks/useHaptics";
 import { useLocale } from "@/hooks/useLocale";
@@ -57,6 +59,26 @@ const ITEM_WIDTH =
 		ITEM_GAP * (NUM_COLUMNS - 1) -
 		(ITEM_PADDING * 2 + BORDER_WIDTH * 2) * NUM_COLUMNS) /
 	NUM_COLUMNS;
+
+// #934 【設計】各セクション見出し。accessibilityRole="header" を持たせ、必須バッジは
+// 別要素として視覚表示しつつスクリーンリーダー向けには見出しの accessibilityLabel に合成する
+// (別々に読み上げられるより「(必須)」まで一続きで聞こえた方が分かりやすいため)
+function SectionHeader({ icon, title, required }: { icon: React.ReactNode; title: string; required?: boolean }) {
+	const label = required ? `${title} (${i18n.t("Search.required")})` : title;
+	return (
+		<View style={styles.sectionHeader}>
+			{icon}
+			<Text style={styles.sectionTitle} accessibilityRole="header" accessibilityLabel={label}>
+				{title}
+			</Text>
+			{required && (
+				<View style={styles.requiredBadge} importantForAccessibility="no-hide-descendants" accessibilityElementsHidden>
+					<Text style={styles.requiredText}>{i18n.t("Search.required")}</Text>
+				</View>
+			)}
+		</View>
+	);
+}
 
 export default function SearchScreen() {
 	const { locale, isJapanese } = useLocale();
@@ -350,13 +372,11 @@ export default function SearchScreen() {
 				showsVerticalScrollIndicator={false}>
 				{/* Location Input */}
 				<View style={styles.section}>
-					<View style={styles.sectionHeader}>
-						<MapPin size={20} color="#F05537" />
-						<Text style={styles.sectionTitle}>{i18n.t("Search.sections.location")}</Text>
-						<View style={styles.requiredBadge}>
-							<Text style={styles.requiredText}>{i18n.t("Search.required")}</Text>
-						</View>
-					</View>
+					<SectionHeader
+						icon={<MapPin size={20} color="#F05537" />}
+						title={i18n.t("Search.sections.location")}
+						required
+					/>
 					<View style={styles.locationSection}>
 						<LocationAutocomplete
 							value={locationQuery}
@@ -377,106 +397,76 @@ export default function SearchScreen() {
 
 				{/* #667 【設計】Time of Day - カード無し、画像グリッド表示（4列1行） */}
 				<View style={styles.section}>
-					<View style={styles.sectionHeader}>
-						<SunMoon size={20} color="#F05537" />
-						<Text style={styles.sectionTitle}>{i18n.t("Search.sections.time")}</Text>
-						<View style={styles.requiredBadge}>
-							<Text style={styles.requiredText}>{i18n.t("Search.required")}</Text>
-						</View>
-					</View>
-					<View style={styles.gridContainer}>
+					<SectionHeader icon={<SunMoon size={20} color="#F05537" />} title={i18n.t("Search.sections.time")} required />
+					<View
+						style={styles.gridContainer}
+						accessibilityRole="radiogroup"
+						accessibilityLabel={i18n.t("Search.sections.time")}>
 						{timeSlots.map((slot) => (
-							<Pressable
+							<SelectableGridItem
 								key={slot.id}
 								testID={`search-time-slot-${slot.id}`}
-								style={[styles.gridItem, timeSlot === slot.id && styles.selectedGridItem]}
-								onPress={() => handleTimeSlotSelect(slot.id)}>
-								<Image
-									source={slot.image}
-									style={[{ width: ITEM_WIDTH, height: ITEM_WIDTH }, styles.gridItemImage]}
-									contentFit="cover"
-									transition={0}
-									priority="high"
-									cachePolicy="memory"
-								/>
-								<Text style={[styles.gridItemLabel, timeSlot === slot.id && styles.selectedGridItemLabel]}>
-									{i18n.t(slot.label)}
-								</Text>
-							</Pressable>
+								selected={timeSlot === slot.id}
+								onPress={() => handleTimeSlotSelect(slot.id)}
+								image={slot.image}
+								label={i18n.t(slot.label)}
+								itemWidth={ITEM_WIDTH}
+							/>
 						))}
 					</View>
 				</View>
 
 				{/* #667 【設計】Scene - カード無し、画像グリッド表示（4列2行） */}
 				<View style={styles.section}>
-					<View style={styles.sectionHeader}>
-						<Users size={20} color="#F05537" />
-						<Text style={styles.sectionTitle}>{i18n.t("Search.sections.scene")}</Text>
-						<View style={styles.requiredBadge}>
-							<Text style={styles.requiredText}>{i18n.t("Search.required")}</Text>
-						</View>
-					</View>
-					<View style={styles.gridContainer}>
+					<SectionHeader icon={<Users size={20} color="#F05537" />} title={i18n.t("Search.sections.scene")} required />
+					<View
+						style={styles.gridContainer}
+						accessibilityRole="radiogroup"
+						accessibilityLabel={i18n.t("Search.sections.scene")}>
 						{sceneOptions.map((option) => (
-							<Pressable
+							<SelectableGridItem
 								key={option.id}
 								testID={`search-scene-${option.id}`}
-								style={[styles.gridItem, scene === option.id && styles.selectedGridItem]}
-								onPress={() => handleSceneSelect(option.id)}>
-								<Image
-									source={option.image}
-									style={[{ width: ITEM_WIDTH, height: ITEM_WIDTH }, styles.gridItemImage]}
-									contentFit="cover"
-									transition={0}
-									priority="high"
-									cachePolicy="memory"
-								/>
-								<Text style={[styles.gridItemLabel, scene === option.id && styles.selectedGridItemLabel]}>
-									{i18n.t(option.label)}
-								</Text>
-							</Pressable>
+								selected={scene === option.id}
+								onPress={() => handleSceneSelect(option.id)}
+								image={option.image}
+								label={i18n.t(option.label)}
+								itemWidth={ITEM_WIDTH}
+							/>
 						))}
 					</View>
 				</View>
 
 				{/* Price Levels */}
 				<View style={styles.section}>
-					<View style={styles.sectionHeader}>
-						<DollarSign size={20} color="#F05537" />
-						<Text style={styles.sectionTitle}>{i18n.t("Search.sections.budget")}</Text>
-					</View>
+					<SectionHeader icon={<DollarSign size={20} color="#F05537" />} title={i18n.t("Search.sections.budget")} />
 					<View style={styles.sliderSection}>
 						<PriceLevelsMultiSelect
 							selectedPriceLevels={priceLevels}
 							onPriceLevelsChange={setPriceLevels}
-							customStyles={{
-								chipGrid: styles.chipGrid,
-								chip: styles.chip,
-								selectedChip: styles.selectedChip,
-								chipText: styles.chipText,
-								selectedChipText: styles.selectedChipText,
-							}}
+							customStyles={{ chipGrid: styles.chipGrid }}
+							groupAccessibilityLabel={i18n.t("Search.sections.budget")}
 						/>
 					</View>
 				</View>
 
 				{/* Dining Pace */}
 				<View style={styles.section}>
-					<View style={styles.sectionHeader}>
-						<Timer size={20} color="#F05537" />
-						<Text style={styles.sectionTitle}>{i18n.t("Search.sections.diningPace")}</Text>
-					</View>
-					<View style={styles.chipGrid}>
+					<SectionHeader icon={<Timer size={20} color="#F05537" />} title={i18n.t("Search.sections.diningPace")} />
+					<View
+						style={styles.chipGrid}
+						accessibilityRole="radiogroup"
+						accessibilityLabel={i18n.t("Search.sections.diningPace")}>
 						{diningPaceOptions.map((option) => (
-							<TouchableOpacity
+							<SelectableChip
 								key={option.id}
-								style={[styles.chip, diningPace === option.id && styles.selectedChip]}
-								onPress={() => handleDiningPaceSelect(option.id)}>
-								<Text style={styles.chipEmoji}>{option.icon}</Text>
-								<Text style={[styles.chipText, diningPace === option.id && styles.selectedChipText]}>
-									{i18n.t(option.label)}
-								</Text>
-							</TouchableOpacity>
+								role="radio"
+								selected={diningPace === option.id}
+								label={i18n.t(option.label)}
+								icon={option.icon}
+								onPress={() => handleDiningPaceSelect(option.id)}
+								testID={`search-dining-pace-${option.id}`}
+							/>
 						))}
 					</View>
 				</View>
@@ -499,10 +489,7 @@ export default function SearchScreen() {
 					<>
 						{/* Distance */}
 						<View style={styles.section}>
-							<View style={styles.sectionHeader}>
-								<Ruler size={20} color="#F05537" />
-								<Text style={styles.sectionTitle}>{i18n.t("Search.sections.distance")}</Text>
-							</View>
+							<SectionHeader icon={<Ruler size={20} color="#F05537" />} title={i18n.t("Search.sections.distance")} />
 							<View style={styles.sliderSection}>
 								<Text style={styles.sliderValue}>
 									{distanceOptions.find((option) => option.value === distance)?.label}
@@ -513,24 +500,24 @@ export default function SearchScreen() {
 
 						{/* Food Style */}
 						<View style={styles.section}>
-							<View style={styles.sectionHeader}>
-								<ChefHat size={20} color="#F05537" />
-								<Text style={styles.sectionTitle}>{i18n.t("Search.sections.foodStyle")}</Text>
-							</View>
-							<View style={styles.chipGrid}>
+							<SectionHeader icon={<ChefHat size={20} color="#F05537" />} title={i18n.t("Search.sections.foodStyle")} />
+							<View
+								style={styles.chipGrid}
+								accessibilityRole="radiogroup"
+								accessibilityLabel={i18n.t("Search.sections.foodStyle")}>
 								{foodStyleOptions.map((option) => {
 									const isSelected =
 										option.featureType === "taste" ? taste === option.id : coreIngredient === option.id;
 									return (
-										<TouchableOpacity
+										<SelectableChip
 											key={`${option.featureType}:${option.id}`}
-											style={[styles.chip, isSelected && styles.selectedChip]}
-											onPress={() => handleFoodStyleSelect(option)}>
-											<Text style={styles.chipEmoji}>{option.icon}</Text>
-											<Text style={[styles.chipText, isSelected && styles.selectedChipText]}>
-												{i18n.t(option.label)}
-											</Text>
-										</TouchableOpacity>
+											role="radio"
+											selected={isSelected}
+											label={i18n.t(option.label)}
+											icon={option.icon}
+											onPress={() => handleFoodStyleSelect(option)}
+											testID={`search-food-style-${option.featureType}-${option.id}`}
+										/>
 									);
 								})}
 							</View>
@@ -590,7 +577,8 @@ export default function SearchScreen() {
 				onRequestCurrentLocation={handleTutorialRequestLocation}
 			/>
 			{/* #642 【設計】オフスクリーンでチュートリアル画像を一度描画して decode */}
-			<View style={{ width: 0, height: 0, position: "absolute", overflow: "hidden" }}>
+			{/* #934 【修正】decode専用で内容を持たないため aria-hidden で支援技術から隠す(axe: image-alt 対策) */}
+			<View style={{ width: 0, height: 0, position: "absolute", overflow: "hidden" }} aria-hidden>
 				{PRELOAD_IMAGES.map((src, i) => (
 					<Image key={i} source={src} />
 				))}
@@ -672,35 +660,6 @@ const styles = StyleSheet.create({
 		flexWrap: "wrap",
 		gap: ITEM_GAP,
 	},
-	// #667 【設計】グリッドアイテム（画像+ラベル）
-	gridItem: {
-		width: ITEM_WIDTH + 2 * ITEM_PADDING + 2 * BORDER_WIDTH,
-		maxWidth: 256,
-		alignItems: "center",
-		overflow: "hidden",
-		padding: ITEM_PADDING,
-		borderRadius: 16,
-		borderWidth: BORDER_WIDTH,
-		borderColor: "transparent",
-	},
-	selectedGridItem: {
-		borderColor: "#000000",
-		backgroundColor: "#E5E5E5",
-	},
-	gridItemImage: {
-		borderRadius: 16,
-		maxWidth: 256,
-		maxHeight: 256,
-	},
-	// #667 【設計】グリッドアイテムのラベル
-	gridItemLabel: {
-		marginTop: 4,
-		fontSize: 11,
-		color: "#000000",
-		fontWeight: "600",
-		textAlign: "center",
-	},
-	selectedGridItemLabel: {},
 	// #667 【設計】ムード用の横並びコンテナ
 	moodContainer: {
 		flexDirection: "row",
@@ -753,32 +712,6 @@ const styles = StyleSheet.create({
 		flexWrap: "wrap",
 		gap: 12,
 	},
-	chip: {
-		flexDirection: "row",
-		alignItems: "center",
-		backgroundColor: "#F8F9FA",
-		paddingHorizontal: 12,
-		paddingVertical: 6,
-		borderRadius: 24,
-		borderWidth: BORDER_WIDTH,
-		borderColor: "#C9C9C9",
-		marginBottom: 6,
-	},
-	selectedChip: {
-		// 濃い灰色
-		backgroundColor: "#E5E5E5",
-		borderColor: "#000000",
-	},
-	chipEmoji: {
-		fontSize: 14,
-		marginRight: 4,
-	},
-	chipText: {
-		fontSize: 13,
-		color: "#000000",
-		fontWeight: "600",
-	},
-	selectedChipText: {},
 	sliderSection: {
 		alignItems: "center",
 	},

--- a/app-expo/features/search/components/PriceLevelsMultiSelect.tsx
+++ b/app-expo/features/search/components/PriceLevelsMultiSelect.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { View, Text, TouchableOpacity, TextStyle } from "react-native";
+import { View, StyleSheet, StyleProp, ViewStyle } from "react-native";
 import { priceLevelOptions } from "@/features/search/constants";
 import { useHaptics } from "@/hooks/useHaptics";
-import { StyleSheet } from "react-native";
-import { StyleProp } from "react-native";
-import { ViewStyle } from "react-native";
+import { SelectableChip } from "@/features/search/components/SelectableChip";
 import i18n from "@/lib/i18n";
 
 interface PriceLevelsMultiSelectProps {
@@ -12,18 +10,16 @@ interface PriceLevelsMultiSelectProps {
 	onPriceLevelsChange: (priceLevels: (typeof priceLevelOptions)[number]["value"][]) => void;
 	customStyles?: {
 		chipGrid?: StyleProp<ViewStyle>;
-		chip?: StyleProp<ViewStyle>;
-		selectedChip?: StyleProp<ViewStyle>;
-		chipEmoji?: StyleProp<TextStyle>;
-		chipText?: StyleProp<TextStyle>;
-		selectedChipText?: StyleProp<TextStyle>;
 	};
+	/** #934 【設計】チップ群のグループラベル(スクリーンリーダー向け。画面側のセクション見出しと合わせる) */
+	groupAccessibilityLabel?: string;
 }
 
 export function PriceLevelsMultiSelect({
 	selectedPriceLevels,
 	onPriceLevelsChange,
 	customStyles,
+	groupAccessibilityLabel,
 }: PriceLevelsMultiSelectProps) {
 	const { lightImpact } = useHaptics();
 
@@ -41,18 +37,20 @@ export function PriceLevelsMultiSelect({
 
 	return (
 		<View style={styles.container}>
-			<View style={[customStyles?.chipGrid]}>
+			{/* #934 【設計】複数選択チップのグループ。RN の AccessibilityRole に group 相当が無いため
+			    accessibilityLabel のみでグループの意味付けを行う(各チップ自体は role="checkbox" を持つ) */}
+			<View style={[customStyles?.chipGrid]} accessibilityLabel={groupAccessibilityLabel}>
 				{priceLevelOptions.map((option) => {
 					const isSelected = selectedPriceLevels.includes(option.value);
 					return (
-						<TouchableOpacity
+						<SelectableChip
 							key={option.value}
-							style={[customStyles?.chip, isSelected && customStyles?.selectedChip]}
-							onPress={() => togglePriceLevel(option.value)}>
-							<Text style={[customStyles?.chipText, isSelected && customStyles?.selectedChipText]}>
-								{i18n.t(option.label)}
-							</Text>
-						</TouchableOpacity>
+							role="checkbox"
+							selected={isSelected}
+							label={i18n.t(option.label)}
+							onPress={() => togglePriceLevel(option.value)}
+							testID={`search-price-level-${option.value}`}
+						/>
 					);
 				})}
 			</View>

--- a/app-expo/features/search/components/SelectableChip.tsx
+++ b/app-expo/features/search/components/SelectableChip.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { TouchableOpacity, Text, StyleSheet } from "react-native";
+import { Check } from "lucide-react-native";
+
+interface SelectableChipProps {
+	/** 表示ラベル(i18n 済み文字列) */
+	label: string;
+	/** ラベル前に表示する絵文字(任意) */
+	icon?: string;
+	/** 選択中かどうか */
+	selected: boolean;
+	/** 押下時のハンドラ */
+	onPress: () => void;
+	/** 単一選択なら "radio"、複数選択なら "checkbox" */
+	role: "radio" | "checkbox";
+	/** E2E テスト用: Web では data-testid として出力される */
+	testID?: string;
+}
+
+// #934 【設計】食事時間・系統・価格帯など「チップの単一/複数選択」で共通利用するコンポーネント。
+// role で radio(単一選択)/checkbox(複数選択)を切り替え、選択状態は枠線色だけでなく
+// チェックマークでも表現する(色のみに依存しない)。
+// [注意] react-native-web は accessibilityState.checked を DOM の aria-checked へ変換しない
+// (#930 の PrimaryButton disabled と同種の既知の非対応)。native/web 両対応の aria-checked を
+// 直接指定することで、RN(iOS/Android) と RNW(Web) の両方で同じ挙動にする。
+export function SelectableChip({ label, icon, selected, onPress, role, testID }: SelectableChipProps) {
+	return (
+		<TouchableOpacity
+			testID={testID}
+			style={[styles.chip, selected && styles.selectedChip]}
+			onPress={onPress}
+			accessibilityRole={role}
+			aria-checked={selected}
+			accessibilityLabel={label}>
+			{selected && <Check size={12} color="#000000" strokeWidth={3} style={styles.checkIcon} />}
+			{icon && <Text style={styles.emoji}>{icon}</Text>}
+			<Text style={[styles.text, selected && styles.selectedText]}>{label}</Text>
+		</TouchableOpacity>
+	);
+}
+
+const styles = StyleSheet.create({
+	chip: {
+		flexDirection: "row",
+		alignItems: "center",
+		backgroundColor: "#F8F9FA",
+		paddingHorizontal: 12,
+		paddingVertical: 6,
+		borderRadius: 24,
+		borderWidth: 2,
+		borderColor: "#C9C9C9",
+		marginBottom: 6,
+	},
+	selectedChip: {
+		backgroundColor: "#E5E5E5",
+		borderColor: "#000000",
+	},
+	checkIcon: {
+		marginRight: 4,
+	},
+	emoji: {
+		fontSize: 14,
+		marginRight: 4,
+	},
+	text: {
+		fontSize: 13,
+		color: "#000000",
+		fontWeight: "600",
+	},
+	selectedText: {
+		fontWeight: "800",
+	},
+});

--- a/app-expo/features/search/components/SelectableGridItem.tsx
+++ b/app-expo/features/search/components/SelectableGridItem.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { Pressable, View, Text, StyleSheet, type ImageSourcePropType } from "react-native";
+import { Image } from "expo-image";
+import { Check } from "lucide-react-native";
+
+interface SelectableGridItemProps {
+	/** 表示ラベル(i18n 済み文字列) */
+	label: string;
+	/** グリッド画像 */
+	image: ImageSourcePropType;
+	/** 選択中かどうか */
+	selected: boolean;
+	/** 押下時のハンドラ */
+	onPress: () => void;
+	/** 画像/アイテムの一辺のサイズ(呼び出し元の画面幅計算に合わせる) */
+	itemWidth: number;
+	/** E2E テスト用: Web では data-testid として出力される */
+	testID?: string;
+}
+
+// #934 【設計】時間帯・同行者など「画像+ラベルの単一選択グリッド」で共通利用するアイテム。
+// accessibilityRole="radio" + aria-checked でネイティブなセマンティクスを持たせ、
+// 選択状態は枠線色だけでなくチェックマークバッジでも表現する(色のみに依存しない)。
+// [注意] react-native-web は accessibilityState.checked を DOM の aria-checked へ変換しない
+// (#930 の PrimaryButton disabled と同種の既知の非対応)。native/web 両対応の aria-checked を
+// 直接指定することで、RN(iOS/Android) と RNW(Web) の両方で同じ挙動にする。
+export function SelectableGridItem({ label, image, selected, onPress, itemWidth, testID }: SelectableGridItemProps) {
+	return (
+		<Pressable
+			testID={testID}
+			style={[styles.item, { width: itemWidth + 2 * ITEM_PADDING + 2 * BORDER_WIDTH }, selected && styles.selectedItem]}
+			onPress={onPress}
+			accessibilityRole="radio"
+			aria-checked={selected}
+			accessibilityLabel={label}>
+			<View style={styles.imageWrapper}>
+				<Image
+					source={image}
+					style={[{ width: itemWidth, height: itemWidth }, styles.image]}
+					contentFit="cover"
+					transition={0}
+					priority="high"
+					cachePolicy="memory"
+					// #934 【修正】画像はラベル(親のPressableのaccessibilityLabel)と重複する装飾のため
+					// accessibilityLabel="" で読み上げ対象から除外する(axe: image-alt 違反の解消)。
+					// expo-image の web 実装(ExpoImage.web.tsx)は img の alt 属性を
+					// alt prop ではなく accessibilityLabel prop から生成するため注意
+					accessibilityLabel=""
+				/>
+				{selected && (
+					<View style={styles.checkBadge}>
+						<Check size={12} color="#FFFFFF" strokeWidth={3} />
+					</View>
+				)}
+			</View>
+			<Text style={[styles.label, selected && styles.selectedLabel]}>{label}</Text>
+		</Pressable>
+	);
+}
+
+const ITEM_PADDING = 3;
+const BORDER_WIDTH = 2;
+
+const styles = StyleSheet.create({
+	item: {
+		maxWidth: 256,
+		alignItems: "center",
+		overflow: "visible",
+		padding: ITEM_PADDING,
+		borderRadius: 16,
+		borderWidth: BORDER_WIDTH,
+		borderColor: "transparent",
+	},
+	selectedItem: {
+		borderColor: "#000000",
+		backgroundColor: "#E5E5E5",
+	},
+	imageWrapper: {
+		position: "relative",
+	},
+	image: {
+		borderRadius: 16,
+		maxWidth: 256,
+		maxHeight: 256,
+	},
+	checkBadge: {
+		position: "absolute",
+		top: -4,
+		right: -4,
+		width: 20,
+		height: 20,
+		borderRadius: 10,
+		backgroundColor: "#000000",
+		alignItems: "center",
+		justifyContent: "center",
+		borderWidth: 1.5,
+		borderColor: "#FFFFFF",
+	},
+	label: {
+		marginTop: 4,
+		fontSize: 11,
+		color: "#000000",
+		fontWeight: "600",
+		textAlign: "center",
+	},
+	selectedLabel: {
+		fontWeight: "800",
+	},
+});

--- a/e2e-web/package.json
+++ b/e2e-web/package.json
@@ -16,6 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
+		"@axe-core/playwright": "^4.12.1",
 		"@playwright/test": "^1.54.2",
 		"@supabase/supabase-js": "^2.49.4",
 		"@types/node": "^22.15.3",

--- a/e2e-web/tests/search/search-accessibility.spec.ts
+++ b/e2e-web/tests/search/search-accessibility.spec.ts
@@ -1,0 +1,61 @@
+import AxeBuilder from "@axe-core/playwright";
+import { test, expect } from "../../fixtures/test";
+import { SearchPage } from "../../pages/SearchPage";
+
+/**
+ * ♿ 検索フォームのアクセシビリティ監査(#934)
+ *
+ * 背景: 時間帯/同行者(画像グリッド)・価格帯(チップ)・食事時間/系統(チップ)に
+ * accessibilityRole/State/Label が一切無く、選択状態も枠線色のみで表現されていた
+ * (色のみに依存 = WCAG 1.4.1 違反)。SelectableGridItem/SelectableChip へ切り出し、
+ * radio/radiogroup/checkbox のネイティブセマンティクスとチェックマークによる視覚表現を追加した。
+ *
+ * このファイルは @axe-core/playwright で重大な違反(critical/serious)が無いことを保証する。
+ */
+test.describe("検索フォームのアクセシビリティ", () => {
+	test("axe監査で重大な違反(critical/serious)が無い", async ({ appPage }) => {
+		const searchPage = new SearchPage(appPage);
+		await searchPage.expectLoaded();
+
+		// 詳細条件も含めて監査対象にする(距離・系統セクション)
+		await searchPage.advancedToggle.click();
+		await expect(appPage.getByText("どんな系統が食べたい？")).toBeVisible();
+
+		const results = await new AxeBuilder({ page: appPage }).include("body").analyze();
+
+		const seriousOrCritical = results.violations.filter((v) => v.impact === "critical" || v.impact === "serious");
+
+		// 失敗時に原因を特定しやすいよう、違反内容をエラーメッセージに含める
+		expect(
+			seriousOrCritical,
+			seriousOrCritical
+				.map((v) => `${v.id}(${v.impact}): ${v.description}\n  ${v.nodes.map((n) => n.target).join(", ")}`)
+				.join("\n"),
+		).toEqual([]);
+	});
+
+	// ─ テストケース: 時間帯グリッドが radiogroup/radio セマンティクスを持つ ─
+	test("時間帯グリッドが radiogroup/radio ロールを持つ", async ({ appPage }) => {
+		const timeSlotDinner = appPage.getByTestId("search-time-slot-dinner");
+		await expect(timeSlotDinner).toHaveAttribute("role", "radio");
+		await expect(timeSlotDinner).toHaveAttribute("aria-checked", "false");
+
+		await timeSlotDinner.click();
+		await expect(timeSlotDinner).toHaveAttribute("aria-checked", "true");
+	});
+
+	// ─ テストケース: 価格帯チップが checkbox セマンティクスを持ち複数選択できる ─
+	test("価格帯チップが checkbox ロールを持ち複数選択できる", async ({ appPage }) => {
+		const inexpensive = appPage.getByTestId("search-price-level-PRICE_LEVEL_INEXPENSIVE");
+		const moderate = appPage.getByTestId("search-price-level-PRICE_LEVEL_MODERATE");
+		await expect(inexpensive).toHaveAttribute("role", "checkbox");
+
+		await inexpensive.click();
+		await expect(inexpensive).toHaveAttribute("aria-checked", "true");
+
+		// 複数選択可能(radioと異なり他の選択を解除しない)であることを確認
+		await moderate.click();
+		await expect(inexpensive).toHaveAttribute("aria-checked", "true");
+		await expect(moderate).toHaveAttribute("aria-checked", "true");
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,9 @@ importers:
 
   e2e-web:
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.12.1(playwright-core@1.61.1)
       '@playwright/test':
         specifier: ^1.54.2
         version: 1.61.1
@@ -584,6 +587,11 @@ packages:
 
   '@apphosting/common@0.0.9':
     resolution: {integrity: sha512-ZbPZDcVhEN+8m0sf90PmQN4xWaKmmySnBSKKPaIOD0JvcDsRr509WenFEFlojP++VSxwFZDGG/TYsHs1FMMqpw==}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.10.4':
     resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
@@ -1200,7 +1208,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.24.22':
     resolution: {integrity: sha512-cEg6/F8ZWjoVkEwm0rXKReWbsCUROFbLFBYht+d5RzHnDwJoTX4QWJKx4m+TGNDPamRUIGw36U4z41Fvev0XmA==}
@@ -3555,6 +3563,10 @@ packages:
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -10013,6 +10025,11 @@ snapshots:
 
   '@apphosting/common@0.0.9': {}
 
+  '@axe-core/playwright@4.12.1(playwright-core@1.61.1)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.61.1
+
   '@babel/code-frame@7.10.4':
     dependencies:
       '@babel/highlight': 7.25.9
@@ -13913,6 +13930,8 @@ snapshots:
   await-to-js@3.0.0: {}
 
   aws-ssl-profiles@1.1.2: {}
+
+  axe-core@4.12.1: {}
 
   b4a@1.7.3: {}
 


### PR DESCRIPTION
## Summary

根因: 時間帯/同行者(画像グリッド)・価格帯(チップ)・食事時間・系統(チップ)に `accessibilityRole`/`State`/`Label` が一切無く、選択状態は枠線色のみで表現されていた(`selectedGridItemLabel`/`selectedChipText` は空オブジェクト)。リポジトリ全体で radio/checkbox ロールの使用実績もゼロだった。

- `features/search/components/SelectableGridItem.tsx`(新規): 時間帯・同行者用。`accessibilityRole="radio"` + `aria-checked` を持ち、選択時はチェックマークバッジ+ラベル太字化で色以外の視覚的な選択表現も行う。
- `features/search/components/SelectableChip.tsx`(新規): 食事時間・系統・価格帯用。`role` で radio(単一選択)/checkbox(複数選択)を切り替え可能。
- `PriceLevelsMultiSelect.tsx`: 上記 `SelectableChip`(role="checkbox")へ置換。
- `search/index.tsx`: 各グリッド/チップ群に `accessibilityRole="radiogroup"` + `accessibilityLabel` を付与。各セクション見出しに `accessibilityRole="header"` を付与する `SectionHeader` を追加し、必須バッジは視覚要素を残しつつ見出しの `accessibilityLabel` に「(必須)」として合成。不要になった `gridItem*`/`chip*` 系スタイルを削除。

**ハマりどころ2点(コメントに詳細記載)**
1. react-native-web は `accessibilityState.checked` を DOM の `aria-checked` へ変換しない(#930 の `PrimaryButton` disabled と同種の既知の非対応)。`aria-checked` を直接指定することで解決。
2. expo-image の web 実装は `<img alt>` を `alt` prop ではなく `accessibilityLabel` prop から生成する。装飾画像を読み上げ対象から除外するには `accessibilityLabel=""` が必要(`alt=""` は効果が無く axe で検知した)。

**e2e-web**: `@axe-core/playwright` を追加し `tests/search/search-accessibility.spec.ts` を新設。axe で critical/serious 違反が無いこと、時間帯グリッドの radio/radiogroup、価格帯チップの checkbox(複数選択可)を検証。オフスクリーンのチュートリアル画像 decode 用コンテナにも `aria-hidden` を追加(axe が検知した既存の別違反)。

## Test plan
- [x] `pnpm --filter app-expo exec tsc -p tsconfig.dev.json --noEmit` 通過
- [x] `pnpm --filter app-expo build:web` 成功
- [x] `e2e-web`: `tests/search/` 配下14件(新規3件+既存11件)が全て green
- [x] Playwright(実 dev API 接続)で選択状態(チェックマーク+太字)を目視確認、スクリーンショットは `tmp/934-検索条件カードのネイティブセマンティクス化/` に保存

🤖 Generated with [Claude Code](https://claude.com/claude-code)