### PR TITLE
#934 fix: チップ選択チェックを右上バッジ化し選択時のレイアウト移動を解消

### DIFF
--- a/app-expo/features/search/components/SelectableChip.tsx
+++ b/app-expo/features/search/components/SelectableChip.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TouchableOpacity, Text, StyleSheet } from "react-native";
+import { TouchableOpacity, Text, StyleSheet, View } from "react-native";
 import { Check } from "lucide-react-native";
 
 interface SelectableChipProps {
@@ -32,9 +32,16 @@ export function SelectableChip({ label, icon, selected, onPress, role, testID }:
 			accessibilityRole={role}
 			aria-checked={selected}
 			accessibilityLabel={label}>
-			{selected && <Check size={12} color="#000000" strokeWidth={3} style={styles.checkIcon} />}
 			{icon && <Text style={styles.emoji}>{icon}</Text>}
 			<Text style={[styles.text, selected && styles.selectedText]}>{label}</Text>
+			{/* #934 【修正】チェックをラベルと同じ行に入れるとチップの横幅が変わり選択のたびに
+			    レイアウトが動くため(レビュー指摘)、SelectableGridItem(時間帯グリッド)と同じ
+			    右上の絶対配置バッジに変更して幅を不変にする */}
+			{selected && (
+				<View style={styles.checkBadge}>
+					<Check size={10} color="#FFFFFF" strokeWidth={3} />
+				</View>
+			)}
 		</TouchableOpacity>
 	);
 }
@@ -50,13 +57,27 @@ const styles = StyleSheet.create({
 		borderWidth: 2,
 		borderColor: "#C9C9C9",
 		marginBottom: 6,
+		// #934 【設計】右上バッジをチップの角に少しはみ出して重ねるため
+		position: "relative",
+		overflow: "visible",
 	},
 	selectedChip: {
 		backgroundColor: "#E5E5E5",
 		borderColor: "#000000",
 	},
-	checkIcon: {
-		marginRight: 4,
+	// #934 【設計】SelectableGridItem の checkBadge と同じ見た目(黒地・白縁・白チェック)
+	checkBadge: {
+		position: "absolute",
+		top: -6,
+		right: -6,
+		width: 16,
+		height: 16,
+		borderRadius: 8,
+		backgroundColor: "#000000",
+		alignItems: "center",
+		justifyContent: "center",
+		borderWidth: 1.5,
+		borderColor: "#FFFFFF",
 	},
 	emoji: {
 		fontSize: 14,


### PR DESCRIPTION
## 概要
re: #934 (レビュー指摘「チップの横幅が変わってレイアウトが変わるので、右上にチェック(時間帯と同じ)にしたい」)

## 変更内容
- `SelectableChip.tsx`: インラインのチェックマーク(ラベルと同じ行、幅が変わる)を廃止し、`SelectableGridItem`(時間帯グリッド)と同じ**右上の絶対配置バッジ**(黒地・白縁・白チェック)に変更
- 共通コンポーネントのため、価格帯・食事時間・系統の全チップに一括で効く

## テスト
- Playwright: 選択前後で boundingBox 幅が不変(80px)であることを確認(スクショ: `tmp/934-チップ選択チェックの右上バッジ化/`)
- search-accessibility / search-form e2e 8件 回帰なし(aria-checked セマンティクスは維持)
- `npx tsc --noEmit` エラーなし / `build:web` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)