### PR TITLE
#1009 Topics画像管理の設計意図をコードコメントに明記

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/topics.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/topics.tsx
@@ -738,8 +738,9 @@ export default function TopicsScreen() {
 				{visibleTopics.length > 0 && (
 					<View style={styles.thumbnailGrid}>
 						{visibleTopics.map((topic, index) => {
-							// #929 【設計】メインカードと同じ imageState を参照し、画面単位で1回だけ取得したリソースを共有する。
-							// native は取得済み ImageRef、web は直接指定の uri であり、いずれも独自に再取得しない。
+							// #929 【設計】サムネイルを独立した URL ローダーにせず、メインカードと同じ
+							// source を参照する。native は同一 ImageRef を共有して再取得・再デコードを避け、
+							// web は同一 URL を共有してブラウザ側のリクエスト重複排除を利用する。
 							const thumbnailImageState = getImageState(topic);
 							return (
 								<TouchableOpacity
@@ -764,13 +765,14 @@ export default function TopicsScreen() {
 											source={thumbnailImageState.image}
 											style={styles.thumbnailImage}
 											contentFit="cover"
+											// Carousel/一覧の View 再利用時に、別 topic の bitmap を一瞬残さないための表示 identity。
+											// リソース共有キーとは責務が異なるので、ImageRef を共有しても削除しない。
 											recyclingKey={`topic-thumbnail:${topic.categoryId}`}
 											// #937 【仕様】親 TouchableOpacity 側で読み上げるため、画像自体は装飾扱いにする
 											alt=""
 											accessibilityElementsHidden
 											importantForAccessibility="no"
-											// #929 【修正】web は ready でも実際の読み込み成否が未検証のため、
-											// 失敗を共有 state へ反映してカード側の失敗UI/再試行に繋げる
+											// web の ready は URL 確定を表すだけなので、実際の表示失敗は共有 state へ戻す。
 											onError={() => markImageError(topic)}
 										/>
 									) : (

--- a/app-expo/features/topics/components/TopicVisualCard.tsx
+++ b/app-expo/features/topics/components/TopicVisualCard.tsx
@@ -21,8 +21,7 @@ type TopicVisualCardProps = {
 	topRightContent?: ReactNode;
 	bottomContent?: ReactNode;
 	onImageRetry?: () => void;
-	/** #929 【設計】表示側 <Image> の読み込み失敗通知。web は取得を介さず URL を直接渡すため、
-	 * ここで初めて失敗が分かる(PR #980 レビュー指摘)。呼び出し元が error 状態へ遷移させる */
+	/** web の URL 共有経路で実際の読み込み失敗を共有 state へ返すための通知。 */
 	onImageLoadError?: () => void;
 };
 
@@ -46,10 +45,14 @@ export function TopicVisualCard({
 
 	return (
 		<View style={[styles.card, { width: cardWidth, height: cardHeight }]}>
-			{/* #802 【設計】Topics ではプリロード済み ImageRef(web は直接指定の uri)を優先し、Carousel 内 Image の load 順序に依存しない。 */}
+			{/* #802/#929 【設計】Topics では共有 state の source だけを描画し、Carousel 内の
+			    onLoad/onLoadEnd 順序を ready 判定に使わない。native の source は取得済み
+			    ImageRef なので、下の cachePolicy は loadAsync の disk cache を制御しない。 */}
 			{shouldRenderImage ? (
 				<Image
 					source={resolvedImageSource}
+					// #785 【設計】同一 URL を異なる cachePolicy で読み込むと iOS の画像パイプラインが
+					// 分かれてイベントが欠落し得るため、既存の memory 契約を呼び出しごとに変えない。
 					cachePolicy="memory"
 					transition={100}
 					style={styles.cardImage}

--- a/app-expo/features/topics/hooks/useTopicImageResources.ts
+++ b/app-expo/features/topics/hooks/useTopicImageResources.ts
@@ -8,8 +8,8 @@ import { useLogger } from "@/hooks/useLogger";
 export type TopicImageResourceState =
 	| { status: "idle" }
 	| { status: "loading" }
-	// #929 【設計】image は native では Image.loadAsync 済みの ImageRef、web では直接渡す URI ソース。
-	// どちらも同一の state を cards/thumbnails 双方へ渡すことで、画面単位で1回だけ取得したリソースを共有する。
+	// #802/#929 【設計】ready は表示イベントではなく、画面で共有できる source が確定した状態。
+	// native は取得済み ImageRef、web は直接 URL を持ち、カードとサムネイルは必ず同じ値を参照する。
 	| { status: "ready"; image: ImageRef | ImageSource }
 	| { status: "error"; errorMessage?: string };
 
@@ -20,6 +20,7 @@ type UseTopicImageResourcesParams = {
 	sessionKey: string;
 };
 
+// categoryId だけでは同じ料理の画像 URL 更新を検知できないため、リソースの世代を URL まで含めて識別する。
 const getTopicImageKey = (topic: Topic) => `${topic.categoryId}::${topic.imageUrl}`;
 
 const cloneTopicImageStates = (states: TopicImageResourceStates): TopicImageResourceStates => ({ ...states });
@@ -35,11 +36,10 @@ const releaseIfImageRef = (image: ImageRef | ImageSource) => {
 };
 
 /**
- * #802 【設計】Topics 画面の画像リソース取得状態を管理する。
- * 入力: 表示中の topics と検索条件を表す sessionKey。
- * 出力: cards/thumbnails が参照する画像 state、retry/reset 用の操作。
- * 副作用: 未取得画像を Image.loadAsync で先読みし、失敗時は error state として保持する。
- * 失敗時: 古い session の非同期結果は破棄し、現在 session の state のみ更新する。
+ * #802/#929 【設計】Topics 画面を画像リソースの所有境界とし、カードとサムネイルへ同じ source を配る。
+ * native は Image.loadAsync の完了を ready の根拠にして同じ ImageRef を共有し、表示側の onLoad 系イベントには依存しない。
+ * web は Blob の生成と重複取得を避けるため URL を共有し、実際の表示失敗だけを onError から error へ反映する。
+ * sessionKey が変わった後の非同期結果は現セッションへ混ぜず、所有権を失った ImageRef は必ず解放する。
  */
 export const useTopicImageResources = ({ topics, sessionKey }: UseTopicImageResourcesParams) => {
 	const { logFrontendEvent } = useLogger();
@@ -60,6 +60,7 @@ export const useTopicImageResources = ({ topics, sessionKey }: UseTopicImageReso
 	}, []);
 
 	const resetImageStates = useCallback(() => {
+		// generation を先に進めることで、キャンセル不能な旧 loadAsync の完了を新セッションへ混入させない。
 		imageLoadGenerationRef.current += 1;
 		const previousStates = topicImageStatesRef.current;
 		topicImageStatesRef.current = {};
@@ -85,13 +86,9 @@ export const useTopicImageResources = ({ topics, sessionKey }: UseTopicImageReso
 			};
 			setTopicImageStates(cloneTopicImageStates(topicImageStatesRef.current));
 
-			// #929 【設計】web の Image.loadAsync は fetch→blob→createObjectURL を internally 行い、
-			// release() が実質no-opでBlob URLを解放できない(expo-image 2.4.1)。検索を繰り返す本画面では
-			// Blob が蓄積し続けるため、web は取得を介さずURLをそのまま cards/thumbnails 双方へ渡す。
-			// #929 【バグ】source に headers を渡すと(値が空オブジェクトでも)、expo-image web の
-			// useHeaders が同じ fetch→blob 変換を <Image> インスタンスごとに個別実行してしまい、
-			// ブラウザキャッシュ共有もdedupeも効かなくなる。web は #719 により実際のヘッダーを
-			// 送れないため、headers キー自体を省略して plain <img src> 経路のみを使う。
+			// #719/#929 【設計】expo-image 2.4.1 の web は loadAsync や空の headers でも
+			// fetch→Blob URL を生成し、表示ごとの重複取得と解放不能な Blob を生む。
+			// headers キーも含めず同じ URL を配り、ブラウザの通常キャッシュとリクエスト共有に委ねる。
 			if (Platform.OS === "web") {
 				topicImageStatesRef.current = {
 					...topicImageStatesRef.current,
@@ -103,9 +100,12 @@ export const useTopicImageResources = ({ topics, sessionKey }: UseTopicImageReso
 
 			const loadStartedAt = Date.now();
 			try {
+				// #802/#929 【設計】native の URL 取得とキャッシュキー決定はこの一箇所に集約する。
+				// loadAsync は native の disk cache を利用し、返した ImageRef を表示側が再利用するため、
+				// 表示側 <Image> の cachePolicy を変えてもこの取得経路の disk cache 設定にはならない。
 				const image = await Image.loadAsync({ uri: topic.imageUrl, headers: WIKIMEDIA_HEADERS, cacheKey: key });
 				if (imageLoadGenerationRef.current !== imageLoadGeneration) {
-					// #929 【設計】古い検索セッションの結果はUIへ渡らないため、保持し続けずその場で解放する。
+					// 旧セッションの ImageRef はどの表示にも所有権を渡さないため、完了した時点で解放する。
 					image.release();
 					return;
 				}
@@ -114,6 +114,7 @@ export const useTopicImageResources = ({ topics, sessionKey }: UseTopicImageReso
 					[key]: { status: "ready", image },
 				};
 				setTopicImageStates(cloneTopicImageStates(topicImageStatesRef.current));
+				// 表示イベントではなく共有リソースの準備時間を測り、onLoad 欠落が計測値や状態を左右しないようにする。
 				logFrontendEvent({
 					event_name: "topic_image_resource_ready",
 					error_level: "log",
@@ -161,19 +162,14 @@ export const useTopicImageResources = ({ topics, sessionKey }: UseTopicImageReso
 	);
 
 	/**
-	 * #929 【修正】表示側 <Image> の onError から呼び、該当 topic を error 状態へ遷移させる。
-	 * web の ready state は URL を渡すだけで実際の読み込み成否を検証していないため
-	 * (PR #980 レビュー指摘)、期限切れ・無効・一時的に取得不能な画像が「ready のまま
-	 * 白いカード」になっていた。error へ遷移させることで native と同じ失敗オーバーレイと
-	 * 再試行導線(retryImage)が表示される。retryImage は error state からの再取得を行うため、
-	 * 一時的な失敗ならリトライで復帰できる。
+	 * web の ready は「共有する URL が確定済み」を表し、ネットワーク成功までは保証しない。
+	 * 表示側の失敗だけをここで共有 error に変換し、カードとサムネイルに同じ再試行導線を出す。
 	 */
 	const markImageError = useCallback(
 		(topic: Topic, errorMessage?: string) => {
 			const key = getTopicImageKey(topic);
 			const current = topicImageStatesRef.current[key];
-			// すでに error / 再取得中(loading)の場合は上書きしない(遅延到着した onError で
-			// リトライ中の状態を巻き戻さないため)
+			// 古い描画の onError で、すでに開始した再試行を error へ巻き戻さない。
 			if (current?.status === "error" || current?.status === "loading") return;
 
 			topicImageStatesRef.current = {


### PR DESCRIPTION
## 変更内容

- Topics 画像リソースの native / web 別の責務をコメントに明記
- `Image.loadAsync`、`ImageRef` 共有、generation guard、release のライフサイクル契約をコメントに明記
- `cachePolicy="memory"` を維持する理由と、表示側の `cachePolicy` が native の `Image.loadAsync` の disk cache を制御しない点をコメントに明記
- サムネイルがメインカードと source を共有する理由、および `recyclingKey` の独立した責務をコメントに明記

## 理由

Issue #1009 と PR #980 のコメントに残っていた Topics 画像管理の設計前提がコード上で十分に説明されておらず、`cachePolicy` の変更や画像取得経路の再分離によって過去の不具合を再発させる可能性がありました。`.codex/commentary-policy.md` に従い、処理の説明ではなく、変更時に維持すべき契約と判断理由を該当コードの直前へ残しています。

コードの動作変更はありません。

## 検証

- `pnpm --dir app-expo typecheck`
- 対象 3 ファイルの Prettier check
- `git diff --check`