### PR TITLE
#987 距離スライダーに根拠付き移動時間を追加

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/index.tsx
@@ -25,7 +25,6 @@ import {
 	sceneOptions,
 	foodStyleOptions,
 	diningPaceOptions,
-	distanceOptions,
 	priceLevelOptions,
 	TUTORIAL_PAGES,
 	PRELOAD_IMAGES,
@@ -528,11 +527,7 @@ export default function SearchScreen() {
 						<View style={styles.section}>
 							<SectionHeader icon={<Ruler size={20} color="#F05537" />} title={i18n.t("Search.sections.distance")} />
 							<View style={styles.sliderSection}>
-								<Text style={styles.sliderValue}>
-									{i18n.t(
-										distanceOptions.find((option) => option.value === distance)?.label ?? distanceOptions[0].label,
-									)}
-								</Text>
+								{/* #987 【設計】距離値・おすすめ移動時間・詳細開閉を一つのコンパクトな操作領域に集約 */}
 								<DistanceSlider distance={distance} setDistance={setDistance} />
 							</View>
 						</View>
@@ -752,14 +747,7 @@ const styles = StyleSheet.create({
 		gap: 12,
 	},
 	sliderSection: {
-		alignItems: "center",
-	},
-	sliderValue: {
-		fontSize: 18,
-		fontWeight: "700",
-		color: "#000000",
-		marginBottom: 8,
-		textAlign: "center",
+		width: "100%",
 	},
 	searchFabContainer: {
 		position: "absolute",

--- a/app-expo/features/search/components/DistanceSlider.tsx
+++ b/app-expo/features/search/components/DistanceSlider.tsx
@@ -7,7 +7,14 @@ import {
 	TouchableOpacity,
 	type LayoutChangeEvent,
 } from "react-native";
-import { Bike, CarFront, ChevronDown, ChevronUp, Footprints, TrainFront } from "lucide-react-native";
+import {
+	Bike,
+	CarFront,
+	ChevronDown,
+	ChevronUp,
+	Footprints,
+	TrainFront,
+} from "lucide-react-native";
 import { distanceOptions } from "@/features/search/constants";
 import {
 	getRecommendedTravelTimeEstimates,
@@ -48,19 +55,35 @@ interface DistanceSliderProps {
 	setDistance: (value: number) => void;
 }
 
-function TravelEstimateChip({ estimate, secondary = false }: { estimate: TravelTimeEstimate; secondary?: boolean }) {
+function TravelEstimateChip({
+	estimate,
+	secondary = false,
+}: {
+	estimate: TravelTimeEstimate;
+	secondary?: boolean;
+}) {
 	const Icon = TRAVEL_MODE_ICONS[estimate.mode];
 	const modeLabel = i18n.t(TRAVEL_MODE_LABEL_KEYS[estimate.mode]);
-	const minutesLabel = i18n.t("Search.DistanceSlider.approxMinutes", { minutes: estimate.minutes });
+	const minutesLabel = i18n.t("Search.DistanceSlider.approxMinutes", {
+		minutes: estimate.minutes,
+	});
 
 	return (
 		<View
 			style={[styles.estimateChip, secondary && styles.secondaryEstimateChip]}
 			accessibilityLabel={`${modeLabel} ${minutesLabel}`}
-			testID={`search-distance-estimate-${estimate.mode}`}>
+			testID={`search-distance-estimate-${estimate.mode}`}
+		>
 			<Icon size={16} color={secondary ? "#6B7280" : "#F05537"} />
 			<Text style={styles.estimateLabel}>{modeLabel}</Text>
-			<Text style={[styles.estimateMinutes, secondary && styles.secondaryEstimateMinutes]}>{minutesLabel}</Text>
+			<Text
+				style={[
+					styles.estimateMinutes,
+					secondary && styles.secondaryEstimateMinutes,
+				]}
+			>
+				{minutesLabel}
+			</Text>
 		</View>
 	);
 }
@@ -71,18 +94,27 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 	const [showAllEstimates, setShowAllEstimates] = useState(false);
 
 	const currentIndex = useMemo(() => {
-		const index = distanceOptions.findIndex((option) => option.value === distance);
+		const index = distanceOptions.findIndex(
+			(option) => option.value === distance,
+		);
 		return index === -1 ? 0 : index;
 	}, [distance]);
 
-	const allEstimates = useMemo(() => getTravelTimeEstimates(distance), [distance]);
-	const recommendedEstimates = useMemo(() => getRecommendedTravelTimeEstimates(distance), [distance]);
+	const allEstimates = useMemo(
+		() => getTravelTimeEstimates(distance),
+		[distance],
+	);
+	const recommendedEstimates = useMemo(
+		() => getRecommendedTravelTimeEstimates(distance),
+		[distance],
+	);
 	const recommendedModes = useMemo(
 		() => new Set(recommendedEstimates.map((estimate) => estimate.mode)),
 		[recommendedEstimates],
 	);
 	const otherEstimates = useMemo(
-		() => allEstimates.filter((estimate) => !recommendedModes.has(estimate.mode)),
+		() =>
+			allEstimates.filter((estimate) => !recommendedModes.has(estimate.mode)),
 		[allEstimates, recommendedModes],
 	);
 
@@ -175,15 +207,22 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 	}, [selectionChanged]);
 
 	const currentOption = distanceOptions[currentIndex];
-	const thumbCenter = trackWidth > 0 ? (currentIndex / (distanceOptions.length - 1)) * trackWidth : 0;
+	const thumbCenter =
+		trackWidth > 0
+			? (currentIndex / (distanceOptions.length - 1)) * trackWidth
+			: 0;
 	const thumbPosition = thumbCenter - THUMB_SIZE / 2;
 
 	return (
 		<View style={styles.sliderContainer}>
 			<View style={styles.sliderHeader}>
-				<Text style={styles.sliderHint}>{i18n.t("Search.DistanceSlider.edgeEstimate")}</Text>
+				<Text style={styles.sliderHint}>
+					{i18n.t("Search.DistanceSlider.edgeEstimate")}
+				</Text>
 				<View style={styles.distanceBadge}>
-					<Text style={styles.distanceValue}>{i18n.t(currentOption.label)}</Text>
+					<Text style={styles.distanceValue}>
+						{i18n.t(currentOption.label)}
+					</Text>
 				</View>
 			</View>
 
@@ -205,10 +244,17 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 				aria-valuetext={i18n.t(currentOption.label)}
 				focusable
 				{...({ onKeyDown: handleKeyDown } as Record<string, unknown>)}
-				testID="search-distance-slider">
-				<View pointerEvents="none" style={[styles.sliderProgress, { width: thumbCenter }]} />
+				testID="search-distance-slider"
+			>
+				<View
+					pointerEvents="none"
+					style={[styles.sliderProgress, { width: thumbCenter }]}
+				/>
 				{distanceOptions.map((option, index) => {
-					const tickCenter = trackWidth > 0 ? (index / (distanceOptions.length - 1)) * trackWidth : 0;
+					const tickCenter =
+						trackWidth > 0
+							? (index / (distanceOptions.length - 1)) * trackWidth
+							: 0;
 					return (
 						<View
 							key={option.value}
@@ -221,14 +267,18 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 						/>
 					);
 				})}
-				<View pointerEvents="none" style={[styles.sliderThumb, { left: thumbPosition }]} />
+				<View
+					pointerEvents="none"
+					style={[styles.sliderThumb, { left: thumbPosition }]}
+				/>
 			</View>
 
 			<View
 				style={styles.estimateRow}
 				accessibilityRole="list"
 				accessibilityHint={i18n.t("Search.DistanceSlider.estimateHint")}
-				testID="search-distance-recommended-estimates">
+				testID="search-distance-recommended-estimates"
+			>
 				{recommendedEstimates.map((estimate) => (
 					<TravelEstimateChip key={estimate.mode} estimate={estimate} />
 				))}
@@ -238,9 +288,14 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 						onPress={toggleEstimates}
 						accessibilityRole="button"
 						accessibilityState={{ expanded: showAllEstimates }}
-						testID="search-distance-estimates-toggle">
+						testID="search-distance-estimates-toggle"
+					>
 						<Text style={styles.moreButtonText}>
-							{i18n.t(showAllEstimates ? "Search.DistanceSlider.showLess" : "Search.DistanceSlider.showMore")}
+							{i18n.t(
+								showAllEstimates
+									? "Search.DistanceSlider.showLess"
+									: "Search.DistanceSlider.showMore",
+							)}
 						</Text>
 						{showAllEstimates ? (
 							<ChevronUp size={14} color="#F05537" />
@@ -252,9 +307,16 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 			</View>
 
 			{showAllEstimates && (
-				<View style={styles.estimateRow} testID="search-distance-other-estimates">
+				<View
+					style={styles.estimateRow}
+					testID="search-distance-other-estimates"
+				>
 					{otherEstimates.map((estimate) => (
-						<TravelEstimateChip key={estimate.mode} estimate={estimate} secondary />
+						<TravelEstimateChip
+							key={estimate.mode}
+							estimate={estimate}
+							secondary
+						/>
 					))}
 				</View>
 			)}

--- a/app-expo/features/search/components/DistanceSlider.tsx
+++ b/app-expo/features/search/components/DistanceSlider.tsx
@@ -33,7 +33,7 @@ import { useHaptics } from "@/hooks/useHaptics";
 
 const THUMB_SIZE = 28;
 const TICK_SIZE = 6;
-const THUMB_HIT_SLOP = { top: 16, bottom: 16, left: 16, right: 16 };
+const THUMB_HIT_SLOP = { top: 19, bottom: 19, left: 19, right: 19 };
 const DRAG_ACTIVATION_THRESHOLD_PX = 4;
 
 const TRAVEL_MODE_LABEL_KEYS = {
@@ -426,6 +426,7 @@ const styles = StyleSheet.create({
 		flexDirection: "row",
 		alignItems: "center",
 		gap: 2,
+		minHeight: 44,
 		paddingHorizontal: 4,
 		paddingVertical: 7,
 	},

--- a/app-expo/features/search/components/DistanceSlider.tsx
+++ b/app-expo/features/search/components/DistanceSlider.tsx
@@ -227,7 +227,8 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 			<View
 				style={styles.estimateRow}
 				accessibilityRole="list"
-				accessibilityHint={i18n.t("Search.DistanceSlider.estimateHint")}>
+				accessibilityHint={i18n.t("Search.DistanceSlider.estimateHint")}
+				testID="search-distance-recommended-estimates">
 				{recommendedEstimates.map((estimate) => (
 					<TravelEstimateChip key={estimate.mode} estimate={estimate} />
 				))}

--- a/app-expo/features/search/components/DistanceSlider.tsx
+++ b/app-expo/features/search/components/DistanceSlider.tsx
@@ -26,14 +26,21 @@ import i18n from "@/lib/i18n";
 import { useHaptics } from "@/hooks/useHaptics";
 
 // #935 【設計】距離スライダーの再実装。旧実装は以下の不具合を抱えていた:
-//   1. gestureState.moveX のマジックナンバー補正で相対座標を誤変換していた
-//   2. トラックタップ・十分なヒット領域・アクセシビリティ操作に対応していなかった
-//   3. ScrollView の縦スクロールと競合し、PanResponder も毎レンダー生成していた
-// 本実装は onLayout で実測したトラック幅と locationX を使い、端末サイズに依存しない。
+//   1. `gestureState.moveX - 50` というマジックナンバーで画面絶対座標→トラック相対座標を
+//      誤変換していた(実際のオフセットは画面幅に依存し、広い画面ほどズレて端に張り付く)
+//   2. onPanResponderGrant が無く、タップしても値が変わらなかった(トラックタップ不可)
+//   3. サム(28×28)のみタッチ対象でヒットスロップも無く、指が少しズレるだけで操作できなかった
+//   4. PanResponder.create を毎レンダー再生成しており、パフォーマンス上望ましくなかった
+//   5. ScrollView 内でも常にレスポンダを奪うため、縦スクロールと衝突しうる状態だった
+//   6. accessibilityRole 等が無く、スクリーンリーダー・キーボードで操作できなかった
+// 本実装は onLayout で実測したトラック幅を使い、locationX ベースで位置を計算することで
+// 端末サイズに依存しない正確なタップ/ドラッグ操作を実現する。
 
 const THUMB_SIZE = 28;
 const TICK_SIZE = 6;
 const THUMB_HIT_SLOP = { top: 19, bottom: 19, left: 19, right: 19 };
+// ドラッグとして確定する最小水平移動量。ScrollView の縦スクロールと共存させるため、
+// 「横方向の移動が縦方向より明確に大きい」場合のみこのスライダーがジェスチャーを奪う
 const DRAG_ACTIVATION_THRESHOLD_PX = 4;
 
 const TRAVEL_MODE_LABEL_KEYS = {
@@ -118,7 +125,8 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 		[allEstimates, recommendedModes],
 	);
 
-	// #935 【設計】PanResponder は生成時のクロージャを使い続けるため、最新値を ref 経由で参照する
+	// #935 【設計】PanResponder のコールバックは生成時のクロージャを使い続けるため、
+	// 最新値を ref 経由で参照する(useRef で1回だけ生成し毎レンダーの再生成を避けるため)
 	const trackWidthRef = useRef(trackWidth);
 	trackWidthRef.current = trackWidth;
 	const currentIndexRef = useRef(currentIndex);
@@ -149,10 +157,12 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 
 	const panResponder = useRef(
 		PanResponder.create({
+			// #935 【修正】トラック全体をタップ対象にする(サム単体ではなくトラック View に付与)
 			onStartShouldSetPanResponder: () => true,
 			onMoveShouldSetPanResponder: (_evt, gestureState) =>
 				Math.abs(gestureState.dx) > DRAG_ACTIVATION_THRESHOLD_PX &&
 				Math.abs(gestureState.dx) > Math.abs(gestureState.dy),
+			// #935 【修正】タップした瞬間にその位置へジャンプする
 			onPanResponderGrant: (evt) => {
 				updateFromLocationX(evt.nativeEvent.locationX);
 			},
@@ -174,6 +184,7 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 		commitIndex(currentIndexRef.current + 1);
 	}, [commitIndex]);
 
+	// #935 【設計】iOS/Android の adjustable ロール向け increment/decrement アクション
 	const handleAccessibilityAction = useCallback(
 		(event: { nativeEvent: { actionName: string } }) => {
 			switch (event.nativeEvent.actionName) {
@@ -188,6 +199,9 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 		[increment, decrement],
 	);
 
+	// #935 【修正】web は accessibilityActions が効かないため、矢印キーで同等の操作を行えるようにする。
+	// react-native-web はこの View を最終的に div として描画し、未知の onKeyDown はそのまま
+	// DOM イベントハンドラとして forward されるため native 側には影響しない
 	const handleKeyDown = useCallback(
 		(event: { key: string; preventDefault: () => void }) => {
 			if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
@@ -229,8 +243,10 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 			<View
 				style={styles.sliderTrack}
 				onLayout={handleTrackLayout}
+				// #935 【修正】視覚上の高さ(6px)より広い範囲でタップ/ドラッグを受け付ける
 				hitSlop={THUMB_HIT_SLOP}
 				{...panResponder.panHandlers}
+				// #935 【修正】ネイティブなセマンティクス(adjustable=スライダー)を付与
 				accessibilityRole="adjustable"
 				accessibilityLabel={i18n.t("Search.sections.distance")}
 				accessibilityActions={[
@@ -238,10 +254,15 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 					{ name: "decrement", label: i18n.t("Search.DistanceSlider.near") },
 				]}
 				onAccessibilityAction={handleAccessibilityAction}
+				// [注意] react-native-web は accessibilityValue を DOM の aria-value* へ変換しないため
+				// (#930/#934 と同種の既知の非対応)、native/web 両対応の aria-value* を直接指定する
 				aria-valuemin={0}
 				aria-valuemax={distanceOptions.length - 1}
 				aria-valuenow={currentIndex}
 				aria-valuetext={i18n.t(currentOption.label)}
+				// #935 【修正】web でキーボードのタブ移動・矢印操作を受け付けられるようにする。
+				// onKeyDown は RN の ViewProps 型には無い web専用の DOM イベントだが、
+				// react-native-web は未知のプロパティをそのまま div へ forward するため実際には機能する
 				focusable
 				{...({ onKeyDown: handleKeyDown } as Record<string, unknown>)}
 				testID="search-distance-slider"

--- a/app-expo/features/search/components/DistanceSlider.tsx
+++ b/app-expo/features/search/components/DistanceSlider.tsx
@@ -1,42 +1,92 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { View, Text, PanResponder, StyleSheet, type LayoutChangeEvent } from "react-native";
+import {
+	View,
+	Text,
+	PanResponder,
+	StyleSheet,
+	TouchableOpacity,
+	type LayoutChangeEvent,
+} from "react-native";
+import { Bike, CarFront, ChevronDown, ChevronUp, Footprints, TrainFront } from "lucide-react-native";
 import { distanceOptions } from "@/features/search/constants";
+import {
+	getRecommendedTravelTimeEstimates,
+	getTravelTimeEstimates,
+	type TravelMode,
+	type TravelTimeEstimate,
+} from "@/features/search/travelTimeEstimates";
 import i18n from "@/lib/i18n";
 import { useHaptics } from "@/hooks/useHaptics";
 
 // #935 【設計】距離スライダーの再実装。旧実装は以下の不具合を抱えていた:
-//   1. `gestureState.moveX - 50` というマジックナンバーで画面絶対座標→トラック相対座標を
-//      誤変換していた(実際のオフセットは画面幅に依存し、広い画面ほどズレて端に張り付く)
-//   2. onPanResponderGrant が無く、タップしても値が変わらなかった(トラックタップ不可)
-//   3. サム(28×28)のみタッチ対象でヒットスロップも無く、指が少しズレるだけで操作できなかった
-//   4. PanResponder.create を毎レンダー再生成しており、パフォーマンス上望ましくなかった
-//   5. ScrollView 内でも常にレスポンダを奪うため、縦スクロールと衝突しうる状態だった
-//   6. accessibilityRole 等が無く、スクリーンリーダー・キーボードで操作できなかった
-// 本実装は onLayout で実測したトラック幅を使い、locationX ベースで位置を計算することで
-// 端末サイズに依存しない正確なタップ/ドラッグ操作を実現する。
+//   1. gestureState.moveX のマジックナンバー補正で相対座標を誤変換していた
+//   2. トラックタップ・十分なヒット領域・アクセシビリティ操作に対応していなかった
+//   3. ScrollView の縦スクロールと競合し、PanResponder も毎レンダー生成していた
+// 本実装は onLayout で実測したトラック幅と locationX を使い、端末サイズに依存しない。
 
 const THUMB_SIZE = 28;
+const TICK_SIZE = 6;
 const THUMB_HIT_SLOP = { top: 16, bottom: 16, left: 16, right: 16 };
-// ドラッグとして確定する最小水平移動量。ScrollView の縦スクロールと共存させるため、
-// 「横方向の移動が縦方向より明確に大きい」場合のみこのスライダーがジェスチャーを奪う
 const DRAG_ACTIVATION_THRESHOLD_PX = 4;
+
+const TRAVEL_MODE_LABEL_KEYS = {
+	walk: "Search.DistanceSlider.modes.walk",
+	bike: "Search.DistanceSlider.modes.bike",
+	car: "Search.DistanceSlider.modes.car",
+	train: "Search.DistanceSlider.modes.train",
+} as const satisfies Record<TravelMode, string>;
+
+const TRAVEL_MODE_ICONS = {
+	walk: Footprints,
+	bike: Bike,
+	car: CarFront,
+	train: TrainFront,
+} as const;
 
 interface DistanceSliderProps {
 	distance: number;
 	setDistance: (value: number) => void;
 }
 
+function TravelEstimateChip({ estimate, secondary = false }: { estimate: TravelTimeEstimate; secondary?: boolean }) {
+	const Icon = TRAVEL_MODE_ICONS[estimate.mode];
+	const modeLabel = i18n.t(TRAVEL_MODE_LABEL_KEYS[estimate.mode]);
+	const minutesLabel = i18n.t("Search.DistanceSlider.approxMinutes", { minutes: estimate.minutes });
+
+	return (
+		<View
+			style={[styles.estimateChip, secondary && styles.secondaryEstimateChip]}
+			accessibilityLabel={`${modeLabel} ${minutesLabel}`}
+			testID={`search-distance-estimate-${estimate.mode}`}>
+			<Icon size={16} color={secondary ? "#6B7280" : "#F05537"} />
+			<Text style={styles.estimateLabel}>{modeLabel}</Text>
+			<Text style={[styles.estimateMinutes, secondary && styles.secondaryEstimateMinutes]}>{minutesLabel}</Text>
+		</View>
+	);
+}
+
 export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 	const { selectionChanged } = useHaptics();
 	const [trackWidth, setTrackWidth] = useState(0);
+	const [showAllEstimates, setShowAllEstimates] = useState(false);
 
 	const currentIndex = useMemo(() => {
 		const index = distanceOptions.findIndex((option) => option.value === distance);
 		return index === -1 ? 0 : index;
 	}, [distance]);
 
-	// #935 【設計】PanResponder のコールバックは生成時のクロージャを使い続けるため、
-	// 最新値を ref 経由で参照する(useRef で1回だけ生成し毎レンダーの再生成を避けるため)
+	const allEstimates = useMemo(() => getTravelTimeEstimates(distance), [distance]);
+	const recommendedEstimates = useMemo(() => getRecommendedTravelTimeEstimates(distance), [distance]);
+	const recommendedModes = useMemo(
+		() => new Set(recommendedEstimates.map((estimate) => estimate.mode)),
+		[recommendedEstimates],
+	);
+	const otherEstimates = useMemo(
+		() => allEstimates.filter((estimate) => !recommendedModes.has(estimate.mode)),
+		[allEstimates, recommendedModes],
+	);
+
+	// #935 【設計】PanResponder は生成時のクロージャを使い続けるため、最新値を ref 経由で参照する
 	const trackWidthRef = useRef(trackWidth);
 	trackWidthRef.current = trackWidth;
 	const currentIndexRef = useRef(currentIndex);
@@ -67,12 +117,10 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 
 	const panResponder = useRef(
 		PanResponder.create({
-			// #935 【修正】トラック全体をタップ対象にする(サム単体ではなくトラック View に付与)
 			onStartShouldSetPanResponder: () => true,
 			onMoveShouldSetPanResponder: (_evt, gestureState) =>
 				Math.abs(gestureState.dx) > DRAG_ACTIVATION_THRESHOLD_PX &&
 				Math.abs(gestureState.dx) > Math.abs(gestureState.dy),
-			// #935 【修正】タップした瞬間にその位置へジャンプする
 			onPanResponderGrant: (evt) => {
 				updateFromLocationX(evt.nativeEvent.locationX);
 			},
@@ -94,7 +142,6 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 		commitIndex(currentIndexRef.current + 1);
 	}, [commitIndex]);
 
-	// #935 【設計】iOS/Android の adjustable ロール向け increment/decrement アクション
 	const handleAccessibilityAction = useCallback(
 		(event: { nativeEvent: { actionName: string } }) => {
 			switch (event.nativeEvent.actionName) {
@@ -109,9 +156,6 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 		[increment, decrement],
 	);
 
-	// #935 【修正】web は accessibilityActions が効かないため、矢印キーで同等の操作を行えるようにする。
-	// react-native-web はこの View を最終的に div として描画し、未知の onKeyDown はそのまま
-	// DOM イベントハンドラとして forward されるため native 側には影響しない
 	const handleKeyDown = useCallback(
 		(event: { key: string; preventDefault: () => void }) => {
 			if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
@@ -125,19 +169,29 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 		[increment, decrement],
 	);
 
+	const toggleEstimates = useCallback(() => {
+		selectionChanged();
+		setShowAllEstimates((current) => !current);
+	}, [selectionChanged]);
+
 	const currentOption = distanceOptions[currentIndex];
-	const thumbPosition =
-		trackWidth > 0 ? (currentIndex / (distanceOptions.length - 1)) * trackWidth - THUMB_SIZE / 2 : -THUMB_SIZE / 2;
+	const thumbCenter = trackWidth > 0 ? (currentIndex / (distanceOptions.length - 1)) * trackWidth : 0;
+	const thumbPosition = thumbCenter - THUMB_SIZE / 2;
 
 	return (
 		<View style={styles.sliderContainer}>
+			<View style={styles.sliderHeader}>
+				<Text style={styles.sliderHint}>{i18n.t("Search.DistanceSlider.edgeEstimate")}</Text>
+				<View style={styles.distanceBadge}>
+					<Text style={styles.distanceValue}>{i18n.t(currentOption.label)}</Text>
+				</View>
+			</View>
+
 			<View
 				style={styles.sliderTrack}
 				onLayout={handleTrackLayout}
-				// #935 【修正】視覚上の高さ(6px)より広い範囲でタップ/ドラッグを受け付ける
 				hitSlop={THUMB_HIT_SLOP}
 				{...panResponder.panHandlers}
-				// #935 【修正】ネイティブなセマンティクス(adjustable=スライダー)を付与
 				accessibilityRole="adjustable"
 				accessibilityLabel={i18n.t("Search.sections.distance")}
 				accessibilityActions={[
@@ -145,39 +199,121 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 					{ name: "decrement", label: i18n.t("Search.DistanceSlider.near") },
 				]}
 				onAccessibilityAction={handleAccessibilityAction}
-				// [注意] react-native-web は accessibilityValue を DOM の aria-value* へ変換しないため
-				// (#930/#934 と同種の既知の非対応)、native/web 両対応の aria-value* を直接指定する
 				aria-valuemin={0}
 				aria-valuemax={distanceOptions.length - 1}
 				aria-valuenow={currentIndex}
 				aria-valuetext={i18n.t(currentOption.label)}
-				// #935 【修正】web でキーボードのタブ移動・矢印操作を受け付けられるようにする。
-				// onKeyDown は RN の ViewProps 型には無い web専用の DOM イベントだが、
-				// react-native-web は未知のプロパティをそのまま div へ forward するため実際には機能する
 				focusable
 				{...({ onKeyDown: handleKeyDown } as Record<string, unknown>)}
 				testID="search-distance-slider">
-				<View style={[styles.sliderThumb, { left: thumbPosition }]} />
+				<View pointerEvents="none" style={[styles.sliderProgress, { width: thumbCenter }]} />
+				{distanceOptions.map((option, index) => {
+					const tickCenter = trackWidth > 0 ? (index / (distanceOptions.length - 1)) * trackWidth : 0;
+					return (
+						<View
+							key={option.value}
+							pointerEvents="none"
+							style={[
+								styles.sliderTick,
+								index <= currentIndex && styles.activeSliderTick,
+								{ left: tickCenter - TICK_SIZE / 2 },
+							]}
+						/>
+					);
+				})}
+				<View pointerEvents="none" style={[styles.sliderThumb, { left: thumbPosition }]} />
 			</View>
-			<View style={styles.sliderLabels}>
-				<Text style={styles.sliderLabelLeft}>{i18n.t("Search.DistanceSlider.near")}</Text>
-				<Text style={styles.sliderLabelRight}>{i18n.t("Search.DistanceSlider.far")}</Text>
+
+			<View
+				style={styles.estimateRow}
+				accessibilityRole="list"
+				accessibilityHint={i18n.t("Search.DistanceSlider.estimateHint")}>
+				{recommendedEstimates.map((estimate) => (
+					<TravelEstimateChip key={estimate.mode} estimate={estimate} />
+				))}
+				{otherEstimates.length > 0 && (
+					<TouchableOpacity
+						style={styles.moreButton}
+						onPress={toggleEstimates}
+						accessibilityRole="button"
+						accessibilityState={{ expanded: showAllEstimates }}
+						testID="search-distance-estimates-toggle">
+						<Text style={styles.moreButtonText}>
+							{i18n.t(showAllEstimates ? "Search.DistanceSlider.showLess" : "Search.DistanceSlider.showMore")}
+						</Text>
+						{showAllEstimates ? (
+							<ChevronUp size={14} color="#F05537" />
+						) : (
+							<ChevronDown size={14} color="#F05537" />
+						)}
+					</TouchableOpacity>
+				)}
 			</View>
+
+			{showAllEstimates && (
+				<View style={styles.estimateRow} testID="search-distance-other-estimates">
+					{otherEstimates.map((estimate) => (
+						<TravelEstimateChip key={estimate.mode} estimate={estimate} secondary />
+					))}
+				</View>
+			)}
 		</View>
 	);
 }
 
 const styles = StyleSheet.create({
 	sliderContainer: {
-		width: 300,
-		justifyContent: "center",
+		width: "100%",
+	},
+	sliderHeader: {
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "space-between",
+		gap: 12,
+		marginBottom: 14,
+	},
+	sliderHint: {
+		flex: 1,
+		fontSize: 12,
+		lineHeight: 18,
+		color: "#6B7280",
+	},
+	distanceBadge: {
+		backgroundColor: "#FDEBE7",
+		paddingHorizontal: 12,
+		paddingVertical: 5,
+		borderRadius: 14,
+	},
+	distanceValue: {
+		fontSize: 16,
+		fontWeight: "700",
+		color: "#F05537",
 	},
 	sliderTrack: {
 		height: 6,
-		backgroundColor: "#C9C9C9",
+		backgroundColor: "#D1D5DB",
 		borderRadius: 3,
 		position: "relative",
-		marginHorizontal: 16,
+		marginHorizontal: THUMB_SIZE / 2,
+		marginBottom: 18,
+	},
+	sliderProgress: {
+		position: "absolute",
+		left: 0,
+		top: 0,
+		height: 6,
+		backgroundColor: "#F05537",
+		borderRadius: 3,
+	},
+	sliderTick: {
+		position: "absolute",
+		width: TICK_SIZE,
+		height: TICK_SIZE,
+		borderRadius: TICK_SIZE / 2,
+		backgroundColor: "#D1D5DB",
+	},
+	activeSliderTick: {
+		backgroundColor: "#F05537",
 	},
 	sliderThumb: {
 		position: "absolute",
@@ -187,27 +323,54 @@ const styles = StyleSheet.create({
 		borderRadius: THUMB_SIZE / 2,
 		top: -11,
 		borderWidth: 3,
-		borderColor: "#000000",
-		shadowColor: "#000",
-		shadowOffset: { width: 0, height: 4 },
-		shadowOpacity: 0.15,
-		shadowRadius: 8,
-		elevation: 6,
+		borderColor: "#F05537",
+		shadowColor: "#000000",
+		shadowOffset: { width: 0, height: 2 },
+		shadowOpacity: 0.12,
+		shadowRadius: 4,
+		elevation: 4,
 	},
-	sliderLabels: {
+	estimateRow: {
 		flexDirection: "row",
-		justifyContent: "space-between",
-		marginTop: 12,
-		paddingHorizontal: 16,
+		alignItems: "center",
+		flexWrap: "wrap",
+		gap: 8,
 	},
-	sliderLabelLeft: {
-		fontSize: 13,
-		color: "#000000",
-		fontWeight: "600",
+	estimateChip: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 5,
+		backgroundColor: "#FFF7F5",
+		paddingHorizontal: 10,
+		paddingVertical: 7,
+		borderRadius: 16,
 	},
-	sliderLabelRight: {
-		fontSize: 13,
-		color: "#000000",
+	secondaryEstimateChip: {
+		backgroundColor: "#F3F4F6",
+	},
+	estimateLabel: {
+		fontSize: 12,
 		fontWeight: "600",
+		color: "#111827",
+	},
+	estimateMinutes: {
+		fontSize: 12,
+		fontWeight: "700",
+		color: "#F05537",
+	},
+	secondaryEstimateMinutes: {
+		color: "#4B5563",
+	},
+	moreButton: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 2,
+		paddingHorizontal: 4,
+		paddingVertical: 7,
+	},
+	moreButtonText: {
+		fontSize: 12,
+		fontWeight: "600",
+		color: "#F05537",
 	},
 });

--- a/app-expo/features/search/components/DistanceSlider.tsx
+++ b/app-expo/features/search/components/DistanceSlider.tsx
@@ -291,11 +291,9 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 						testID="search-distance-estimates-toggle"
 					>
 						<Text style={styles.moreButtonText}>
-							{i18n.t(
-								showAllEstimates
-									? "Search.DistanceSlider.showLess"
-									: "Search.DistanceSlider.showMore",
-							)}
+							{showAllEstimates
+								? i18n.t("Search.DistanceSlider.showLess")
+								: i18n.t("Search.DistanceSlider.showMore")}
 						</Text>
 						{showAllEstimates ? (
 							<ChevronUp size={14} color="#F05537" />

--- a/app-expo/features/search/travelTimeEstimates.ts
+++ b/app-expo/features/search/travelTimeEstimates.ts
@@ -67,11 +67,14 @@ const TRAVEL_MODE_RULES = [
  */
 export function getTravelTimeEstimates(distanceMeters: number): TravelTimeEstimate[] {
 	const normalizedDistanceMeters = Math.max(0, distanceMeters);
-	const distanceKm = normalizedDistanceMeters / METERS_PER_KILOMETER;
 
 	return TRAVEL_MODE_RULES.map((rule) => ({
 		mode: rule.mode,
-		minutes: Math.ceil(rule.fixedMinutes + (distanceKm / rule.speedKmh) * MINUTES_PER_HOUR),
+		// #987 【実装】kmへ先に変換すると整数分の境界で丸め誤差が出るため、メートルのまま計算する
+		minutes: Math.ceil(
+			rule.fixedMinutes +
+				(normalizedDistanceMeters * MINUTES_PER_HOUR) / (METERS_PER_KILOMETER * rule.speedKmh),
+		),
 		isRecommended:
 			normalizedDistanceMeters >= rule.recommendedMinMeters &&
 			normalizedDistanceMeters <= rule.recommendedMaxMeters,

--- a/app-expo/features/search/travelTimeEstimates.ts
+++ b/app-expo/features/search/travelTimeEstimates.ts
@@ -66,13 +66,15 @@ const TRAVEL_MODE_RULES = [
  * 副作用: なし。
  */
 export function getTravelTimeEstimates(distanceMeters: number): TravelTimeEstimate[] {
-	const distanceKm = Math.max(0, distanceMeters) / METERS_PER_KILOMETER;
+	const normalizedDistanceMeters = Math.max(0, distanceMeters);
+	const distanceKm = normalizedDistanceMeters / METERS_PER_KILOMETER;
 
 	return TRAVEL_MODE_RULES.map((rule) => ({
 		mode: rule.mode,
 		minutes: Math.ceil(rule.fixedMinutes + (distanceKm / rule.speedKmh) * MINUTES_PER_HOUR),
 		isRecommended:
-			distanceMeters >= rule.recommendedMinMeters && distanceMeters <= rule.recommendedMaxMeters,
+			normalizedDistanceMeters >= rule.recommendedMinMeters &&
+			normalizedDistanceMeters <= rule.recommendedMaxMeters,
 	})).sort((left, right) => {
 		if (left.minutes !== right.minutes) return left.minutes - right.minutes;
 		const leftOrder = TRAVEL_MODE_RULES.find((rule) => rule.mode === left.mode)?.order ?? 0;

--- a/app-expo/features/search/travelTimeEstimates.ts
+++ b/app-expo/features/search/travelTimeEstimates.ts
@@ -44,7 +44,7 @@ const TRAVEL_MODE_RULES = [
 		mode: "car",
 		fixedMinutes: 7,
 		speedKmh: 17.5,
-		recommendedMinMeters: 3000,
+		recommendedMinMeters: 5000,
 		recommendedMaxMeters: Number.POSITIVE_INFINITY,
 		order: 2,
 	},

--- a/app-expo/features/search/travelTimeEstimates.ts
+++ b/app-expo/features/search/travelTimeEstimates.ts
@@ -1,0 +1,95 @@
+export type TravelMode = "walk" | "bike" | "car" | "train";
+
+export interface TravelTimeEstimate {
+	mode: TravelMode;
+	minutes: number;
+	isRecommended: boolean;
+}
+
+interface TravelModeRule {
+	mode: TravelMode;
+	fixedMinutes: number;
+	speedKmh: number;
+	recommendedMinMeters: number;
+	recommendedMaxMeters: number;
+	order: number;
+}
+
+const MINUTES_PER_HOUR = 60;
+const METERS_PER_KILOMETER = 1000;
+export const MAX_RECOMMENDED_TRAVEL_MODES = 2;
+
+// #987 【仕様】国土交通省の一般化所要時間モデルと距離帯別交通実態を、既存の距離プリセットへ対応させる
+// https://www.mlit.go.jp/sogoseisaku/soukou/soukou-magazine/rennraku7.1.pdf
+// https://www.mlit.go.jp/common/001292044.pdf
+// https://www.mlit.go.jp/common/001156467.pdf
+const TRAVEL_MODE_RULES = [
+	{
+		mode: "walk",
+		fixedMinutes: 0,
+		speedKmh: 4.8,
+		recommendedMinMeters: 0,
+		recommendedMaxMeters: 2000,
+		order: 0,
+	},
+	{
+		mode: "bike",
+		fixedMinutes: 4,
+		speedKmh: 15,
+		recommendedMinMeters: 500,
+		recommendedMaxMeters: 5000,
+		order: 1,
+	},
+	{
+		mode: "car",
+		fixedMinutes: 7,
+		speedKmh: 17.5,
+		recommendedMinMeters: 3000,
+		recommendedMaxMeters: Number.POSITIVE_INFINITY,
+		order: 2,
+	},
+	{
+		mode: "train",
+		fixedMinutes: 17,
+		speedKmh: 32,
+		recommendedMinMeters: 10000,
+		recommendedMaxMeters: Number.POSITIVE_INFINITY,
+		order: 3,
+	},
+] as const satisfies readonly TravelModeRule[];
+
+/**
+ * 検索半径の端までの一般化所要時間を、短い順で返す。
+ *
+ * 入力: 検索半径（メートル）。負値は0mとして扱う。
+ * 出力: 交通手段、切り上げ後の分数、距離帯に基づくおすすめ可否。
+ * 副作用: なし。
+ */
+export function getTravelTimeEstimates(distanceMeters: number): TravelTimeEstimate[] {
+	const distanceKm = Math.max(0, distanceMeters) / METERS_PER_KILOMETER;
+
+	return TRAVEL_MODE_RULES.map((rule) => ({
+		mode: rule.mode,
+		minutes: Math.ceil(rule.fixedMinutes + (distanceKm / rule.speedKmh) * MINUTES_PER_HOUR),
+		isRecommended:
+			distanceMeters >= rule.recommendedMinMeters && distanceMeters <= rule.recommendedMaxMeters,
+	})).sort((left, right) => {
+		if (left.minutes !== right.minutes) return left.minutes - right.minutes;
+		const leftOrder = TRAVEL_MODE_RULES.find((rule) => rule.mode === left.mode)?.order ?? 0;
+		const rightOrder = TRAVEL_MODE_RULES.find((rule) => rule.mode === right.mode)?.order ?? 0;
+		return leftOrder - rightOrder;
+	});
+}
+
+/**
+ * 距離帯に適した交通手段を、所要時間が短い順で最大2件返す。
+ *
+ * 入力: 検索半径（メートル）。
+ * 出力: おすすめ対象の所要時間。対象が無い場合は全手段の上位を返す。
+ * 副作用: なし。
+ */
+export function getRecommendedTravelTimeEstimates(distanceMeters: number): TravelTimeEstimate[] {
+	const estimates = getTravelTimeEstimates(distanceMeters);
+	const recommended = estimates.filter((estimate) => estimate.isRecommended);
+	return (recommended.length > 0 ? recommended : estimates).slice(0, MAX_RECOMMENDED_TRAVEL_MODES);
+}

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -89,7 +89,18 @@
 		"currentLocation": "الموقع الحالي",
 		"DistanceSlider": {
 			"near": "قريب",
-			"far": "بعيد"
+			"far": "بعيد",
+			"edgeEstimate": "الوقت التقديري إلى حدود نطاق البحث",
+			"approxMinutes": "حوالي {{minutes}} دقيقة",
+			"modes": {
+				"walk": "مشيًا",
+				"bike": "دراجة",
+				"car": "سيارة",
+				"train": "قطار"
+			},
+			"showMore": "عرض المزيد",
+			"showLess": "عرض أقل",
+			"estimateHint": "يختلف الوقت حسب المسار والازدحام ووقت الانتظار"
 		},
 		"BudgetSlider": {
 			"cheap": "رخيص",

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -89,7 +89,18 @@
 		"currentLocation": "Current location",
 		"DistanceSlider": {
 			"near": "Near",
-			"far": "Far"
+			"far": "Far",
+			"edgeEstimate": "Estimated time to the edge of the search area",
+			"approxMinutes": "About {{minutes}} min",
+			"modes": {
+				"walk": "Walk",
+				"bike": "Bike",
+				"car": "Car",
+				"train": "Train"
+			},
+			"showMore": "Show more",
+			"showLess": "Show less",
+			"estimateHint": "Times vary by route, traffic, and waiting time"
 		},
 		"BudgetSlider": {
 			"cheap": "Cheap",

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -89,7 +89,18 @@
 		"currentLocation": "Ubicación actual",
 		"DistanceSlider": {
 			"near": "Cerca",
-			"far": "Lejos"
+			"far": "Lejos",
+			"edgeEstimate": "Tiempo estimado hasta el límite del área",
+			"approxMinutes": "Aprox. {{minutes}} min",
+			"modes": {
+				"walk": "A pie",
+				"bike": "Bicicleta",
+				"car": "Coche",
+				"train": "Tren"
+			},
+			"showMore": "Ver más",
+			"showLess": "Ver menos",
+			"estimateHint": "Los tiempos varían según la ruta, el tráfico y la espera"
 		},
 		"BudgetSlider": {
 			"cheap": "Barato",

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -89,7 +89,18 @@
 		"currentLocation": "Localisation actuelle",
 		"DistanceSlider": {
 			"near": "Proche",
-			"far": "Loin"
+			"far": "Loin",
+			"edgeEstimate": "Temps estimé jusqu’à la limite de la zone",
+			"approxMinutes": "Env. {{minutes}} min",
+			"modes": {
+				"walk": "À pied",
+				"bike": "Vélo",
+				"car": "Voiture",
+				"train": "Train"
+			},
+			"showMore": "Voir plus",
+			"showLess": "Voir moins",
+			"estimateHint": "Les temps varient selon l’itinéraire, le trafic et l’attente"
 		},
 		"BudgetSlider": {
 			"cheap": "Bon marché",

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -89,7 +89,18 @@
 		"currentLocation": "वर्तमान स्थान",
 		"DistanceSlider": {
 			"near": "पास",
-			"far": "दूर"
+			"far": "दूर",
+			"edgeEstimate": "खोज क्षेत्र की सीमा तक अनुमानित समय",
+			"approxMinutes": "लगभग {{minutes}} मिनट",
+			"modes": {
+				"walk": "पैदल",
+				"bike": "साइकिल",
+				"car": "कार",
+				"train": "ट्रेन"
+			},
+			"showMore": "और देखें",
+			"showLess": "कम दिखाएं",
+			"estimateHint": "समय मार्ग, यातायात और प्रतीक्षा के अनुसार बदल सकता है"
 		},
 		"BudgetSlider": {
 			"cheap": "सस्ता",

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -89,7 +89,18 @@
 		"currentLocation": "現在地",
 		"DistanceSlider": {
 			"near": "近い",
-			"far": "遠い"
+			"far": "遠い",
+			"edgeEstimate": "検索範囲の端までの目安",
+			"approxMinutes": "約{{minutes}}分",
+			"modes": {
+				"walk": "徒歩",
+				"bike": "自転車",
+				"car": "車",
+				"train": "電車"
+			},
+			"showMore": "もっと見る",
+			"showLess": "閉じる",
+			"estimateHint": "経路・混雑・待ち時間により変わります"
 		},
 		"BudgetSlider": {
 			"cheap": "安い",

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -89,7 +89,18 @@
 		"currentLocation": "현재 위치",
 		"DistanceSlider": {
 			"near": "가까움",
-			"far": "멀리"
+			"far": "멀리",
+			"edgeEstimate": "검색 범위 끝까지 예상 시간",
+			"approxMinutes": "약 {{minutes}}분",
+			"modes": {
+				"walk": "도보",
+				"bike": "자전거",
+				"car": "자동차",
+				"train": "전철"
+			},
+			"showMore": "더 보기",
+			"showLess": "접기",
+			"estimateHint": "경로, 교통 상황, 대기 시간에 따라 달라집니다"
 		},
 		"BudgetSlider": {
 			"cheap": "저렴함",

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -89,7 +89,18 @@
 		"currentLocation": "当前位置",
 		"DistanceSlider": {
 			"near": "近",
-			"far": "远"
+			"far": "远",
+			"edgeEstimate": "到搜索范围边缘的预计时间",
+			"approxMinutes": "约{{minutes}}分钟",
+			"modes": {
+				"walk": "步行",
+				"bike": "自行车",
+				"car": "汽车",
+				"train": "轨道交通"
+			},
+			"showMore": "查看更多",
+			"showLess": "收起",
+			"estimateHint": "所需时间会因路线、交通和等候时间而异"
 		},
 		"BudgetSlider": {
 			"cheap": "便宜",

--- a/docs/ux/987-distance-slider-a.svg
+++ b/docs/ux/987-distance-slider-a.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="520" viewBox="0 0 1200 520" role="img" aria-labelledby="title description">
+	<title id="title">距離スライダー A案の変更前後</title>
+	<desc id="description">変更前、変更後の通常表示、もっと見る展開時を比較する実装プレビュー</desc>
+	<rect width="1200" height="520" fill="#F7F7F8"/>
+	<text x="48" y="48" font-family="sans-serif" font-size="24" font-weight="700" fill="#111827">#987 距離スライダー — A案</text>
+	<text x="48" y="76" font-family="sans-serif" font-size="14" fill="#6B7280">検索範囲の端までの目安を、おすすめ順でコンパクトに表示</text>
+
+	<!-- Before -->
+	<g transform="translate(48 104)">
+		<rect width="336" height="356" rx="24" fill="#FFFFFF" stroke="#E5E7EB"/>
+		<rect x="20" y="20" width="72" height="28" rx="14" fill="#F3F4F6"/>
+		<text x="56" y="39" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="700" fill="#6B7280">変更前</text>
+		<text x="24" y="88" font-family="sans-serif" font-size="22" font-weight="700" fill="#111827">📏  距離は？</text>
+		<text x="168" y="146" text-anchor="middle" font-family="sans-serif" font-size="28" font-weight="700" fill="#111827">500m</text>
+		<line x1="44" y1="190" x2="292" y2="190" stroke="#D1D5DB" stroke-width="8" stroke-linecap="round"/>
+		<circle cx="106" cy="190" r="17" fill="#FFFFFF" stroke="#111827" stroke-width="5"/>
+		<text x="44" y="232" font-family="sans-serif" font-size="16" font-weight="600" fill="#111827">近い</text>
+		<text x="292" y="232" text-anchor="end" font-family="sans-serif" font-size="16" font-weight="600" fill="#111827">遠い</text>
+		<rect x="24" y="278" width="288" height="50" rx="12" fill="#F9FAFB"/>
+		<text x="168" y="308" text-anchor="middle" font-family="sans-serif" font-size="13" fill="#9CA3AF">距離だけでは移動感が分かりにくい</text>
+	</g>
+
+	<!-- After collapsed -->
+	<g transform="translate(432 104)">
+		<rect width="336" height="356" rx="24" fill="#FFFFFF" stroke="#F05537" stroke-width="2"/>
+		<rect x="20" y="20" width="104" height="28" rx="14" fill="#FDEBE7"/>
+		<text x="72" y="39" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="700" fill="#F05537">変更後・通常</text>
+		<text x="24" y="88" font-family="sans-serif" font-size="22" font-weight="700" fill="#111827">📏  距離は？</text>
+		<text x="24" y="126" font-family="sans-serif" font-size="12" fill="#6B7280">検索範囲の端までの目安</text>
+		<rect x="254" y="105" width="58" height="28" rx="14" fill="#FDEBE7"/>
+		<text x="283" y="125" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#F05537">500m</text>
+		<line x1="38" y1="164" x2="298" y2="164" stroke="#D1D5DB" stroke-width="6" stroke-linecap="round"/>
+		<line x1="38" y1="164" x2="103" y2="164" stroke="#F05537" stroke-width="6" stroke-linecap="round"/>
+		<circle cx="103" cy="164" r="14" fill="#FFFFFF" stroke="#F05537" stroke-width="4"/>
+		<rect x="24" y="202" width="136" height="40" rx="20" fill="#FFF7F5"/>
+		<text x="92" y="227" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="700" fill="#111827">🚲 自転車  <tspan fill="#F05537">約6分</tspan></text>
+		<rect x="168" y="202" width="120" height="40" rx="20" fill="#FFF7F5"/>
+		<text x="228" y="227" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="700" fill="#111827">🚶 徒歩  <tspan fill="#F05537">約7分</tspan></text>
+		<text x="168" y="280" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="700" fill="#F05537">もっと見る⌄</text>
+		<text x="168" y="320" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#6B7280">おすすめ2件だけで高さを抑える</text>
+	</g>
+
+	<!-- After expanded -->
+	<g transform="translate(816 104)">
+		<rect width="336" height="356" rx="24" fill="#FFFFFF" stroke="#E5E7EB"/>
+		<rect x="20" y="20" width="104" height="28" rx="14" fill="#FDEBE7"/>
+		<text x="72" y="39" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="700" fill="#F05537">もっと見る</text>
+		<text x="24" y="88" font-family="sans-serif" font-size="22" font-weight="700" fill="#111827">📏  距離は？</text>
+		<text x="24" y="126" font-family="sans-serif" font-size="12" fill="#6B7280">検索範囲の端までの目安</text>
+		<rect x="254" y="105" width="58" height="28" rx="14" fill="#FDEBE7"/>
+		<text x="283" y="125" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#F05537">500m</text>
+		<line x1="38" y1="164" x2="298" y2="164" stroke="#D1D5DB" stroke-width="6" stroke-linecap="round"/>
+		<line x1="38" y1="164" x2="103" y2="164" stroke="#F05537" stroke-width="6" stroke-linecap="round"/>
+		<circle cx="103" cy="164" r="14" fill="#FFFFFF" stroke="#F05537" stroke-width="4"/>
+		<rect x="24" y="196" width="136" height="36" rx="18" fill="#FFF7F5"/>
+		<text x="92" y="219" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="700" fill="#111827">🚲 自転車  <tspan fill="#F05537">約6分</tspan></text>
+		<rect x="168" y="196" width="120" height="36" rx="18" fill="#FFF7F5"/>
+		<text x="228" y="219" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="700" fill="#111827">🚶 徒歩  <tspan fill="#F05537">約7分</tspan></text>
+		<rect x="24" y="242" width="120" height="36" rx="18" fill="#F3F4F6"/>
+		<text x="84" y="265" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="700" fill="#111827">🚗 車  <tspan fill="#4B5563">約9分</tspan></text>
+		<rect x="152" y="242" width="136" height="36" rx="18" fill="#F3F4F6"/>
+		<text x="220" y="265" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="700" fill="#111827">🚆 電車  <tspan fill="#4B5563">約18分</tspan></text>
+		<text x="168" y="314" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="700" fill="#F05537">閉じる⌃</text>
+	</g>
+
+	<text x="600" y="496" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#6B7280">表示時間は実経路のETAではなく、国土交通省の一般化所要時間モデルによる検索半径端までの目安</text>
+</svg>

--- a/e2e-web/pages/SearchPage.ts
+++ b/e2e-web/pages/SearchPage.ts
@@ -25,6 +25,10 @@ export class SearchPage {
 	readonly submitButton: Locator;
 	/** 詳細条件の展開トグル */
 	readonly advancedToggle: Locator;
+	/** 距離スライダー */
+	readonly distanceSlider: Locator;
+	/** おすすめ外の移動時間を開閉するトグル */
+	readonly distanceEstimatesToggle: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
@@ -35,6 +39,8 @@ export class SearchPage {
 		this.locationSuggestions = page.getByTestId("search-location-autocomplete-suggestions");
 		this.submitButton = page.getByTestId("search-submit-button");
 		this.advancedToggle = page.getByTestId("search-advanced-toggle");
+		this.distanceSlider = page.getByTestId("search-distance-slider");
+		this.distanceEstimatesToggle = page.getByTestId("search-distance-estimates-toggle");
 	}
 
 	/** 指定 URL へ直接遷移する（locale プレフィックス必須） */
@@ -82,5 +88,10 @@ export class SearchPage {
 	/** シーングリッドの項目の Locator を返す（id は sceneOptions 定義の値） */
 	scene(id: string): Locator {
 		return this.page.getByTestId(`search-scene-${id}`);
+	}
+
+	/** 交通手段ごとの所要時間チップを返す */
+	distanceEstimate(mode: "walk" | "bike" | "car" | "train"): Locator {
+		return this.page.getByTestId(`search-distance-estimate-${mode}`);
 	}
 }

--- a/e2e-web/pages/SearchPage.ts
+++ b/e2e-web/pages/SearchPage.ts
@@ -27,6 +27,8 @@ export class SearchPage {
 	readonly advancedToggle: Locator;
 	/** 距離スライダー */
 	readonly distanceSlider: Locator;
+	/** 初期表示されるおすすめ移動時間の並び */
+	readonly distanceRecommendedEstimates: Locator;
 	/** おすすめ外の移動時間を開閉するトグル */
 	readonly distanceEstimatesToggle: Locator;
 
@@ -40,6 +42,7 @@ export class SearchPage {
 		this.submitButton = page.getByTestId("search-submit-button");
 		this.advancedToggle = page.getByTestId("search-advanced-toggle");
 		this.distanceSlider = page.getByTestId("search-distance-slider");
+		this.distanceRecommendedEstimates = page.getByTestId("search-distance-recommended-estimates");
 		this.distanceEstimatesToggle = page.getByTestId("search-distance-estimates-toggle");
 	}
 

--- a/e2e-web/tests/search/search-form.spec.ts
+++ b/e2e-web/tests/search/search-form.spec.ts
@@ -64,14 +64,20 @@ test.describe("検索フォーム", () => {
 	});
 
 	// ─ テストケース: 距離に適した移動手段だけをおすすめ順で表示する ─
-	// #987 【仕様】500mでは自転車・徒歩、10kmでは電車・車を既定表示し、
-	// おすすめ外の手段は「もっと見る」を操作したときだけ表示する。
+	// #987 【仕様】近距離の車・電車は既定表示せず、国交省資料の距離帯を満たす手段を
+	// 一般化所要時間の短い順で表示する。おすすめ外は「もっと見る」でだけ確認できる。
 	test("距離に応じて移動時間のおすすめ表示が切り替わる", async ({ appPage }) => {
 		const searchPage = new SearchPage(appPage);
+		const recommended = searchPage.distanceRecommendedEstimates.locator(
+			'[data-testid^="search-distance-estimate-"]',
+		);
 
 		await searchPage.advancedToggle.click();
 
-		// デフォルト500m: 一般化所要時間が短いおすすめ2件のみを表示
+		// デフォルト500m: 自転車6分、徒歩7分の順
+		await expect(recommended).toHaveCount(2);
+		await expect(recommended.nth(0)).toHaveAttribute("data-testid", "search-distance-estimate-bike");
+		await expect(recommended.nth(1)).toHaveAttribute("data-testid", "search-distance-estimate-walk");
 		await expect(searchPage.distanceEstimate("bike")).toContainText("6");
 		await expect(searchPage.distanceEstimate("walk")).toContainText("7");
 		await expect(searchPage.distanceEstimate("car")).not.toBeVisible();
@@ -85,12 +91,30 @@ test.describe("検索フォーム", () => {
 		await expect(searchPage.distanceEstimate("car")).not.toBeVisible();
 		await expect(searchPage.distanceEstimate("train")).not.toBeVisible();
 
-		// 500m（index 2）から10km（index 8）へキーボード操作で変更
 		await searchPage.distanceSlider.focus();
-		for (let step = 0; step < 6; step += 1) {
+
+		// 3km: 4km以上という根拠を満たさないため車はまだ既定表示しない
+		for (let step = 0; step < 4; step += 1) {
 			await searchPage.distanceSlider.press("ArrowRight");
 		}
+		await expect(recommended).toHaveCount(1);
+		await expect(recommended.nth(0)).toHaveAttribute("data-testid", "search-distance-estimate-bike");
+		await expect(searchPage.distanceEstimate("bike")).toContainText("16");
+		await expect(searchPage.distanceEstimate("car")).not.toBeVisible();
 
+		// 5km: 自転車24分、車25分の順
+		await searchPage.distanceSlider.press("ArrowRight");
+		await expect(recommended).toHaveCount(2);
+		await expect(recommended.nth(0)).toHaveAttribute("data-testid", "search-distance-estimate-bike");
+		await expect(recommended.nth(1)).toHaveAttribute("data-testid", "search-distance-estimate-car");
+		await expect(searchPage.distanceEstimate("bike")).toContainText("24");
+		await expect(searchPage.distanceEstimate("car")).toContainText("25");
+
+		// 10km: 電車36分、車42分の順
+		await searchPage.distanceSlider.press("ArrowRight");
+		await expect(recommended).toHaveCount(2);
+		await expect(recommended.nth(0)).toHaveAttribute("data-testid", "search-distance-estimate-train");
+		await expect(recommended.nth(1)).toHaveAttribute("data-testid", "search-distance-estimate-car");
 		await expect(searchPage.distanceEstimate("train")).toContainText("36");
 		await expect(searchPage.distanceEstimate("car")).toContainText("42");
 		await expect(searchPage.distanceEstimate("bike")).not.toBeVisible();

--- a/e2e-web/tests/search/search-form.spec.ts
+++ b/e2e-web/tests/search/search-form.spec.ts
@@ -62,4 +62,38 @@ test.describe("検索フォーム", () => {
 		await expect(appPage.getByText("距離は？")).toBeVisible();
 		await expect(appPage.getByText("どんな系統が食べたい？")).toBeVisible();
 	});
+
+	// ─ テストケース: 距離に適した移動手段だけをおすすめ順で表示する ─
+	// #987 【仕様】500mでは自転車・徒歩、10kmでは電車・車を既定表示し、
+	// おすすめ外の手段は「もっと見る」を操作したときだけ表示する。
+	test("距離に応じて移動時間のおすすめ表示が切り替わる", async ({ appPage }) => {
+		const searchPage = new SearchPage(appPage);
+
+		await searchPage.advancedToggle.click();
+
+		// デフォルト500m: 一般化所要時間が短いおすすめ2件のみを表示
+		await expect(searchPage.distanceEstimate("bike")).toContainText("6");
+		await expect(searchPage.distanceEstimate("walk")).toContainText("7");
+		await expect(searchPage.distanceEstimate("car")).not.toBeVisible();
+		await expect(searchPage.distanceEstimate("train")).not.toBeVisible();
+
+		// おすすめ外は明示操作した場合だけ表示
+		await searchPage.distanceEstimatesToggle.click();
+		await expect(searchPage.distanceEstimate("car")).toContainText("9");
+		await expect(searchPage.distanceEstimate("train")).toContainText("18");
+		await searchPage.distanceEstimatesToggle.click();
+		await expect(searchPage.distanceEstimate("car")).not.toBeVisible();
+		await expect(searchPage.distanceEstimate("train")).not.toBeVisible();
+
+		// 500m（index 2）から10km（index 8）へキーボード操作で変更
+		await searchPage.distanceSlider.focus();
+		for (let step = 0; step < 6; step += 1) {
+			await searchPage.distanceSlider.press("ArrowRight");
+		}
+
+		await expect(searchPage.distanceEstimate("train")).toContainText("36");
+		await expect(searchPage.distanceEstimate("car")).toContainText("42");
+		await expect(searchPage.distanceEstimate("bike")).not.toBeVisible();
+		await expect(searchPage.distanceEstimate("walk")).not.toBeVisible();
+	});
 });

--- a/e2e-web/tests/search/search-form.spec.ts
+++ b/e2e-web/tests/search/search-form.spec.ts
@@ -119,5 +119,10 @@ test.describe("検索フォーム", () => {
 		await expect(searchPage.distanceEstimate("car")).toContainText("42");
 		await expect(searchPage.distanceEstimate("bike")).not.toBeVisible();
 		await expect(searchPage.distanceEstimate("walk")).not.toBeVisible();
+
+		// 展開時の値も確認し、整数分の境界が浮動小数点誤差で1分増えないことを保証
+		await searchPage.distanceEstimatesToggle.click();
+		await expect(searchPage.distanceEstimate("bike")).toContainText("44");
+		await expect(searchPage.distanceEstimate("walk")).toContainText("125");
 	});
 });


### PR DESCRIPTION
Closes #987

## 概要

距離スライダーをA案のコンパクト表示へ刷新し、検索範囲の端までの移動時間をおすすめ順で表示します。

- 通常時は距離帯に適した交通手段を所要時間昇順で最大2件表示
- おすすめ外の手段は「もっと見る」で展開し、「閉じる」で戻す
- 近距離では車・電車を既定表示しない
- 既存の11段階、タップ、ドラッグ、キーボード、ハプティクス、スクリーンリーダー操作を維持
- UI文言を全8言語へ追加

## 表示時間の定義

国土交通省の一般化所要時間モデルを採用し、検索半径の端までの時間を1分単位で切り上げます。

| 手段 | 計算条件 |
| --- | --- |
| 徒歩 | 4.8km/h |
| 自転車 | 入出庫4分 + 15km/h |
| 車 | 入出庫7分 + 17.5km/h |
| 電車 | 駅アクセス・待ち等17分 + 32km/h |

実経路のETAではないため、UIでは「検索範囲の端までの目安」と明記しています。

## おすすめ表示の境界

| 手段 | 初期表示の対象距離 | 根拠の対応 |
| --- | --- | --- |
| 徒歩 | 2km以下 | 2km以内では徒歩割合が5割超 |
| 自転車 | 500m〜5km | 約500m〜5km弱で所要時間が最短。5kmプリセットを上限境界として採用 |
| 車 | 5km以上 | 地方都市では4km以上で分担率7割超。既存値で条件を満たす最初のプリセット |
| 電車 | 10km以上 | 三大都市圏では8km以上で分担率上昇。既存値で条件を満たす最初のプリセット |

対象手段の中を一般化所要時間の短い順に並べます。地域差・経路差があるため、おすすめ外も明示操作で確認できます。

## 主な表示例

- 500m: 自転車 約6分 → 徒歩 約7分（車・電車は折りたたみ）
- 3km: 自転車 約16分のみ（車は折りたたみ）
- 5km: 自転車 約24分 → 車 約25分
- 10km: 電車 約36分 → 車 約42分

## 根拠資料

- 国土交通省「都市交通としての自転車の利用について」
  https://www.mlit.go.jp/sogoseisaku/soukou/soukou-magazine/rennraku7.1.pdf
- 国土交通省「自転車通勤導入に関する手引き」
  https://www.mlit.go.jp/common/001292044.pdf
- 国土交通省「全国都市パーソントリップ調査」
  https://www.mlit.go.jp/common/001156467.pdf

## 変更前後

![距離スライダー A案の変更前後](https://raw.githubusercontent.com/Ayato-kosaka/nanitabeyo/7b3d9684ff6ed626b3441538ee479d607ecd115b/docs/ux/987-distance-slider-a.svg)

## 検証

- [x] Prettier 3.2.5（DistanceSlider.tsx）
- [x] 全8言語の必須キーと `{{minutes}}` 補間をMCP取得結果から検査
- [x] 既存11距離プリセットの計算値・おすすめ境界を検査
- [x] 500m / 3km / 5km / 10km と「もっと見る」のPlaywright E2Eを追加
- [x] 10km徒歩が浮動小数点誤差で126分にならず125分になることをE2Eに追加
- [ ] リポジトリ全体のtypecheck / E2E実行（MCPのみで実装したため、PR CIで確認）

## 影響範囲

検索画面の詳細条件にある距離セクションのみです。検索APIへ渡す距離値や検索条件の形式は変更していません。
