### PR TITLE
#989 fix: 検索FABコンテナのクリック遮断とaxe critical違反を修正しe2e 5件の恒常失敗を解消

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/index.tsx
@@ -639,7 +639,10 @@ export default function SearchScreen() {
 			</ScrollView>
 
 			{/* Search FAB */}
-			<View style={styles.searchFabContainer}>
+			{/* #989 【修正】絶対配置の全幅コンテナがボタン以外の透明領域でもクリックを奪い、
+			    この帯域に重なるフォーム要素(距離スライダー等)がマウス操作不能になっていたため、
+			    コンテナ自体はヒット対象から外し子のボタンだけが反応するようにする */}
+			<View style={styles.searchFabContainer} pointerEvents="box-none">
 				<PrimaryButton
 					testID="search-submit-button"
 					label={i18n.t("Search.searchButton")}

--- a/app-expo/features/search/components/DistanceSlider.tsx
+++ b/app-expo/features/search/components/DistanceSlider.tsx
@@ -1,20 +1,6 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import {
-	View,
-	Text,
-	PanResponder,
-	StyleSheet,
-	TouchableOpacity,
-	type LayoutChangeEvent,
-} from "react-native";
-import {
-	Bike,
-	CarFront,
-	ChevronDown,
-	ChevronUp,
-	Footprints,
-	TrainFront,
-} from "lucide-react-native";
+import { View, Text, PanResponder, StyleSheet, TouchableOpacity, type LayoutChangeEvent } from "react-native";
+import { Bike, CarFront, ChevronDown, ChevronUp, Footprints, TrainFront } from "lucide-react-native";
 import { distanceOptions } from "@/features/search/constants";
 import {
 	getRecommendedTravelTimeEstimates,
@@ -62,13 +48,7 @@ interface DistanceSliderProps {
 	setDistance: (value: number) => void;
 }
 
-function TravelEstimateChip({
-	estimate,
-	secondary = false,
-}: {
-	estimate: TravelTimeEstimate;
-	secondary?: boolean;
-}) {
+function TravelEstimateChip({ estimate, secondary = false }: { estimate: TravelTimeEstimate; secondary?: boolean }) {
 	const Icon = TRAVEL_MODE_ICONS[estimate.mode];
 	const modeLabel = i18n.t(TRAVEL_MODE_LABEL_KEYS[estimate.mode]);
 	const minutesLabel = i18n.t("Search.DistanceSlider.approxMinutes", {
@@ -79,18 +59,10 @@ function TravelEstimateChip({
 		<View
 			style={[styles.estimateChip, secondary && styles.secondaryEstimateChip]}
 			accessibilityLabel={`${modeLabel} ${minutesLabel}`}
-			testID={`search-distance-estimate-${estimate.mode}`}
-		>
+			testID={`search-distance-estimate-${estimate.mode}`}>
 			<Icon size={16} color={secondary ? "#6B7280" : "#F05537"} />
 			<Text style={styles.estimateLabel}>{modeLabel}</Text>
-			<Text
-				style={[
-					styles.estimateMinutes,
-					secondary && styles.secondaryEstimateMinutes,
-				]}
-			>
-				{minutesLabel}
-			</Text>
+			<Text style={[styles.estimateMinutes, secondary && styles.secondaryEstimateMinutes]}>{minutesLabel}</Text>
 		</View>
 	);
 }
@@ -101,27 +73,18 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 	const [showAllEstimates, setShowAllEstimates] = useState(false);
 
 	const currentIndex = useMemo(() => {
-		const index = distanceOptions.findIndex(
-			(option) => option.value === distance,
-		);
+		const index = distanceOptions.findIndex((option) => option.value === distance);
 		return index === -1 ? 0 : index;
 	}, [distance]);
 
-	const allEstimates = useMemo(
-		() => getTravelTimeEstimates(distance),
-		[distance],
-	);
-	const recommendedEstimates = useMemo(
-		() => getRecommendedTravelTimeEstimates(distance),
-		[distance],
-	);
+	const allEstimates = useMemo(() => getTravelTimeEstimates(distance), [distance]);
+	const recommendedEstimates = useMemo(() => getRecommendedTravelTimeEstimates(distance), [distance]);
 	const recommendedModes = useMemo(
 		() => new Set(recommendedEstimates.map((estimate) => estimate.mode)),
 		[recommendedEstimates],
 	);
 	const otherEstimates = useMemo(
-		() =>
-			allEstimates.filter((estimate) => !recommendedModes.has(estimate.mode)),
+		() => allEstimates.filter((estimate) => !recommendedModes.has(estimate.mode)),
 		[allEstimates, recommendedModes],
 	);
 
@@ -221,22 +184,15 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 	}, [selectionChanged]);
 
 	const currentOption = distanceOptions[currentIndex];
-	const thumbCenter =
-		trackWidth > 0
-			? (currentIndex / (distanceOptions.length - 1)) * trackWidth
-			: 0;
+	const thumbCenter = trackWidth > 0 ? (currentIndex / (distanceOptions.length - 1)) * trackWidth : 0;
 	const thumbPosition = thumbCenter - THUMB_SIZE / 2;
 
 	return (
 		<View style={styles.sliderContainer}>
 			<View style={styles.sliderHeader}>
-				<Text style={styles.sliderHint}>
-					{i18n.t("Search.DistanceSlider.edgeEstimate")}
-				</Text>
+				<Text style={styles.sliderHint}>{i18n.t("Search.DistanceSlider.edgeEstimate")}</Text>
 				<View style={styles.distanceBadge}>
-					<Text style={styles.distanceValue}>
-						{i18n.t(currentOption.label)}
-					</Text>
+					<Text style={styles.distanceValue}>{i18n.t(currentOption.label)}</Text>
 				</View>
 			</View>
 
@@ -265,17 +221,10 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 				// react-native-web は未知のプロパティをそのまま div へ forward するため実際には機能する
 				focusable
 				{...({ onKeyDown: handleKeyDown } as Record<string, unknown>)}
-				testID="search-distance-slider"
-			>
-				<View
-					pointerEvents="none"
-					style={[styles.sliderProgress, { width: thumbCenter }]}
-				/>
+				testID="search-distance-slider">
+				<View pointerEvents="none" style={[styles.sliderProgress, { width: thumbCenter }]} />
 				{distanceOptions.map((option, index) => {
-					const tickCenter =
-						trackWidth > 0
-							? (index / (distanceOptions.length - 1)) * trackWidth
-							: 0;
+					const tickCenter = trackWidth > 0 ? (index / (distanceOptions.length - 1)) * trackWidth : 0;
 					return (
 						<View
 							key={option.value}
@@ -288,18 +237,16 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 						/>
 					);
 				})}
-				<View
-					pointerEvents="none"
-					style={[styles.sliderThumb, { left: thumbPosition }]}
-				/>
+				<View pointerEvents="none" style={[styles.sliderThumb, { left: thumbPosition }]} />
 			</View>
 
+			{/* #989 【修正】accessibilityRole="list" は子に listitem を要求するため(axe:
+			    aria-required-children critical)、チップ+ボタン混在のこの行には付与しない。
+			    各チップは accessibilityLabel で個別に読み上げられるため list 化は不要 */}
 			<View
 				style={styles.estimateRow}
-				accessibilityRole="list"
 				accessibilityHint={i18n.t("Search.DistanceSlider.estimateHint")}
-				testID="search-distance-recommended-estimates"
-			>
+				testID="search-distance-recommended-estimates">
 				{recommendedEstimates.map((estimate) => (
 					<TravelEstimateChip key={estimate.mode} estimate={estimate} />
 				))}
@@ -309,33 +256,19 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 						onPress={toggleEstimates}
 						accessibilityRole="button"
 						accessibilityState={{ expanded: showAllEstimates }}
-						testID="search-distance-estimates-toggle"
-					>
+						testID="search-distance-estimates-toggle">
 						<Text style={styles.moreButtonText}>
-							{showAllEstimates
-								? i18n.t("Search.DistanceSlider.showLess")
-								: i18n.t("Search.DistanceSlider.showMore")}
+							{showAllEstimates ? i18n.t("Search.DistanceSlider.showLess") : i18n.t("Search.DistanceSlider.showMore")}
 						</Text>
-						{showAllEstimates ? (
-							<ChevronUp size={14} color="#F05537" />
-						) : (
-							<ChevronDown size={14} color="#F05537" />
-						)}
+						{showAllEstimates ? <ChevronUp size={14} color="#F05537" /> : <ChevronDown size={14} color="#F05537" />}
 					</TouchableOpacity>
 				)}
 			</View>
 
 			{showAllEstimates && (
-				<View
-					style={styles.estimateRow}
-					testID="search-distance-other-estimates"
-				>
+				<View style={styles.estimateRow} testID="search-distance-other-estimates">
 					{otherEstimates.map((estimate) => (
-						<TravelEstimateChip
-							key={estimate.mode}
-							estimate={estimate}
-							secondary
-						/>
+						<TravelEstimateChip key={estimate.mode} estimate={estimate} secondary />
 					))}
 				</View>
 			)}

--- a/e2e-web/tests/search/distance-slider.spec.ts
+++ b/e2e-web/tests/search/distance-slider.spec.ts
@@ -11,10 +11,18 @@ import { test, expect } from "../../fixtures/test";
  * タップ・ドラッグ・キーボード操作それぞれで値が正しく更新されることを検証する。
  */
 test.describe("距離スライダー", () => {
+	// #989 【修正】画面下部固定の検索FAB(全幅の実ボタン)と重なる位置では
+	// クリックがボタンに奪われるため、scrollIntoViewIfNeeded(=見えていれば
+	// スクロールしない)ではなく block:"center" でビューポート中央へ出してから操作する。
+	// 実ユーザーも FAB の下に重なった状態では操作できない(スクロールして操作する)ため、
+	// これはテスト都合ではなく実際の操作手順の再現である
+	const scrollSliderToCenter = (slider: import("@playwright/test").Locator) =>
+		slider.evaluate((el) => el.scrollIntoView({ block: "center" }));
+
 	test("タップでその位置に応じた値へ即座にジャンプする", async ({ appPage }) => {
 		await appPage.getByTestId("search-advanced-toggle").click();
 		const slider = appPage.getByTestId("search-distance-slider");
-		await slider.scrollIntoViewIfNeeded();
+		await scrollSliderToCenter(slider);
 		const box = await slider.boundingBox();
 		if (!box) throw new Error("slider bounding box not found");
 
@@ -23,14 +31,16 @@ test.describe("距離スライダー", () => {
 		await expect(slider).toHaveAttribute("aria-valuenow", "9");
 
 		// 左端付近をタップ → 近い距離側の低いインデックスへジャンプすること
-		await appPage.mouse.click(box.x + box.width * 0.05, box.y + box.height / 2);
+		// #989 【修正】5% は 11 段階(10 区間)のちょうど丸め境界(ratio 0.05 → 0.5 → round で 1)に
+		// あたり丸め実装依存で結果が揺れるため、境界を避けた 2% 位置で検証する
+		await appPage.mouse.click(box.x + box.width * 0.02, box.y + box.height / 2);
 		await expect(slider).toHaveAttribute("aria-valuenow", "0");
 	});
 
 	test("ドラッグで指の位置に追従して値が更新される", async ({ appPage }) => {
 		await appPage.getByTestId("search-advanced-toggle").click();
 		const slider = appPage.getByTestId("search-distance-slider");
-		await slider.scrollIntoViewIfNeeded();
+		await scrollSliderToCenter(slider);
 		const box = await slider.boundingBox();
 		if (!box) throw new Error("slider bounding box not found");
 

--- a/e2e-web/tests/search/search-accessibility.spec.ts
+++ b/e2e-web/tests/search/search-accessibility.spec.ts
@@ -35,13 +35,28 @@ test.describe("検索フォームのアクセシビリティ", () => {
 	});
 
 	// ─ テストケース: 時間帯グリッドが radiogroup/radio セマンティクスを持つ ─
+	// #989 【修正】時間帯には現在時刻に応じた初期選択があるため、「夜ごはんは未選択」の
+	// 決め打ちは時間帯によって失敗する。未選択のスロットを動的に選び、radio の
+	// 排他動作(選ぶと aria-checked が付け替わる)を検証する形に変更
 	test("時間帯グリッドが radiogroup/radio ロールを持つ", async ({ appPage }) => {
 		const timeSlotDinner = appPage.getByTestId("search-time-slot-dinner");
 		await expect(timeSlotDinner).toHaveAttribute("role", "radio");
-		await expect(timeSlotDinner).toHaveAttribute("aria-checked", "false");
 
-		await timeSlotDinner.click();
-		await expect(timeSlotDinner).toHaveAttribute("aria-checked", "true");
+		// 現在未選択のスロットを1つ探す(初期選択は現在時刻依存)
+		const slotIds = ["morning", "lunch", "dinner", "late_night"];
+		let uncheckedId: string | null = null;
+		for (const slot of slotIds) {
+			const el = appPage.getByTestId(`search-time-slot-${slot}`);
+			if ((await el.getAttribute("aria-checked")) === "false") {
+				uncheckedId = slot;
+				break;
+			}
+		}
+		expect(uncheckedId, "未選択の時間帯スロットが存在しない").not.toBeNull();
+
+		const unchecked = appPage.getByTestId(`search-time-slot-${uncheckedId}`);
+		await unchecked.click();
+		await expect(unchecked).toHaveAttribute("aria-checked", "true");
 	});
 
 	// ─ テストケース: 価格帯チップが checkbox セマンティクスを持ち複数選択できる ─

--- a/e2e-web/tests/search/search-form.spec.ts
+++ b/e2e-web/tests/search/search-form.spec.ts
@@ -10,15 +10,11 @@ import { SearchPage } from "../../pages/SearchPage";
  */
 test.describe("検索フォーム", () => {
 	// ─ テストケース: 場所が未確定のまま検索ボタンを押しても遷移しない ─
-	// 手順:
-	//   1. appPage で起動(検索画面)。search-submit-button(PrimaryButton)は
-	//      disabled 時、コンポーネント内部の handlePress が onPress 呼び出し自体を
-	//      ガードする実装になっている(disabled/aria-disabled は DOM に反映されないため
-	//      Playwright の toBeDisabled() では検証できず、handleSearch 内の
-	//      「検索場所を選択してください」スナックバー分岐も実質到達不能)。
-	//      そのため「非活性の結果、押しても何も起きない」ことを振る舞いで検証する
-	//   2. 場所を明示的に未入力の状態で検索ボタンをクリックする
-	//   3. トピック画面へ遷移しておらず、検索画面のヘッダが表示され続けることを検証
+	// #989 【修正】#951 で PrimaryButton が実 disabled 属性 + aria-disabled を DOM に出す
+	// ようになったため、旧実装前提の「普通にクリックして何も起きないことを確認」は
+	// Playwright がクリック自体を拒否してタイムアウトするようになった。
+	// 現仕様では「disabled 属性で押下不能」がそのまま保証内容なので、
+	// disabled/aria-disabled の検証 + force クリックでも遷移しないことの検証に変更
 	test("場所が未確定のまま検索ボタンを押しても遷移しない", async ({ appPage }) => {
 		const searchPage = new SearchPage(appPage);
 
@@ -27,7 +23,11 @@ test.describe("検索フォーム", () => {
 			await searchPage.locationClearButton.click();
 		}
 
-		await searchPage.submitButton.click();
+		await expect(searchPage.submitButton).toBeDisabled();
+		await expect(searchPage.submitButton).toHaveAttribute("aria-disabled", "true");
+
+		// actionability チェックを迂回して物理クリックしても遷移しないこと
+		await searchPage.submitButton.click({ force: true });
 		await appPage.waitForTimeout(500);
 		await expect(appPage).not.toHaveURL(/\/search\/topics/);
 		await searchPage.expectLoaded();
@@ -68,9 +68,7 @@ test.describe("検索フォーム", () => {
 	// 一般化所要時間の短い順で表示する。おすすめ外は「もっと見る」でだけ確認できる。
 	test("距離に応じて移動時間のおすすめ表示が切り替わる", async ({ appPage }) => {
 		const searchPage = new SearchPage(appPage);
-		const recommended = searchPage.distanceRecommendedEstimates.locator(
-			'[data-testid^="search-distance-estimate-"]',
-		);
+		const recommended = searchPage.distanceRecommendedEstimates.locator('[data-testid^="search-distance-estimate-"]');
 
 		await searchPage.advancedToggle.click();
 


### PR DESCRIPTION
## 概要
close #989

#988(#987 移動時間目安の統合)マージ後、`e2e-web/tests/search/` 配下の5テストが恒常失敗するようになった。調査の結果、**アプリ側の実バグ2件**と**テスト前提の陳腐化2件**が混在していた。

## アプリ側の修正
- `search/index.tsx`: `searchFabContainer`(position:absolute・全幅)に `pointerEvents="box-none"` を付与。ボタン以外の透明領域もクリックを奪っており、#987 のレイアウト変更で距離スライダーがこの帯域に重なった結果、**デスクトップ web でスライダーがマウス操作不能**になっていた(web では `hitSlop` が効かず 6px トラックが唯一のヒット領域である点も重なった)。実ユーザー影響のあるバグ。
- `DistanceSlider.tsx`: `estimateRow` の `accessibilityRole="list"` を除去。子が `listitem` でないため axe の `aria-required-children`(**critical**)違反になっていた。各チップは `accessibilityLabel` で個別に読み上げられるため list 化は不要。

## テスト側の修正
- `search-accessibility.spec.ts`: 「夜ごはんは初期未選択」の決め打ちが時間帯依存の初期選択と衝突するため、未選択スロットを動的に選ぶ方式へ変更(時間帯非依存化)
- `search-form.spec.ts`: #951 で PrimaryButton が実 `disabled` 属性を出すようになり旧前提が崩れたため、disabled/aria-disabled 検証 + force クリックで遷移しないことの検証へ変更
- `distance-slider.spec.ts`: FAB と重なる位置ではユーザーも操作できない(スクロールして操作する)ため `block:"center"` スクロールへ変更。左端タップ位置 5% が11段階の丸め境界ちょうど(ratio 0.5)だったため 2% へ修正

## テスト
- `tests/search/` + `tests/smoke/` 全29件 pass(desktop-chrome)
- `npx tsc -p tsconfig.dev.json --noEmit`: エラーなし
- `pnpm --filter app-expo build:web`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)