### PR TITLE
#958 fix: 中央カラムからダイアログと結果フィードカードがはみ出す問題を修正

### DIFF
--- a/app-expo/contexts/DialogProvider.tsx
+++ b/app-expo/contexts/DialogProvider.tsx
@@ -11,6 +11,7 @@ import React, {
 } from "react";
 import { BackHandler, Platform, ScrollView, StyleSheet, View } from "react-native";
 import { Portal, Dialog, Button, Paragraph, Text, TextInput, HelperText } from "react-native-paper";
+import { useContentWidth } from "@/hooks/useContentWidth";
 
 /**
  * =========================
@@ -266,6 +267,13 @@ const useIsMountedRef = () => {
 
 export const DialogProvider = ({ children }: { children: ReactNode }) => {
 	const isMountedRef = useIsMountedRef();
+
+	// #958 【修正】paper の Portal は PaperProvider 直下のホスト(=CenteredAppShell の外側)に
+	// 描画されるため、Dialog がウィンドウ全幅に広がり web の中央カラムからはみ出していた。
+	// Dialog 自体をカラム幅(-左右マージン26px相当)に制約し中央寄せする。
+	// native では contentWidth = 画面幅のため、paper 既定(marginHorizontal:26)と同じ見た目になる。
+	const contentWidth = useContentWidth();
+	const dialogWidth = Math.max(0, contentWidth - 52);
 
 	/**
 	 * キューは ref で持つ（state で持つと無駄レンダーが増えやすい）
@@ -830,7 +838,7 @@ export const DialogProvider = ({ children }: { children: ReactNode }) => {
 			<Portal>
 				<Dialog
 					visible={visible}
-					style={styles.dialog}
+					style={[styles.dialog, { width: dialogWidth, alignSelf: "center" }]}
 					/**
 					 * onDismiss は「呼ばれる」ので、許可しない場合は handleDismiss 内で弾く（6）
 					 */

--- a/app-expo/features/dishMedia/components/DishMediaMap.tsx
+++ b/app-expo/features/dishMedia/components/DishMediaMap.tsx
@@ -26,8 +26,12 @@ import { PrimaryButton } from "@/components/PrimaryButton";
 import { LoadingIndicator } from "@/components/LoadingIndicator";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { useDishMediaBackgroundImageResources } from "@/features/dishMedia/hooks/useDishMediaBackgroundImageResources";
+import { useContentWidth } from "@/hooks/useContentWidth";
 
-const { width, height } = Dimensions.get("window");
+// #958 【修正】カルーセルの幅は window 実幅ではなく中央カラム幅に追従させる必要があるため、
+// コンポーネント内の useContentWidth() を使う(下の contentWidth)。height はカルーセルの
+// 高さ比率計算にのみ使い、横レイアウトには影響しないため据え置き
+const { height } = Dimensions.get("window");
 
 // #605 【設計】Carousel の展開/縮小比率（画面高さに対する割合）
 const EXPANDED_RATIO = 0.8;
@@ -66,6 +70,10 @@ export default function DishMediaMap({
 	entriesKey,
 	idType,
 }: DishMediaMapProps) {
+	// #958 【修正】web の中央カラム内では window 実幅でカルーセルを描画するとカードが
+	// カラムからはみ出すため、カラム幅(native では画面幅)を基準にする
+	const contentWidth = useContentWidth();
+
 	const selector = useCallback(
 		(state: DishMediaEntriesStore) => selectIdsByKey(entriesKey, idType)(state),
 		[entriesKey, idType],
@@ -170,7 +178,7 @@ export default function DishMediaMap({
 		}
 
 		// マップのアスペクト比
-		const aspectRatio = width / height;
+		const aspectRatio = contentWidth / height;
 
 		// 全ピンの最小・最大座標を取得
 		const latitudes = restaurants.map((restaurant) => restaurant.coordinate.latitude);
@@ -199,7 +207,7 @@ export default function DishMediaMap({
 			latitudeDelta: latDelta,
 			longitudeDelta: lngDelta,
 		};
-	}, [restaurants, initialLocation]);
+	}, [restaurants, initialLocation, contentWidth]);
 	const region = useMemo(() => getMapRegion(), [getMapRegion]);
 
 	useEffect(() => {
@@ -400,7 +408,7 @@ export default function DishMediaMap({
 				{/* Carousel - Bottom 4/5 of screen, overlapping map */}
 				<Carousel
 					ref={carouselRef}
-					width={width}
+					width={contentWidth}
 					height={CAROUSEL_HEIGHT}
 					data={ids}
 					renderItem={renderCarouselItem}


### PR DESCRIPTION
## 概要
re: #958 (レビュー指摘「ダイアログがはみ出る。DishMediaMaps でカードがはみ出る」)

## 根因と修正

### 1. ダイアログ(DialogProvider 経由の全ダイアログ)
react-native-paper の `Portal` は **PaperProvider 直下のホスト(= CenteredAppShell の外側)** へ描画されるため、「直近の position 祖先から幅を継承する」という #958 当初の想定が Dialog には当てはまらず、ウィンドウ全幅に広がっていた。
→ Dialog 自体に `useContentWidth` 由来の幅(カラム幅 − 52px)+ `alignSelf: "center"` を指定。native では contentWidth = 画面幅のため paper 既定(左右マージン26px)と同じ見た目。

### 2. DishMediaMap(結果フィード)
モジュールスコープの `Dimensions.get("window").width` をカルーセル幅と地図アスペクト比に使用しており、カードがウィンドウ幅で描画されてカラムをはみ出していた(#958 当初「地図の座標計算のみ」と誤判定してスコープ外にしていた分)。
→ `useContentWidth()` へ置換(リサイズ追従も改善)。

## テスト
- Playwright(1440px): 0件フォールバックダイアログがカラム内 508px 中央に収まることをスクショ+実測で確認(修正前はほぼ全幅)
- 結果フィードのカードがカラム内に収まり、横スクロールなし
- smoke / topics-flow / topics-tutorial 11件回帰なし
- `npx tsc --noEmit` エラーなし / `build:web` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)