### PR TITLE
#952 fix: 同名の別店舗が dedup で消える問題を修正(PR #980 レビュー対応)

### DIFF
--- a/api/src/v1/locations/locations.service.spec.ts
+++ b/api/src/v1/locations/locations.service.spec.ts
@@ -520,5 +520,83 @@ describe('LocationsService', () => {
       expect(result).toHaveLength(1);
       expect(result[0].place_id).toBe('place-1');
     });
+
+    it('should keep multiple same-name establishments (e.g. chain branches)', async () => {
+      // #952 【テスト】PR #980 レビュー指摘: 同名チェーンの別店舗(establishment 同士、
+      // place_id・secondaryText が異なる)は表示名が同じでも別地点なので全て残ること
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion(
+            'place-sbux-1',
+            'スターバックス',
+            '日本、東京都渋谷区道玄坂',
+            ['cafe', 'establishment'],
+          ),
+          buildSuggestion(
+            'place-sbux-2',
+            'スターバックス',
+            '日本、東京都渋谷区宇田川町',
+            ['cafe', 'establishment'],
+          ),
+          buildSuggestion(
+            'place-sbux-addr',
+            'スターバックス',
+            '日本、東京都渋谷区２丁目',
+            ['geocode'],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      // establishment 2店舗は残り、同名の番地レベル geocode だけが落ちる
+      expect(result).toHaveLength(2);
+      expect(result.map((place) => place.place_id)).toEqual([
+        'place-sbux-1',
+        'place-sbux-2',
+      ]);
+    });
+
+    it('should keep non-establishment candidates when no same-name establishment exists', async () => {
+      // #952 【テスト】同名の establishment が無い場合、住所系候補はそのまま残ること
+      // (住所そのものを検索したいケースを壊さない)
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion('place-addr-1', '渋谷２丁目', '日本、東京都渋谷区', [
+            'geocode',
+          ]),
+          buildSuggestion('place-town', '渋谷区', '日本、東京都', [
+            'locality',
+            'political',
+            'geocode',
+          ]),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should collapse exact duplicates (same mainText and secondaryText)', async () => {
+      // #952 【テスト】表示が完全一致する候補は区別できないため1件に畳むこと
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion('place-dup-1', '渋谷駅', '日本、東京都渋谷区', [
+            'train_station',
+            'establishment',
+          ]),
+          buildSuggestion('place-dup-2', '渋谷駅', '日本、東京都渋谷区', [
+            'transit_station',
+            'establishment',
+          ]),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].place_id).toBe('place-dup-1');
+    });
   });
 });

--- a/api/src/v1/locations/locations.service.ts
+++ b/api/src/v1/locations/locations.service.ts
@@ -566,54 +566,55 @@ export class LocationsService {
   }
 
   /**
-   * #952 【設計】Autocomplete 候補の同名重複を除去する。
+   * #952 【設計】Autocomplete 候補の「同一地点の粒度違い重複」を除去する。
    *
-   * ルール:
-   * 1. mainText を正規化(NFKC + 空白除去)したものをグループキーにする。
-   *    「渋谷駅」と「渋谷駅前」のような別地点は別キーになり残る。
-   * 2. 同名グループ内では `establishment` を types に持つ候補(実在施設としての
-   *    prediction)を優先する。番地レベルの重複(street_address / premise /
-   *    純粋な geocode)は establishment を持たないため、これで自然に落ちる。
-   * 3. 優先度が同じ候補同士は Google の関連度順(配列順)で先勝ち。
-   * 4. 返却順は元の関連度順を維持する(グループの初出位置)。
-   *
-   * なお Autocomplete (New) は最大5件固定で追加取得手段がないため、
-   * dedup により件数は減りうる(通常は0〜1件)。同名重複が並ぶより
-   * 少なくてもクリーンな候補の方が選びやすい、という判断を優先している。
+   * ルール(PR #980 レビュー指摘を受けた改訂版):
+   * 1. mainText を正規化(NFKC + 空白除去)したものを同名判定のキーにする。
+   *    「渋谷駅」と「渋谷駅前」のような別名は別キーになり残る。
+   * 2. 落とすのは「同名の establishment(実在施設)が存在する場合の非 establishment 候補」
+   *    だけに限定する。これが「渋谷駅(駅)と 渋谷駅(番地レベル geocode)」のような
+   *    同一地点の粒度違い重複に相当する。
+   * 3. 同名でも establishment 同士(例: 同名チェーンの別店舗。place_id・secondaryText が
+   *    異なる別の実在地点)は全て残す。表示名だけで別地点を消してはならない。
+   * 4. 完全重複(mainText と secondaryText の両方が一致)だけは同名同士でも1件に畳む。
+   * 5. 返却順は Google の関連度順(元の配列順)を維持する。
    */
   private dedupeAutocompletePlaces(
     places: AutocompleteLocationsResponse,
   ): AutocompleteLocationsResponse {
-    const normalizeKey = (mainText: string): string =>
-      mainText.normalize('NFKC').replace(/\s+/g, '');
+    const normalizeKey = (text: string): string =>
+      text.normalize('NFKC').replace(/\s+/g, '');
 
     const isEstablishment = (place: { types: string[] }): boolean =>
       place.types.includes('establishment');
 
-    const bestByKey = new Map<
-      string,
-      { place: AutocompleteLocationsResponse[number]; firstIndex: number }
-    >();
+    // 同名の establishment が1件でも存在する mainText キーの集合
+    const establishmentNameKeys = new Set(
+      places
+        .filter((place) => isEstablishment(place))
+        .map((place) => normalizeKey(place.mainText)),
+    );
 
-    places.forEach((place, index) => {
-      const key = normalizeKey(place.mainText);
-      const existing = bestByKey.get(key);
+    const seenExactKeys = new Set<string>();
 
-      if (!existing) {
-        bestByKey.set(key, { place, firstIndex: index });
-        return;
+    return places.filter((place) => {
+      const nameKey = normalizeKey(place.mainText);
+
+      // ルール4: mainText + secondaryText まで完全一致する候補は同一表示になるため1件に畳む
+      const exactKey = `${nameKey}\u0000${normalizeKey(place.secondaryText)}`;
+      if (seenExactKeys.has(exactKey)) {
+        return false;
+      }
+      seenExactKeys.add(exactKey);
+
+      // ルール2: 同名の establishment が存在するなら、非 establishment(番地レベルの
+      // geocode / street_address / premise 等)は同一地点の粒度違いとみなして落とす
+      if (!isEstablishment(place) && establishmentNameKeys.has(nameKey)) {
+        return false;
       }
 
-      // 既存より優先すべきは「後から来た establishment vs 既存の非 establishment」のみ。
-      // それ以外(同格)は関連度順の先勝ちを維持する。
-      if (isEstablishment(place) && !isEstablishment(existing.place)) {
-        bestByKey.set(key, { place, firstIndex: existing.firstIndex });
-      }
+      return true;
     });
-
-    return [...bestByKey.values()]
-      .sort((a, b) => a.firstIndex - b.firstIndex)
-      .map((entry) => entry.place);
   }
 
   /**


### PR DESCRIPTION
## 概要
PR #980 のレビュー指摘([P1: Preserve distinct places that share a display name](https://github.com/Ayato-kosaka/nanitabeyo/pull/980#discussion_r3659508852))への対応。

## 根因
従来の dedup は正規化 `mainText` のみをキーに1件へ畳むため、同名チェーンの別店舗(establishment 同士、`place_id`・`secondaryText` が異なる正当な別地点)まで消えていた。

## 変更内容
落とす対象を「**同名の establishment が存在する場合の非 establishment 候補**」だけに限定:
- 渋谷駅(駅)+ 渋谷駅(番地レベル geocode)→ geocode だけ落ちる(本来の目的、従来どおり)
- スターバックス道玄坂店 + 宇田川町店(共に establishment)→ **両方残る**(修正点)
- 同名 establishment が無い住所系候補 → そのまま残る(住所検索を壊さない)
- 表示が完全一致(mainText+secondaryText)する候補のみ1件に畳む

## テスト
- 単体テスト3件追加(同名別店舗の保持/establishment 不在時の住所候補保持/完全重複の畳み込み)
- 既存含む 18件全pass / `npx tsc --noEmit` エラーなし
- UI 変更なし(サーバー側のみ)のため Playwright は locations e2e(サジェスト表示)の回帰のみ後続でまとめて実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)