### PR TITLE
#935 距離スライダーを実測トラック幅ベースで再実装(UX-020)

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/index.tsx
@@ -505,7 +505,9 @@ export default function SearchScreen() {
 							</View>
 							<View style={styles.sliderSection}>
 								<Text style={styles.sliderValue}>
-									{distanceOptions.find((option) => option.value === distance)?.label}
+									{i18n.t(
+										distanceOptions.find((option) => option.value === distance)?.label ?? distanceOptions[0].label,
+									)}
 								</Text>
 								<DistanceSlider distance={distance} setDistance={setDistance} />
 							</View>

--- a/app-expo/features/search/components/DistanceSlider.tsx
+++ b/app-expo/features/search/components/DistanceSlider.tsx
@@ -1,35 +1,163 @@
-import React from "react";
-import { View, Text, PanResponder } from "react-native";
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { View, Text, PanResponder, StyleSheet, type LayoutChangeEvent } from "react-native";
 import { distanceOptions } from "@/features/search/constants";
 import i18n from "@/lib/i18n";
 import { useHaptics } from "@/hooks/useHaptics";
 
-// Slider component to choose search distance
-export function DistanceSlider({ distance, setDistance }: { distance: number; setDistance: (value: number) => void }) {
-	const { selectionChanged } = useHaptics();
-	const currentIndex = distanceOptions.findIndex((option) => option.value === distance);
-	const sliderWidth = 280;
-	const thumbWidth = 24;
-	const trackWidth = sliderWidth - thumbWidth;
-	const thumbPosition = (currentIndex / (distanceOptions.length - 1)) * trackWidth;
+// #935 【設計】距離スライダーの再実装。旧実装は以下の不具合を抱えていた:
+//   1. `gestureState.moveX - 50` というマジックナンバーで画面絶対座標→トラック相対座標を
+//      誤変換していた(実際のオフセットは画面幅に依存し、広い画面ほどズレて端に張り付く)
+//   2. onPanResponderGrant が無く、タップしても値が変わらなかった(トラックタップ不可)
+//   3. サム(28×28)のみタッチ対象でヒットスロップも無く、指が少しズレるだけで操作できなかった
+//   4. PanResponder.create を毎レンダー再生成しており、パフォーマンス上望ましくなかった
+//   5. ScrollView 内でも常にレスポンダを奪うため、縦スクロールと衝突しうる状態だった
+//   6. accessibilityRole 等が無く、スクリーンリーダー・キーボードで操作できなかった
+// 本実装は onLayout で実測したトラック幅を使い、locationX ベースで位置を計算することで
+// 端末サイズに依存しない正確なタップ/ドラッグ操作を実現する。
 
-	const panResponder = PanResponder.create({
-		onStartShouldSetPanResponder: () => true,
-		onMoveShouldSetPanResponder: () => true,
-		onPanResponderMove: (evt, gestureState) => {
-			const newPosition = Math.max(0, Math.min(trackWidth, gestureState.moveX - 50));
-			const newIndex = Math.round((newPosition / trackWidth) * (distanceOptions.length - 1));
-			if (newIndex !== currentIndex && newIndex >= 0 && newIndex < distanceOptions.length) {
-				selectionChanged();
-				setDistance(distanceOptions[newIndex].value);
+const THUMB_SIZE = 28;
+const THUMB_HIT_SLOP = { top: 16, bottom: 16, left: 16, right: 16 };
+// ドラッグとして確定する最小水平移動量。ScrollView の縦スクロールと共存させるため、
+// 「横方向の移動が縦方向より明確に大きい」場合のみこのスライダーがジェスチャーを奪う
+const DRAG_ACTIVATION_THRESHOLD_PX = 4;
+
+interface DistanceSliderProps {
+	distance: number;
+	setDistance: (value: number) => void;
+}
+
+export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
+	const { selectionChanged } = useHaptics();
+	const [trackWidth, setTrackWidth] = useState(0);
+
+	const currentIndex = useMemo(() => {
+		const index = distanceOptions.findIndex((option) => option.value === distance);
+		return index === -1 ? 0 : index;
+	}, [distance]);
+
+	// #935 【設計】PanResponder のコールバックは生成時のクロージャを使い続けるため、
+	// 最新値を ref 経由で参照する(useRef で1回だけ生成し毎レンダーの再生成を避けるため)
+	const trackWidthRef = useRef(trackWidth);
+	trackWidthRef.current = trackWidth;
+	const currentIndexRef = useRef(currentIndex);
+	currentIndexRef.current = currentIndex;
+	const setDistanceRef = useRef(setDistance);
+	setDistanceRef.current = setDistance;
+	const selectionChangedRef = useRef(selectionChanged);
+	selectionChangedRef.current = selectionChanged;
+
+	const commitIndex = useCallback((newIndex: number) => {
+		const clamped = Math.max(0, Math.min(distanceOptions.length - 1, newIndex));
+		if (clamped !== currentIndexRef.current) {
+			currentIndexRef.current = clamped;
+			selectionChangedRef.current();
+			setDistanceRef.current(distanceOptions[clamped].value);
+		}
+	}, []);
+
+	const updateFromLocationX = useCallback(
+		(locationX: number) => {
+			const width = trackWidthRef.current;
+			if (width <= 0) return;
+			const ratio = Math.max(0, Math.min(1, locationX / width));
+			commitIndex(Math.round(ratio * (distanceOptions.length - 1)));
+		},
+		[commitIndex],
+	);
+
+	const panResponder = useRef(
+		PanResponder.create({
+			// #935 【修正】トラック全体をタップ対象にする(サム単体ではなくトラック View に付与)
+			onStartShouldSetPanResponder: () => true,
+			onMoveShouldSetPanResponder: (_evt, gestureState) =>
+				Math.abs(gestureState.dx) > DRAG_ACTIVATION_THRESHOLD_PX &&
+				Math.abs(gestureState.dx) > Math.abs(gestureState.dy),
+			// #935 【修正】タップした瞬間にその位置へジャンプする
+			onPanResponderGrant: (evt) => {
+				updateFromLocationX(evt.nativeEvent.locationX);
+			},
+			onPanResponderMove: (evt) => {
+				updateFromLocationX(evt.nativeEvent.locationX);
+			},
+		}),
+	).current;
+
+	const handleTrackLayout = useCallback((event: LayoutChangeEvent) => {
+		setTrackWidth(event.nativeEvent.layout.width);
+	}, []);
+
+	const decrement = useCallback(() => {
+		commitIndex(currentIndexRef.current - 1);
+	}, [commitIndex]);
+
+	const increment = useCallback(() => {
+		commitIndex(currentIndexRef.current + 1);
+	}, [commitIndex]);
+
+	// #935 【設計】iOS/Android の adjustable ロール向け increment/decrement アクション
+	const handleAccessibilityAction = useCallback(
+		(event: { nativeEvent: { actionName: string } }) => {
+			switch (event.nativeEvent.actionName) {
+				case "increment":
+					increment();
+					break;
+				case "decrement":
+					decrement();
+					break;
 			}
 		},
-	});
+		[increment, decrement],
+	);
+
+	// #935 【修正】web は accessibilityActions が効かないため、矢印キーで同等の操作を行えるようにする。
+	// react-native-web はこの View を最終的に div として描画し、未知の onKeyDown はそのまま
+	// DOM イベントハンドラとして forward されるため native 側には影響しない
+	const handleKeyDown = useCallback(
+		(event: { key: string; preventDefault: () => void }) => {
+			if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
+				event.preventDefault();
+				decrement();
+			} else if (event.key === "ArrowRight" || event.key === "ArrowUp") {
+				event.preventDefault();
+				increment();
+			}
+		},
+		[increment, decrement],
+	);
+
+	const currentOption = distanceOptions[currentIndex];
+	const thumbPosition =
+		trackWidth > 0 ? (currentIndex / (distanceOptions.length - 1)) * trackWidth - THUMB_SIZE / 2 : -THUMB_SIZE / 2;
 
 	return (
 		<View style={styles.sliderContainer}>
-			<View style={styles.sliderTrack}>
-				<View style={[styles.sliderThumb, { left: thumbPosition }]} {...panResponder.panHandlers} />
+			<View
+				style={styles.sliderTrack}
+				onLayout={handleTrackLayout}
+				// #935 【修正】視覚上の高さ(6px)より広い範囲でタップ/ドラッグを受け付ける
+				hitSlop={THUMB_HIT_SLOP}
+				{...panResponder.panHandlers}
+				// #935 【修正】ネイティブなセマンティクス(adjustable=スライダー)を付与
+				accessibilityRole="adjustable"
+				accessibilityLabel={i18n.t("Search.sections.distance")}
+				accessibilityActions={[
+					{ name: "increment", label: i18n.t("Search.DistanceSlider.far") },
+					{ name: "decrement", label: i18n.t("Search.DistanceSlider.near") },
+				]}
+				onAccessibilityAction={handleAccessibilityAction}
+				// [注意] react-native-web は accessibilityValue を DOM の aria-value* へ変換しないため
+				// (#930/#934 と同種の既知の非対応)、native/web 両対応の aria-value* を直接指定する
+				aria-valuemin={0}
+				aria-valuemax={distanceOptions.length - 1}
+				aria-valuenow={currentIndex}
+				aria-valuetext={i18n.t(currentOption.label)}
+				// #935 【修正】web でキーボードのタブ移動・矢印操作を受け付けられるようにする。
+				// onKeyDown は RN の ViewProps 型には無い web専用の DOM イベントだが、
+				// react-native-web は未知のプロパティをそのまま div へ forward するため実際には機能する
+				focusable
+				{...({ onKeyDown: handleKeyDown } as Record<string, unknown>)}
+				testID="search-distance-slider">
+				<View style={[styles.sliderThumb, { left: thumbPosition }]} />
 			</View>
 			<View style={styles.sliderLabels}>
 				<Text style={styles.sliderLabelLeft}>{i18n.t("Search.DistanceSlider.near")}</Text>
@@ -39,8 +167,7 @@ export function DistanceSlider({ distance, setDistance }: { distance: number; se
 	);
 }
 
-// Styles mirror the ones in the original screen
-const styles = {
+const styles = StyleSheet.create({
 	sliderContainer: {
 		width: 300,
 		justifyContent: "center",
@@ -54,10 +181,10 @@ const styles = {
 	},
 	sliderThumb: {
 		position: "absolute",
-		width: 28,
-		height: 28,
+		width: THUMB_SIZE,
+		height: THUMB_SIZE,
 		backgroundColor: "#FFFFFF",
-		borderRadius: 14,
+		borderRadius: THUMB_SIZE / 2,
 		top: -11,
 		borderWidth: 3,
 		borderColor: "#000000",
@@ -83,4 +210,4 @@ const styles = {
 		color: "#000000",
 		fontWeight: "600",
 	},
-} as const;
+});

--- a/app-expo/features/search/constants.ts
+++ b/app-expo/features/search/constants.ts
@@ -57,20 +57,23 @@ export const diningPaceOptions = [
 	{ id: "leisurely", label: "Search.diningPaceOptions.leisurely", icon: "🐢" },
 ] as const;
 
+// #935 【修正】label はモジュール評価時に i18n.t() を呼んでいたため、
+// 起動時ロケールの文言で固定されロケール切替後も更新されないバグがあった
+// (timeSlots 等の他オプション定義と同様、キー文字列を保持し使用箇所で i18n.t() する方式に統一)。
 // Distance options in meters
 export const distanceOptions = [
-	{ value: 100, label: i18n.t("Search.distanceLabels.100m") },
-	{ value: 300, label: i18n.t("Search.distanceLabels.300m") },
-	{ value: 500, label: i18n.t("Search.distanceLabels.500m") },
-	{ value: 800, label: i18n.t("Search.distanceLabels.800m") },
-	{ value: 1000, label: i18n.t("Search.distanceLabels.1km") },
-	{ value: 2000, label: i18n.t("Search.distanceLabels.2km") },
-	{ value: 3000, label: i18n.t("Search.distanceLabels.3km") },
-	{ value: 5000, label: i18n.t("Search.distanceLabels.5km") },
-	{ value: 10000, label: i18n.t("Search.distanceLabels.10km") },
-	{ value: 15000, label: i18n.t("Search.distanceLabels.15km") },
-	{ value: 20000, label: i18n.t("Search.distanceLabels.20km") },
-];
+	{ value: 100, label: "Search.distanceLabels.100m" },
+	{ value: 300, label: "Search.distanceLabels.300m" },
+	{ value: 500, label: "Search.distanceLabels.500m" },
+	{ value: 800, label: "Search.distanceLabels.800m" },
+	{ value: 1000, label: "Search.distanceLabels.1km" },
+	{ value: 2000, label: "Search.distanceLabels.2km" },
+	{ value: 3000, label: "Search.distanceLabels.3km" },
+	{ value: 5000, label: "Search.distanceLabels.5km" },
+	{ value: 10000, label: "Search.distanceLabels.10km" },
+	{ value: 15000, label: "Search.distanceLabels.15km" },
+	{ value: 20000, label: "Search.distanceLabels.20km" },
+] as const;
 
 // Price level options (Google Maps PriceLevel enum compliant, excluding FREE)
 export const priceLevelOptions = [

--- a/e2e-web/tests/search/distance-slider.spec.ts
+++ b/e2e-web/tests/search/distance-slider.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "../../fixtures/test";
+
+/**
+ * 📏 距離スライダー(#935)の操作テスト
+ *
+ * 背景: 旧実装は `gestureState.moveX - 50` というマジックナンバーで画面絶対座標を
+ * トラック相対座標へ誤変換しており、画面幅に依存してズレる(広い画面ほど端に張り付く)
+ * 不具合があった。加えて onPanResponderGrant が無くタップでは値が変わらず、
+ * サム(28×28)のみがタッチ対象でヒットスロップも無かった。
+ * onLayout で実測したトラック幅を使う実装へ作り直したため、ここでは
+ * タップ・ドラッグ・キーボード操作それぞれで値が正しく更新されることを検証する。
+ */
+test.describe("距離スライダー", () => {
+	test("タップでその位置に応じた値へ即座にジャンプする", async ({ appPage }) => {
+		await appPage.getByTestId("search-advanced-toggle").click();
+		const slider = appPage.getByTestId("search-distance-slider");
+		await slider.scrollIntoViewIfNeeded();
+		const box = await slider.boundingBox();
+		if (!box) throw new Error("slider bounding box not found");
+
+		// 右端付近をタップ → 遠い距離側の高いインデックスへジャンプすること
+		await appPage.mouse.click(box.x + box.width * 0.9, box.y + box.height / 2);
+		await expect(slider).toHaveAttribute("aria-valuenow", "9");
+
+		// 左端付近をタップ → 近い距離側の低いインデックスへジャンプすること
+		await appPage.mouse.click(box.x + box.width * 0.05, box.y + box.height / 2);
+		await expect(slider).toHaveAttribute("aria-valuenow", "0");
+	});
+
+	test("ドラッグで指の位置に追従して値が更新される", async ({ appPage }) => {
+		await appPage.getByTestId("search-advanced-toggle").click();
+		const slider = appPage.getByTestId("search-distance-slider");
+		await slider.scrollIntoViewIfNeeded();
+		const box = await slider.boundingBox();
+		if (!box) throw new Error("slider bounding box not found");
+
+		await appPage.mouse.move(box.x + 2, box.y + box.height / 2);
+		await appPage.mouse.down();
+		await appPage.mouse.move(box.x + box.width * 0.6, box.y + box.height / 2, { steps: 10 });
+		await appPage.mouse.up();
+
+		await expect(slider).toHaveAttribute("aria-valuenow", "6");
+		await expect(slider).toHaveAttribute("aria-valuetext", "3km");
+	});
+
+	// ─ テストケース: フォーカス後、矢印キーで1段階ずつ増減できる(web専用のキーボード操作) ─
+	test("矢印キーで1段階ずつ増減できる", async ({ appPage }) => {
+		await appPage.getByTestId("search-advanced-toggle").click();
+		const slider = appPage.getByTestId("search-distance-slider");
+		await slider.scrollIntoViewIfNeeded();
+		await slider.focus();
+
+		const initial = await slider.getAttribute("aria-valuenow");
+		await appPage.keyboard.press("ArrowRight");
+		await expect(slider).toHaveAttribute("aria-valuenow", String(Number(initial) + 1));
+
+		await appPage.keyboard.press("ArrowLeft");
+		await appPage.keyboard.press("ArrowLeft");
+		await expect(slider).toHaveAttribute("aria-valuenow", String(Number(initial) - 1));
+	});
+});


### PR DESCRIPTION
## Summary

根因(`DistanceSlider.tsx` 旧実装、自作 `PanResponder`):
- `gestureState.moveX - 50` というマジックナンバーで画面絶対座標→トラック相対座標を誤変換していた(実際のオフセットは画面幅依存で、広い画面ほどズレて端に張り付く)
- `onPanResponderGrant` が無く、タップしても値が変わらなかった(トラックタップ不可)
- サム(28×28)のみタッチ対象でヒットスロップも無く、指が少しズレると操作できなかった
- `PanResponder.create` を毎レンダー再生成していた
- ScrollView 内でも常にレスポンダを奪うため縦スクロールと衝突しうる状態だった
- `accessibilityRole` 等が無くスクリーンリーダー・キーボードで操作できなかった
- `distanceOptions` の `label` がモジュール評価時に `i18n.t()` を呼んでいたため、起動時ロケールの文言で固定されロケール切替後も更新されないバグもあった

## 対応
- `features/search/components/DistanceSlider.tsx`: `onLayout` で実測したトラック幅を使い `locationX` ベースで位置を計算する実装へ全面的に作り直した。`onPanResponderGrant` でタップ位置へ即ジャンプ。トラック `View` 全体を `panHandlers` の対象にし `hitSlop` も付与。`PanResponder` は `useRef` で1回だけ生成し最新値は ref 経由で参照。`onMoveShouldSetPanResponder` で dx/dy を比較し横方向の意図的な操作のみ奪うことで ScrollView の縦スクロールと共存させた。`accessibilityRole="adjustable"` + increment/decrement アクションを追加し、web はキーボードの矢印操作にも対応。
  - [注意] react-native-web は `accessibilityValue` を DOM の `aria-value*` へ変換しない(#930/#934 と同種の既知の非対応)ため、`aria-valuemin`/`max`/`now`/`text` を直接指定した。
- `features/search/constants.ts`: `distanceOptions` の `label` を i18n キー文字列で保持する方式(`timeSlots` 等の他オプションと同じパターン)に変更し、ロケール切替で更新されるよう修正。
- `search/index.tsx`: 上記に合わせ距離表示テキストで `i18n.t(label)` を呼ぶよう修正。

## Test plan
- [x] `pnpm --filter app-expo exec tsc -p tsconfig.dev.json --noEmit` 通過
- [x] `pnpm --filter app-expo build:web` 成功
- [x] `e2e-web`: `e2e-web/tests/search/distance-slider.spec.ts` を新設(タップでの即時ジャンプ・ドラッグでの追従・矢印キーでの1段階増減)。既存 `tests/search/` 配下と合わせ全14件が green
- [x] Playwright(実 dev API 接続、320px幅)でタップ/ドラッグ操作を目視確認、スクリーンショットは `tmp/935-距離スライダーの作り直し/` に保存

🤖 Generated with [Claude Code](https://claude.com/claude-code)