### PR TITLE
claude-worker.yml: 初回実行の不具合修正とSKILL.mdへの教訓反映

### DIFF
--- a/.claude/skills/parallel-development/SKILL.md
+++ b/.claude/skills/parallel-development/SKILL.md
@@ -176,6 +176,8 @@ Workerへ渡すpromptには、必要な項目だけを具体的に含める。
 
 `mcp__github__*` や無制限の `Bash` は、対象を限定できない例外時だけ使う。通常は実ツール名とコマンドパターンを列挙する。Claude Code Actionまたは内蔵GitHub MCP serverのpinを更新するときは、ツール名と権限境界を公式ソースで再確認する。
 
+**`Bash(pnpm *)` 等のprefixパターンは実装runで機能しないことがある**: 許可パターンは実行コマンド文字列の先頭一致のため、`cd api && pnpm dev` や `mkdir -p tmp && cp ...` のような複合コマンドは対象コマンドで始まっていても丸ごと拒否される。実装run(`access=write`)でこれが起きると、権限拒否のたびにturnを浪費し、`error_max_turns` で失敗しつつ何もcommit・pushされない(branchもPRも作られない)まま課金だけが発生する。実装runで許可パターンを絞る場合は、対象プロジェクトのpackage managerが要求する複合コマンド(`cd`後の実行、`&&`連結、環境変数のinlineセットなど)を実際に洗い出してから列挙する。洗い出しが難しい、または初回runなら、`Bash`(無制限)を使い、対象branch・禁止事項をpromptの文面側で縛る方が安全で安価になりやすい。
+
 ## 設計レビューを回す
 
 1. 設計者の結果がSub-issueへ記録されていることを確認する。
@@ -237,6 +239,12 @@ Workerへ渡すpromptには、必要な項目だけを具体的に含める。
 - デフォルトブランチへマージしないこと
 
 WorkerがbranchをpushしたがPRを作らなかった場合は、リーダーが `gh pr create --draft` で作る。PR本文はテンプレートへ依存せず、対象Issue、設計、変更、検証、Artifact、依存PR、残課題をその都度まとめる。
+
+**`mcp__github__create_pull_request` を実装runのallowedToolsへ入れない**: このMCPツールはGitHub API経由でファイルをcommitし、現在checkoutしているlocal branchとは無関係な新規branch(英語スラグの自動生成名になることがある)を作ることがある。結果として、`branch_name` で指定したbranchとは別のbranchにPRが作られ、かつlocalで実行したはずのtypecheck/build/testがそのAPI commitには反映されていない(pnpm等のBashツールでの検証と、実際にpushされる変更が乖離する)、という事故が起きた。実装runでは `gh pr create` (Bash経由、現在のlocal branchを対象にする)だけを許可し、`mcp__github__create_pull_request` は外す。
+
+**max_turnsは実測に基づいて決める**: `pnpm install`(初回1分前後)+ モノレポ全体の `pnpm run typecheck`/`pnpm build`(数分)+ 実装 + 検証 + `gh pr create` までを1 write runでやり切るには、単純な1ファイル変更でも40〜50では不足しがちで、80〜100が必要だった。低いmax_turnsで打ち切られると `error_max_turns` で失敗し、branchもPRも一切残らないまま課金だけが発生する。
+
+**runの`conclusion: success`は「成果物ができた」ことを保証しない**: Claude Codeが権限拒否やエラーで行き詰まり、何も達成せずに応答を終えても、SDK的には `is_error: false` で「成功」と報告されることがある。runが成功扱いでも、必ず `git ls-remote --heads origin <branch_name>` とPR一覧で実際にbranch・PRが存在するかを確認すること。存在しなければ、権限・max_turns・promptを見直して再実行する。
 
 ## PRレビューを回す
 

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -45,9 +45,9 @@ on:
         default: ""
         type: string
       max_turns:
-        description: "Claude Codeの最大ターン数"
+        description: "Claude Codeの最大ターン数（pnpm installやモノレポ全体のtypecheck/buildを伴う実装runは80〜150程度が目安）"
         required: true
-        default: 20
+        default: 40
         type: number
       extra_claude_args:
         description: "allowedToolsやeffort等、モデル・最大ターン数以外のClaude Code CLI引数"
@@ -89,8 +89,8 @@ jobs:
             exit 1
           fi
 
-          if (( MAX_TURNS < 1 || MAX_TURNS > 100 )); then
-            echo "::error::max_turns は1〜100で指定してください。"
+          if (( MAX_TURNS < 1 || MAX_TURNS > 300 )); then
+            echo "::error::max_turns は1〜300で指定してください。"
             exit 1
           fi
 
@@ -176,6 +176,35 @@ jobs:
           show_full_output: false
           display_report: false
 
+      - name: 実行結果を要約
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT=/home/runner/work/_temp/claude-execution-output.json
+          if [[ ! -f "$OUT" ]]; then
+            echo "::warning::実行結果ログ($OUT)が見つかりません。"
+            exit 0
+          fi
+          # ファイルはJSONL（改行区切りJSON）。-s で1つの配列にslurpしてから
+          # type=result の最後の要素（実行全体のサマリ）を取り出す。
+          SUBTYPE=$(jq -rs '[.[] | select(.type=="result")] | last | .subtype // "unknown"' "$OUT" 2>/dev/null || echo unknown)
+          IS_ERROR=$(jq -rs '[.[] | select(.type=="result")] | last | .is_error // false' "$OUT" 2>/dev/null || echo unknown)
+          NUM_TURNS=$(jq -rs '[.[] | select(.type=="result")] | last | .num_turns // "?"' "$OUT" 2>/dev/null || echo "?")
+          COST=$(jq -rs '[.[] | select(.type=="result")] | last | .total_cost_usd // "?"' "$OUT" 2>/dev/null || echo "?")
+          DENIALS=$(jq -rs '[.[] | select(.type=="result")] | last | .permission_denials_count // 0' "$OUT" 2>/dev/null || echo 0)
+          {
+            echo "### Claude Code 実行結果"
+            echo "- subtype: \`$SUBTYPE\` / is_error: \`$IS_ERROR\`"
+            echo "- turns: $NUM_TURNS / cost: \$$COST / permission denials: $DENIALS"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$DENIALS" != "0" && "$DENIALS" != "null" ]]; then
+            echo "::warning::permission_denials_count=$DENIALS。allowedToolsのBashパターンが実際のコマンドと一致していない可能性があります（複合コマンドはprefixパターンに丸ごと弾かれます）。"
+          fi
+          if [[ "$SUBTYPE" == "error_max_turns" ]]; then
+            echo "::warning::max_turns($NUM_TURNS)に到達して打ち切られました。タスクを分割するか max_turns を増やして再実行してください。"
+          fi
+
       - name: テストエビデンスを保存
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -229,6 +258,11 @@ jobs:
             git switch --create "$BRANCH_NAME"
           fi
 
+      - name: 実行前のHEADを記録
+        id: pre_claude
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Artifact格納先を準備
         shell: bash
         # 実装ファイルとテストエビデンスを分離し、誤commitを防ぐ。
@@ -257,6 +291,64 @@ jobs:
             actions: read
           show_full_output: false
           display_report: false
+
+      - name: 実行結果を要約
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT=/home/runner/work/_temp/claude-execution-output.json
+          if [[ ! -f "$OUT" ]]; then
+            echo "::warning::実行結果ログ($OUT)が見つかりません。"
+            exit 0
+          fi
+          SUBTYPE=$(jq -rs '[.[] | select(.type=="result")] | last | .subtype // "unknown"' "$OUT" 2>/dev/null || echo unknown)
+          IS_ERROR=$(jq -rs '[.[] | select(.type=="result")] | last | .is_error // false' "$OUT" 2>/dev/null || echo unknown)
+          NUM_TURNS=$(jq -rs '[.[] | select(.type=="result")] | last | .num_turns // "?"' "$OUT" 2>/dev/null || echo "?")
+          COST=$(jq -rs '[.[] | select(.type=="result")] | last | .total_cost_usd // "?"' "$OUT" 2>/dev/null || echo "?")
+          DENIALS=$(jq -rs '[.[] | select(.type=="result")] | last | .permission_denials_count // 0' "$OUT" 2>/dev/null || echo 0)
+          {
+            echo "### Claude Code 実行結果"
+            echo "- subtype: \`$SUBTYPE\` / is_error: \`$IS_ERROR\`"
+            echo "- turns: $NUM_TURNS / cost: \$$COST / permission denials: $DENIALS"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$DENIALS" != "0" && "$DENIALS" != "null" ]]; then
+            echo "::warning::permission_denials_count=$DENIALS。allowedToolsのBashパターンが実際のコマンドと一致していない可能性があります（複合コマンドはprefixパターンに丸ごと弾かれます）。"
+          fi
+          if [[ "$SUBTYPE" == "error_max_turns" ]]; then
+            echo "::warning::max_turns($NUM_TURNS)に到達して打ち切られました。タスクを分割するか max_turns を増やして再実行してください。"
+          fi
+
+      - name: commit・pushされたことを検証
+        # このstepは常に実行し、Claude Codeが権限拒否やturn切れで行き詰まり
+        # 何もcommit・pushしないまま終了した場合でもjobを明示的に失敗させる。
+        # (SDKの実行自体は is_error:false で「成功」報告されることがあるため、
+        # workflow runのconclusionだけでは成果物の有無を判断できない)
+        if: always()
+        shell: bash
+        env:
+          BRANCH_NAME: ${{ inputs.branch_name }}
+          PRE_SHA: ${{ steps.pre_claude.outputs.sha }}
+        run: |
+          set -euo pipefail
+          POST_SHA=$(git rev-parse HEAD)
+          if [[ "$PRE_SHA" == "$POST_SHA" ]]; then
+            echo "::error::作業ブランチ '$BRANCH_NAME' に新しいcommitがありません（実行前後でHEADが変化していません）。Claude Codeが権限不足・turn切れ・その他の理由で変更を確定できなかった可能性があります。"
+            exit 1
+          fi
+          echo "✓ HEADが変化: $PRE_SHA -> $POST_SHA"
+
+          git fetch origin "refs/heads/$BRANCH_NAME" 2>/dev/null || true
+          REMOTE_SHA=$(git rev-parse "origin/$BRANCH_NAME" 2>/dev/null || echo "")
+          if [[ -z "$REMOTE_SHA" ]]; then
+            echo "::error::作業ブランチ '$BRANCH_NAME' がoriginへpushされていません。commitはローカルに存在しますが共有されていません。"
+            exit 1
+          fi
+          if [[ "$REMOTE_SHA" != "$POST_SHA" ]]; then
+            echo "::warning::originの '$BRANCH_NAME' ($REMOTE_SHA) が最新のローカルcommit ($POST_SHA) と一致しません。最後の変更がpushされていない可能性があります。"
+          else
+            echo "✓ originへpush済み: $REMOTE_SHA"
+          fi
 
       - name: テストエビデンスを保存
         if: always()


### PR DESCRIPTION
## 背景
#1003 の並列実装(parallel-development skill)で `claude-worker.yml` を初めて実運用したところ、複数の不具合・落とし穴が判明した。

## 判明した問題と対応
1. **`mcp__github__create_pull_request` が意図しないbranchへcommitする**: GitHub API経由でcommitするため、checkout済みのlocal branchとは別の(英語スラグ自動生成の)branchが作られ、しかもBashでの検証結果がそのcommitに反映されない事故が発生(#1014の初回実装で発生)。→ SKILL.mdで実装runへの使用を明確に禁止し、`gh pr create`(local branch対象)のみを使うよう明記。
2. **`Bash(pnpm *)` 等のprefixパターンが複合コマンドを弾く**: `cd api && pnpm dev` のようなコマンドは対象コマンドで始まっていても丸ごと拒否され、拒否のたびにturnを浪費する(最大29回の拒否を観測)。→ SKILL.mdに注記を追加。
3. **max_turnsの実測値が想定より大きい**: pnpm install + モノレポ全体のtypecheck/build + 実装 + 検証 + PR作成を1 runでやり切るには80〜150程度必要だったが、旧上限は100で頭打ちになっていた。→ 検証上限を300へ拡大、SKILL.mdの目安値を更新。
4. **`is_error:false`(成功)でもcommit・pushが皆無のまま終了することがある**: turn切れ寸前で諦めて終了すると、workflow run自体は成功扱いになるが実際は何も残らない。→ `write` jobにexecution前後のHEAD比較でcommit・push有無を検証するstepを追加し、何も変更が無ければ明示的にjob failさせるようにした。

## 変更内容
- `.github/workflows/claude-worker.yml`: max_turns検証上限拡大(100→300)、write jobへcommit/push検証step追加、observe/write両方へ実行結果サマリstep追加(GITHUB_STEP_SUMMARYへturns/cost/permission_denials/subtypeを出力)。
- `.claude/skills/parallel-development/SKILL.md`: 上記1〜4の教訓を「ツールを動的に絞る」「実装ワーカーを並列起動する」節へ追記。

## 検証
- YAML構文チェック(`python3 -c "import yaml; yaml.safe_load(...)"`)は通過。
- 実際の `workflow_dispatch` 動作確認は、このbranchを `--ref` に指定して #1003 の残タスク(#1007クラスタ、#1011/#1012)の再実行時に行う予定。