### PR TITLE
app-expo: e2e-mobile 向け testID / 状態別 accessibilityLabel を追加 #1031

### DIFF
--- a/app-expo/app/[locale]/(tabs)/review/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/review/index.tsx
@@ -97,8 +97,13 @@ export default function ReviewScreen() {
 					{user?.is_anonymous !== false ? (
 						// #644 【設計】ゲスト状態：ログイン導線を表示
 						<>
-							<Text style={styles.guestDescription}>{i18n.t("Review.guest.description")}</Text>
+							{/* #1031 【設計】Detox から表示確認できるよう testID を追加 */}
+							<Text testID="review-guest-description" style={styles.guestDescription}>
+								{i18n.t("Review.guest.description")}
+							</Text>
+							{/* #1031 【設計】ログイン導線タップを Detox から検証できるよう testID を追加 */}
 							<PrimaryButton
+								testID="review-guest-login-button"
 								onPress={handleLoginPress}
 								label={i18n.t("Review.guest.loginButton")}
 								style={styles.ctaButton}
@@ -106,7 +111,9 @@ export default function ReviewScreen() {
 						</>
 					) : (
 						// #644 【設計】ログイン済み状態：レビュー投稿導線を表示
+						// #1031 【設計】投稿導線タップを Detox から検証できるよう testID を追加
 						<PrimaryButton
+							testID="review-post-button"
 							onPress={handlePostReviewPress}
 							label={i18n.t("Review.authenticated.postButton")}
 							style={styles.ctaButton}

--- a/app-expo/app/[locale]/(tabs)/search/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/index.tsx
@@ -440,7 +440,10 @@ export default function SearchScreen() {
 		<SafeAreaView style={styles.container} edges={["top"]}>
 			{/* Header */}
 			<View style={styles.header}>
-				<Text style={styles.headerTitle}>{i18n.t("Search.headerTitle")}</Text>
+				{/* #1031 【設計】Detox から表示確認できるよう testID を追加 */}
+				<Text testID="search-header-title" style={styles.headerTitle}>
+					{i18n.t("Search.headerTitle")}
+				</Text>
 				{/* #642 【設計】ヘルプアイコンからチュートリアルを再表示 */}
 				{isJapanese && (
 					<TouchableOpacity

--- a/app-expo/app/[locale]/(tabs)/search/topics.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/topics.tsx
@@ -581,7 +581,9 @@ export default function TopicsScreen() {
 	return (
 		<View style={styles.container}>
 			{/* #674 【仕様】ヘッダー（戻るボタン + タイトル） */}
+			{/* #1031 【設計】Detox からタイトル表示を検証できるよう testID を追加 */}
 			<ScreenHeader
+				testID="topics-header"
 				title={i18n.t("Topics.headerTitle")}
 				onPressBack={handleBack}
 				rightContent={

--- a/app-expo/components/ScreenHeader.tsx
+++ b/app-expo/components/ScreenHeader.tsx
@@ -18,9 +18,18 @@ export type ScreenHeaderProps = {
 	containerStyle?: StyleProp<ViewStyle>;
 	/** タイトルの追加スタイル（必要であれば） */
 	titleStyle?: StyleProp<TextStyle>;
+	// #1031 【設計】画面ごとにタイトル表示を検証できるよう testID を付与できるようにする（`${testID}-title` をタイトル Text に付与）
+	testID?: string;
 };
 
-export function ScreenHeader({ title, onPressBack, rightContent, containerStyle, titleStyle }: ScreenHeaderProps) {
+export function ScreenHeader({
+	title,
+	onPressBack,
+	rightContent,
+	containerStyle,
+	titleStyle,
+	testID,
+}: ScreenHeaderProps) {
 	const insets = useSafeAreaInsets();
 	return (
 		<View style={[{ paddingTop: insets.top + 8 }, styles.container, containerStyle]}>
@@ -34,7 +43,11 @@ export function ScreenHeader({ title, onPressBack, rightContent, containerStyle,
 				<ChevronLeft size={24} color="#1A1A1A" />
 			</TouchableOpacity>
 
-			<Text style={[styles.title, titleStyle]} numberOfLines={1} ellipsizeMode="tail">
+			<Text
+				testID={testID ? `${testID}-title` : undefined}
+				style={[styles.title, titleStyle]}
+				numberOfLines={1}
+				ellipsizeMode="tail">
 				{title}
 			</Text>
 

--- a/app-expo/features/dishMedia/components/ActionButtons.tsx
+++ b/app-expo/features/dishMedia/components/ActionButtons.tsx
@@ -320,26 +320,34 @@ export function ActionButtons({ id, idType, onLayout, buttonsGesture }: ActionBu
 				</TouchableOpacity>
 
 				<View style={styles.actionContainer}>
+					{/* #1031 【設計】Detox から状態(いいね済みか)を検証できるよう、状態別の accessibilityLabel を付与 */}
 					<TouchableOpacity
 						testID="dish-action-like"
 						style={styles.actionButton}
 						onPress={handleLike}
 						hitSlop={buttonHitSlop}
 						accessibilityRole="button"
-						accessibilityLabel={i18n.t("DishMediaContent.accessibility.like", { name: restaurant.name })}
+						accessibilityLabel={i18n.t(
+							isLiked ? "DishMediaContent.accessibility.likeActive" : "DishMediaContent.accessibility.likeInactive",
+							{ name: restaurant.name },
+						)}
 						aria-selected={isLiked}>
 						<Heart size={28} color={isLiked ? "#FF3040" : "#FFFFFF"} fill={isLiked ? "#FF3040" : "white"} />
 					</TouchableOpacity>
 					<Text style={styles.actionText}>{formatLikeCount(likeCount)}</Text>
 				</View>
 
+				{/* #1031 【設計】Detox から状態(保存済みか)を検証できるよう、状態別の accessibilityLabel を付与 */}
 				<TouchableOpacity
 					testID="dish-action-save"
 					style={styles.actionButton}
 					onPress={handleSave}
 					hitSlop={buttonHitSlop}
 					accessibilityRole="button"
-					accessibilityLabel={i18n.t("DishMediaContent.accessibility.save", { name: restaurant.name })}
+					accessibilityLabel={i18n.t(
+						isSaved ? "DishMediaContent.accessibility.saveActive" : "DishMediaContent.accessibility.saveInactive",
+						{ name: restaurant.name },
+					)}
 					aria-selected={isSaved}>
 					<Bookmark size={30} color={"transparent"} fill={isSaved ? "orange" : "white"} />
 				</TouchableOpacity>

--- a/app-expo/features/profile/components/LoginbackModal.tsx
+++ b/app-expo/features/profile/components/LoginbackModal.tsx
@@ -265,7 +265,11 @@ export function LoginbackModal({ onClose }: LoginbackModalProps) {
 						{i18n.t("auth.consent_login_terms")}
 					</Text>
 					{i18n.t("auth.consent_login_and")}
-					<Text style={styles.consentLink} onPress={() => handleOpenLegalDocument("privacy")}>
+					{/* #1031 【設計】Detox からリーガルモーダルへの導線をタップできるよう testID を追加 */}
+					<Text
+						testID="login-privacy-link"
+						style={styles.consentLink}
+						onPress={() => handleOpenLegalDocument("privacy")}>
 						{i18n.t("auth.consent_login_privacy")}
 					</Text>
 					{i18n.t("auth.consent_login_suffix")}
@@ -285,8 +289,13 @@ export function LoginbackModal({ onClose }: LoginbackModalProps) {
 			</OtpModalComponent>
 
 			{/* Legal ドキュメントモーダル */}
+			{/* #1031 【設計】Detox からモーダル表示を検証できるよう testID を追加 */}
 			<LegalDocumentModal>
-				{selectedLegalDocument && <LegalDocument documentType={selectedLegalDocument} />}
+				{selectedLegalDocument && (
+					<View testID="legal-document-modal">
+						<LegalDocument documentType={selectedLegalDocument} />
+					</View>
+				)}
 			</LegalDocumentModal>
 		</View>
 	);

--- a/app-expo/features/profile/components/ProfileHeader.tsx
+++ b/app-expo/features/profile/components/ProfileHeader.tsx
@@ -92,7 +92,8 @@ export function ProfileHeader({
 					{/* <TouchableOpacity style={styles.shareButton} onPress={onShare || (() => {})}>
 						<Share size={24} color="#666" />
 					</TouchableOpacity> */}
-					<TouchableOpacity style={styles.settingButton} onPress={handleSettings}>
+					{/* #1031 【設計】Detox から設定画面への実UI導線を検証するため testID を追加 */}
+					<TouchableOpacity testID="profile-settings-button" style={styles.settingButton} onPress={handleSettings}>
 						<Settings size={24} color="#666" />
 					</TouchableOpacity>
 				</View>

--- a/app-expo/features/search/components/TutorialBottomSheet.tsx
+++ b/app-expo/features/search/components/TutorialBottomSheet.tsx
@@ -165,6 +165,9 @@ export function TutorialBottomSheet({
 	// 現在ページの CTA 設定
 	const currentConfig = tutorialPages[currentPage] ?? tutorialPages[0];
 
+	// #1031 【設計】プライマリCTAが「つぎへ」か「はじめよう(finish)」かを Detox から判別できるよう testID を出し分ける
+	const isLastPage = currentPage === tutorialPages.length - 1;
+
 	return (
 		<TrueSheet
 			ref={sheetRef}
@@ -177,7 +180,8 @@ export function TutorialBottomSheet({
 			dimmed
 			dismissible
 			onDidDismiss={handleDidDismiss}>
-			<View style={[styles.container, { width: contentWidth }]}>
+			{/* #1031 【設計】Detox からチュートリアル表示を検証できるよう testID を追加 */}
+			<View testID="search-tutorial-overlay" style={[styles.container, { width: contentWidth }]}>
 				{/* 上：横スワイプで動くコンテンツ */}
 				<FlatList
 					ref={listRef}
@@ -213,6 +217,7 @@ export function TutorialBottomSheet({
 					{/* CTA ボタン群 */}
 					<View style={styles.ctaContainer}>
 						<TouchableOpacity
+							testID={isLastPage ? "search-tutorial-finish" : "search-tutorial-next"}
 							style={styles.primaryButton}
 							onPress={currentConfig.onPrimaryCtaPress}
 							activeOpacity={0.7}>
@@ -222,6 +227,7 @@ export function TutorialBottomSheet({
 						<View style={styles.secondaryWrapper}>
 							{currentConfig.secondaryCtaLabel && currentConfig.onSecondaryCtaPress ? (
 								<TouchableOpacity
+									testID="search-tutorial-later"
 									style={styles.secondaryButton}
 									onPress={currentConfig.onSecondaryCtaPress}
 									activeOpacity={0.7}>

--- a/app-expo/features/topics/components/TopicCard.tsx
+++ b/app-expo/features/topics/components/TopicCard.tsx
@@ -231,7 +231,9 @@ export const TopicCard = ({
 				collapsable={false}
 				style={styles.selectButtonTarget}
 				testID={tutorialTargetRefs ? "topics-tutorial-target-select" : undefined}>
+				{/* #1031 【設計】カルーセルで複数カードが同時マウントされるため atIndex(0) で先頭を指定できるよう testID を追加 */}
 				<TouchableOpacity
+					testID="topics-choose-button"
 					style={styles.selectButton}
 					onPress={() => onSelect(item)}
 					activeOpacity={0.85}

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -371,8 +371,10 @@
 		},
 		"accessibility": {
 			"viewRestaurant": "عرض تفاصيل مطعم {{name}}",
-			"like": "الإعجاب بـ {{name}}",
-			"save": "حفظ {{name}}",
+			"likeActive": "إلغاء الإعجاب بـ {{name}}",
+			"likeInactive": "الإعجاب بـ {{name}}",
+			"saveActive": "إلغاء حفظ {{name}}",
+			"saveInactive": "حفظ {{name}}",
 			"share": "مشاركة {{name}}",
 			"openMap": "فتح خريطة {{name}}",
 			"reviewLike": "الإعجاب بمراجعة {{username}}"

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -371,8 +371,10 @@
 		},
 		"accessibility": {
 			"viewRestaurant": "View {{name}}'s restaurant details",
-			"like": "Like {{name}}",
-			"save": "Save {{name}}",
+			"likeActive": "Unlike {{name}}",
+			"likeInactive": "Like {{name}}",
+			"saveActive": "Unsave {{name}}",
+			"saveInactive": "Save {{name}}",
 			"share": "Share {{name}}",
 			"openMap": "Open map for {{name}}",
 			"reviewLike": "Like {{username}}'s review"

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -371,8 +371,10 @@
 		},
 		"accessibility": {
 			"viewRestaurant": "Ver detalles del restaurante de {{name}}",
-			"like": "Me gusta {{name}}",
-			"save": "Guardar {{name}}",
+			"likeActive": "Quitar me gusta de {{name}}",
+			"likeInactive": "Me gusta {{name}}",
+			"saveActive": "Quitar {{name}} de guardados",
+			"saveInactive": "Guardar {{name}}",
 			"share": "Compartir {{name}}",
 			"openMap": "Abrir el mapa de {{name}}",
 			"reviewLike": "Me gusta la reseña de {{username}}"

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -371,8 +371,10 @@
 		},
 		"accessibility": {
 			"viewRestaurant": "Voir les détails du restaurant {{name}}",
-			"like": "Aimer {{name}}",
-			"save": "Enregistrer {{name}}",
+			"likeActive": "Ne plus aimer {{name}}",
+			"likeInactive": "Aimer {{name}}",
+			"saveActive": "Retirer {{name}} des enregistrements",
+			"saveInactive": "Enregistrer {{name}}",
 			"share": "Partager {{name}}",
 			"openMap": "Ouvrir la carte de {{name}}",
 			"reviewLike": "Aimer l'avis de {{username}}"

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -371,8 +371,10 @@
 		},
 		"accessibility": {
 			"viewRestaurant": "{{name}} के रेस्तरां का विवरण देखें",
-			"like": "{{name}} को पसंद करें",
-			"save": "{{name}} सेव करें",
+			"likeActive": "{{name}} की पसंद हटाएं",
+			"likeInactive": "{{name}} को पसंद करें",
+			"saveActive": "{{name}} को सेव से हटाएं",
+			"saveInactive": "{{name}} सेव करें",
 			"share": "{{name}} शेयर करें",
 			"openMap": "{{name}} का मानचित्र खोलें",
 			"reviewLike": "{{username}} की समीक्षा को पसंद करें"

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -371,8 +371,10 @@
 		},
 		"accessibility": {
 			"viewRestaurant": "{{name}}の店舗詳細を見る",
-			"like": "{{name}}にいいね",
-			"save": "{{name}}を保存",
+			"likeActive": "{{name}}のいいねを解除",
+			"likeInactive": "{{name}}にいいね",
+			"saveActive": "{{name}}の保存を解除",
+			"saveInactive": "{{name}}を保存",
 			"share": "{{name}}をシェア",
 			"openMap": "{{name}}の地図を開く",
 			"reviewLike": "{{username}}の口コミにいいね"

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -371,8 +371,10 @@
 		},
 		"accessibility": {
 			"viewRestaurant": "{{name}} 매장 상세 보기",
-			"like": "{{name}} 좋아요",
-			"save": "{{name}} 저장",
+			"likeActive": "{{name}} 좋아요 취소",
+			"likeInactive": "{{name}} 좋아요",
+			"saveActive": "{{name}} 저장 취소",
+			"saveInactive": "{{name}} 저장",
 			"share": "{{name}} 공유",
 			"openMap": "{{name}} 지도 열기",
 			"reviewLike": "{{username}}님의 리뷰에 좋아요"

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -371,8 +371,10 @@
 		},
 		"accessibility": {
 			"viewRestaurant": "查看{{name}}的门店详情",
-			"like": "点赞{{name}}",
-			"save": "保存{{name}}",
+			"likeActive": "取消点赞{{name}}",
+			"likeInactive": "点赞{{name}}",
+			"saveActive": "取消保存{{name}}",
+			"saveInactive": "保存{{name}}",
 			"share": "分享{{name}}",
 			"openMap": "打开{{name}}的地图",
 			"reviewLike": "为{{username}}的点评点赞"


### PR DESCRIPTION
## 対象 Issue

- #1031(テストカタログ設計・testID ギャップ分析)— 設計確定コメントの P0/P2 + レビュー B1a/B2/B5 対応
- 親: #1027

## 概要

Detox E2E(e2e-mobile)がネイティブでセレクタ・状態検証に使う testID / accessibilityLabel を **加算のみ** で追加する。

- 設計 §3 P0/P2: ProfileHeader 歯車、review/index の PrimaryButton×2、TopicCard 選択ボタン、search 系ヘッダ(ScreenHeader へ `testID` prop 追加)
- レビュー B1a: ActionButtons のいいね/保存を状態別 accessibilityLabel 化(`likeActive/likeInactive/saveActive/saveInactive`、**全8言語へキー追加**)
- レビュー B2: `login-privacy-link` / `legal-document-modal`
- レビュー B5: TutorialBottomSheet へ `search-tutorial-*` 4件

## 検証

- worker run にて `pnpm -F shared run build` → app-expo typecheck(新規エラーなし)実施、ログは Actions Artifact(`claude-issue-1031-impl-pr1-testids-*`)参照
- リーダー検証: e2e-web の `dish-media-accessibility.spec` はラベルの非空・相異のみ検証しており文言変更の影響なし / 削除した旧 i18n キー(`accessibility.like`/`save`)への参照残なし(grep 確認)

## スクショ免除の理由

表示文言・レイアウト・挙動に影響なし(testID / accessibilityLabel / i18n キーの追加のみ)。※ スクリーンリーダー向け読み上げ文言のみ状態別により正確な表現へ変化

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8)_