### PR TITLE
#957 web-vitalsを導入しCore Web VitalsをRUMとしてBigQueryへ計測(UX-117)

### DIFF
--- a/.codex/bigquery/event-catalog.md
+++ b/.codex/bigquery/event-catalog.md
@@ -58,6 +58,21 @@ group by function_name, api_name, endpoint, method
 order by count desc;
 ```
 
+Web Vitals p75 (#957。SLO: LCP≤2.5s / INP≤200ms / CLS≤0.1。`payload` は JSON 文字列想定のため
+`JSON_VALUE`/`JSON_VALUE_ARRAY` 等、実際のカラム型に応じて調整すること):
+
+```sql
+select
+  JSON_VALUE(payload, '$.metric') as metric,
+  APPROX_QUANTILES(CAST(JSON_VALUE(payload, '$.value') AS FLOAT64), 100)[OFFSET(75)] as p75_value,
+  count(1) as sample_count
+from `food-scroll.nanitabeyo_logs_prod.frontend_event_logs`
+where event_name = 'web_vital'
+  and created_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
+group by metric
+order by metric;
+```
+
 ## Source-Confirmed Frontend Event Groups
 
 Source checked with:
@@ -313,6 +328,9 @@ rg -o 'event_name:\s*"[^"]+"' app-expo --glob '!**/node_modules/**'
 - `performance_timer_end`
 - `performance_measure`
 - `performance_measure_async`
+- `web_vital` (#957: Core Web Vitals RUM, web のみ。`payload.metric` は `"LCP" | "INP" | "CLS" | "TTFB" | "FCP"`、
+  `payload.value`/`payload.rating`(`"good" | "needs-improvement" | "poor"`)/`payload.path` を伴う。
+  発火元は `components/AppProvider.web.tsx`。p75 集計例は below)
 
 ## Source-Confirmed External API Logs
 

--- a/app-expo/components/AppProvider.web.tsx
+++ b/app-expo/components/AppProvider.web.tsx
@@ -1,7 +1,10 @@
 import { LoadScript } from "@react-google-maps/api";
-import { ReactNode, useMemo } from "react";
+import { ReactNode, useEffect, useMemo, useRef } from "react";
+import { onCLS, onFCP, onINP, onLCP, onTTFB, type Metric } from "web-vitals";
+import { usePathname } from "expo-router";
 import { Env } from "@/constants/Env";
 import { useLocale } from "@/hooks/useLocale";
+import { useLogger } from "@/hooks/useLogger";
 
 function deriveLanguageAndRegion(locale: string): { language: string; region: string } {
 	// locale examples: 'ja', 'en-US', 'zh-Hant-TW'
@@ -19,9 +22,54 @@ function deriveLanguageAndRegion(locale: string): { language: string; region: st
 	return { language, region };
 }
 
+// #957 【設計】web のみ RUM(Real User Monitoring) として Core Web Vitals を計測する。
+// 外部 SaaS(Sentry/GA等)は導入せず、既存の logFrontendEvent → Cloud Logging → BigQuery の
+// 経路にそのまま乗せる(event_name: "web_vital"。詳細は .codex/bigquery/event-catalog.md 参照)。
+// native(iOS/Android)は Web Vitals がブラウザ固有指標のため対象外(#957 決定事項)。
+function useWebVitalsReporting() {
+	const { logFrontendEvent } = useLogger();
+	const pathname = usePathname();
+
+	// #957 【設計】各指標のコールバックは PerformanceObserver ベースで発火タイミングが
+	// 不定(ページ離脱時・INPは操作の都度 delta 更新等)のため、常に最新の pathname を
+	// ref 経由で参照する(コールバック登録自体はマウント時の1回のみで良い)
+	const pathnameRef = useRef(pathname);
+	useEffect(() => {
+		pathnameRef.current = pathname;
+	}, [pathname]);
+
+	const logFrontendEventRef = useRef(logFrontendEvent);
+	logFrontendEventRef.current = logFrontendEvent;
+
+	useEffect(() => {
+		const reportWebVital = (metric: Metric) => {
+			logFrontendEventRef.current({
+				event_name: "web_vital",
+				error_level: "log",
+				payload: {
+					metric: metric.name,
+					value: metric.value,
+					rating: metric.rating,
+					path: pathnameRef.current,
+				},
+			});
+		};
+
+		onLCP(reportWebVital);
+		onINP(reportWebVital);
+		onCLS(reportWebVital);
+		onTTFB(reportWebVital);
+		onFCP(reportWebVital);
+		// #957 【設計】web-vitals の on* はページ生存期間中コールバックを保持し続ける想定の API
+		// (登録解除手段が提供されていない)ため、マウント時の1回のみ登録する
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+}
+
 export const AppProvider = ({ children }: { children: ReactNode }) => {
 	const { locale } = useLocale();
 	const { language, region } = useMemo(() => deriveLanguageAndRegion(locale), [locale]);
+	useWebVitalsReporting();
 	return (
 		<LoadScript
 			googleMapsApiKey={Env.GOOGLE_MAPS_WEB_API_KEY}

--- a/app-expo/package.json
+++ b/app-expo/package.json
@@ -91,6 +91,7 @@
 		"react-native-view-shot": "^4.0.3",
 		"react-native-web": "^0.20.0",
 		"react-native-webview": "13.13.5",
+		"web-vitals": "^6.0.0",
 		"zustand": "^5.0.8"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
       react-native-webview:
         specifier: 13.13.5
         version: 13.13.5(react-native@0.79.5(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      web-vitals:
+        specifier: ^6.0.0
+        version: 6.0.0
       zustand:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.0.14)(react@19.0.0)(use-sync-external-store@1.6.0(react@19.0.0))
@@ -1200,7 +1203,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.24.22':
     resolution: {integrity: sha512-cEg6/F8ZWjoVkEwm0rXKReWbsCUROFbLFBYht+d5RzHnDwJoTX4QWJKx4m+TGNDPamRUIGw36U4z41Fvev0XmA==}
@@ -9649,6 +9652,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -21208,6 +21214,8 @@ snapshots:
       defaults: 1.0.4
 
   web-streams-polyfill@3.3.3: {}
+
+  web-vitals@6.0.0: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## Summary

背景: RUM・Web Vitals計測が一切なく(web-vitals/Sentry/GAすべて不使用)、本番webの体感速度を計測する手段がなかった。一方で `logFrontendEvent` → `POST /v1/logs/frontend` → Cloud Logging → BigQuery の経路と RemoteConfig によるログレベル制御は既に整備済み。

外部SaaSを追加せず、既存の計測基盤にそのまま乗せる方針を採用(チケット内の決定事項どおり)。

- `app-expo/package.json`: `web-vitals`(3KB)を追加
- `components/AppProvider.web.tsx`: web専用の初期化点(既存の `.web.tsx` 分岐)で `onLCP`/`onINP`/`onCLS`/`onTTFB`/`onFCP` を登録し、`event_name: "web_vital"`、`payload: {metric, value, rating, path}` で `logFrontendEvent` へ送信する `useWebVitalsReporting` を追加。native(iOS/Android)は Web Vitals がブラウザ固有指標のため対象外(チケット内の決定事項、将来は Firebase Performance Monitoring で別途対応予定)。
- `.codex/bigquery/event-catalog.md`: `web_vital` イベントをカタログに追記し、p75集計クエリ例(SLO: LCP≤2.5s / INP≤200ms / CLS≤0.1)を追加。

## Test plan
- [x] `pnpm --filter app-expo exec tsc -p tsconfig.dev.json --noEmit` 通過
- [x] `pnpm --filter app-expo build:web` 成功
- [x] Playwright(実 dev API 接続、静的ビルド配信)でネットワークリクエストを検証し、TTFB/FCP/LCP が正しい `event_name`・`payload` 形状(`metric`/`value`/`rating`/`path`)で `v1/logs/frontend` へ送信されることを確認。実際に送信されたペイロードは `tmp/957-WebVitalsRUM導入/captured-events.json` に保存(CLS/INP はページ非表示時点で確定する累積指標のためヘッドレス環境では安定して再現できず、TTFB/FCP/LCP の疎通確認をもって配線の正しさの証跡とした)
- [x] 既存の `tests/smoke/` 7件・`tests/search/` 11件も green で回帰が無いことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)