### PR TITLE
#929 fix: webの画像読み込み失敗をerror状態に遷移させ失敗UI/再試行を表示(PR #980 レビュー対応)

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/topics.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/topics.tsx
@@ -282,7 +282,7 @@ export default function TopicsScreen() {
 		}
 	}, [createGroupVote, locale, logFrontendEvent, params, showSnackbar, visibleTopics]);
 
-	const { getImageState, retryImage } = useTopicImageResources({
+	const { getImageState, retryImage, markImageError } = useTopicImageResources({
 		topics: visibleTopics,
 		sessionKey: searchParams ?? "",
 	});
@@ -544,6 +544,7 @@ export default function TopicsScreen() {
 				cardHeight={cardHeight}
 				imageState={imageState}
 				onImageRetry={retryImage}
+				onImageLoadError={markImageError}
 				// 非表示カードによるref上書きを防ぐため、アクティブカードにだけ登録する。
 				tutorialTargetRefs={isActiveCard ? tutorialTargetRefs : undefined}
 			/>
@@ -768,6 +769,9 @@ export default function TopicsScreen() {
 											alt=""
 											accessibilityElementsHidden
 											importantForAccessibility="no"
+											// #929 【修正】web は ready でも実際の読み込み成否が未検証のため、
+											// 失敗を共有 state へ反映してカード側の失敗UI/再試行に繋げる
+											onError={() => markImageError(topic)}
 										/>
 									) : (
 										<SkeletonShimmer width="100%" height="100%" />

--- a/app-expo/features/topics/components/TopicCard.tsx
+++ b/app-expo/features/topics/components/TopicCard.tsx
@@ -34,6 +34,7 @@ export const TopicCard = ({
 	cardHeight,
 	imageState,
 	onImageRetry,
+	onImageLoadError,
 	tutorialTargetRefs,
 }: {
 	item: Topic;
@@ -47,6 +48,8 @@ export const TopicCard = ({
 	cardHeight: number;
 	imageState: TopicImageResourceState;
 	onImageRetry?: (topic: Topic) => void;
+	/** #929 【設計】表示側 <Image> の読み込み失敗通知(TopicVisualCard から中継) */
+	onImageLoadError?: (topic: Topic) => void;
 	/**
 	 * アクティブなCarouselカードにだけ渡すチュートリアル用ref。
 	 *
@@ -150,6 +153,7 @@ export const TopicCard = ({
 						imageState={imageState}
 						recyclingKey={item.categoryId}
 						onImageRetry={onImageRetry ? () => onImageRetry(item) : undefined}
+						onImageLoadError={onImageLoadError ? () => onImageLoadError(item) : undefined}
 						bottomContent={
 							<View style={styles.bottomContent}>
 								{deepDiveOptions.length > 0 ? (

--- a/app-expo/features/topics/components/TopicVisualCard.tsx
+++ b/app-expo/features/topics/components/TopicVisualCard.tsx
@@ -21,6 +21,9 @@ type TopicVisualCardProps = {
 	topRightContent?: ReactNode;
 	bottomContent?: ReactNode;
 	onImageRetry?: () => void;
+	/** #929 【設計】表示側 <Image> の読み込み失敗通知。web は取得を介さず URL を直接渡すため、
+	 * ここで初めて失敗が分かる(PR #980 レビュー指摘)。呼び出し元が error 状態へ遷移させる */
+	onImageLoadError?: () => void;
 };
 
 export function TopicVisualCard({
@@ -34,6 +37,7 @@ export function TopicVisualCard({
 	topRightContent,
 	bottomContent,
 	onImageRetry,
+	onImageLoadError,
 }: TopicVisualCardProps) {
 	const shouldShowSkeleton = imageState ? imageState.status === "idle" || imageState.status === "loading" : false;
 	const shouldShowFailureUI = imageState?.status === "error";
@@ -54,6 +58,7 @@ export function TopicVisualCard({
 					// #937 【仕様】料理名を伝える情報画像として alt/accessibilityLabel を付与する
 					alt={title}
 					accessibilityLabel={title}
+					onError={onImageLoadError}
 				/>
 			) : (
 				<View style={styles.cardImage} />

--- a/app-expo/features/topics/hooks/useTopicImageResources.ts
+++ b/app-expo/features/topics/hooks/useTopicImageResources.ts
@@ -160,6 +160,42 @@ export const useTopicImageResources = ({ topics, sessionKey }: UseTopicImageReso
 		[loadTopicImage, logFrontendEvent],
 	);
 
+	/**
+	 * #929 【修正】表示側 <Image> の onError から呼び、該当 topic を error 状態へ遷移させる。
+	 * web の ready state は URL を渡すだけで実際の読み込み成否を検証していないため
+	 * (PR #980 レビュー指摘)、期限切れ・無効・一時的に取得不能な画像が「ready のまま
+	 * 白いカード」になっていた。error へ遷移させることで native と同じ失敗オーバーレイと
+	 * 再試行導線(retryImage)が表示される。retryImage は error state からの再取得を行うため、
+	 * 一時的な失敗ならリトライで復帰できる。
+	 */
+	const markImageError = useCallback(
+		(topic: Topic, errorMessage?: string) => {
+			const key = getTopicImageKey(topic);
+			const current = topicImageStatesRef.current[key];
+			// すでに error / 再取得中(loading)の場合は上書きしない(遅延到着した onError で
+			// リトライ中の状態を巻き戻さないため)
+			if (current?.status === "error" || current?.status === "loading") return;
+
+			topicImageStatesRef.current = {
+				...topicImageStatesRef.current,
+				[key]: { status: "error", errorMessage },
+			};
+			setTopicImageStates(cloneTopicImageStates(topicImageStatesRef.current));
+			logFrontendEvent({
+				event_name: "topic_image_resource_load_error",
+				error_level: "warn",
+				payload: {
+					topic_id: topic.categoryId,
+					image_url: topic.imageUrl,
+					error_message: errorMessage ?? "render-side image load failed",
+					platform: Platform.OS,
+					source: "render_onerror",
+				},
+			});
+		},
+		[logFrontendEvent],
+	);
+
 	const getImageState = useCallback(
 		(topic: Topic) => topicImageStates[getTopicImageKey(topic)] ?? { status: "idle" as const },
 		[topicImageStates],
@@ -184,8 +220,9 @@ export const useTopicImageResources = ({ topics, sessionKey }: UseTopicImageReso
 			imageStates: topicImageStates,
 			getImageState,
 			retryImage,
+			markImageError,
 			resetImageStates,
 		}),
-		[getImageState, retryImage, topicImageStates, resetImageStates],
+		[getImageState, retryImage, markImageError, topicImageStates, resetImageStates],
 	);
 };


### PR DESCRIPTION
## 概要
PR #980 のレビュー指摘([P2: Transition web images to error state when loading fails](https://github.com/Ayato-kosaka/nanitabeyo/pull/980#discussion_r3659508861))への対応。

## 根因
web の画像リソース管理は Blob リーク回避のため取得を介さず URL を直接渡して**即 ready 扱い**にしており、実際の `<img>` 読み込み成否を観測していなかった。失敗した画像は ready のまま**白いカード**で表示され続け、native では出る失敗オーバーレイ・再試行導線が web では出なかった。

## 変更内容
- `useTopicImageResources`: 表示側 `<Image>` の `onError` から呼ぶ `markImageError` を追加(error 状態へ遷移、リトライ中の loading は上書きしない、`topic_image_resource_load_error` を記録)
- `TopicVisualCard` → `TopicCard` → `topics.tsx` に `onImageLoadError` を配線(カード+サムネイル両方。state 共有のためどちらで失敗しても失敗UIが出る)
- 既存の `retryImage` が error からの再取得を担うため、一時的な失敗はリトライで復帰

## テスト
- Playwright で画像リクエストを妨害: 全カードに失敗オーバーレイ(壊れ画像アイコン+「タップして再読み込み」)表示 → 妨害解除後のリトライで該当カード復帰(オーバーレイ 6→5)を確認(スクショ: `tmp/929-web画像読み込み失敗のerror遷移/`)
- topics-flow / topics-tutorial / location-autocomplete e2e 8件 回帰なし
- `npx tsc --noEmit` エラーなし / `build:web` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)