### PR TITLE
claude-worker.yml: 環境構築の事前実行とPRのbase明示漏れ対策

### DIFF
--- a/.claude/skills/parallel-development/SKILL.md
+++ b/.claude/skills/parallel-development/SKILL.md
@@ -36,8 +36,11 @@ description: CSVまたはGitHubの親Issueから複数課題を読み取り、�
 | `max_turns`         | 作業の大きさに合わせ、必要以上に増やさない           |
 | `extra_claude_args` | `allowedTools`、effort、出力形式を動的に指定する     |
 | `retention_days`    | エビデンスを人間が確認できる期間を確保する           |
+| `setup_playwright`  | UI変更を検証するrunでは`true`にする（下記参照）      |
 
 `task_key` は `[a-z0-9._-]` のみを使い、Issue、PR、役割を判別できるようにする。例: `issue-123-design-security`。
+
+**Workflowが実行前に済ませておくこと**: `write`/`observe` 両jobとも、Claude Code実行前に `pnpm install --frozen-lockfile` と `pnpm --filter shared build` を済ませている。promptで「依存関係は既にinstall済み、sharedもbuild済みなので再実行不要」と明記し、turnを節約すること。`setup_playwright: true` を指定すると、さらに EAS CLI で development環境変数を `app-expo/.env` へ取得し、Playwright(chromium)ブラウザをインストールし、`TEST_USER_EMAIL`/`TEST_USER_PASSWORD` をClaude Code実行時のenvへ渡す（`.github/workflows/e2e-web-test.yml` と同じ手順）。UI変更を伴う実装run・レビューrunでは基本的に `true` にし、promptで「`pnpm --filter app-expo build:web` → dist配信 → `pnpm --filter e2e-web test` (または個別spec) でスクリーンショットを撮ること」まで具体的に指示する。単純な依存バージョン更新やバックエンドのみの変更では `false`(既定)のままでよい。
 
 ## 認証と利用枠
 
@@ -235,14 +238,16 @@ Workerへ渡すpromptには、必要な項目だけを具体的に含める。
 - 必須テストと期待結果
 - `/tmp/claude-artifacts/` へ保存するエビデンス
 - commitとpushを行うこと
-- PRを作る場合はDraftにすること
+- PRを作る場合はDraftにすること、かつ **`gh pr create --draft --base "<base_branchの値>"` のように `--base` を必ず明示すること**（省略するとリポジトリの既定ブランチ宛のPRが作られてしまう。統合ブランチ運用では毎回事故る）
 - デフォルトブランチへマージしないこと
 
-WorkerがbranchをpushしたがPRを作らなかった場合は、リーダーが `gh pr create --draft` で作る。PR本文はテンプレートへ依存せず、対象Issue、設計、変更、検証、Artifact、依存PR、残課題をその都度まとめる。
+WorkerがbranchをpushしたがPRを作らなかった場合、または誤ったbaseでPRを作ってしまった場合は、リーダーが `gh pr create --draft --base <base>` で作る／`gh pr edit <number> --base <base>` で修正する。PR本文はテンプレートへ依存せず、対象Issue、設計、変更、検証、Artifact、依存PR、残課題をその都度まとめる。
 
 **`mcp__github__create_pull_request` を実装runのallowedToolsへ入れない**: このMCPツールはGitHub API経由でファイルをcommitし、現在checkoutしているlocal branchとは無関係な新規branch(英語スラグの自動生成名になることがある)を作ることがある。結果として、`branch_name` で指定したbranchとは別のbranchにPRが作られ、かつlocalで実行したはずのtypecheck/build/testがそのAPI commitには反映されていない(pnpm等のBashツールでの検証と、実際にpushされる変更が乖離する)、という事故が起きた。実装runでは `gh pr create` (Bash経由、現在のlocal branchを対象にする)だけを許可し、`mcp__github__create_pull_request` は外す。
 
-**max_turnsは実測に基づいて決める**: `pnpm install`(初回1分前後)+ モノレポ全体の `pnpm run typecheck`/`pnpm build`(数分)+ 実装 + 検証 + `gh pr create` までを1 write runでやり切るには、単純な1ファイル変更でも40〜50では不足しがちで、80〜100が必要だった。低いmax_turnsで打ち切られると `error_max_turns` で失敗し、branchもPRも一切残らないまま課金だけが発生する。
+**max_turnsは実測に基づいて決める**: install/shared buildをWorkflow側で先に済ませるようになった（上記参照）後でも、単一Issueの実装 + typecheck + 検証 + `gh pr create` で40〜50、複数Issueを1PRへ束ねる場合や機能追加＋functional test追加を伴う場合は150〜200を見ておく。低いmax_turnsで打ち切られると `error_max_turns` で失敗し、branchもPRも一切残らないまま課金だけが発生する。
+
+**`--ref` にはデフォルトブランチだけを指定できる（例外なし）**: `workflow_dispatch` はGitHubの仕様上、`--ref` で指定したブランチ上のWorkflowファイルが**既定ブランチ上のバージョンと1バイトでも違う**場合、`Claude Codeを実行` ステップ自体を無言でスキップする(`Skipping action due to workflow validation`という警告のみ)。これは `claude-worker.yml` 自体を修正した直後に踏みやすい罠で、修正branchを`--ref`に指定して試し撃ちしても何も起きず、後段のcommit検証stepが「変更なし」でjob failするだけになる。Workflow自体の変更を試すときは、**まずmainへマージしてから**改めてdispatchすること。
 
 **runの`conclusion: success`は「成果物ができた」ことを保証しない**: Claude Codeが権限拒否やエラーで行き詰まり、何も達成せずに応答を終えても、SDK的には `is_error: false` で「成功」と報告されることがある。runが成功扱いでも、必ず `git ls-remote --heads origin <branch_name>` とPR一覧で実際にbranch・PRが存在するかを確認すること。存在しなければ、権限・max_turns・promptを見直して再実行する。
 

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -59,6 +59,11 @@ on:
         required: true
         default: 14
         type: number
+      setup_playwright:
+        description: "true にすると、Claude Code実行前に依存install・shared build・EAS development環境変数のapp-expo/.envへの取得・Playwright(chromium)ブラウザのインストールを済ませる。UI変更を伴うrunでturnを節約するために使う。"
+        required: false
+        default: false
+        type: boolean
 
 # 権限は各Jobで明示し、Workflow全体には暗黙の書込権限を与えない。
 permissions: {}
@@ -145,6 +150,47 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: PNPMをセットアップ
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.8.0
+
+      - name: Node.jsをセットアップ
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: 依存関係をインストール
+        shell: bash
+        # Claude Code自身がturnを使ってinstallする手間を省く。実装runでは特に効果が大きい。
+        run: pnpm install --frozen-lockfile
+
+      - name: sharedパッケージをビルド
+        shell: bash
+        # app-expo/api の typecheck・build は shared/dist を前提にしている。
+        run: pnpm --filter shared build
+
+      - name: Expo & EAS CLIをセットアップ
+        if: inputs.setup_playwright
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: development環境変数をapp-expo/.envへ取得
+        if: inputs.setup_playwright
+        working-directory: app-expo
+        shell: bash
+        # e2e-web-test.yml と同じ取得方法。EXPO_PUBLIC_BACKEND_BASE_URL 等が
+        # dev環境向けの値で焼き込まれる。
+        run: pnpx eas-cli env:pull development --non-interactive --path .env
+
+      - name: Playwrightブラウザをインストール
+        if: inputs.setup_playwright
+        shell: bash
+        run: pnpm --filter e2e-web exec playwright install --with-deps chromium
+
       - name: Artifact格納先を準備
         shell: bash
         # Git管理下へエビデンスを置くと、実装commitへの混入につながるため/tmpへ分離する。
@@ -156,6 +202,10 @@ jobs:
         env:
           # workflow_dispatchのrefではなく、実際に調査するrefをGitHub MCPへ渡す。
           CLAUDE_BRANCH: ${{ inputs.base_ref || inputs.base_branch || github.event.repository.default_branch }}
+          # setup_playwright時、e2e-webのテストがログイン系specを自動実行できるようにする
+          # (TEST_USER_*未設定時はテスト側のskip条件で自動的にスキップされる)。
+          TEST_USER_EMAIL: ${{ inputs.setup_playwright && secrets.TEST_USER_EMAIL || '' }}
+          TEST_USER_PASSWORD: ${{ inputs.setup_playwright && secrets.TEST_USER_PASSWORD || '' }}
         with:
           # Maxプランで生成した長期OAuthトークンを使用し、APIキー課金を発生させない。
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -263,6 +313,45 @@ jobs:
         shell: bash
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: PNPMをセットアップ
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.8.0
+
+      - name: Node.jsをセットアップ
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: 依存関係をインストール
+        shell: bash
+        # Claude Code自身がturnを使ってinstallする手間を省く。実装runでは特に効果が大きい。
+        run: pnpm install --frozen-lockfile
+
+      - name: sharedパッケージをビルド
+        shell: bash
+        # app-expo/api の typecheck・build は shared/dist を前提にしている。
+        run: pnpm --filter shared build
+
+      - name: Expo & EAS CLIをセットアップ
+        if: inputs.setup_playwright
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: development環境変数をapp-expo/.envへ取得
+        if: inputs.setup_playwright
+        working-directory: app-expo
+        shell: bash
+        run: pnpx eas-cli env:pull development --non-interactive --path .env
+
+      - name: Playwrightブラウザをインストール
+        if: inputs.setup_playwright
+        shell: bash
+        run: pnpm --filter e2e-web exec playwright install --with-deps chromium
+
       - name: Artifact格納先を準備
         shell: bash
         # 実装ファイルとテストエビデンスを分離し、誤commitを防ぐ。
@@ -274,6 +363,8 @@ jobs:
         env:
           # Action内部のGitHub MCPも、事前に切り替えた同じ作業ブランチだけを更新させる。
           CLAUDE_BRANCH: ${{ inputs.branch_name }}
+          TEST_USER_EMAIL: ${{ inputs.setup_playwright && secrets.TEST_USER_EMAIL || '' }}
+          TEST_USER_PASSWORD: ${{ inputs.setup_playwright && secrets.TEST_USER_PASSWORD || '' }}
         with:
           # Maxプランで生成した長期OAuthトークンを使用し、APIキー課金を発生させない。
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## 背景
#1003 の並列実装を継続する中で、#1022 で直した問題とは別に2件の改善点が見つかった。

## 変更内容
1. **環境構築の前倒し**: `pnpm install` / `pnpm --filter shared build` をClaude Code実行前のWorkflow stepへ移動。これまでClaude Code自身がturnを使ってこれらを実行しており、単純なタスクでも数turn〜十数turnが消費されていた。
2. **Playwright検証を使えるようにする**: 新規input `setup_playwright`(既定false)を追加。`true`にすると、`.github/workflows/e2e-web-test.yml` と同じ手順(EAS CLIで`app-expo/.env`にdevelopment環境変数を取得、Playwright chromiumをインストール、`TEST_USER_EMAIL`/`TEST_USER_PASSWORD`をClaude Code実行時のenvへ渡す)を事前に済ませる。これまでワーカーはこの環境構築ができず、UI変更のPRでも「Playwrightが使えないため省略」という報告が続いていた。
3. **PRのbase明示漏れの防止**: `gh pr create` に `--base` を付け忘れ、統合ブランチ運用のつもりが既定ブランチ(main)宛のPRが作られる事故が実際に2件発生(#1014, #1023の初回)。SKILL.mdで `--base` の明示を必須事項として追記。

SKILL.md側にも、実測に基づいたmax_turnsの目安(単一Issue40〜50、複数Issue束ね150〜200)と、`--ref`にデフォルトブランチ以外を指定するとWorkflowの変更が(エラーにならず黙って)無視されるというGitHub側の制約を追記した。

## 検証
- YAML構文チェック通過(`python3 -c "import yaml; yaml.safe_load(...)"`)
- 実際の動作確認は、mainへマージ後に #1003 の残タスクまたは次回のworkflow_dispatchで行う。