### PR TITLE
#940 fix: 描画クラッシュ白画面・API無限待ち・エラー不可視のインフラ3バグ修正(スコープ削減)

### DIFF
--- a/app-expo/app/[locale]/_layout.tsx
+++ b/app-expo/app/[locale]/_layout.tsx
@@ -8,6 +8,7 @@ import { SnackbarProvider } from "@/contexts/SnackbarProvider";
 import { PaperProvider, Portal } from "react-native-paper";
 import { SplashHandler } from "@/components/SplashHandler";
 import { AppProvider } from "@/components/AppProvider";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { HealthCheckInitializer } from "@/components/HealthCheckInitializer";
 import { PushTokenRegistration } from "@/components/PushTokenRegistration";
 import { MetaAppEventsInitializer } from "@/components/MetaAppEventsInitializer";
@@ -101,10 +102,14 @@ export default function RootLayout() {
 										<SplashHandler>
 											<HealthCheckInitializer>
 												<AppProvider>
-													<Stack screenOptions={{ header: () => null }}>
-														<Stack.Screen name="(tabs)" options={{ header: () => null }} />
-														<Stack.Screen name="+not-found" />
-													</Stack>
+													{/* #940 【設計】render中の未捕捉例外で白画面になるのを防ぐ最終防波堤。
+													    再試行はアプリのルートへ戻すことで安全な状態に復帰させる */}
+													<ErrorBoundary onRetry={() => router.replace("/")}>
+														<Stack screenOptions={{ header: () => null }}>
+															<Stack.Screen name="(tabs)" options={{ header: () => null }} />
+															<Stack.Screen name="+not-found" />
+														</Stack>
+													</ErrorBoundary>
 													<StatusBar style="light" />
 												</AppProvider>
 											</HealthCheckInitializer>

--- a/app-expo/components/ErrorBoundary.tsx
+++ b/app-expo/components/ErrorBoundary.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { PrimaryButton } from "@/components/PrimaryButton";
+import { useLogger } from "@/hooks/useLogger";
+import i18n from "@/lib/i18n";
+
+// #940 【設計】リポジトリに ErrorBoundary が0件だったため、render中の未捕捉例外
+// (DishMediaContent.tsx/ActionButtons.tsx の「entry is undefined」throw 等)が
+// そのまま web では白画面になっていた。React の ErrorBoundary は class component でしか
+// 実装できない(componentDidCatch/getDerivedStateFromError はクラスAPI専用)ため、
+// ログ送信に必要な useLogger() は外側の関数コンポーネントで呼び出し props 経由で渡す。
+
+interface ErrorBoundaryClassProps {
+	children: React.ReactNode;
+	/** 再試行ボタン押下時に呼ばれる。渡さない場合はエラー状態のリセットのみ行う */
+	onRetry?: () => void;
+	logFrontendEvent: ReturnType<typeof useLogger>["logFrontendEvent"];
+}
+
+interface ErrorBoundaryClassState {
+	error: Error | null;
+}
+
+class ErrorBoundaryClass extends React.Component<ErrorBoundaryClassProps, ErrorBoundaryClassState> {
+	constructor(props: ErrorBoundaryClassProps) {
+		super(props);
+		this.state = { error: null };
+	}
+
+	static getDerivedStateFromError(error: Error): ErrorBoundaryClassState {
+		return { error };
+	}
+
+	componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+		this.props.logFrontendEvent({
+			event_name: "error_boundary_caught",
+			error_level: "error",
+			payload: {
+				error: error.message,
+				componentStack: errorInfo.componentStack ?? undefined,
+			},
+		});
+	}
+
+	handleRetry = () => {
+		this.props.onRetry?.();
+		this.setState({ error: null });
+	};
+
+	render() {
+		if (this.state.error) {
+			return (
+				<View style={styles.container} testID="error-boundary-fallback">
+					<View style={styles.card}>
+						<Text style={styles.text}>{i18n.t("Common.errors.unexpected")}</Text>
+						<PrimaryButton style={styles.button} label={i18n.t("Common.retry")} onPress={this.handleRetry} />
+					</View>
+				</View>
+			);
+		}
+		return this.props.children;
+	}
+}
+
+interface ErrorBoundaryProps {
+	children: React.ReactNode;
+	/** 再試行ボタン押下時に呼ばれる(データの再取得等)。渡さない場合はエラー状態のリセットのみ行う */
+	onRetry?: () => void;
+}
+
+export function ErrorBoundary({ children, onRetry }: ErrorBoundaryProps) {
+	const { logFrontendEvent } = useLogger();
+	return (
+		<ErrorBoundaryClass onRetry={onRetry} logFrontendEvent={logFrontendEvent}>
+			{children}
+		</ErrorBoundaryClass>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		justifyContent: "center",
+		alignItems: "center",
+		padding: 16,
+		backgroundColor: "#FFFFFF",
+	},
+	card: {
+		backgroundColor: "#FFFFFF",
+		borderRadius: 20,
+		padding: 32,
+		alignItems: "center",
+		justifyContent: "center",
+		shadowColor: "#000",
+		shadowOffset: { width: 0, height: 0 },
+		shadowOpacity: 0.08,
+		shadowRadius: 16,
+		elevation: 4,
+	},
+	text: {
+		fontSize: 16,
+		color: "#6B7280",
+		textAlign: "center",
+	},
+	button: {
+		marginTop: 16,
+	},
+});

--- a/app-expo/features/dishMedia/components/ActionButtons.tsx
+++ b/app-expo/features/dishMedia/components/ActionButtons.tsx
@@ -40,26 +40,43 @@ export function ActionButtons({ id, idType, onLayout, buttonsGesture }: ActionBu
 	const router = useRouter();
 	const { locale } = useLocale();
 
+	// #940 【修正】entry 未取得時に throw する前に理由を記録する。throw 自体は残す
+	// (このコンポーネントは entry の存在を前提に構築されており、無ければ描画できないため)。
+	// ErrorBoundary(親の DishMediaMap.renderCarouselItem に設置済み)がこの throw を捕捉する
 	const selector = useCallback(
 		(state: DishMediaEntriesStore) => {
 			const entry = idType === "dish_media" ? selectEntryByMediaId(id)(state) : selectEntryByReviewId(id)(state);
-			if (!entry) throw new Error("ActionButtons: entry is undefined");
+			if (!entry) {
+				logFrontendEvent({
+					event_name: "action_buttons_entry_missing",
+					error_level: "error",
+					payload: { id, idType, context: "selector" },
+				});
+				throw new Error("ActionButtons: entry is undefined");
+			}
 			return {
 				isSaved: entry.dish_media.isSaved,
 				isLiked: entry.dish_media.isLiked,
 				likeCount: entry.dish_media.likeCount,
 			};
 		},
-		[id, idType],
+		[id, idType, logFrontendEvent],
 	);
 	const { isSaved, isLiked, likeCount } = useDishMediaEntriesStore(selector, shallow);
 
 	const { dishMediaId, restaurant } = useMemo(() => {
 		const state = useDishMediaEntriesStore.getState(); // ← subscribe しない snapshot 読み
 		const entry = idType === "dish_media" ? selectEntryByMediaId(id)(state) : selectEntryByReviewId(id)(state);
-		if (!entry) throw new Error("ActionButtons: entry is undefined");
+		if (!entry) {
+			logFrontendEvent({
+				event_name: "action_buttons_entry_missing",
+				error_level: "error",
+				payload: { id, idType, context: "memo" },
+			});
+			throw new Error("ActionButtons: entry is undefined");
+		}
 		return { dishMediaId: entry.dish_media.id, restaurant: entry.restaurant };
-	}, [id, idType]);
+	}, [id, idType, logFrontendEvent]);
 
 	// #613 【設計】ActionButtons の押下処理を hooks で共通化
 	const { openInGoogleMaps, shareRestaurant } = useDishMediaActions({

--- a/app-expo/features/dishMedia/components/DishMediaContent.tsx
+++ b/app-expo/features/dishMedia/components/DishMediaContent.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/stores/useDishMediaEntriesStore";
 import type { MediaProcessingStatus, QueryDishMediaByIdsResponse } from "@shared/api/v1/res";
 import { useAPICall } from "@/hooks/useAPICall";
+import { useLogger } from "@/hooks/useLogger";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
 import { SkeletonShimmer } from "@/components/SkeletonShimmer";
@@ -48,11 +49,24 @@ export default function DishMediaContent({
 	displayIndex,
 	backgroundImageState,
 }: DishMediaContentProps) {
+	// #940 【修正】entry 未取得時に throw する前に理由を記録する。throw 自体は残す
+	// (このコンポーネントは entry の存在を前提に構築されており、無ければ描画できないため)。
+	// ErrorBoundary(親の DishMediaMap.renderCarouselItem に設置済み)がこの throw を捕捉し、
+	// カード単位のリトライ表示に変換することで white screen を防ぐ
+	const { logFrontendEvent } = useLogger();
+
 	// #530 【設計】dishMediaEntry を useState で管理し、ポーリング結果を反映できるようにする
 	const [dishMediaEntry, setDishMediaEntry] = useState<NormalizedDishMediaEntry>(() => {
 		const state = useDishMediaEntriesStore.getState(); // ← subscribe しない snapshot 読み
 		const entry = idType === "dish_media" ? selectEntryByMediaId(id)(state) : selectEntryByReviewId(id)(state);
-		if (!entry) throw new Error("DishMediaContent: entry is undefined");
+		if (!entry) {
+			logFrontendEvent({
+				event_name: "dish_media_content_entry_missing",
+				error_level: "error",
+				payload: { id, idType, entriesKey },
+			});
+			throw new Error("DishMediaContent: entry is undefined");
+		}
 		return entry;
 	});
 

--- a/app-expo/features/dishMedia/components/DishMediaMap.tsx
+++ b/app-expo/features/dishMedia/components/DishMediaMap.tsx
@@ -24,6 +24,7 @@ import { useActionSheet } from "@expo/react-native-action-sheet";
 import { useDishMediaActions } from "../hooks/useDishMediaActions";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { LoadingIndicator } from "@/components/LoadingIndicator";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { useDishMediaBackgroundImageResources } from "@/features/dishMedia/hooks/useDishMediaBackgroundImageResources";
 
 const { width, height } = Dimensions.get("window");
@@ -97,7 +98,10 @@ export default function DishMediaMap({
 	}, [ids, idType]);
 
 	// #802 【責務分離】Map は ids とレイアウト/Carousel 制御だけを担い、背景画像 preload の最小購読は hook に閉じる。
-	const backgroundImagesSessionKey = useMemo(() => `${entriesKey}::${idType}::${ids.join(",")}`, [entriesKey, idType, ids]);
+	const backgroundImagesSessionKey = useMemo(
+		() => `${entriesKey}::${idType}::${ids.join(",")}`,
+		[entriesKey, idType, ids],
+	);
 	const { getBackgroundImageState } = useDishMediaBackgroundImageResources({
 		ids,
 		idType,
@@ -298,18 +302,22 @@ export default function DishMediaMap({
 	const renderCarouselItem = useCallback(
 		({ item, index }: { item: string; index: number }) => (
 			<View style={styles.carouselItem}>
-				<DishMediaContent
-					id={item}
-					carouselRef={carouselRef}
-					isActive={index === currentIndex}
-					getTitle={getTitle}
-					sessionId={sessionId.current}
-					entriesKey={entriesKey}
-					idType={idType}
-					onCardPress={handleCardPress} // #613 【設計】カード押下時のコールバックを渡す
-					displayIndex={index}
-					backgroundImageState={getBackgroundImageState(item)}
-				/>
+				{/* #940 【設計】1枚のカードの描画中例外(entry未取得等)で結果画面全体を巻き込まないよう、
+				    カード単位で ErrorBoundary を設置する(アプリ全体の ErrorBoundary は最終防波堤として別途設置済み) */}
+				<ErrorBoundary>
+					<DishMediaContent
+						id={item}
+						carouselRef={carouselRef}
+						isActive={index === currentIndex}
+						getTitle={getTitle}
+						sessionId={sessionId.current}
+						entriesKey={entriesKey}
+						idType={idType}
+						onCardPress={handleCardPress} // #613 【設計】カード押下時のコールバックを渡す
+						displayIndex={index}
+						backgroundImageState={getBackgroundImageState(item)}
+					/>
+				</ErrorBoundary>
 			</View>
 		),
 		[currentIndex, getTitle, entriesKey, idType, handleCardPress, getBackgroundImageState],
@@ -343,8 +351,11 @@ export default function DishMediaMap({
 				</View>
 			)}
 
+			{/* #940 【修正】centerContainer が通常のフローに置かれ zIndex も無かったため、
+			    直後に絶対配置される mapContainer(zIndex:1) の下敷きになり実質見えなくなっていた。
+			    最前面に絶対配置し、地図の下敷きにならないようにする */}
 			{error && (
-				<View style={styles.centerContainer}>
+				<View style={styles.errorOverlay}>
 					<Text style={styles.errorText}>{error}</Text>
 				</View>
 			)}
@@ -490,6 +501,19 @@ const styles = StyleSheet.create({
 		marginTop: 16,
 		color: "#FFF",
 		fontSize: 16,
+	},
+	// #940 【修正】mapContainer(zIndex:1)より前面に絶対配置し、地図の下敷きにならないようにする
+	errorOverlay: {
+		position: "absolute",
+		top: 0,
+		left: 0,
+		right: 0,
+		bottom: 0,
+		zIndex: 5,
+		justifyContent: "center",
+		alignItems: "center",
+		backgroundColor: "rgba(0, 0, 0, 0.85)",
+		paddingHorizontal: 20,
 	},
 	errorText: {
 		color: "#FF6B6B",

--- a/app-expo/hooks/useAPICall.ts
+++ b/app-expo/hooks/useAPICall.ts
@@ -16,13 +16,13 @@ import { fetchWithAuth } from "@/lib/fetchWithAuth";
 export type ApiError = {
 	/** クライアント側で使う大まかな分類コード */
 	code:
-	| "maintenance_mode"
-	| "unsupported_version"
-	| "forbidden"
-	| "http_error"
-	| "api_error"
-	| "invalid_response"
-	| "network_error";
+		| "maintenance_mode"
+		| "unsupported_version"
+		| "forbidden"
+		| "http_error"
+		| "api_error"
+		| "invalid_response"
+		| "network_error";
 
 	/** HTTP ステータス。ネットワークエラー等の場合は undefined or 0 */
 	status?: number;
@@ -43,6 +43,10 @@ export type ApiError = {
 	/** 必要があれば生のレスポンスや追加情報 */
 	raw?: unknown;
 };
+
+// #940 【設計】応答が返らないまま無期限に待ち続ける(=ユーザーがローディング画面に留まり続ける)のを
+// 防ぐためのタイムアウト。リトライを含む呼び出し全体で共有する(各試行ごとにリセットはしない)
+const API_CALL_TIMEOUT_MS = 30_000;
 
 /**
  * ☁️ API 呼び出しフック
@@ -103,83 +107,105 @@ export const useAPICall = () => {
 
 			// #897 リトライ上限は初回を含め2回に固定する。401・GETの一時障害が重なっても
 			// API呼び出し単位で無制限に再送せず、最終失敗は従来どおり下の共通処理へ渡す。
+			// #940 【設計】リトライを含む呼び出し全体で1つの AbortController を共有し、
+			// 30秒応答が無ければ中断して network_error として分類する
 			let response: Response | undefined;
 			let endpoint = endpointName;
 			let networkError: unknown;
+			let didTimeout = false;
+			const abortController = new AbortController();
+			const timeoutId = setTimeout(() => {
+				didTimeout = true;
+				abortController.abort();
+			}, API_CALL_TIMEOUT_MS);
 
-			for (let attempt = 0; attempt < 2; attempt++) {
-				response = undefined;
-				try {
-					const result = await fetchWithAuth(
-						endpointName,
-						{
-							method,
-							requestPayload,
-							isMultipart,
-						},
-						accessToken,
-					);
-					response = result.response;
-					endpoint = result.endpoint;
-					networkError = undefined;
-				} catch (error) {
-					networkError = error;
-					// 通信到達が不明なPOST等は重複作成を避ける。副作用のないGETだけを再送する。
-					if (method === "GET" && attempt === 0) {
-						logFrontendEvent({
-							event_name: "api_call_retry",
-							error_level: "warn",
-							payload: { endpoint: endpointName, method, reason: "network_error" },
-						});
-						await new Promise((resolve) => setTimeout(resolve, 500));
-						continue;
-					}
-					break;
-				}
-
-				// 自動refreshだけでは失敗済みリクエストは復旧しないため、新tokenで1回だけ再送する。
-				// 401は認証段階で拒否された応答なので、POSTを含めても処理の二重実行にはならない。
-				if (response.status === 401 && attempt === 0) {
+			try {
+				for (let attempt = 0; attempt < 2; attempt++) {
+					response = undefined;
 					try {
-						const refreshedSession = await refreshSession();
-						if (!refreshedSession?.access_token) break;
-						accessToken = refreshedSession.access_token;
-						logFrontendEvent({
-							event_name: "api_call_retry",
-							error_level: "warn",
-							payload: { endpoint: endpointName, method, reason: "session_refreshed_after_401" },
-						});
-						continue;
-					} catch (error) {
-						logFrontendEvent({
-							event_name: "api_call_session_refresh_failed",
-							error_level: "error",
-							payload: {
-								endpoint: endpointName,
-								error: error instanceof Error ? error.message : String(error),
+						const result = await fetchWithAuth(
+							endpointName,
+							{
+								method,
+								requestPayload,
+								isMultipart,
+								signal: abortController.signal,
 							},
-						});
+							accessToken,
+						);
+						response = result.response;
+						endpoint = result.endpoint;
+						networkError = undefined;
+					} catch (error) {
+						networkError = error;
+						// タイムアウト後はリトライせず即座に打ち切る(既に応答期限を超過しているため)
+						if (didTimeout) {
+							logFrontendEvent({
+								event_name: "api_call_timeout",
+								error_level: "warn",
+								payload: { endpoint: endpointName, method, timeoutMs: API_CALL_TIMEOUT_MS },
+							});
+							break;
+						}
+						// 通信到達が不明なPOST等は重複作成を避ける。副作用のないGETだけを再送する。
+						if (method === "GET" && attempt === 0) {
+							logFrontendEvent({
+								event_name: "api_call_retry",
+								error_level: "warn",
+								payload: { endpoint: endpointName, method, reason: "network_error" },
+							});
+							await new Promise((resolve) => setTimeout(resolve, 500));
+							continue;
+						}
 						break;
 					}
-				}
 
-				// 503は一時的な過負荷でも返る。GETに限定し、Retry-Afterを最大5秒まで尊重する。
-				if (response.status === 503 && method === "GET" && attempt === 0) {
-					const retryAfterHeader = response.headers.get("retry-after");
-					const retryAfterSeconds = retryAfterHeader === null ? Number.NaN : Number(retryAfterHeader);
-					const retryDelayMs = Number.isFinite(retryAfterSeconds)
-						? Math.min(Math.max(retryAfterSeconds * 1000, 0), 5000)
-						: 500;
-					logFrontendEvent({
-						event_name: "api_call_retry",
-						error_level: "warn",
-						payload: { endpoint: endpointName, method, reason: "service_unavailable", retryDelayMs },
-					});
-					await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
-					continue;
-				}
+					// 自動refreshだけでは失敗済みリクエストは復旧しないため、新tokenで1回だけ再送する。
+					// 401は認証段階で拒否された応答なので、POSTを含めても処理の二重実行にはならない。
+					if (response.status === 401 && attempt === 0) {
+						try {
+							const refreshedSession = await refreshSession();
+							if (!refreshedSession?.access_token) break;
+							accessToken = refreshedSession.access_token;
+							logFrontendEvent({
+								event_name: "api_call_retry",
+								error_level: "warn",
+								payload: { endpoint: endpointName, method, reason: "session_refreshed_after_401" },
+							});
+							continue;
+						} catch (error) {
+							logFrontendEvent({
+								event_name: "api_call_session_refresh_failed",
+								error_level: "error",
+								payload: {
+									endpoint: endpointName,
+									error: error instanceof Error ? error.message : String(error),
+								},
+							});
+							break;
+						}
+					}
 
-				break;
+					// 503は一時的な過負荷でも返る。GETに限定し、Retry-Afterを最大5秒まで尊重する。
+					if (response.status === 503 && method === "GET" && attempt === 0) {
+						const retryAfterHeader = response.headers.get("retry-after");
+						const retryAfterSeconds = retryAfterHeader === null ? Number.NaN : Number(retryAfterHeader);
+						const retryDelayMs = Number.isFinite(retryAfterSeconds)
+							? Math.min(Math.max(retryAfterSeconds * 1000, 0), 5000)
+							: 500;
+						logFrontendEvent({
+							event_name: "api_call_retry",
+							error_level: "warn",
+							payload: { endpoint: endpointName, method, reason: "service_unavailable", retryDelayMs },
+						});
+						await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+						continue;
+					}
+
+					break;
+				}
+			} finally {
+				clearTimeout(timeoutId);
 			}
 
 			if (!response) {
@@ -191,12 +217,15 @@ export const useAPICall = () => {
 						method,
 						status: 0,
 						error: networkError instanceof Error ? networkError.message : String(networkError),
+						timedOut: didTimeout,
 					},
 				});
 				throw {
 					code: "network_error",
 					status: 0,
-					message: `Network error while calling ${endpointName}`,
+					message: didTimeout
+						? `Network timeout (${API_CALL_TIMEOUT_MS}ms) while calling ${endpointName}`
+						: `Network error while calling ${endpointName}`,
 					raw: networkError,
 				} satisfies ApiError;
 			}

--- a/app-expo/lib/fetchWithAuth.ts
+++ b/app-expo/lib/fetchWithAuth.ts
@@ -47,10 +47,13 @@ export async function fetchWithAuth<TRequest extends Record<string, any> | FormD
 		method = "POST",
 		requestPayload,
 		isMultipart = false,
+		signal,
 	}: {
 		method?: "GET" | "POST" | "PATCH" | "DELETE";
 		requestPayload: TRequest;
 		isMultipart?: boolean;
+		// #940 【設計】応答が返らないまま無期限に待ち続けるのを防ぐためのタイムアウト用シグナル
+		signal?: AbortSignal;
 	},
 	accessToken: string,
 ) {
@@ -78,6 +81,7 @@ export async function fetchWithAuth<TRequest extends Record<string, any> | FormD
 			body: buildRequestBody(method, shouldUseQuery, isMultipart, requestPayload),
 			// Include credentials for web to receive CDN signed cookies
 			credentials: Platform.OS === "web" ? "include" : "same-origin",
+			signal,
 		}),
 		endpoint,
 	};

--- a/app-expo/stores/useDishMediaEntriesStore.ts
+++ b/app-expo/stores/useDishMediaEntriesStore.ts
@@ -586,7 +586,16 @@ const handleAsyncAction = <T>(
 			await onSuccess(items);
 		})
 		.catch((err) => {
-			const errorMessage = err ? (err instanceof Error ? err.message : String(err)) : null;
+			// #940 【修正】useAPICall は API/HTTPエラーを Error インスタンスではなく
+			// ApiError(プレーンオブジェクト、message フィールドを持つ)として throw するため、
+			// String(err) では "[object Object]" になっていた。message フィールドを優先して抽出する
+			const errorMessage = err
+				? err instanceof Error
+					? err.message
+					: typeof err === "object" && typeof (err as { message?: unknown }).message === "string"
+						? (err as { message: string }).message
+						: String(err)
+				: null;
 			set((state) => ({
 				errorByKey: {
 					...state.errorByKey,


### PR DESCRIPTION
## 概要
close #940

**レビューを受けたスコープ削減(force push 済み)**: 当初の「0件時の画面内リカバリUI(距離を広げて再検索等)」は、0件時には #828 の Google Maps フォールバックダイアログが既に存在し白画面の行き止まりにならないことが確認されたため全て破棄した(result.tsx/topics.tsx 変更・専用ロケール・e2e spec も削除)。単体で価値が残るインフラ修正のみを残している。

## 残した修正
1. **`components/ErrorBoundary.tsx`(新規)**: render 中の未捕捉例外を捕捉し再試行UIを表示、`componentDidCatch` で `logFrontendEvent`。`[locale]/_layout.tsx` に最終防波堤として設置し、`DishMediaMap.tsx` のカード単位にも設置。`DishMediaContent`/`ActionButtons` は entry 未取得時に render 中 throw する設計のため、従来は1枚のクラッシュが web で画面全体の白画面になっていた。throw 前に理由を `logFrontendEvent` する変更も維持。
2. **`hooks/useAPICall.ts`・`lib/fetchWithAuth.ts`**: リトライを含む呼び出し全体で共有する AbortController ベースの30秒タイムアウトを追加(無限スピナー防止)。`network_error` として分類。
3. **`stores/useDishMediaEntriesStore.ts`**: `ApiError`(プレーンオブジェクト)を `String(err)` するとエラーメッセージが常に `"[object Object]"` になる実バグを修正(`message` フィールド優先)。
4. **`DishMediaMap.tsx`**: エラーテキストが通常フロー配置+zIndex 無しのため `mapContainer`(zIndex:1)の下敷きになり実質見えなかった問題を、絶対配置+zIndex:5 のオーバーレイで修正。旧版の `onRetryError` prop は呼び出し元が無くなったため削除。

## テスト
- `npx tsc -p tsconfig.dev.json --noEmit`: エラーなし
- `pnpm --filter app-expo build:web`: 成功
- Playwright smoke + search スイート回帰なし(実行時点の base で確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)