### PR TITLE
#991 fix: デスクトップwebで地点サジェストが普通の速さのクリックで選択できない不具合を修正

### DIFF
--- a/app-expo/components/DishCategoryAutocomplete.tsx
+++ b/app-expo/components/DishCategoryAutocomplete.tsx
@@ -22,6 +22,16 @@ import { LoadingIndicator } from "./LoadingIndicator";
 const MIN_SEARCH_LENGTH = 2;
 const DEBOUNCE_DELAY_MS = 300;
 
+/**
+ * #991 【修正】web で候補パネル内の mousedown の既定動作(TextInput からのフォーカス移動)を抑止する。
+ * 抑止しないと mousedown → 即 blur → 150ms 後にパネル非表示が予約され、mousedown→mouseup が
+ * 150ms を超える人間の普通のクリックでは押し終わる前に行が消えて onPress が発火しない
+ * (詳細は LocationAutocomplete.tsx の同名定数を参照。native には mouse イベントが無く影響しない)
+ */
+const preventFocusStealOnWeb = {
+	onMouseDown: (event: { preventDefault: () => void }) => event.preventDefault(),
+} as Record<string, unknown>;
+
 interface DishCategoryAutocompleteProps {
 	/** 入力値 */
 	value: string;
@@ -250,7 +260,7 @@ export function DishCategoryAutocomplete({
 
 			{/* 候補リスト */}
 			{showSuggestions && suggestions.length > 0 && (
-				<View style={styles.suggestionsContainer}>
+				<View style={styles.suggestionsContainer} {...preventFocusStealOnWeb}>
 					<ScrollView
 						keyboardShouldPersistTaps="handled"
 						showsVerticalScrollIndicator={false}

--- a/app-expo/components/LocationAutocomplete.tsx
+++ b/app-expo/components/LocationAutocomplete.tsx
@@ -58,6 +58,19 @@ const BLUR_AFTER_SELECT_DELAY_MS = 100;
 const AUTOFOCUS_DELAY_MS = 100;
 
 /**
+ * #991 【修正】web でサジェストパネル内の mousedown の既定動作(TextInput からのフォーカス移動)を
+ * 抑止する props。抑止しないと mousedown → 即 blur → 150ms 後にパネル非表示が予約され、
+ * mousedown→mouseup が 150ms を超える人間の普通のクリックでは「押し終わる前に行が消えて
+ * onPress(=mouseup 時)が発火しない」= 選択が成立しない不具合になる(タッチ操作では blur の
+ * 発生順序が異なるため起きず、デスクトップのマウス操作でのみ発生していた)。
+ * react-native-web は未知の props をそのまま DOM へ forward するため onMouseDown を直接渡せる
+ * (#935 の onKeyDown と同じパターン)。native には mouse イベントが存在しないため影響しない。
+ */
+const preventFocusStealOnWeb = {
+	onMouseDown: (event: { preventDefault: () => void }) => event.preventDefault(),
+} as Record<string, unknown>;
+
+/**
  * Unified location autocomplete component that combines text input and suggestions.
  * Handles debouncing, API calls, keyboard navigation, and accessibility.
  */
@@ -322,7 +335,7 @@ export const LocationAutocomplete = forwardRef<LocationAutocompleteHandle, Locat
 
 				{/* #953 最近使った場所 */}
 				{showRecentLocations && (
-					<View style={styles.suggestionsContainer}>
+					<View style={styles.suggestionsContainer} {...preventFocusStealOnWeb}>
 						<View style={styles.recentLocationsHeader}>
 							<Text style={styles.recentLocationsTitle}>{i18n.t("Search.recentLocations.title")}</Text>
 							{onClearRecentLocations && (
@@ -372,7 +385,7 @@ export const LocationAutocomplete = forwardRef<LocationAutocompleteHandle, Locat
 
 				{/* Suggestions List */}
 				{showSuggestions && displayStatus === "success" && suggestions.length > 0 && (
-					<View style={styles.suggestionsContainer}>
+					<View style={styles.suggestionsContainer} {...preventFocusStealOnWeb}>
 						<ScrollView
 							keyboardShouldPersistTaps="handled"
 							showsVerticalScrollIndicator={false}
@@ -413,8 +426,9 @@ export const LocationAutocomplete = forwardRef<LocationAutocompleteHandle, Locat
 				)}
 
 				{/* #931 Error message: 0件(=正常応答)とは別文言で表示し、再試行を提供する */}
+				{/* #991 再試行ボタンも同じフォーカス移動起因の競合(#931)を持つため mousedown を抑止する */}
 				{showSuggestions && displayStatus === "error" && (
-					<View style={styles.noResultsContainer}>
+					<View style={styles.noResultsContainer} {...preventFocusStealOnWeb}>
 						<Text style={styles.noResultsText}>{i18n.t("Search.errors.searchFailed")}</Text>
 						<TouchableOpacity
 							style={styles.retryButton}

--- a/e2e-web/tests/search/location-autocomplete.spec.ts
+++ b/e2e-web/tests/search/location-autocomplete.spec.ts
@@ -38,4 +38,31 @@ test.describe("場所オートコンプリート(実 API)", () => {
 		await expect(searchPage.locationInput).toHaveValue("");
 		await expect(searchPage.locationSuggestions).toHaveCount(0);
 	});
+
+	// ─ テストケース: 人間の速さのクリック(mousedown 保持)でもサジェストを選択できる ─
+	// #991 【背景】blur の 150ms 後にパネルを閉じる実装のため、mousedown で input が blur すると
+	// mousedown→mouseup が 150ms を超える普通のクリックでは押し終わる前に行が消え、
+	// onPress(mouseup 時)が発火しない不具合があった。Playwright の click() は press 時間が
+	// ほぼ 0ms のため既存テストでは検知できず、実ユーザーのマウス操作でのみ再現していた。
+	// パネル内 mousedown の preventDefault(フォーカス維持)で修正済み。ここでは
+	// mousedown を 250ms 保持してから離す「スロークリック」で選択が成立することを保証する。
+	test("mousedownを250ms保持するスロークリックでもサジェストを選択できる", async ({ appPage }) => {
+		const searchPage = new SearchPage(appPage);
+		await searchPage.typeLocation("渋谷");
+		await expect(searchPage.locationSuggestion(0)).toBeVisible();
+
+		const box = await searchPage.locationSuggestion(0).boundingBox();
+		if (!box) throw new Error("suggestion bounding box not found");
+
+		await appPage.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+		await appPage.mouse.down();
+		await appPage.waitForTimeout(250);
+		// 押している間にパネルが消えていない(=blurの遅延非表示が予約されていない)こと
+		await expect(searchPage.locationSuggestion(0)).toBeVisible();
+		await appPage.mouse.up();
+
+		// 選択が成立し、入力欄に候補の mainText が反映されること
+		await expect(searchPage.locationInput).not.toHaveValue("渋谷");
+		await expect(searchPage.locationInput).not.toHaveValue("");
+	});
 });


### PR DESCRIPTION
## 概要
close #991

デスクトップ web(実マウス)で「渋谷駅」を検索してサジェストをクリックしても選択が成立せず、「探して!」で「検索場所を選択してください」になる報告への対応。Device Toolbar(タッチエミュレーション)では動くという症状も根因と整合する。

## 根因
`LocationAutocomplete` は blur の **150ms 後**にサジェストパネルを閉じる。web のマウス操作ではサジェスト行への mousedown の既定動作で TextInput が即 blur してこのタイマーが走るため、**mousedown→mouseup が 150ms を超える人間の普通のクリックでは、押し終わる前に行がアンマウントされ onPress(mouseup 時)が発火しない**。

- Playwright の `click()` は押下時間ほぼ 0ms のため既存 e2e では検知不能だった
- mousedown を 250ms 保持するスクリプトで 100% 再現を確認(押下中にパネルが消えるのを観測)
- `DishCategoryAutocomplete`(レビュー投稿の料理カテゴリ入力)にも同一パターンがあり同様に修正

## 変更内容
- `LocationAutocomplete.tsx` / `DishCategoryAutocomplete.tsx`: パネルコンテナに web でのみ効く `onMouseDown` の `preventDefault`(`preventFocusStealOnWeb`)を追加。mousedown の既定動作であるフォーカス移動自体を抑止するため blur が発生せず、クリック速度に依存しなくなる。react-native-web が未知 props を DOM へ forward する仕様を利用(#935 の `onKeyDown` と同パターン)。native には mouse イベントが無く影響なし。#931 で個別対処していた再試行ボタンの blur 競合も構造的に解消される
- `location-autocomplete.spec.ts`: 再発防止の「mousedown を 250ms 保持するスロークリックでも選択できる」テストを追加(押下中にパネルが消えないことも検証)

## テスト
- 新規スロークリックテスト含む location-autocomplete 3件 pass
- 1440px でユーザー報告と同じ流れ(渋谷駅入力→スロークリック選択→探して!)でトピック生成まで進むことを確認(スナックバー非表示)
- `tests/smoke/` + `tests/search/`: 30件 pass
  - ※ `topics-tutorial.spec.ts` の1件はクリーンな base でも失敗する既存の問題で本修正とは無関係(別途対応要)
- `npx tsc --noEmit` エラーなし / `build:web` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)