### PR TITLE
#932 fix: 現在地取得がタイムアウトする退行(キャッシュ位置禁止)と文言を修正

### DIFF
--- a/app-expo/hooks/useCurrentLocationPosition.ts
+++ b/app-expo/hooks/useCurrentLocationPosition.ts
@@ -4,6 +4,9 @@ import { LocationPermissionError } from "./locationPermissionError";
 // #932 【設計】native側は端末の位置情報サービス自体が無効/権限がロック等で
 // getCurrentPositionAsync が長時間ハングするケースがあるため、明示的にタイムアウトを設ける
 const TIMEOUT_MS = 10000;
+// #932 【修正】検索の起点用途では数分前の位置で十分なため、まず OS が保持する直近の
+// 既知位置(キャッシュ)を許容して即時応答を優先する(web 実装の maximumAge と同じ方針)
+const MAX_LAST_KNOWN_AGE_MS = 5 * 60 * 1000;
 
 /**
  * 現在地の緯度経度を取得する(native実装)。
@@ -16,6 +19,13 @@ export async function getCurrentLocationPosition(): Promise<{ latitude: number; 
 	}
 
 	try {
+		// #932 【修正】新規測位を待つ前に直近の既知位置があれば即座に返す
+		// (getLastKnownPositionAsync は失敗しても新規測位にフォールバックするだけなので握りつぶす)
+		const lastKnown = await Location.getLastKnownPositionAsync({ maxAge: MAX_LAST_KNOWN_AGE_MS }).catch(() => null);
+		if (lastKnown) {
+			return { latitude: lastKnown.coords.latitude, longitude: lastKnown.coords.longitude };
+		}
+
 		const position = await Promise.race([
 			Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced }),
 			new Promise<never>((_, reject) => {

--- a/app-expo/hooks/useCurrentLocationPosition.web.ts
+++ b/app-expo/hooks/useCurrentLocationPosition.web.ts
@@ -5,6 +5,11 @@ import { LocationPermissionError } from "./locationPermissionError";
 // 出ないままクラッシュしていた。web では expo-location を経由せず navigator.geolocation を直接使い、
 // permissions.query は「あれば試すだけ」のオプショナル事前チェックに留める。
 const TIMEOUT_MS = 10000;
+// #932 【修正】maximumAge: 0 はキャッシュ位置を禁止して毎回新規測位を強制するため、
+// GPS を持たないPCでは Wi-Fi/IP 測位待ちになり「以前は即反映されていたのにタイムアウトする」
+// 退行を起こしていた(移行前の expo-location はキャッシュを許容)。検索の起点用途では
+// 数分前の位置で十分なため、キャッシュを許容して即時応答を優先する
+const MAXIMUM_AGE_MS = 5 * 60 * 1000;
 
 /**
  * 現在地の緯度経度を取得する(web実装)。
@@ -48,7 +53,7 @@ export async function getCurrentLocationPosition(): Promise<{ latitude: number; 
 						break;
 				}
 			},
-			{ enableHighAccuracy: false, timeout: TIMEOUT_MS, maximumAge: 0 },
+			{ enableHighAccuracy: false, timeout: TIMEOUT_MS, maximumAge: MAXIMUM_AGE_MS },
 		);
 	});
 }

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -112,7 +112,7 @@
 			"getCurrentLocation": "現在地の取得に失敗しました",
 			"getCurrentLocationDenied": "位置情報の利用が許可されていません。地名を直接入力してください。",
 			"getCurrentLocationUnsupported": "この環境では現在地の取得に対応していません。地名を直接入力してください。",
-			"getCurrentLocationTimeout": "現在地の取得がタイムアウトしました。もう一度お試しいただくか、下の欄に直接入力してください。",
+			"getCurrentLocationTimeout": "現在地の取得がタイムアウトしました。もう一度お試しいただくか、直接入力してください。",
 			"noLocationSelected": "検索場所を選択してください",
 			"noTimeSlotSelected": "時間帯を選択してください",
 			"noSceneSelected": "シーンを選択してください",

--- a/e2e-web/tests/search/current-location.spec.ts
+++ b/e2e-web/tests/search/current-location.spec.ts
@@ -97,7 +97,7 @@ test.describe("現在地取得", () => {
 		await appPage.getByTestId("search-current-location-button").click();
 
 		await expect(
-			appPage.getByText("現在地の取得がタイムアウトしました。もう一度お試しいただくか、下の欄に直接入力してください。"),
+			appPage.getByText("現在地の取得がタイムアウトしました。もう一度お試しいただくか、直接入力してください。"),
 		).toBeVisible();
 	});
 });


### PR DESCRIPTION
## 概要
re: #932 (レビュー指摘「現在地ボタンを押すとタイムアウトする。以前まで即反映されていた」+文言修正)

## 根因
#932 の実装移行時、web の `getCurrentPosition` に **`maximumAge: 0`(キャッシュ位置の使用禁止=毎回新規測位を強制)** を指定していた。GPS を持たない PC では Wi-Fi/IP 測位待ちになり 10 秒でタイムアウトする。移行前の expo-location はキャッシュを許容していたため「以前は即反映」だった。

## 変更内容
- web: `maximumAge` を 5 分に変更(検索の起点用途では数分前の位置で十分)→ キャッシュがあれば即時応答
- native: 同方針で `getLastKnownPositionAsync(maxAge: 5分)` を先に試し、既知位置があれば新規測位を待たず即時返す
- ja-JP: タイムアウト文言「〜もう一度お試しいただくか、**下の欄に**直接入力してください。」→「〜もう一度お試しいただくか、直接入力してください。」(指定どおり。#931 の denied/unsupported と同じ位置非依存表現に統一)。e2e 期待値も追従

## テスト
- current-location e2e 5件(許可/拒否/未対応/タイムアウト)全pass
- `npx tsc --noEmit` エラーなし / `build:web` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)