### PR TITLE
#959 feat: reduced motion 対応と web の Animated JS フォールバック警告を解消(UX-113)

### DIFF
--- a/app-expo/components/SkeletonShimmer.tsx
+++ b/app-expo/components/SkeletonShimmer.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef } from "react";
 import { View, StyleSheet, Animated, Easing, ViewStyle } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { DimensionValue } from "react-native";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 
 /**
  * SkeletonShimmer（iOSっぽい見た目）
@@ -75,9 +76,14 @@ export const SkeletonShimmer: React.FC<SkeletonShimmerProps> = ({
 	// #615【設計】0→1 の進捗値を使い、translate に変換する
 	const progress = useRef(new Animated.Value(0)).current;
 
+	// #959【設計】OS の「モーションを減らす」設定が有効なときは、装飾目的のループアニメを止めて静的表示にする
+	const reducedMotion = useReducedMotion();
+	const shouldAnimate = enabled && !reducedMotion;
+
 	useEffect(() => {
 		// #615【パフォーマンス】enabled=false のときは停止して見た目を固定
-		if (!enabled) {
+		// #959【アクセシビリティ】reduced motion 時も同様に停止する
+		if (!shouldAnimate) {
 			progress.stopAnimation();
 			progress.setValue(0);
 			return;
@@ -94,7 +100,7 @@ export const SkeletonShimmer: React.FC<SkeletonShimmerProps> = ({
 		);
 		anim.start();
 		return () => anim.stop();
-	}, [enabled, durationMs, progress]);
+	}, [shouldAnimate, durationMs, progress]);
 
 	// #615【設計】移動距離（サイズが数値ならレスポンシブに算出）
 	const travelDistance = useMemo(() => {

--- a/app-expo/components/SkeletonShimmer.web.tsx
+++ b/app-expo/components/SkeletonShimmer.web.tsx
@@ -1,0 +1,146 @@
+import React, { useEffect, useMemo } from "react";
+import { View, StyleSheet, ViewStyle, DimensionValue } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+
+/**
+ * SkeletonShimmer（web 専用実装）
+ * ------------------------------------------------------------
+ * #959【根因】RNW 0.20 は native の Animated モジュールを持たないため、
+ * `useNativeDriver: true` を指定した Animated は必ず
+ * 「Animated: `useNativeDriver` is not supported ... Falling back to JS-based animation」
+ * という console.warn を出す(vendor/react-native/Animated/NativeAnimatedHelper.js 参照)。
+ * SkeletonShimmer.tsx（native 実装）は複数画面で常時マウントされるため、この警告が
+ * web コンソールを埋め尽くしていた。
+ *
+ * 対応方針: web だけは Animated を一切使わず、CSS @keyframes + transform で
+ * 同じ「光の帯が流れる」見た目を再現する。react-native-web の createDOMProps は
+ * RN の style オブジェクトに含まれる未知のプロパティ(animationName 等)をそのまま
+ * inline style として DOM へ転送するため、この方法でネイティブアニメーション相当の
+ * 滑らかさ(ブラウザ側のコンポジタスレッドで動く)を維持できる。
+ *
+ * 型定義は SkeletonShimmer.tsx と同一だが、Metro の `.web.tsx` プラットフォーム解決の都合上
+ * 同一ファイル名を相互 import すると自己参照になり得るため、あえて重複定義している。
+ */
+
+export type ShimmerDirection = "horizontal" | "vertical";
+
+interface SkeletonShimmerProps {
+	width: DimensionValue;
+	height: DimensionValue;
+	borderRadius?: number;
+	direction?: ShimmerDirection;
+	durationMs?: number;
+	baseColor?: string;
+	highlightColor?: string;
+	bandSizePx?: number;
+	enabled?: boolean;
+	style?: ViewStyle;
+}
+
+const KEYFRAMES_STYLE_ELEMENT_ID = "nanitabeyo-skeleton-shimmer-keyframes";
+
+/**
+ * #959【設計】@keyframes は inline style では定義できないため、初回のみ <style> タグを
+ * document.head に注入する(以降のマウントでは ID の存在チェックで再注入をスキップ)。
+ */
+function ensureKeyframesInjected(): void {
+	if (typeof document === "undefined") return;
+	if (document.getElementById(KEYFRAMES_STYLE_ELEMENT_ID)) return;
+
+	const styleElement = document.createElement("style");
+	styleElement.id = KEYFRAMES_STYLE_ELEMENT_ID;
+	styleElement.textContent = `
+@keyframes nanitabeyo-skeleton-shimmer-h {
+	from { transform: translateX(-100%); }
+	to { transform: translateX(100%); }
+}
+@keyframes nanitabeyo-skeleton-shimmer-v {
+	from { transform: translateY(-100%); }
+	to { transform: translateY(100%); }
+}
+`;
+	document.head.appendChild(styleElement);
+}
+
+export const SkeletonShimmer: React.FC<SkeletonShimmerProps> = ({
+	width,
+	height,
+	borderRadius = 0,
+	direction = "horizontal",
+	durationMs = 1100,
+	baseColor = "#E9ECEF",
+	highlightColor = "#FFFFFF",
+	bandSizePx,
+	enabled = true,
+	style,
+}) => {
+	// #959【アクセシビリティ】OS/ブラウザの「モーションを減らす」設定時は装飾アニメを止めて静的表示にする
+	const reducedMotion = useReducedMotion();
+	const shouldAnimate = enabled && !reducedMotion;
+
+	useEffect(() => {
+		if (shouldAnimate) ensureKeyframesInjected();
+	}, [shouldAnimate]);
+
+	const bandThickness = useMemo(() => {
+		if (bandSizePx) return bandSizePx;
+		const base = direction === "horizontal" ? width : height;
+		return typeof base === "number" ? Math.max(96, Math.floor(base * 0.35)) : 140;
+	}, [bandSizePx, direction, width, height]);
+
+	const bandStyle = useMemo(() => {
+		return direction === "horizontal"
+			? { width: bandThickness, height: "100%" as const }
+			: { width: "100%" as const, height: bandThickness };
+	}, [direction, bandThickness]);
+
+	const gradientColors = useMemo(() => {
+		return [
+			"rgba(255,255,255,0.0)",
+			"rgba(255,255,255,0.25)",
+			highlightColor,
+			"rgba(255,255,255,0.25)",
+			"rgba(255,255,255,0.0)",
+		] as const;
+	}, [highlightColor]);
+
+	// #959【設計】animationName 等は React Native の ViewStyle 型に存在しないため
+	// unknown 経由でキャストする(#935 の onKeyDown と同じ、web 専用プロパティを渡す既存パターン)
+	const animationStyle = shouldAnimate
+		? ({
+				animationName: direction === "horizontal" ? "nanitabeyo-skeleton-shimmer-h" : "nanitabeyo-skeleton-shimmer-v",
+				animationDuration: `${durationMs}ms`,
+				animationTimingFunction: "linear",
+				animationIterationCount: "infinite",
+			} as unknown as ViewStyle)
+		: undefined;
+
+	return (
+		<View style={[styles.container, { width, height, borderRadius, backgroundColor: baseColor }, style]}>
+			<View pointerEvents="none" style={[styles.bandWrap, animationStyle]}>
+				<LinearGradient
+					colors={gradientColors}
+					start={{ x: 0, y: 0 }}
+					end={direction === "horizontal" ? { x: 1, y: 0 } : { x: 0, y: 1 }}
+					style={[styles.band, bandStyle]}
+				/>
+			</View>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		overflow: "hidden",
+	},
+	bandWrap: {
+		...StyleSheet.absoluteFillObject,
+		justifyContent: "center",
+		alignItems: "center",
+	},
+	band: {
+		borderRadius: 999,
+		opacity: 0.95,
+	},
+});

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteVoteCard.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteVoteCard.tsx
@@ -11,6 +11,7 @@ import type { DishCategoryGroupVoteCandidate, DishCategoryGroupVoteReaction } fr
 import i18n from "@/lib/i18n";
 import { CARD_MAX_HEIGHT, height as SCREEN_HEIGHT } from "@/features/topics/constants";
 import { TopicVisualCard } from "@/features/topics/components/TopicVisualCard";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 
 type Props = {
 	candidate: DishCategoryGroupVoteCandidate;
@@ -25,6 +26,15 @@ export function DishCategoryGroupVoteVoteCard({ candidate, onVote }: Props) {
 	useEffect(() => {
 		onVoteRef.current = onVote;
 	}, [onVote]);
+
+	// #959【アクセシビリティ】PanResponder は useRef(...).current で 1 度だけ生成されるクロージャのため、
+	// onVoteRef と同じ理由で reducedMotion も ref 経由で参照する(直接参照すると初回値に固定されてしまう)
+	const reducedMotion = useReducedMotion();
+	const reducedMotionRef = useRef(reducedMotion);
+
+	useEffect(() => {
+		reducedMotionRef.current = reducedMotion;
+	}, [reducedMotion]);
 
 	const panResponder = useRef(
 		PanResponder.create({
@@ -42,7 +52,12 @@ export function DishCategoryGroupVoteVoteCard({ candidate, onVote }: Props) {
 					translateX.setValue(0);
 					return;
 				}
-				Animated.spring(translateX, { toValue: 0, useNativeDriver: true }).start();
+				// #959【アクセシビリティ】reduced motion 時は中央へのバウンド演出(spring)を省略し即座に戻す
+				if (reducedMotionRef.current) {
+					translateX.setValue(0);
+				} else {
+					Animated.spring(translateX, { toValue: 0, useNativeDriver: true }).start();
+				}
 			},
 		}),
 	).current;

--- a/app-expo/hooks/useReducedMotion.ts
+++ b/app-expo/hooks/useReducedMotion.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { AccessibilityInfo } from "react-native";
+
+/**
+ * #959 【設計】OS の「モーションを減らす」設定(iOS: 視差効果を減らす / Android: アニメーションを削除)に追従する。
+ * native では AccessibilityInfo が唯一の取得手段のため、初期値は非同期取得までの間 false(通常表示)とする。
+ * web 版(useReducedMotion.web.ts)は matchMedia(prefers-reduced-motion) を使う別実装。
+ */
+export function useReducedMotion(): boolean {
+	const [reducedMotion, setReducedMotion] = useState(false);
+
+	useEffect(() => {
+		let isMounted = true;
+
+		AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
+			if (isMounted) setReducedMotion(enabled);
+		});
+
+		// #959 【設計】設定画面から戻ってきた場合など、アプリ起動中の変更にも追従する
+		const subscription = AccessibilityInfo.addEventListener("reduceMotionChanged", setReducedMotion);
+
+		return () => {
+			isMounted = false;
+			subscription.remove();
+		};
+	}, []);
+
+	return reducedMotion;
+}

--- a/app-expo/hooks/useReducedMotion.web.ts
+++ b/app-expo/hooks/useReducedMotion.web.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/** #959 【設計】SSR/古いブラウザで matchMedia が無い場合は通常表示(false)にフォールバック */
+function getInitialReducedMotion(): boolean {
+	if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+	return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+/**
+ * #959 【設計】native 版(useReducedMotion.ts)の web 実装。
+ * ブラウザ/OS の prefers-reduced-motion 設定に matchMedia の change イベントで追従する。
+ */
+export function useReducedMotion(): boolean {
+	const [reducedMotion, setReducedMotion] = useState(getInitialReducedMotion);
+
+	useEffect(() => {
+		if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+
+		const mediaQueryList = window.matchMedia(REDUCED_MOTION_QUERY);
+		const handleChange = (event: MediaQueryListEvent) => setReducedMotion(event.matches);
+
+		mediaQueryList.addEventListener("change", handleChange);
+		return () => mediaQueryList.removeEventListener("change", handleChange);
+	}, []);
+
+	return reducedMotion;
+}


### PR DESCRIPTION
## 概要
close #959

RNW 0.20 には native animated module が無いため、`useNativeDriver: true` を指定した `Animated` は必ず「Falling back to JS-based animation」という `console.warn` を出す。`SkeletonShimmer` は検索結果/トピックカードなど複数画面で常時マウントされ、この警告で web コンソールが埋まっていた。また OS の「モーションを減らす」設定(`prefers-reduced-motion` / `AccessibilityInfo.isReduceMotionEnabled`)に追従する仕組みが存在しなかった。

## 変更内容
- `hooks/useReducedMotion.ts`(native: `AccessibilityInfo.isReduceMotionEnabled` + `reduceMotionChanged` イベント購読) / `hooks/useReducedMotion.web.ts`(web: `matchMedia(prefers-reduced-motion)` + `change` イベント購読)を新設
- `components/SkeletonShimmer.tsx`: `enabled` prop に加え、reduced motion 時もループアニメを停止して静的表示にするよう修正
- `components/SkeletonShimmer.web.tsx`(新設): web だけは RN の `Animated` を一切使わず CSS `@keyframes` + `transform` で同じ見た目を再現し、フォールバック警告の発生源そのものを断つ
  - react-native-web の `createDOMProps` が RN の style オブジェクトに含まれる未知プロパティ(`animationName` 等)をそのまま inline style として DOM へ転送する仕様を利用
  - `@keyframes` は `<style>` タグとして初回のみ `document.head` に注入
- `features/dishCategoryGroupVotes/components/DishCategoryGroupVoteVoteCard.tsx`: 投票カードをスワイプで戻す際の `Animated.spring` による中央復帰演出を、reduced motion 時は即時 `setValue(0)` に置き換えて停止
  - `PanResponder` は `useRef` で1度だけ生成されるクロージャのため、既存の `onVoteRef` と同じパターンで `reducedMotionRef` 経由で参照(直接参照すると初回値に固定される)

## スコープ外(意図的に未対応)
- カルーセル/ボトムシートの開閉アニメーション(`DishMediaMap.tsx` の `translateY` spring 等)は機能上必須のため対象外(チケット記載の方針通り)
- `react-native-paper` の `Snackbar`/`Dialog` 内部が起動時に出す同種の警告は third-party 起因のため対象外(受入条件は「自アプリ起因で0件」)

## テスト
- `npx tsc -p tsconfig.dev.json --noEmit`: エラーなし
- `npx prettier --write`: 差分なし
- `pnpm --filter app-expo build:web`: 成功
- Playwright(実 API・`api-development` 環境、`expo export --platform web` の静的ビルドを配信):
  - 検索→候補→結果の一連のフローで console 上のフォールバック警告を計測し、`react-native-paper` の `Snackbar` 起因と特定できる最大1件を超えて発生しないこと(= 自アプリ起因で0件)を確認
  - `prefers-reduced-motion: reduce` をエミュレートした環境でも同フローが問題なく動作することを確認(スクリーンショット添付)
  - 既存の smoke・search スイート(17件)を回帰実行し全て pass

## スクリーンショット
`tmp/959-モーション品質とreduced-motion/screenshots/` に通常時/reduced-motion 時のスクリーンショットを保存(CI 対象外のためリポジトリ管理外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)