### PR TITLE
#927 fix: スポットライトチュートリアルの位置ずれ(Androidステータスバー/計測タイミング)を修正

### DIFF
--- a/app-expo/features/topics/components/TopicsSpotlightTutorial.tsx
+++ b/app-expo/features/topics/components/TopicsSpotlightTutorial.tsx
@@ -3,7 +3,9 @@ import {
 	AccessibilityInfo,
 	findNodeHandle,
 	Modal,
+	Platform,
 	ScrollView,
+	StatusBar,
 	StyleSheet,
 	Text,
 	TouchableOpacity,
@@ -97,6 +99,16 @@ const isUsableRect = (rect: TopicsTutorialRect) =>
 	[rect.x, rect.y, rect.width, rect.height].every(Number.isFinite) && rect.width > 0 && rect.height > 0;
 
 /**
+ * #927 【修正】Android の measureInWindow はアプリのウィンドウ(ステータスバーの下から始まる)
+ * 基準の座標を返すが、オーバーレイの Modal は statusBarTranslucent のため画面最上端から
+ * 描画される。座標基準の差 = ステータスバー高さのぶん、穴が対象より上にずれていたため、
+ * Android でのみ y に StatusBar.currentHeight を加算して Modal の座標系へ揃える。
+ * (iOS はウィンドウ=画面全体、web は viewport 基準で Modal と一致するため補正不要。
+ *  将来 edge-to-edge を有効化した場合はウィンドウが画面全体になるためこの補正は不要になる)
+ */
+const ANDROID_STATUS_BAR_OFFSET = Platform.OS === "android" ? (StatusBar.currentHeight ?? 0) : 0;
+
+/**
  * 1つのViewを画面座標で計測する。
  *
  * measureInWindowは対象が未mountの場合にcallbackが返らない実装差もあり得るため、
@@ -121,10 +133,26 @@ const measureTarget = (
 
 		requestAnimationFrame(() => {
 			target.measureInWindow((x, y, width, height) => {
-				finish({ x, y, width, height });
+				finish({ x, y: y + ANDROID_STATUS_BAR_OFFSET, width, height });
 			});
 		});
 	});
+};
+
+/**
+ * #927 【修正】2回の計測結果が実質同一(各値の差が1px以内)かを判定する。
+ * カルーセルの初期スナップや画像ロードによるレイアウト確定前に計測すると、
+ * その瞬間の座標で穴が固定され全プラットフォームで「ずれた」表示になるため、
+ * 連続2回一致するまで待って「動いていない」ことを確認してから表示する。
+ */
+const isSameRect = (a: TopicsTutorialRect | null | undefined, b: TopicsTutorialRect | null | undefined) => {
+	if (!a || !b) return false;
+	return (
+		Math.abs(a.x - b.x) <= 1 &&
+		Math.abs(a.y - b.y) <= 1 &&
+		Math.abs(a.width - b.width) <= 1 &&
+		Math.abs(a.height - b.height) <= 1
+	);
 };
 
 /** 複数スポットの外接矩形。吹き出しの配置基準にだけ使い、穴自体は個別に描画する。 */
@@ -293,6 +321,7 @@ export function TopicsSpotlightTutorial({
 		const prepare = async () => {
 			const targetKeys = Array.from(new Set(candidateSteps.flatMap((step) => step.targetKeys)));
 			let latestMeasurements: MeasuredTargets = {};
+			let previousMeasurements: MeasuredTargets = {};
 
 			for (let attempt = 0; attempt < MEASURE_RETRY_COUNT; attempt += 1) {
 				if (attempt > 0) {
@@ -303,10 +332,17 @@ export function TopicsSpotlightTutorial({
 				const entries = await Promise.all(
 					targetKeys.map(async (targetKey) => [targetKey, await measureTarget(targetKey, targetRefs)] as const),
 				);
+				previousMeasurements = latestMeasurements;
 				latestMeasurements = Object.fromEntries(entries.filter(([, rect]) => rect !== null)) as MeasuredTargets;
 
-				// optionalを含め全ターゲットが揃えば、最終リトライを待たずに表示できる。
-				if (targetKeys.every((targetKey) => latestMeasurements[targetKey])) {
+				// #927 【修正】optionalを含め全ターゲットが揃い、かつ直前の計測と一致(=レイアウトが
+				// 静止)したときだけ確定する。カルーセルの初期スナップや画像ロードで座標が動いている
+				// 最中の値で穴を固定すると、全プラットフォームで「ずれた」スポットライトになるため。
+				const allMeasured = targetKeys.every((targetKey) => latestMeasurements[targetKey]);
+				const allStable = targetKeys.every((targetKey) =>
+					isSameRect(latestMeasurements[targetKey], previousMeasurements[targetKey]),
+				);
+				if (allMeasured && allStable) {
 					break;
 				}
 			}
@@ -378,20 +414,26 @@ export function TopicsSpotlightTutorial({
 
 		const remeasureCurrentStep = async () => {
 			let entries: readonly (readonly [TopicsTutorialTargetKey, TopicsTutorialRect | null])[] = [];
+			let previousEntries: ReadonlyMap<TopicsTutorialTargetKey, TopicsTutorialRect | null> = new Map();
 
 			// ステップ切替直後の1フレームだけrefが不安定でも閉じないよう、短く再試行する。
+			// #927 【修正】prepare と同様に、連続2回一致するまで待ってレイアウト静止を確認する
+			// (回転・リサイズ直後の遷移アニメーション中の座標で穴を固定しないため)。
 			for (let attempt = 0; attempt < 3; attempt += 1) {
 				if (attempt > 0) {
 					await wait(MEASURE_RETRY_INTERVAL_MS);
 				}
 				if (isCancelled) return;
 
+				previousEntries = new Map(entries);
 				entries = await Promise.all(
 					currentStep.targetKeys.map(
 						async (targetKey) => [targetKey, await measureTarget(targetKey, targetRefs)] as const,
 					),
 				);
-				if (entries.every(([, rect]) => rect !== null)) break;
+				const allMeasured = entries.every(([, rect]) => rect !== null);
+				const allStable = entries.every(([targetKey, rect]) => isSameRect(rect, previousEntries.get(targetKey)));
+				if (allMeasured && allStable) break;
 			}
 			if (isCancelled) return;
 

--- a/e2e-web/tests/search/topics-tutorial.spec.ts
+++ b/e2e-web/tests/search/topics-tutorial.spec.ts
@@ -38,7 +38,9 @@ test.describe("料理提案チュートリアル(ja-JP 初回訪問)", () => {
 		// Step 2: 深掘り候補がある料理だけ表示する。候補なしならStep 3へ直接進む。
 		await expect(topicsPage.tutorialDeepDiveStep.or(topicsPage.tutorialActionsStep)).toBeVisible();
 		if (await topicsPage.tutorialDeepDiveStep.isVisible()) {
-			await expect(appPage.getByText("似た料理をもっと見る", { exact: true })).toBeVisible();
+			// #927 【修正】#975 の文言変更(深堀→再検索表現)に追従。旧文言「似た料理をもっと見る」の
+			// 決め打ちが残っていたため、このスペックはマージ当初から失敗し続けていた
+			await expect(appPage.getByText("気分に合わせて深堀再検索", { exact: true })).toBeVisible();
 			await topicsPage.tutorialNextButton.click();
 		}
 
@@ -49,7 +51,8 @@ test.describe("料理提案チュートリアル(ja-JP 初回訪問)", () => {
 
 		// Step 4: 発見しにくいグループ投票は必須ステップ。
 		await expect(topicsPage.tutorialGroupVoteStep).toBeVisible();
-		await expect(appPage.getByText("みんなで決める", { exact: true })).toBeVisible();
+		// #927 【修正】現行文言「友達と決める」(Topics.tutorial.steps.groupVote.title)に追従
+		await expect(appPage.getByText("友達と決める", { exact: true })).toBeVisible();
 		await topicsPage.tutorialFinishButton.click();
 		await expect(topicsPage.tutorialOverlay).toHaveCount(0);
 


### PR DESCRIPTION
## 概要
re: #927 (レビュー指摘「web, iOS, Android 共にこの料理にするボタン、深堀検索などのスポットライトする位置がずれる(SafeAreaの関係?)」)

## 根因と修正(2つ)

### 1. Android: ステータスバー分の縦ずれ(ご推察の「SafeAreaの関係」に相当)
`measureInWindow` は**アプリのウィンドウ(ステータスバーの下から始まる)基準**の座標を返す一方、オーバーレイの `Modal` は `statusBarTranslucent` のため**画面最上端から**描画される。この座標基準の差=ステータスバー高さぶん、穴が対象より上にずれていた。
→ Android でのみ `y += StatusBar.currentHeight` で Modal の座標系へ揃えた(将来 edge-to-edge を有効化した場合は不要になる旨コメントに明記)。

### 2. 全プラットフォーム: レイアウト静止前の計測凍結
カルーセルの初期スナップや画像ロードでレイアウトが動いている最中に計測が成立すると、その瞬間の座標で穴が固定されたまま表示される。開くタイミング次第で web/iOS でも再現しうる。
→ prepare / 再計測の両ループに「**連続2回の計測が1px以内で一致するまで待つ**」静止判定を追加。

## e2e スペック修正(既報の恒常失敗)
`topics-tutorial.spec.ts` はマージ当初から失敗し続けていたが、原因は #975 の文言変更に追従していない旧文言(「似た料理をもっと見る」「みんなで決める」)の決め打ち。現行文言(「気分に合わせて深堀再検索」「友達と決める」)へ修正し、**初めて green** になった。

## テスト
- web(1280px)で全4ステップの穴とターゲット矩形の一致(pad 10px ちょうど、画面端は clamp)を数値検証
- `topics-tutorial.spec.ts` pass(初)
- `npx tsc --noEmit` エラーなし / `build:web` 成功
- ※ Android のステータスバー補正は実機/エミュレータが本環境に無いため理論修正です。**iOS/Android 実機での見え方の最終確認をお願いします**(iOS は補正なし=従来から座標系が一致している想定で、ずれが残る場合は計測タイミング起因だったはずなので今回の静止判定で解消される見込み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)