### PR TITLE
#939 店舗・料理アクションにa11y名を付与(UX-058)

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/result.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/result.tsx
@@ -169,11 +169,20 @@ export default function ResultScreen() {
 		<LinearGradient colors={["#FFFFFF", "#F8F9FA"]} style={styles.container}>
 			{/* Header with Back Button */}
 			<View style={{ ...styles.closeButtonContainer, top: Platform.OS === "ios" ? 40 : 0 }}>
-				<TouchableOpacity testID="result-close-button" style={styles.closeButton} onPress={handleCloseWithHaptic}>
+				<TouchableOpacity
+					testID="result-close-button"
+					style={styles.closeButton}
+					onPress={handleCloseWithHaptic}
+					accessibilityRole="button"
+					accessibilityLabel={i18n.t("Common.close")}>
 					<X size={24} color="#000" />
 				</TouchableOpacity>
 				{/* #659 【UI】一括シェアボタン - 閉じるボタンの直下に配置 */}
-				<TouchableOpacity style={styles.shareButton} onPress={handleBulkShare}>
+				<TouchableOpacity
+					style={styles.shareButton}
+					onPress={handleBulkShare}
+					accessibilityRole="button"
+					accessibilityLabel={i18n.t("Search.result.accessibility.bulkShare")}>
 					<Share2 size={24} color="#000" />
 				</TouchableOpacity>
 			</View>

--- a/app-expo/components/Stars.tsx
+++ b/app-expo/components/Stars.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import { FontAwesome } from "@expo/vector-icons";
+import i18n from "@/lib/i18n";
 
 interface StarsProps {
 	rating: number; // 評価 (例: 4.5)
@@ -15,13 +16,31 @@ const Stars: React.FC<StarsProps> = ({ rating, maxStars = 5, size = 12, color = 
 	const emptyStars = maxStars - fullStars - (halfStar ? 1 : 0);
 
 	return (
-		<View style={styles.container}>
+		// #939 【修正】星アイコンの並びには名前が無く、スクリーンリーダーでは評価値を判別できなかった。
+		// コンテナに評価値のラベルを付け、個々の星アイコン(装飾)は読み上げ対象から除外する
+		<View style={styles.container} accessible accessibilityLabel={i18n.t("Stars.accessibility.rating", { rating })}>
 			{Array.from({ length: fullStars }).map((_, index) => (
-				<FontAwesome key={`full-${index}`} name="star" size={size} color={color} />
+				<FontAwesome
+					key={`full-${index}`}
+					name="star"
+					size={size}
+					color={color}
+					importantForAccessibility="no"
+					aria-hidden
+				/>
 			))}
-			{halfStar && <FontAwesome name="star-half" size={size} color={color} />}
+			{halfStar && (
+				<FontAwesome name="star-half" size={size} color={color} importantForAccessibility="no" aria-hidden />
+			)}
 			{Array.from({ length: emptyStars }).map((_, index) => (
-				<FontAwesome key={`empty-${index}`} name="star-o" size={size} color={color} />
+				<FontAwesome
+					key={`empty-${index}`}
+					name="star-o"
+					size={size}
+					color={color}
+					importantForAccessibility="no"
+					aria-hidden
+				/>
 			))}
 		</View>
 	);

--- a/app-expo/features/dishMedia/components/ActionButtons.tsx
+++ b/app-expo/features/dishMedia/components/ActionButtons.tsx
@@ -286,7 +286,12 @@ export function ActionButtons({ id, idType, onLayout, buttonsGesture }: ActionBu
 	return (
 		<GestureDetector gesture={buttonsGesture}>
 			<View style={styles.rightActions} onLayout={handleLayout}>
-				<TouchableOpacity style={styles.actionButton} onPress={handleViewRestaurant} hitSlop={buttonHitSlop}>
+				<TouchableOpacity
+					style={styles.actionButton}
+					onPress={handleViewRestaurant}
+					hitSlop={buttonHitSlop}
+					accessibilityRole="button"
+					accessibilityLabel={i18n.t("DishMediaContent.accessibility.viewRestaurant", { name: restaurant.name })}>
 					<Image
 						source={{ uri: restaurant.imageUrls?.sm, cacheKey: getCacheKeyForImage(restaurant.imageUrls?.sm) }}
 						style={styles.restaurantAvatar}
@@ -299,7 +304,10 @@ export function ActionButtons({ id, idType, onLayout, buttonsGesture }: ActionBu
 						testID="dish-action-like"
 						style={styles.actionButton}
 						onPress={handleLike}
-						hitSlop={buttonHitSlop}>
+						hitSlop={buttonHitSlop}
+						accessibilityRole="button"
+						accessibilityLabel={i18n.t("DishMediaContent.accessibility.like", { name: restaurant.name })}
+						aria-selected={isLiked}>
 						<Heart size={28} color={isLiked ? "#FF3040" : "#FFFFFF"} fill={isLiked ? "#FF3040" : "white"} />
 					</TouchableOpacity>
 					<Text style={styles.actionText}>{formatLikeCount(likeCount)}</Text>
@@ -309,19 +317,32 @@ export function ActionButtons({ id, idType, onLayout, buttonsGesture }: ActionBu
 					testID="dish-action-save"
 					style={styles.actionButton}
 					onPress={handleSave}
-					hitSlop={buttonHitSlop}>
+					hitSlop={buttonHitSlop}
+					accessibilityRole="button"
+					accessibilityLabel={i18n.t("DishMediaContent.accessibility.save", { name: restaurant.name })}
+					aria-selected={isSaved}>
 					<Bookmark size={30} color={"transparent"} fill={isSaved ? "orange" : "white"} />
 				</TouchableOpacity>
 
 				<View style={styles.actionContainer}>
-					<TouchableOpacity style={styles.actionButton} onPress={handleSharePress} hitSlop={buttonHitSlop}>
+					<TouchableOpacity
+						style={styles.actionButton}
+						onPress={handleSharePress}
+						hitSlop={buttonHitSlop}
+						accessibilityRole="button"
+						accessibilityLabel={i18n.t("DishMediaContent.accessibility.share", { name: restaurant.name })}>
 						<Share size={28} color="#FFFFFF" />
 					</TouchableOpacity>
 					<Text style={styles.actionText}>{i18n.t("DishMediaContent.actions.share")}</Text>
 				</View>
 
 				<View style={styles.actionContainer}>
-					<TouchableOpacity style={styles.actionButton} onPress={handleMapPinPress} hitSlop={buttonHitSlop}>
+					<TouchableOpacity
+						style={styles.actionButton}
+						onPress={handleMapPinPress}
+						hitSlop={buttonHitSlop}
+						accessibilityRole="button"
+						accessibilityLabel={i18n.t("DishMediaContent.accessibility.openMap", { name: restaurant.name })}>
 						<MapPinned size={28} color="#FFFFFF" />
 					</TouchableOpacity>
 					<Text style={styles.actionText}>{i18n.t("DishMediaContent.actions.openMap")}</Text>
@@ -343,7 +364,9 @@ export function ActionButtons({ id, idType, onLayout, buttonsGesture }: ActionBu
 								onPress={() => {
 									option.onPress();
 									closeMenuModal();
-								}}>
+								}}
+								accessibilityRole="button"
+								accessibilityLabel={option.label}>
 								<option.icon size={20} color="#FFFFFF" />
 								<Text style={styles.menuItemText}>{option.label}</Text>
 							</TouchableOpacity>

--- a/app-expo/features/dishMedia/components/DishReviewsSection.tsx
+++ b/app-expo/features/dishMedia/components/DishReviewsSection.tsx
@@ -160,14 +160,25 @@ export function DishReviewsSection({ id, idType, paddingRight, carouselRef }: Di
 										{displayText}
 										{isTruncated && "...  "}
 										{isTruncated && (
-											<TouchableOpacity style={styles.seeMoreButton} onPress={() => handleSeeMore(review.id)}>
+											<TouchableOpacity
+												style={styles.seeMoreButton}
+												onPress={() => handleSeeMore(review.id)}
+												accessibilityRole="button"
+												accessibilityLabel={i18n.t("DishMediaContent.actions.seeMore")}>
 												<Text style={styles.seeMoreText}>{i18n.t("DishMediaContent.actions.seeMore")}</Text>
 											</TouchableOpacity>
 										)}
 									</Text>
 								</View>
 								<View style={styles.commentActions}>
-									<TouchableOpacity style={styles.commentLikeButton} onPress={() => handleReviewLike(review.id)}>
+									<TouchableOpacity
+										style={styles.commentLikeButton}
+										onPress={() => handleReviewLike(review.id)}
+										accessibilityRole="button"
+										accessibilityLabel={i18n.t("DishMediaContent.accessibility.reviewLike", {
+											username: review.username,
+										})}
+										aria-selected={review.isLiked ?? false}>
 										<Heart
 											size={14}
 											color={review.isLiked ? "#FF3040" : "#CCCCCC"}

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -198,6 +198,11 @@
 			"seafoodAllergy": "حساسية المأكولات البحرية",
 			"halal": "حلال"
 		},
+		"result": {
+			"accessibility": {
+				"bulkShare": "مشاركة الكل"
+			}
+		},
 		"tutorial": {
 			"page1": {
 				"title": "اكتشف ما تريد أن تأكله",
@@ -301,6 +306,14 @@
 		"buttons": {
 			"viewRestaurant": "عرض المطعم"
 		},
+		"accessibility": {
+			"viewRestaurant": "عرض تفاصيل مطعم {{name}}",
+			"like": "الإعجاب بـ {{name}}",
+			"save": "حفظ {{name}}",
+			"share": "مشاركة {{name}}",
+			"openMap": "فتح خريطة {{name}}",
+			"reviewLike": "الإعجاب بمراجعة {{username}}"
+		},
 		"processing": "جارٍ معالجة الوسائط...",
 		"info": {
 			"walkFromShibuya": "على بُعد 13 دقيقة سيرًا من محطة شيبويا"
@@ -312,6 +325,11 @@
 	},
 	"ImageCardGrid": {
 		"openItemDetails": "فتح تفاصيل العنصر"
+	},
+	"Stars": {
+		"accessibility": {
+			"rating": "التقييم {{rating}}/5"
+		}
 	},
 	"Tabs": {
 		"home": "الصفحة الرئيسية",

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -198,6 +198,11 @@
 			"seafoodAllergy": "Seafood allergy",
 			"halal": "Halal"
 		},
+		"result": {
+			"accessibility": {
+				"bulkShare": "Share all"
+			}
+		},
 		"tutorial": {
 			"page1": {
 				"title": "Discover what you want to eat",
@@ -301,6 +306,14 @@
 		"buttons": {
 			"viewRestaurant": "View restaurant"
 		},
+		"accessibility": {
+			"viewRestaurant": "View {{name}}'s restaurant details",
+			"like": "Like {{name}}",
+			"save": "Save {{name}}",
+			"share": "Share {{name}}",
+			"openMap": "Open map for {{name}}",
+			"reviewLike": "Like {{username}}'s review"
+		},
 		"processing": "Processing media...",
 		"errors": {
 			"mapOpenFailed": "Could not open map application",
@@ -312,6 +325,11 @@
 	},
 	"ImageCardGrid": {
 		"openItemDetails": "Open item details"
+	},
+	"Stars": {
+		"accessibility": {
+			"rating": "Rating {{rating}}/5"
+		}
 	},
 	"Tabs": {
 		"home": "Home",

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -198,6 +198,11 @@
 			"seafoodAllergy": "Alergia a mariscos",
 			"halal": "Halal"
 		},
+		"result": {
+			"accessibility": {
+				"bulkShare": "Compartir todo"
+			}
+		},
 		"tutorial": {
 			"page1": {
 				"title": "Descubre lo que quieres comer",
@@ -301,6 +306,14 @@
 		"buttons": {
 			"viewRestaurant": "Ver restaurante"
 		},
+		"accessibility": {
+			"viewRestaurant": "Ver detalles del restaurante de {{name}}",
+			"like": "Me gusta {{name}}",
+			"save": "Guardar {{name}}",
+			"share": "Compartir {{name}}",
+			"openMap": "Abrir el mapa de {{name}}",
+			"reviewLike": "Me gusta la reseña de {{username}}"
+		},
 		"processing": "Procesando el contenido...",
 		"errors": {
 			"mapOpenFailed": "No se pudo abrir la aplicación de mapas",
@@ -312,6 +325,11 @@
 	},
 	"ImageCardGrid": {
 		"openItemDetails": "Abrir detalles del elemento"
+	},
+	"Stars": {
+		"accessibility": {
+			"rating": "Valoración {{rating}}/5"
+		}
 	},
 	"Tabs": {
 		"home": "Inicio",

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -198,6 +198,11 @@
 			"seafoodAllergy": "Allergie aux fruits de mer",
 			"halal": "Halal"
 		},
+		"result": {
+			"accessibility": {
+				"bulkShare": "Tout partager"
+			}
+		},
 		"tutorial": {
 			"page1": {
 				"title": "Découvrez ce que vous voulez manger",
@@ -301,6 +306,14 @@
 		"buttons": {
 			"viewRestaurant": "Voir le restaurant"
 		},
+		"accessibility": {
+			"viewRestaurant": "Voir les détails du restaurant {{name}}",
+			"like": "Aimer {{name}}",
+			"save": "Enregistrer {{name}}",
+			"share": "Partager {{name}}",
+			"openMap": "Ouvrir la carte de {{name}}",
+			"reviewLike": "Aimer l'avis de {{username}}"
+		},
 		"processing": "Traitement du média...",
 		"errors": {
 			"mapOpenFailed": "Impossible d'ouvrir l'application de carte",
@@ -312,6 +325,11 @@
 	},
 	"ImageCardGrid": {
 		"openItemDetails": "Ouvrir les détails de l'article"
+	},
+	"Stars": {
+		"accessibility": {
+			"rating": "Note {{rating}}/5"
+		}
 	},
 	"Tabs": {
 		"home": "Accueil",

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -198,6 +198,11 @@
 			"seafoodAllergy": "समुद्री भोजन से एलर्जी",
 			"halal": "हलाल"
 		},
+		"result": {
+			"accessibility": {
+				"bulkShare": "सभी शेयर करें"
+			}
+		},
 		"tutorial": {
 			"page1": {
 				"title": "आप क्या खाना चाहते हैं, जानें",
@@ -301,6 +306,14 @@
 		"buttons": {
 			"viewRestaurant": "रेस्टोरेंट देखें"
 		},
+		"accessibility": {
+			"viewRestaurant": "{{name}} के रेस्तरां का विवरण देखें",
+			"like": "{{name}} को पसंद करें",
+			"save": "{{name}} सेव करें",
+			"share": "{{name}} शेयर करें",
+			"openMap": "{{name}} का मानचित्र खोलें",
+			"reviewLike": "{{username}} की समीक्षा को पसंद करें"
+		},
 		"processing": "मीडिया प्रोसेस किया जा रहा है...",
 		"info": {
 			"walkFromShibuya": "शिबुया स्टेशन से 13 मिनट की पैदल दूरी"
@@ -312,6 +325,11 @@
 	},
 	"ImageCardGrid": {
 		"openItemDetails": "आइटम विवरण खोलें"
+	},
+	"Stars": {
+		"accessibility": {
+			"rating": "रेटिंग {{rating}}/5"
+		}
 	},
 	"Tabs": {
 		"home": "होम",

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -198,6 +198,11 @@
 			"seafoodAllergy": "魚介アレルギー",
 			"halal": "ハラール"
 		},
+		"result": {
+			"accessibility": {
+				"bulkShare": "まとめてシェア"
+			}
+		},
 		"tutorial": {
 			"page1": {
 				"title": "食べたい料理に気づけるアプリ",
@@ -301,6 +306,14 @@
 		"buttons": {
 			"viewRestaurant": "店を見る"
 		},
+		"accessibility": {
+			"viewRestaurant": "{{name}}の店舗詳細を見る",
+			"like": "{{name}}にいいね",
+			"save": "{{name}}を保存",
+			"share": "{{name}}をシェア",
+			"openMap": "{{name}}の地図を開く",
+			"reviewLike": "{{username}}の口コミにいいね"
+		},
 		"processing": "メディアを処理中...",
 		"errors": {
 			"mapOpenFailed": "地図アプリを開けませんでした",
@@ -312,6 +325,11 @@
 	},
 	"ImageCardGrid": {
 		"openItemDetails": "詳細を表示"
+	},
+	"Stars": {
+		"accessibility": {
+			"rating": "評価 {{rating}}/5"
+		}
 	},
 	"Tabs": {
 		"home": "ホーム",

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -198,6 +198,11 @@
 			"seafoodAllergy": "해산물 알레르기",
 			"halal": "할랄"
 		},
+		"result": {
+			"accessibility": {
+				"bulkShare": "모두 공유"
+			}
+		},
 		"tutorial": {
 			"page1": {
 				"title": "먹고 싶은 음식을 발견하세요",
@@ -301,6 +306,14 @@
 		"buttons": {
 			"viewRestaurant": "가게 보기"
 		},
+		"accessibility": {
+			"viewRestaurant": "{{name}} 매장 상세 보기",
+			"like": "{{name}} 좋아요",
+			"save": "{{name}} 저장",
+			"share": "{{name}} 공유",
+			"openMap": "{{name}} 지도 열기",
+			"reviewLike": "{{username}}님의 리뷰에 좋아요"
+		},
 		"processing": "미디어 처리 중...",
 		"info": {
 			"walkFromShibuya": "시부야역에서 도보 13분"
@@ -312,6 +325,11 @@
 	},
 	"ImageCardGrid": {
 		"openItemDetails": "항목 세부정보 열기"
+	},
+	"Stars": {
+		"accessibility": {
+			"rating": "평점 {{rating}}/5"
+		}
 	},
 	"Tabs": {
 		"home": "홈",

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -198,6 +198,11 @@
 			"seafoodAllergy": "海鲜过敏",
 			"halal": "清真"
 		},
+		"result": {
+			"accessibility": {
+				"bulkShare": "批量分享"
+			}
+		},
 		"tutorial": {
 			"page1": {
 				"title": "发现您想吃的美食",
@@ -301,6 +306,14 @@
 		"buttons": {
 			"viewRestaurant": "查看餐厅"
 		},
+		"accessibility": {
+			"viewRestaurant": "查看{{name}}的门店详情",
+			"like": "点赞{{name}}",
+			"save": "保存{{name}}",
+			"share": "分享{{name}}",
+			"openMap": "打开{{name}}的地图",
+			"reviewLike": "为{{username}}的点评点赞"
+		},
 		"processing": "正在处理媒体...",
 		"errors": {
 			"mapOpenFailed": "无法打开地图应用",
@@ -312,6 +325,11 @@
 	},
 	"ImageCardGrid": {
 		"openItemDetails": "打开项目详情"
+	},
+	"Stars": {
+		"accessibility": {
+			"rating": "评分 {{rating}}/5"
+		}
 	},
 	"Tabs": {
 		"home": "首页",

--- a/e2e-web/tests/search/dish-media-accessibility.spec.ts
+++ b/e2e-web/tests/search/dish-media-accessibility.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "../../fixtures/test";
+import { SearchPage } from "../../pages/SearchPage";
+import { TopicsPage } from "../../pages/TopicsPage";
+import { ResultPage } from "../../pages/ResultPage";
+
+/**
+ * ♿ 店舗・料理アクションのa11y名付与テスト(#939)
+ *
+ * 背景: ActionButtons.tsx の全ボタン(店舗アバター/いいね/保存/シェア/地図/メニュー)に
+ * role/label が一切無く、保存ボタンと店舗アバターは完全に無名(スクリーンリーダーで
+ * 何のボタンか判別不能)だった。result.tsx の閉じる/一括シェアボタンも同様。
+ * 各ボタンに accessibilityRole="button" + 対象(店舗名)付きラベルを付与したため、
+ * ここでは実際に検索フローを通って表示された料理メディアカードのボタン群が
+ * 無名でなくなっていることを確認する。
+ *
+ * 実 API を経由し AI 生成待ちが発生するため @smoke 対象外とする(topics-flow.spec.ts と同様)。
+ */
+test.describe("店舗・料理アクションのアクセシビリティ", () => {
+	test.setTimeout(60_000);
+	// AI レコメンドが選ぶ料理・店舗によっては dev 環境側のデータ不備(画像未処理等)で
+	// 結果フィード取得が 500 になることが実測で確認されている(reactions.spec.ts と同様の
+	// 既知の不安定要素でこのテストの実装不備ではない)。再実行すれば別の料理が選ばれ成功することが多い
+	test.describe.configure({ retries: 2 });
+
+	test("料理メディアカードの操作ボタンが役割・名前を持つ", async ({ appPage }) => {
+		const searchPage = new SearchPage(appPage);
+		const topicsPage = new TopicsPage(appPage);
+		const resultPage = new ResultPage(appPage);
+
+		await searchPage.typeLocation("渋谷");
+		await searchPage.selectLocationSuggestion(0);
+		await searchPage.submitButton.click();
+		await topicsPage.expectLoaded();
+		await topicsPage.chooseFirstTopic();
+		await resultPage.expectLoaded();
+
+		// いいね/保存ボタン: role="button" を持ち、ラベルが空でないこと(店舗名を含む)
+		const likeButton = resultPage.likeButton.first();
+		await expect(likeButton).toHaveAttribute("role", "button");
+		const likeLabel = await likeButton.getAttribute("aria-label");
+		expect(likeLabel).toBeTruthy();
+		expect(likeLabel).not.toBe("");
+
+		const saveButton = resultPage.saveButton.first();
+		await expect(saveButton).toHaveAttribute("role", "button");
+		const saveLabel = await saveButton.getAttribute("aria-label");
+		expect(saveLabel).toBeTruthy();
+		expect(saveLabel).not.toBe(likeLabel); // いいねと保存で異なる文言であること
+
+		// トグル状態が aria-selected で判別できること(押下前は false)
+		await expect(likeButton).toHaveAttribute("aria-selected", "false");
+		await expect(saveButton).toHaveAttribute("aria-selected", "false");
+
+		// 結果画面の閉じる/一括シェアボタンにも名前が付いていること
+		await expect(resultPage.closeButton).toHaveAttribute("role", "button");
+		await expect(resultPage.closeButton).toHaveAttribute("aria-label", "閉じる");
+	});
+});


### PR DESCRIPTION
## Summary

根因: `ActionButtons.tsx` の全ボタン(店舗アバター/いいね/保存/シェア/地図/メニュー)に role/label が一切無く、保存ボタンと店舗アバターは完全に無名だった。`result.tsx` の閉じる/一括シェア、`DishReviewsSection.tsx` のもっと見る/口コミいいねも同様。`Stars.tsx`(星評価)にもラベルが無く、星アイコンの並びからは評価値を判別できなかった。

- `features/dishMedia/components/ActionButtons.tsx`: 店舗アバター/いいね/保存/シェア/地図/メニュー項目に `accessibilityRole="button"` + 対象(店舗名)付きラベル(i18n補間)を付与。いいね/保存はトグル状態を `aria-selected` で判別できるようにした。
- `features/dishMedia/components/DishReviewsSection.tsx`: 口コミの「もっと見る」「いいね」ボタンに role/label を付与。
- `app/[locale]/(tabs)/search/result.tsx`: 閉じる(`Common.close` 流用)・一括シェアボタンに role/label を付与。
- `components/Stars.tsx`: コンテナに評価値のラベル(「評価 {{rating}}/5」)を付与し、個々の星アイコン(装飾)は読み上げ対象から除外(重複読み上げ防止)。
- `locales/*.json`(8言語): 上記のためのキーを追加。

**ハマりどころ**: react-native-web は `accessibilityState.selected` を DOM の `aria-selected` へ変換しない(#930/#934/#935 と同種の既知の非対応)ため、`aria-selected` を直接指定した。

## Test plan
- [x] `pnpm --filter app-expo exec tsc -p tsconfig.dev.json --noEmit` 通過
- [x] `pnpm --filter app-expo build:web` 成功
- [x] `e2e-web`: `tests/search/dish-media-accessibility.spec.ts` を新設(実際に検索フローで表示された料理メディアカードのいいね/保存ボタンが role/aria-selected/重複しないラベルを持つこと、結果画面の閉じるボタンにもラベルが付いていること)。既存 `tests/search/` 配下と合わせ全12件が green
- [x] Playwright(実 dev API 接続)で `aria-label` に実際の店舗名が正しく補間されることを確認(例: 「大勝軒まるいち渋谷店にいいね」)、スクリーンショットは `tmp/939-店舗料理アクションのa11y名付与/` に保存

🤖 Generated with [Claude Code](https://claude.com/claude-code)