### PR TITLE
#935 fix: Androidで距離スライダーが縦ドリフトでブルブル震える不具合を修正

### DIFF
--- a/app-expo/features/search/components/DistanceSlider.tsx
+++ b/app-expo/features/search/components/DistanceSlider.tsx
@@ -118,6 +118,13 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 		[commitIndex],
 	);
 
+	// #935 【修正】ドラッグ開始時のトラック相対X。移動中は locationX を読まず、
+	// この起点 + gestureState.dx(画面座標ベースの累積差分)で位置を計算する。
+	// locationX は「今タッチしているビュー」基準のため、Android では指が高さ6pxの
+	// トラックから縦に外れた瞬間に基準が変わって値が飛び、サムが往復する(ブルブル)
+	// 不具合の原因になっていた。dx はビューに依存せず安定している。
+	const grantLocationXRef = useRef(0);
+
 	const panResponder = useRef(
 		PanResponder.create({
 			// #935 【修正】トラック全体をタップ対象にする(サム単体ではなくトラック View に付与)
@@ -127,11 +134,16 @@ export function DistanceSlider({ distance, setDistance }: DistanceSliderProps) {
 				Math.abs(gestureState.dx) > Math.abs(gestureState.dy),
 			// #935 【修正】タップした瞬間にその位置へジャンプする
 			onPanResponderGrant: (evt) => {
+				grantLocationXRef.current = evt.nativeEvent.locationX;
 				updateFromLocationX(evt.nativeEvent.locationX);
 			},
-			onPanResponderMove: (evt) => {
-				updateFromLocationX(evt.nativeEvent.locationX);
+			onPanResponderMove: (_evt, gestureState) => {
+				updateFromLocationX(grantLocationXRef.current + gestureState.dx);
 			},
+			// #935 【修正】ドラッグ中に指が縦にずれると親 ScrollView がレスポンダを要求するが、
+			// 譲渡する(デフォルト true)とスライダーと ScrollView が交互に掴んで表示が震える。
+			// 一度スライダーが掴んだジェスチャは離すまで手放さない
+			onPanResponderTerminationRequest: () => false,
 		}),
 	).current;
 


### PR DESCRIPTION
## 概要
re: #935 (レビュー指摘「Android で距離スライダーが安定しない(上下にずれるとブルブルになる)」)

## 根因(2つの複合)
1. **locationX のビュー依存性**: ドラッグ移動中も `evt.nativeEvent.locationX` を読み続けていたが、locationX は「今タッチしているビュー」基準の相対座標。指が高さ6pxのトラックから縦に外れた瞬間に基準が変わって値が飛び、サムが往復する(Android で顕著)
2. **レスポンダの奪い合い**: `onPanResponderTerminationRequest` 未指定(デフォルト true)のため、縦ドリフトで親 ScrollView がレスポンダを要求するとスライダーが譲渡し、交互にジェスチャを掴んで表示が震える

## 変更内容
- grant 時の locationX を起点として保持し、移動中はビュー非依存で安定した `gestureState.dx`(画面座標の累積差分)だけで位置を計算する方式へ変更
- `onPanResponderTerminationRequest: () => false` で、一度掴んだジェスチャは離すまで手放さない

## テスト
- web で縦±60pxブレながらのドラッグをスクリプト再現し、値が単調追従(往復なし)することを確認
- 既存の distance-slider / search-form / search-accessibility e2e 11件 全pass
- `npx tsc --noEmit` エラーなし / `build:web` 成功
- ※ Android 実機/エミュレータは本環境に無いため、locationX 非依存化という構造での修正。実機での最終確認をお願いします

🤖 Generated with [Claude Code](https://claude.com/claude-code)