### PR TITLE
#674 fix: スワイプ直後の「この料理にする!」タップが無視される不具合を修正

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/topics.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/topics.tsx
@@ -85,7 +85,6 @@ export default function TopicsScreen() {
 		}
 	}, [pinnedTopicParam]);
 	const { logFrontendEvent } = useLogger();
-	const [isScrolling, setIsScrolling] = useState(false);
 	const [currentIndex, setCurrentIndex] = useState(0);
 	const [loadedSearchSessionKey, setLoadedSearchSessionKey] = useState<string | null>(null);
 	const [carouselAvailableHeight, setCarouselAvailableHeight] = useState(0);
@@ -359,13 +358,18 @@ export default function TopicsScreen() {
 		setCurrentIndex(index);
 	};
 
-	// #674 【仕様】カード・メインCTAタップ時の処理（スクロール中は無視）
+	// #674 【仕様】カード・メインCTAタップ時の処理。
+	// 旧実装は「スクロール中はタップ無視」のガードがあったが、これは当時
+	// visibleTopics[currentIndex] という index 参照で選択しており、スクロール中の
+	// 曖昧な index による誤選択を防ぐためのものだった。現在は押されたカード自身の
+	// topic を直接受け取るため曖昧さはなく、ガードは「押下フィードバックは出るのに
+	// 遷移しない」だけの挙動になっていたため撤去した(レビュー指摘)。
+	// 実スワイプとタップの弁別は Carousel のジェスチャ制御に委ねる。
 	const handleCardPress = useCallback(
 		(topic: Topic) => {
-			if (isScrolling) return;
 			handleViewDetails(topic);
 		},
-		[handleViewDetails, isScrolling],
+		[handleViewDetails],
 	);
 
 	// #674 【仕様】サムネイルタップ時の処理
@@ -715,8 +719,6 @@ export default function TopicsScreen() {
 									data={visibleTopics}
 									renderItem={renderCard}
 									onSnapToItem={handleSnapToItem}
-									onScrollStart={() => setIsScrolling(true)}
-									onScrollEnd={() => setIsScrolling(false)}
 									mode="parallax"
 									modeConfig={{
 										parallaxScrollingScale: 0.9,


### PR DESCRIPTION
## 概要
レビュー指摘「料理提案画面で、スワイプ中に『この料理にする』ボタンを押すとUX上反応するけど次画面に行かない」への対応。

## 根因
`handleCardPress` の「スクロール中はタップ無視」ガード(#674 で追加)。当時は `visibleTopics[currentIndex]` という **index 参照**で選択しており、スクロール中の曖昧な index による誤選択を防ぐ必要があった。その後、押されたカード自身の `topic` を直接受け取る実装へ変わって index の曖昧さは消えたが、ガードだけが残り「押下フィードバックは出るのに遷移しない」不整合が生じていた。

## 変更内容
- ガードを撤去(タップ対象のカード=遷移先が一意に決まるため安全)。実スワイプとタップの弁別は Carousel のジェスチャ制御に委ねる
- 不要になった `isScrolling` state と `onScrollStart` / `onScrollEnd` を削除

## テスト
- Playwright: スワイプして離した直後(スナップアニメーション中)のタップで結果画面へ遷移することを確認(スクショ: `tmp/674-スワイプ中のこの料理にするタップ/`)
- topics-flow / topics-tutorial e2e 5件 回帰なし
- `npx tsc --noEmit` エラーなし / `build:web` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)