### PR TITLE
feat: release向けEAS OTA Updateの監査・配信スキルを追加

### DIFF
--- a/.codex/skills/gh-eas-ota-update/SKILL.md
+++ b/.codex/skills/gh-eas-ota-update/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: gh-eas-ota-update
+description: nanitabeyoのreleaseブランチ間で、gitとghを使ってEAS OTA Updateの互換性調査、マージ、production配信を安全に実施する。mainやrelease/1.11などのブランチを1つ以上のreleaseブランチへマージしたい場合、全体マージがOTA-safeか判定する場合、OTA-unsafeな修正を選択的にバックポートする場合、merge commitのPRを自動作成・マージする場合、productionのEAS Update GitHub Actionsを実行・監視する場合に使用する。
+---
+
+# GitHub EAS OTA Update
+
+ソースブランチの変更をnanitabeyoのreleaseブランチへ安全に展開し、productionのEAS Updateを配信する。ネイティブ互換性、Git上の統合、production配信を、それぞれ独立したゲートとして扱う。
+
+## 必須リソース
+
+- 対象を判定する前に、[references/ota-safety-rules.md](references/ota-safety-rules.md)を最後まで読む。
+- すべてのソース・対象ブランチの組み合わせについて、`scripts/audit-ota-inputs.sh <source> <target>`を実行する。
+- production配信の必須確認が完了するまで、`scripts/dispatch-and-watch-update.sh`を実行しない。
+
+## 絶対に守ること
+
+- ユーザーの変更を保護する。ユーザーのworktreeに未コミット変更がある場合、そのworktreeではrelease作業を行わず、一時worktreeまたは専用のクリーンなブランチを使う。
+- `git fetch --prune origin`後、ブランチを不変のSHAへ解決する。push、PRマージ、workflow実行の直前にもSHAを再確認する。
+- PRとmerge commitを使う。squash、rebase merge、releaseブランチへの直接pushは禁止する。
+- OTA-safeなら、監査後にPR作成、検証、merge commitによるマージまで自動で行う。version以外の競合やチェック失敗があれば停止する。
+- `runtimeVersion`や`package.json`の`version`だけからネイティブ互換性を判断しない。
+- 解決済みExpo config、fingerprintのdebug出力、環境ファイル、トークン、secretを表示しない。
+- production workflowを並列実行しない。workflowは共有の`EXPO_PUBLIC_COMMIT_ID`を更新するため、対象ごとに完了を待って逐次実行する。
+- 最初のproduction workflowを実行する直前で必ず停止し、ユーザーへ明示的な確認を求める。最初の依頼で配信まで指示されていても省略しない。
+- production失敗後に、自動で再実行、rollback、republish、別SHAの配信を行わない。
+
+## フェーズ1: 対象と状態を確定する
+
+1. ソースブランチ、対象releaseブランチ、展開したい修正内容を特定する。
+2. ソース、対象、修正範囲を安全に特定できない場合だけ質問する。
+3. リポジトリ内の指示とworktreeの状態を確認する。
+4. `git`、`gh`、`python3`、プロジェクトのパッケージツールが利用可能か確認する。
+5. 次を実行する。
+
+   ```bash
+   git fetch --prune origin
+   gh auth status
+   ```
+
+6. 次を記録する。
+   - ソースrefとSHA
+   - 各対象refとSHA
+   - merge-baseとahead/behind
+   - 対象のアプリversionとruntimeVersion
+   - 対象runtimeで現在配布されているproductionネイティブビルドの根拠
+
+EASのbuild記録またはproduction build workflowのrun情報から、対象runtimeで実際に配布されたバイナリを特定する。現在の対象ブランチ先端と、端末へ配布されたネイティブビルドが同じだと仮定しない。productionネイティブビルドを十分な確度で特定できなければ`unknown`とし、OTA-unsafeと同じ相談フローへ進む。
+
+## フェーズ2: 対象ごとに監査する
+
+次を実行する。
+
+```bash
+.codex/skills/gh-eas-ota-update/scripts/audit-ota-inputs.sh \
+  "origin/<source>" "origin/<target>"
+```
+
+続いて、対象ツリーからソースツリーまでの完全な差分と、依頼された修正を実装するコミットを確認する。現在の対象ブランチ先端だけでなく、実際に配布された対象バイナリのネイティブ入力と、マージ後の予定ツリーを比較する。
+
+対象を必ず次のいずれか1つに分類する。
+
+1. `ota-safe-direct`
+   - 全体マージ後もネイティブ互換である。
+   - version/runtimeへの処置が不要である。
+2. `ota-safe-with-version-restore`
+   - 全体マージ後もネイティブ互換である。
+   - 既存runtimeへ届けるため、マージ前の対象versionだけを復元する必要がある。
+3. `full-merge-ota-unsafe`
+   - ソース全体が、対象バイナリに存在しないネイティブモジュール、plugin、entitlement、permission、ネイティブアセット・設定、ネイティブコードを必要とする。
+4. `unknown`
+   - 根拠が不足または曖昧である。`full-merge-ota-unsafe`と同様に扱う。
+
+変更を加える前に、分類と簡潔な根拠を報告する。ユーザーがマージと配信を依頼している場合、`ota-safe-direct`と`ota-safe-with-version-restore`は自動PRフローの実行権限を含む。unsafeまたはunknownの場合、Codexがバックポート対象を独断で選んではならない。
+
+## フェーズ3A: OTA-safeな全体マージ
+
+対象ごとに次を行う。
+
+1. 記録済みの対象SHAから一時ブランチを作る。
+2. 履歴を維持するため、記録済みソースSHAを`--no-ff --no-commit`でマージする。
+3. 想定されたトップレベルのアプリversion競合以外は、自動解決せず停止する。
+4. `ota-safe-with-version-restore`の場合、マージ前に記録した対象の`version`値だけを復元する。ソース側の依存関係やscriptsの変更は維持する。計算後のruntimeVersionが対象runtimeと一致することを確認する。
+5. 親が記録済みの2つのSHAである単一のmerge commitを作る。
+6. マージ予定ツリーに対してネイティブ監査を再実行し、想定外のネイティブ入力変更がないことを確認する。
+7. lockfile固定でinstallし、リポジトリに適したformat、typecheck、test、build/exportを実行する。最低でも変更対象アプリと、直接影響を受けるshared packageを検証する。
+8. 一時ブランチをpushし、`gh pr create`でPRを作る。
+9. PR本文に次を含める。
+   - ソースと対象のSHA
+   - 依頼された修正
+   - OTA分類と根拠
+   - マージ前後の対象version/runtime
+   - 実行したテスト
+   - productionは未実行であること
+10. `gh pr checks --watch`で必須チェックを監視する。
+11. マージ直前にソース・対象のremote SHAが移動していないことを確認し、最終PR差分を確認する。
+12. `gh pr merge --merge`でmerge commitとして自動マージする。squashとrebaseは禁止する。
+13. 対象ブランチに作成されたmerge SHAを記録する。
+
+refの移動、チェック失敗、マージ結果の変化、version以外の競合があれば停止して報告する。forceで進めず、再監査する。
+
+## フェーズ3B: OTA-unsafeまたはunknownのバックポート
+
+ソースブランチ全体をマージしない。
+
+1. 依頼された修正を実装する最小限のコミットとfile hunkを特定する。
+2. 修正、refactor、format、生成ファイル、依存関係変更、無関係な挙動を分離する。
+3. 各候補コミットが対象バイナリ内のネイティブ機能だけで動作するか判定する。
+4. 次を提示する。
+   - 候補コミットのSHAとsubject
+   - 必要な関連コミット
+   - 除外するコミットと理由
+   - 想定される競合・適応
+   - 必要なテスト
+   - 残るリスク
+5. cherry-pick・バックポートする正確な範囲についてユーザーの承認を得る。Codexが独断で決めない。
+6. 承認後、記録済み対象SHAから一時ブランチを作り、承認済みコミットを`-x`付きでcherry-pickする。
+7. 古いブランチへ必要な最小限の適応だけを行う。承認範囲が実質的に変わる場合は再度停止して相談する。
+8. 完成予定ツリーに対してOTA監査を再実行する。OTA-safeでなければ配信しない。
+9. safe経路と同じPR、チェック、自動merge commitのフローを使う。
+
+cherry-pick案の承認はproduction配信の確認ではない。次のproductionゲートは必ず別途実施する。
+
+## フェーズ4: 必須のproductionゲート
+
+予定したPRがすべてマージされた後、workflowを1つも実行していない状態で、次を含む最終表を提示する。
+
+- 対象releaseブランチ
+- マージ後の対象SHA
+- アプリversion
+- runtimeVersion
+- OTA分類
+- checkとtest結果
+- 実行するworkflowとchannel（`eas-update.yml`、`production`）
+- 実行順
+
+一覧のSHAをproductionへ配信してよいか明示的に確認し、そのターンを終了して待つ。最初の依頼に含まれる「配信して」などの指示だけでは、このゲートを通過したことにしない。
+
+この最終表に対する明確な肯定だけを、一覧に記載したSHAの実行権限として扱う。確認後にSHAが移動したら承認を無効にし、新しいSHAを示して再確認する。
+
+## フェーズ5: 実行と監視
+
+確認された順序で対象を逐次実行する。
+
+```bash
+.codex/skills/gh-eas-ota-update/scripts/dispatch-and-watch-update.sh \
+  --ref "<release-branch>" \
+  --expected-sha "<確認済みの完全SHA>" \
+  --confirm-production CONFIRM_PRODUCTION
+```
+
+対象ごとに次を行う。
+
+1. remoteブランチが確認済みSHAと一致することを確認する。
+2. `.github/workflows/eas-update.yml`を`channel=production`で実行する。
+3. GitHub Actionsのrun IDとURLを記録する。
+4. terminal状態になるまで監視する。
+5. 成功を確認してから次の対象へ進む。
+6. 失敗したら後続の実行をすべて停止し、失敗stepとlog URLを報告する。
+
+## 最終報告
+
+次を報告する。
+
+- ソースSHA
+- 各対象の変更前・変更後SHA
+- PR URLとmerge commit
+- アプリversionとruntimeVersion
+- OTA分類
+- test/check結果
+- Actions run ID、URL、conclusion
+- 実行しなかった対象と理由
+
+GitHub Actionsが成功しただけで端末への反映完了とは表現しない。EASのupdate記録を別途確認できた場合を除き、「production update workflowが完了した」と報告する。

--- a/.codex/skills/gh-eas-ota-update/agents/openai.yaml
+++ b/.codex/skills/gh-eas-ota-update/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub EAS OTA Update"
+  short_description: "releaseブランチのOTA互換性を監査して安全に配信"
+  default_prompt: "$gh-eas-ota-update を使って、ソースからreleaseへのマージを監査し、productionのEAS Updateを安全に配信してください。"

--- a/.codex/skills/gh-eas-ota-update/references/ota-safety-rules.md
+++ b/.codex/skills/gh-eas-ota-update/references/ota-safety-rules.md
@@ -1,0 +1,193 @@
+# OTA安全性の判定基準
+
+## 目次
+
+1. 安全性モデル
+2. 根拠の優先順位
+3. ネイティブに影響する入力
+4. 分類基準
+5. version復元
+6. マージとバックポート
+7. GitHub Actions
+8. nanitabeyoの既知ベースライン
+
+## 1. 安全性モデル
+
+EAS Updateが置き換えるのは、JavaScriptとOTA管理対象のアセットである。インストール済みiOS・Androidバイナリへコンパイル済みコードや設定を追加・変更することはできない。
+
+次の4点を独立して判定する。
+
+1. **配信先:** EASが意図したバイナリへupdateを配信するか。
+2. **ネイティブ互換性:** 配信されたJavaScriptが、そのバイナリのネイティブABIとコンパイル済み設定で動作するか。
+3. **統合:** ソース変更を、対象の無関係な挙動を壊さずマージできるか。
+4. **配信内容:** 監査したSHAとproductionへ実行するSHAが完全に一致するか。
+
+`runtimeVersion`の一致が答えるのは配信先だけである。このリポジトリではアプリversionのmajor/minorからruntimeVersionを作るため、versionを戻すと旧バイナリへ配信できるが、ネイティブ互換になるとは限らない。
+
+## 2. 根拠の優先順位
+
+次の順で根拠を優先する。
+
+1. 実際に配布されたEAS buildコミットのネイティブ入力と依存関係解決結果
+2. インストール済みapp version・runtime・platformに対応するEAS build metadata
+3. GitHub build workflow runと不変のbuild commit
+4. 配布済みbuildとネイティブ入力が同一だと証明できた場合だけ、対象releaseブランチの先端
+5. ブランチ名やversion規約だけでは根拠にしない
+
+iOSとAndroidを別々に確認する。片方だけsafeな場合がある。現在のworkflowは`--platform all`で配信するため、両platformがsafeでなければ全体をunsafeとする。
+
+fingerprintは補助根拠として使えるが、判断を置き換えない。このプロジェクトはfingerprint policyではなく手動のruntimeVersionを使っている。secretが解決される可能性があるため、fingerprintやExpo configのdebug・詳細JSON出力を表示しない。
+
+## 3. ネイティブに影響する入力
+
+以下をすべて確認する。
+
+### 依存関係と生成されるネイティブABI
+
+- アプリpackage manifestのdependenciesとoptionalDependencies
+- `pnpm-lock.yaml`の解決version
+- `ios`、`android`、podspec、Gradle、codegen、JSI、TurboModule、native viewを持つExpo・React Native package
+- packageの追加、削除、upgrade、downgrade、patch、peer解決の変更
+- ソースツリーで新しく参照されるネイティブpackageのimport
+- React Native、Expo SDK、Hermes、New Architecture、Reanimated、native codegenのversion
+
+devDependencyだから自動的にsafeとは判断しない。production config/prebuildでautolinkまたは使用されないことを確認する。
+
+### Expoとplatform設定
+
+- `app.config.*`、`app.json`、`eas.json`
+- config pluginとlocal plugin
+- bundle/package identifierとscheme
+- entitlement、associated domain、permission、intent filter、URL type
+- Info.plistとAndroidManifest
+- build properties、deployment target、framework、Gradle、CocoaPods
+- `newArchEnabled`、Hermes、architecture flag
+- 環境変数で条件分岐するplugin
+- Google・Firebase service fileとnative SDK設定
+- icon、splash、font、notification assetなどbuild時に埋め込まれるresource
+
+entitlement不足はクラッシュではなく機能劣化になる場合がある。それでもソース側ネイティブbuildと同等ではない。マージ後コードがその機能を必要とする場合はunsafeとする。
+
+### ネイティブprojectとpatch
+
+- `ios/**`、`android/**`
+- Podfile、Gradle、ネイティブソース
+- `patches/**`
+- ネイティブprojectを変更するbuild hookとscript
+- install、prebuild、production build時に実行されるpackage script
+
+### OTA-onlyになり得る変更
+
+新しいネイティブ要件を導入しない場合、次は通常OTA-safeになり得る。
+
+- TypeScript・JavaScriptの挙動
+- styleと文言
+- API呼び出しとstate logic
+- bundleから読み込む画像、JSON、翻訳
+- testとdocument
+- Web専用コードとWeb専用asset
+
+platform suffixと条件付きimportも確認する。Metroのnative bundleが不足moduleを読み込まないことを確認する。
+
+## 4. 分類基準
+
+### `ota-safe-direct`
+
+次をすべて満たす場合だけ使う。
+
+- 全体マージ後が配布済み対象バイナリと同じネイティブ機能だけを使う。
+- 対象version/runtimeが処置なしで維持される。
+- 重要な不確実性が残っていない。
+
+### `ota-safe-with-version-restore`
+
+次をすべて満たす場合だけ使う。
+
+- ネイティブ互換性は`ota-safe-direct`と同等である。
+- マージによって対象のapp version/runtimeが置き換わる。
+- 対象の正確な既存versionを戻すことだけが必要である。
+
+version復元が変更するのは配信先metadataであり、ネイティブ非互換は修復しない。
+
+### `full-merge-ota-unsafe`
+
+マージ後ソースのどこかが、対象バイナリに存在しない、または異なるネイティブ挙動を必要とする場合に使う。例:
+
+- 新しいネイティブpackageをimportする。
+- ネイティブpackage versionやcodegen出力が異なる。
+- config pluginやpermissionが必要である。
+- entitlementやURL schemeへ依存する。
+- native build settingやarchitectureが変わる。
+- コードが期待するnative assetが埋め込まれていない。
+
+### `unknown`
+
+次の場合に使う。
+
+- 配布済みネイティブbuildのcommitを特定できない。
+- production環境変数に依存するconfigを比較できない。
+- platformごとの根拠が矛盾する。
+- fingerprint・hashが異なる理由を安全に切り分けられない。
+
+unknownは相談・バックポート経路へ進める。楽観的にsafeとしない。
+
+## 5. version復元
+
+マージ前に対象の正確なversionを記録する。patch versionが異なる可能性があるため、`release/X.Y`だけから推測しない。
+
+version復元が必要な場合:
+
+1. ソースの履歴を保ったままマージする。
+2. app manifestのトップレベルversionだけを変更する。
+3. ソース側のdependency、script、設定変更を維持する。
+4. secretを表示しない方法でconfigを解決し、runtimeVersionが対象runtimeと一致することを確認する。
+5. iOS・Androidのnative build numberを変更していないことを確認する。
+
+対象側の古いpackage manifest全体を復元してはならない。ソース側dependencyを消し、監査ツリーとPRツリーが異なる危険がある。
+
+## 6. マージとバックポート
+
+- 監査では常に不変SHAを使う。
+- `--no-ff`とmerge commitでソース履歴を維持する。
+- 自動解決するのは想定済みのapp version差だけとする。
+- その他の競合は新しい判断として停止する。
+- PR headの正確なツリーでcheckを実行する。
+- マージ直前にbase/head SHAを再確認する。
+- `gh pr merge --merge`を使い、squash/rebaseは禁止する。
+
+全体マージがunsafeな場合:
+
+- 一貫して動作する最小修正を選ぶ。
+- `cherry-pick -x`で出典を残す。
+- 必須testと関連コミットを含める。
+- 対象ネイティブバイナリが既に機能を持つ場合を除き、dependencyやconfig変更を含めない。
+- 変更前に正確なコミット範囲についてユーザーの承認を得る。
+
+## 7. GitHub Actions
+
+production workflow:
+
+- file: `.github/workflows/eas-update.yml`
+- input: `channel=production`
+- ref: 対象releaseブランチ
+- platform: 現在のworkflowはall platformを配信
+
+実行前:
+
+- 対象ref上にworkflowが存在することを確認する。
+- 確認済みSHAとremote対象SHAが一致することを確認する。
+- app versionとruntimeを最終確認する。
+- 正確なSHAを示した後でproduction実行の明示確認を得る。
+
+workflowが共有の`EXPO_PUBLIC_COMMIT_ID`を更新するため逐次実行する。各runを完了まで監視し、最初の失敗で後続を停止する。
+
+## 8. nanitabeyoの既知ベースライン
+
+このスキル作成のきっかけとなった監査時点では、次の状態だった。
+
+- `release/1.8`〜`release/1.10`は既に`release/1.11`をマージ済みで、復元したapp versionだけが異なっていた。
+- `release/1.5`〜`release/1.7`は`release/1.11`とネイティブ互換だったが、全体マージ後にversion復元が必要だった。
+- `release/1.4`には`lottie-react-native`がなく、後続ソースの共通LoadingIndicatorはそれをimportしていた。
+- それ以前のreleaseにはさらにネイティブ機能差があった。
+
+これは過去の根拠であり、恒久的なallowlistではない。ブランチとproduction buildは変化するため、現在の不変SHAと実際の配布済みbuildから毎回再判定する。

--- a/.codex/skills/gh-eas-ota-update/scripts/audit-ota-inputs.sh
+++ b/.codex/skills/gh-eas-ota-update/scripts/audit-ota-inputs.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# OTA互換性の「判定材料」を、2つのGit refから読み取り専用で収集する。
+#
+# このスクリプト自身はsafe/unsafeを決定しない。ネイティブ互換性は、実際に
+# productionへ配布されたEAS build、環境変数で変化するExpo config、JSからの
+# ネイティブmodule参照を合わせて判断する必要があり、機械的なパス差分だけでは
+# 確定できないためである。
+#
+# 注意:
+# - git fetchは呼び出し元で済ませる。監査中にrefが動くことを避けるためである。
+# - worktree、index、ブランチを変更しない。
+# - Expo configやfingerprintのdebug出力はsecretを含み得るため生成しない。
+
+usage() {
+  echo "使用方法: $0 <ソースref> <対象ref>" >&2
+  exit 2
+}
+
+[[ $# -eq 2 ]] || usage
+
+source_ref=$1
+target_ref=$2
+
+# リポジトリ外から誤実行した場合は、曖昧な結果を出さず直ちに終了する。
+git rev-parse --is-inside-work-tree >/dev/null
+
+# origin/release/X.Yのような完全refと、release/X.Yのような短縮refの両方を
+# 受け付ける。ただし戻り値は必ず不変のcommit SHAに固定する。
+resolve_commit() {
+  local ref=$1
+  git rev-parse --verify "${ref}^{commit}" 2>/dev/null ||
+    git rev-parse --verify "origin/${ref}^{commit}" 2>/dev/null
+}
+
+source_sha=$(resolve_commit "$source_ref") || {
+  echo "ソースrefを解決できません: $source_ref" >&2
+  exit 1
+}
+target_sha=$(resolve_commit "$target_ref") || {
+  echo "対象refを解決できません: $target_ref" >&2
+  exit 1
+}
+merge_base=$(git merge-base "$source_sha" "$target_sha")
+counts=$(git rev-list --left-right --count "${target_sha}...${source_sha}")
+
+# package.jsonが存在しない古いrefや壊れたJSONでも、監査レポート全体は継続する。
+# "<missing>"はsafeを意味せず、呼び出し側がunknownとして扱うための信号である。
+show_json_value() {
+  local commit=$1
+  local path=$2
+  local key=$3
+  git show "${commit}:${path}" 2>/dev/null |
+    python3 -c '
+import json
+import sys
+
+document = json.load(sys.stdin)
+print(document.get(sys.argv[1], "<missing>"))
+' "$key" 2>/dev/null ||
+    printf '%s\n' "<missing>"
+}
+
+source_version=$(show_json_value "$source_sha" app-expo/package.json 'version')
+target_version=$(show_json_value "$target_sha" app-expo/package.json 'version')
+
+echo "OTA監査入力"
+printf 'ソース: %s (%s)\n' "$source_ref" "$source_sha"
+printf '対象: %s (%s)\n' "$target_ref" "$target_sha"
+printf 'merge-base: %s\n' "$merge_base"
+printf '対象のみ/ソースのみのコミット数: %s\n' "$counts"
+printf 'ソースのapp version: %s\n' "$source_version"
+printf '対象のapp version: %s\n' "$target_version"
+
+echo
+echo "履歴関係"
+# targetがsourceの祖先なら通常mergeはfast-forwardになり、source側のversionで
+# targetのruntimeVersionまで置換される。この場合は--no-ffとversion復元の検討が必要。
+if git merge-base --is-ancestor "$target_sha" "$source_sha"; then
+  echo "対象はソースの祖先です。通常のmergeはfast-forwardして対象versionを置き換える可能性があります。"
+elif git merge-base --is-ancestor "$source_sha" "$target_sha"; then
+  echo "ソースは既に対象の祖先です。"
+else
+  echo "ソースと対象は分岐しています。"
+fi
+
+echo
+echo "変更されたネイティブ影響候補パス（対象ツリー → ソースツリー）"
+# ここでは「怪しい入力を漏らさない」方向へ広めに抽出する。
+# eas.jsonやroot lockfileは必ずしもネイティブ差分を意味しないが、無視すると
+# build image、config plugin、解決versionの変化を見落とすため候補に含める。
+native_path_pattern='(^|/)(ios|android)(/|$)|(^|/)(app\.config\.[^/]+|app\.json|eas\.json|package\.json|pnpm-lock\.yaml|package-lock\.json|yarn\.lock|Podfile[^/]*|.*\.podspec|gradle\.properties|settings\.gradle[^/]*|build\.gradle[^/]*|google-services\.json|GoogleService-Info\.plist)$|(^|/)(patches|plugins)(/|$)'
+native_paths=$(
+  git diff --name-status "$target_sha" "$source_sha" |
+    awk -F '\t' '{ print $0 }' |
+    { rg "$native_path_pattern" || true; }
+)
+if [[ -n "$native_paths" ]]; then
+  printf '%s\n' "$native_paths"
+else
+  echo "<パス規則では検出なし>"
+fi
+
+echo
+echo "アプリの直接dependency変更"
+# version文字列の差だけではなく、package名と指定versionの組を比較する。
+# 同じpackage名でもversion指定が変われば、追加側・削除側の両方に表示される。
+# devDependenciesは別途native-sensitive diffとlockfile履歴で確認する。
+# JSON処理には、このリポジトリの開発環境で利用可能なpython3を使う。
+if git cat-file -e "${source_sha}:app-expo/package.json" 2>/dev/null &&
+  git cat-file -e "${target_sha}:app-expo/package.json" 2>/dev/null; then
+  echo "追加または変更:"
+  comm -13 \
+    <(git show "${target_sha}:app-expo/package.json" | python3 -c 'import json, sys; data=json.load(sys.stdin); print(*[f"{key}\t{value}" for key, value in sorted(data.get("dependencies", {}).items())], sep="\n")') \
+    <(git show "${source_sha}:app-expo/package.json" | python3 -c 'import json, sys; data=json.load(sys.stdin); print(*[f"{key}\t{value}" for key, value in sorted(data.get("dependencies", {}).items())], sep="\n")') ||
+    true
+  echo "削除または変更:"
+  comm -23 \
+    <(git show "${target_sha}:app-expo/package.json" | python3 -c 'import json, sys; data=json.load(sys.stdin); print(*[f"{key}\t{value}" for key, value in sorted(data.get("dependencies", {}).items())], sep="\n")') \
+    <(git show "${source_sha}:app-expo/package.json" | python3 -c 'import json, sys; data=json.load(sys.stdin); print(*[f"{key}\t{value}" for key, value in sorted(data.get("dependencies", {}).items())], sep="\n")') ||
+    true
+else
+  echo "<いずれかにapp-expo/package.jsonがありません>"
+fi
+
+echo
+echo "ネイティブ影響候補の差分要約"
+# 出力をstatへ限定し、google-services.jsonなどの内容やsecretを表示しない。
+git diff --stat "$target_sha" "$source_sha" -- \
+  app-expo/package.json \
+  app-expo/app.json \
+  'app-expo/app.config.*' \
+  app-expo/eas.json \
+  app-expo/ios \
+  app-expo/android \
+  app-expo/plugins \
+  app-expo/google-services.json \
+  pnpm-lock.yaml \
+  patches ||
+  true
+
+echo
+echo "アプリソースの新規・変更import（ネイティブpackageか手動確認すること）"
+# package.jsonに追加がなくても、既存またはtransitive dependencyのネイティブmoduleを
+# 新しくimportする場合がある。その見落としを減らす補助一覧である。
+# 最大200行に制限し、巨大差分で監査結果が埋もれることを避ける。
+git diff --unified=0 "$target_sha" "$source_sha" -- \
+  'app-expo/**/*.ts' \
+  'app-expo/**/*.tsx' \
+  'app-expo/**/*.js' \
+  'app-expo/**/*.jsx' |
+  { rg '^\+[^+].*(from[[:space:]]+["'\'']|require\(["'\''])' || true; } |
+  sed -n '1,200p'
+
+echo
+echo "merge-base以降にネイティブ影響候補を変更したコミット"
+# 最終ツリー差分だけでなく履歴も見る。途中でnative dependencyを追加・削除した結果、
+# lockfileや生成物に意図しない残骸があるケースを調べる手掛かりになる。
+git log --oneline --no-merges "${merge_base}..${source_sha}" -- \
+  app-expo/package.json \
+  app-expo/app.json \
+  'app-expo/app.config.*' \
+  app-expo/eas.json \
+  app-expo/ios \
+  app-expo/android \
+  app-expo/plugins \
+  app-expo/google-services.json \
+  pnpm-lock.yaml \
+  patches |
+  sed -n '1,200p'
+
+echo
+echo "このレポートだけではOTA-safe/unsafeを分類しません。"
+echo "マージ予定ツリーを、iOS・Androidそれぞれの実配布済みネイティブbuildと比較してください。"

--- a/.codex/skills/gh-eas-ota-update/scripts/dispatch-and-watch-update.sh
+++ b/.codex/skills/gh-eas-ota-update/scripts/dispatch-and-watch-update.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# production EAS UpdateのGitHub Actionsを、確認済みのrelease SHAへ限定して実行する。
+#
+# 安全設計:
+# - production専用の明示トークンがなければ何も変更しない。
+# - release/*以外のrefを拒否し、main等からの誤配信を防ぐ。
+# - 省略SHAを拒否し、ユーザーへ提示・確認したcommitを一意に固定する。
+# - remote SHAが確認後に動いていれば実行しない。
+# - workflowを実行した後はrun IDを特定し、成功・失敗が確定するまで監視する。
+#
+# このスクリプトは1ブランチだけを処理する。複数releaseを呼び出し側で逐次実行
+# させることで、workflowが更新する共有EXPO_PUBLIC_COMMIT_IDの競合を防ぐ。
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  dispatch-and-watch-update.sh \
+    --ref <release-branch> \
+    --expected-sha <full-commit-sha> \
+    --confirm-production CONFIRM_PRODUCTION
+
+このコマンドはproductionのEAS Update workflowを実行し、完了まで監視します。
+EOF
+  exit 2
+}
+
+release_ref=
+expected_sha=
+confirmation=
+workflow=eas-update.yml
+
+# オプションを曖昧に推測しない。未知の引数や値不足はproduction実行前に拒否する。
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ref)
+      [[ $# -ge 2 ]] || usage
+      release_ref=$2
+      shift 2
+      ;;
+    --expected-sha)
+      [[ $# -ge 2 ]] || usage
+      expected_sha=$2
+      shift 2
+      ;;
+    --confirm-production)
+      [[ $# -ge 2 ]] || usage
+      confirmation=$2
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+[[ -n "$release_ref" && -n "$expected_sha" ]] || usage
+
+# ユーザーへSHA一覧を提示した後の明示確認を、呼び出し側が受け取ったことを示す
+# 固定トークン。通常の実行では入力されない文字列にして、偶発実行を防ぐ。
+if [[ "$confirmation" != "CONFIRM_PRODUCTION" ]]; then
+  echo "production実行を停止しました: 明示的な確認トークンがありません。" >&2
+  exit 3
+fi
+if [[ ! "$release_ref" =~ ^release/[A-Za-z0-9._/-]+$ ]]; then
+  echo "production実行を停止しました: refには明示的なrelease/*ブランチが必要です。" >&2
+  exit 3
+fi
+if [[ ! "$expected_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "production実行を停止しました: --expected-shaには40文字の完全SHAが必要です。" >&2
+  exit 3
+fi
+
+git rev-parse --is-inside-work-tree >/dev/null
+gh auth status >/dev/null
+
+# local tracking refではなくoriginの実体を直接問い合わせる。fetch後にremoteが動いた
+# 場合も検出でき、古いlocal SHAをproductionへ流す事故を防げる。
+remote_line=$(git ls-remote --heads origin "refs/heads/${release_ref}")
+remote_sha=$(awk 'NR == 1 { print $1 }' <<<"$remote_line")
+if [[ -z "$remote_sha" ]]; then
+  echo "production実行を停止しました: remoteブランチが見つかりません: $release_ref" >&2
+  exit 4
+fi
+if [[ "$remote_sha" != "$expected_sha" ]]; then
+  echo "production実行を停止しました: remote SHAが移動しています。" >&2
+  printf '期待値: %s\n実際値: %s\n' "$expected_sha" "$remote_sha" >&2
+  exit 4
+fi
+
+# 対象release refにworkflow定義が存在し、GitHubから参照可能なことをdispatch前に確認する。
+gh workflow view "$workflow" --ref "$release_ref" >/dev/null
+
+# gh workflow runはrun IDを直接返さない。そのためdispatch直前のUTC時刻を記録し、
+# 同じbranch・workflow・head SHAかつ、この時刻以降に作られたrunだけを候補にする。
+started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+printf '%sを%sのSHA %sで実行します（channel=production）\n' \
+  "$workflow" "$release_ref" "$expected_sha"
+gh workflow run "$workflow" --ref "$release_ref" -f channel=production
+
+run_json=
+# GitHub側でworkflow_dispatch eventがrunとして一覧に現れるまで短時間pollする。
+# head SHAと作成時刻を照合するため、過去の同一branch runを誤監視しない。
+for attempt in $(seq 1 40); do
+  run_json=$(
+    gh run list \
+      --workflow "$workflow" \
+      --branch "$release_ref" \
+      --event workflow_dispatch \
+      --limit 30 \
+      --json databaseId,headSha,status,conclusion,createdAt,url |
+      python3 -c '
+import json
+import sys
+
+expected_sha = sys.argv[1]
+started_at = sys.argv[2]
+runs = json.load(sys.stdin)
+candidates = [
+    run
+    for run in runs
+    if run.get("headSha") == expected_sha and run.get("createdAt", "") >= started_at
+]
+if candidates:
+    print(json.dumps(sorted(candidates, key=lambda run: run["createdAt"])[-1], separators=(",", ":")))
+' "$expected_sha" "$started_at"
+  )
+  if [[ -n "$run_json" ]]; then
+    break
+  fi
+  printf 'workflow runの生成を待っています（%d/40）\n' "$attempt"
+  sleep 3
+done
+
+if [[ -z "$run_json" ]]; then
+  echo "workflowは実行されましたが、run IDを特定できませんでした。" >&2
+  exit 5
+fi
+
+run_id=$(
+  python3 -c 'import json, sys; print(json.load(sys.stdin)["databaseId"])' <<<"$run_json"
+)
+run_url=$(
+  python3 -c 'import json, sys; print(json.load(sys.stdin)["url"])' <<<"$run_json"
+)
+printf 'Run ID: %s\nRun URL: %s\n' "$run_id" "$run_url"
+
+# exit-statusによりworkflow失敗をスクリプト失敗として上位へ伝える。
+# 失敗時はrun概要を追加表示するが、自動retryや後続releaseのdispatchは行わない。
+if ! gh run watch "$run_id" --exit-status --interval 10; then
+  echo "production EAS Update workflowが失敗しました。後続releaseを実行しないでください。" >&2
+  gh run view "$run_id"
+  exit 6
+fi
+
+# 呼び出し側が最終報告へそのまま利用できる、機密を含まないrun metadataだけを出力する。
+gh run view "$run_id" --json databaseId,headSha,status,conclusion,createdAt,updatedAt,url


### PR DESCRIPTION
ネイティブ非互換な全体マージの誤配信を防ぐため、互換性監査、merge commit PR、version復元、production実行前確認、逐次監視の手順とガード付きスクリプトを追加