### PR TITLE
e2e-mobile: 確定設計の基盤化(fixtures / globalSetup ラッパー / Tier 機構 / ヘルパ)#1028 #1030

### DIFF
--- a/e2e-mobile/.detoxrc.js
+++ b/e2e-mobile/.detoxrc.js
@@ -3,6 +3,13 @@
 //   （dev client ではなくスタンドアロン相当 = e2e-web の「本番同一成果物」方針と整合させる）
 // - 接続先 API は EAS の development 環境変数（EXPO_PUBLIC_BACKEND_BASE_URL 等）が
 //   JS バンドルへ焼き込まれるため、Detox 側での指定は不要
+const path = require("node:path");
+const dotenv = require("dotenv");
+
+// #1028 【設計】§4-1: ローカル実行用の設定（DETOX_AVD_NAME / TEST_USER_* 等）を e2e-mobile/.env から読む。
+// 無ければ何も起きない（コミット対象は .env.example のみ）。CI は secrets が既に process.env にあるため無害
+dotenv.config({ path: path.resolve(__dirname, ".env") });
+
 /** @type {Detox.DetoxConfig} */
 module.exports = {
 	testRunner: {
@@ -13,6 +20,30 @@ module.exports = {
 		jest: {
 			// #1027 【設計】初回起動はエミュレータへの APK インストールを含むため長めに確保する
 			setupTimeout: 300000,
+		},
+	},
+
+	behavior: {
+		// #1028 【設計】§4-1: Detox のグローバル（device / by / element / expect）を注入しない。
+		// spec からは必ず fixtures/e2e.ts 経由で import させ、グローバルの `expect` が
+		// 「型は Jest・実体は Detox」という食い違いを起こさないようにする（@types/jest 採用との整合）
+		init: { exposeGlobals: false },
+		// #1030 【設計】3-1: 起動は fixtures の launchAppWithSession() が
+		// セッション注入・ロケール・権限まで面倒を見るため、Detox の自動起動は使わない。
+		// 自動起動されると launchArgs 無しの起動が先に走り、**匿名サインインのクォータを余計に消費する**
+		launchApp: "manual",
+	},
+
+	// #1030 【設計】レビュー B-2: launchArgs には refresh_token（長期資格情報）が載る。
+	// public リポジトリの Artifact は実質誰でも取得できるため、**device log は既定で無効**にする。
+	// 収集する場合は launchArgs を渡さない run に限ること（screenshot / video に token は写らない）
+	artifacts: {
+		rootDir: "artifacts",
+		plugins: {
+			log: "none",
+			screenshot: "failing",
+			video: "none",
+			instruments: "none",
 		},
 	},
 	apps: {

--- a/e2e-mobile/.env.example
+++ b/e2e-mobile/.env.example
@@ -1,0 +1,24 @@
+# =============================================================================
+# 🤖 e2e-mobile 環境変数（このファイルを .env にコピーして使用する。 .env はコミット禁止）
+#    cp e2e-mobile/.env.example e2e-mobile/.env
+# =============================================================================
+# ※ Supabase の接続情報（EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_ANON_KEY）は
+#   アプリと同じものを使うため **app-expo/.env** から読み込む（重複管理を避けるため）。
+#   `cd app-expo && pnpx eas-cli env:pull development --path .env` で取得できる。
+
+# --- デバイス指定 -----------------------------------------------------------
+# Android エミュレータの AVD 名。`emulator -list-avds` で確認できる。
+# 未設定時は .detoxrc.js の既定値 "e2e_avd"（CI が作成する AVD 名）が使われる。
+#DETOX_AVD_NAME=e2e_avd
+
+# --- 認証（ログイン済みテスト用） -------------------------------------------
+# Supabase に事前作成したテストユーザー（e2e-web と共用。新規 secret は増やさない方針）。
+# 未設定の場合、describeAuthenticated を使う spec は自動的にスキップされる。
+# ※ Supabase 側で Email provider が ON（Allow new users to sign up は OFF 推奨）である必要がある
+#TEST_USER_EMAIL=
+#TEST_USER_PASSWORD=
+
+# --- ミューテーションテスト -------------------------------------------------
+# dev DB へ書き込むテスト（tests/mutation/）を実行する場合のみ 1 を設定する。
+# 通常は pnpm test:mutation:android / test:all:android が内部で設定するため手動設定は不要。
+#RUN_MUTATION=1

--- a/e2e-mobile/README.md
+++ b/e2e-mobile/README.md
@@ -1,44 +1,289 @@
 # e2e-mobile — Detox E2E テスト
 
-Expo アプリのネイティブビルド（Android エミュレータ / iOS シミュレータ）を対象に、Cloud Run 上の `api-development` へ接続して実環境相当の E2E テストを行うワークスペースです。方針は `e2e-web/`（Playwright）を踏襲しています。
+`app-expo` を `expo prebuild` + Gradle / xcodebuild でネイティブビルドし、Android エミュレータ / iOS シミュレータ上で、Cloud Run の `api-development` に接続して実環境相当の E2E テストを行うワークスペースです。方針は `e2e-web/`(Playwright)を踏襲しています。
 
-> ⚠️ 現在はスパイク段階（Android の起動スモークのみ）。全体設計は Issue #1027 とその Sub-issue を参照。
+> 現在の実装範囲: **Android の起動スモーク + 共通基盤(fixtures / Tier 機構 / 認証セッション注入の呼び出し側)**。
+> iOS 構成・シナリオ拡充・アプリ側の注入フックは Sub-issue で進行中(#1027 / #1028 / #1029 / #1030 / #1031)。
 
 ## 構成の全体像
 
 ```
-[Detox (jest)]
+[Detox (jest ランナー)]
       │ adb / simctl
       ▼
 [Android エミュレータ / iOS シミュレータ]
-      │  app-expo を expo prebuild + Gradle/xcodebuild した release ビルド
-      │  ※ EXPO_PUBLIC_BACKEND_BASE_URL 等はビルド時に焼き込み（eas env:pull development）
+      │  app-expo を expo prebuild + Gradle/xcodebuild した **release ビルド**
+      │  ※ EXPO_PUBLIC_BACKEND_BASE_URL 等はビルド時に焼き込み(eas env:pull development)
       ▼
 [https://api-development.nanitabeyo.net (Cloud Run)] + [Supabase (認証)]
 ```
 
-## ローカル実行手順（Android）
+- テスト対象は **本番と同一形態の成果物**(スタンドアロンの release ビルド)。dev client + Metro ではない
+  - JS バンドルが APK / .app に埋め込まれるため、成果物 1 つでテストが完結する(CI のジョブ分割・artifact 化に向く)
+  - `__DEV__` 分岐・LogBox のエラーオーバーレイが混入しないため、本番と同じコードパスを検証できる
+- 認証は Supabase。アプリは起動時に**匿名サインインを自動実行**する
+- ⚠️ **Supabase の匿名サインインには 30 回/時/IP のレート制限があり、dev/prod で同一プロジェクトを共有している**。
+  そのため本ワークスペースは「Node 側で 1 回だけセッションを確立し、起動引数でアプリへ注入する」方式を採る(後述「匿名セッションの共有」)
+
+## 前提条件
+
+1. **Node 22 / pnpm**(リポジトリルートの README 参照)
+2. **JDK 17**(Gradle / AGP 8.x の要求)+ **Android SDK / エミュレータ**(`adb` にパスが通っていること)
+3. **`app-expo/.env` が dev 向けに設定済み**であること
+   - `EXPO_PUBLIC_BACKEND_BASE_URL` / `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` 等
+   - これらの値は **ネイティブビルド時に JS バンドルへ焼き込まれる**(ビルド後に変更しても反映されない)
+   - `EXPO_PUBLIC_SUPABASE_*` は **テスト側(Node)からも参照する**(Supabase 接続情報の重複管理を避けるため、
+     `e2e-mobile/.env` ではなく `app-expo/.env` を正とする。e2e-web と同じ方針)
+4. **google_apis イメージの AVD**(アプリが Google Play services = Maps / AdMob / Firebase に依存するため)
+5. (ログイン済みテストのみ)テストユーザーの設定(下記「認証」)
+
+## セットアップ
 
 ```bash
 # リポジトリルートで
 pnpm install
 pnpm -F shared run build
 
-# development 環境変数を取得（EXPO_PUBLIC_* がビルドに焼き込まれる）
+# development 環境変数を取得(EXPO_PUBLIC_* がビルドに焼き込まれ、テスト側の Supabase 接続にも使われる)
 cd app-expo && pnpx eas-cli env:pull development --non-interactive --path .env && cd ..
 
-# ネイティブプロジェクト生成（E2E_DETOX=1 で Detox 用 config plugin を有効化）
-cd app-expo && E2E_DETOX=1 pnpm exec expo prebuild --platform android --no-install && cd ..
-
-# ビルド & テスト（AVD が必要。名前が e2e_avd 以外なら DETOX_AVD_NAME で指定）
-pnpm --filter e2e-mobile build:android
-DETOX_AVD_NAME=<あなたのAVD名> pnpm --filter e2e-mobile test:android
+# 環境変数ファイルを作成(ログイン済みテストを動かす場合や AVD 名を変える場合に値を設定)
+cp e2e-mobile/.env.example e2e-mobile/.env
 ```
 
-## CI（GitHub Actions）
+## 実行方法(Android)
 
-`.github/workflows/e2e-mobile-test.yml` を参照。workflow_dispatch で実行できる。
+```bash
+# 1. ネイティブプロジェクト生成(E2E_DETOX=1 で Detox 用 config plugin を有効化)
+cd app-expo && E2E_DETOX=1 pnpm exec expo prebuild --platform android --no-install && cd ..
+
+# 2. release APK + androidTest APK をビルド(アプリ変更後は再実行が必要)
+pnpm --filter e2e-mobile build:android
+
+# 3. テスト実行(AVD が起動していること。名前が e2e_avd 以外なら DETOX_AVD_NAME で指定)
+pnpm test:e2e:mobile                          # ルートから(= pnpm --filter e2e-mobile test)
+
+# e2e-mobile ディレクトリ内での実行バリエーション
+pnpm test:android                             # Tier 1 + 2(tests/mutation/ は除外)
+pnpm test:smoke:android                       # Tier 1(tests/smoke/)のみ
+pnpm test:mutation:android                    # Tier 3(tests/mutation/)のみ ※ dev DB に書き込む
+pnpm test:all:android                         # 全件(@mutation 含む)
+```
+
+- prebuild と native ビルドは `detox test` に**含めていない**(毎回のリビルドを避けるため)。アプリを変更したら手順 1〜2 をやり直すこと
+- ローカルの AVD 名が異なる場合: `DETOX_AVD_NAME=<AVD名> pnpm test:android`(または `e2e-mobile/.env` に記載)
+- 失敗時のスクリーンショットは `e2e-mobile/artifacts/` に出力される
+
+## テスト 3 層構造(CI との棲み分け)
+
+| 層     | ディレクトリ                                                                                | 内容                                       | 実行タイミング                                        |
+| ------ | ------------------------------------------------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------- |
+| Tier 1 | `tests/smoke/`                                                                              | 起動・タブ導線の最小確認                   | 夜間 CI + 手動実行。将来の PR ゲート候補              |
+| Tier 2 | `tests/navigation/` `tests/search/` `tests/review/` `tests/profile/` `tests/authenticated/` | 機能テスト全般(実 API 読み取り)            | 夜間 CI                                               |
+| Tier 3 | `tests/mutation/`                                                                           | dev DB への書き込み(いいね/保存・レビュー) | **既定では実行されない**。`RUN_MUTATION=1` で明示実行 |
+
+**ディレクトリ = Tier を正とする。** `@smoke` / `@mutation` はレポート上の可読性のため `describe` 名にも併記するが、フィルタの正には使わない(タグ文字列とディレクトリの二重管理を避けるため)。
+
+Tier 3 の安全弁は **2 段構え**(#1028 §6-3 / #1030 レビュー M-3):
+
+1. **設定段(主防御)**: `jest.config.js` の `testPathIgnorePatterns` が `tests/mutation/` を探索から外す
+   → `RUN_MUTATION=1` が無い限り**ファイルがロードされない**(テスト名フィルタと違い fail-open しない)
+2. **コード段(二重ガード)**: mutation spec は `describeMutation`(`fixtures/e2e`)を使う
+   → `--testPathPattern` などで設定をバイパスされても skip される
+
+## CI(GitHub Actions)
+
+| ワークフロー          | トリガー          | 内容                                                                                           |
+| --------------------- | ----------------- | ---------------------------------------------------------------------------------------------- |
+| `e2e-mobile-test.yml` | workflow_dispatch | prebuild → Gradle(release + androidTest)→ エミュレータ上で Detox 実行。artifact をアップロード |
+
+必要な GitHub Secrets(リポジトリレベル。**e2e-web と共用で、新規 secret は追加しない**):
+
+- `EXPO_TOKEN` — 既存(`eas env:pull` 用)
+- `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` — E2E テストユーザー(未設定でも `describeAuthenticated` 配下がスキップされるだけで他は動く)
+
+CI 側の要件(#1029 の受け入れ条件):
+
+- **AVD 名の一致**: `.detoxrc.js` の既定値 `e2e_avd` と CI が作る AVD 名を合わせる(または `DETOX_AVD_NAME` を明示的に渡す)
+- **artifact は allowlist**: device log は既定で無効(理由は下記「認証」)。screenshot / video / jest レポートのみを上げ、retention は短め(7 日)にする
+- **cron 時刻を e2e-web と分離**: テストユーザーを共用しているため、同時実行すると `@mutation` の状態とセッションが衝突する
+
+## 認証(ログイン済みテスト / セッション注入)
+
+このアプリのログイン UI は Google/Apple OAuth のみで、外部 IdP は自動化できない。そこで **「Node 側で取得したセッションを起動引数(launchArgs)でアプリへ渡す」** 方式を採る(#1030 確定設計 A' 案)。e2e-web が storageState を注入しているのと同じ思想。
+
+### 仕組み
+
+```
+[fixtures/globalSetup.ts]  ← run ごとに 1 回
+   Node 側 supabase client (persistSession:false / autoRefreshToken:false)
+     ├─ signInAnonymously()   → 匿名クォータ消費 1
+     └─ signInWithPassword()  → creds 未設定なら skip / 設定済みで失敗なら hard fail
+   ↓ process.env 経由でテストワーカーへ受け渡し(**トークンはディスクへ書かない**)
+[各 spec]
+   launchAppWithSession({ as: "anon" | "authenticated" })
+     → device.launchApp({ launchArgs: { e2eAccessToken, e2eRefreshToken, e2eSessionOwner } })
+     → アプリ側フックが setSession() する(app-expo 側。**別 PR で実装中**)
+[fixtures/globalTeardown.ts]
+   signOut({ scope: "global" }) で発行したセッションを revoke
+```
+
+- **パスワードは端末に一切渡らない**。Node プロセス内だけが知っており、端末へ渡るのはトークンのみ
+- **`e2eSessionOwner` を渡すのが要点**(#1030 B-1)。アプリ側は「セッションの有無」ではなく
+  **「期待ユーザーと現在ユーザーの一致」**で再注入を判断する。
+  「匿名セッションが残っているせいで注入がスキップされ、認証済みのつもりのテストが匿名のまま緑になる」事故を防ぐため
+- **アプリ側フックが未実装の間**、launchArgs は単に無視される(アプリは通常どおり自前で匿名サインインする)。
+  渡す側の契約は確定済みなので、アプリ側 PR の合流で自動的に有効になる
+- **fail-loud**: 期待するセッションが用意できていない状態で `launchAppWithSession()` を呼ぶと例外になる。
+  黙って通常起動へフォールバックしない(テストが緑のまま検証内容だけ嘘になるのを防ぐ)
+
+### セキュリティ上の必須事項(#1030 レビュー B-2)
+
+`refresh_token` は **長期資格情報**で、access_token の 1 時間とは無関係に交換可能なまま残る。
+このリポジトリは public で Actions の Artifact は実質誰でも取得できるため、次を **MUST** としている:
+
+- **`globalTeardown` で `signOut({ scope: "global" })`**(globalSetup が途中で失敗した場合も、確立済みのセッションを revoke してから中断する)
+- **Detox の device log artifact は既定で無効**(`.detoxrc.js` の `artifacts.plugins.log: "none"`)。
+  logcat / Detox の debug log には launchArgs が載りうるため。収集したい場合は **launchArgs を渡さない run に限る**こと
+- **トークンをディスクへ書かない**(`process.env` のみ)。ログにも出さない
+
+### テストユーザーの準備(1 回だけ)
+
+e2e-web と同じユーザーを共用する(`e2e-web/README.md`「テストユーザーの準備」と同一)。
+
+1. Supabase ダッシュボード → Authentication → Users → **Add user** で email+password ユーザーを作成
+2. Authentication → Providers → **Email を ON**(OFF だと `Email logins are disabled` で失敗する)
+3. `e2e-mobile/.env` に認証情報を設定する(**コミット禁止**):
+   ```
+   TEST_USER_EMAIL=e2e+ci@nanitabeyo.test
+   TEST_USER_PASSWORD=********
+   ```
+
+未設定の場合、`describeAuthenticated(...)` で書かれた spec は自動的にスキップされる。
+**設定済みなのにログインに失敗した場合は hard fail** させる(skip にすると認証済みテストが黙って消え、「実行されていないのに緑」になるため)。
+
+## 匿名セッションの共有(レート制限対策)
+
+Supabase の匿名サインインは **30 回/時/IP**、しかも **カスタマイズ不可**で、dev/prod で同一プロジェクトを共有している。
+アプリはセッションが無ければ起動時に必ず `signInAnonymously()` するため、素朴に「テストごとにデータを消して起動」すると 1 スイートで上限に達する。
+
+対策は上記のセッション注入方式そのもの。**「状態は好きなだけ捨ててよい、セッションはコストゼロで復元できる」**状態を作ることで、
+「テスト間の状態汚染を避けたい」と「レート制限を超えたくない」の二律背反を解消している。
+
+### 消費見積(1 run / 1 プラットフォームあたり)
+
+| 項目                                                                      | 消費         |
+| ------------------------------------------------------------------------- | ------------ |
+| `globalSetup` の `signInAnonymously`                                      | 1            |
+| `tests/smoke/boot.test.ts`(**launchArgs なし起動**の唯一の例外)           | 1            |
+| ログアウト導線のテスト(`SIGNED_OUT` でアプリが自動的に匿名サインインする) | テスト本数分 |
+
+### 運用ルール
+
+- **`launchAppWithoutSession()` は `tests/smoke/boot.test.ts` 以外で使わない**。
+  「匿名サインインの自動確立そのもの」を検証する spec だけの例外(e2e-web の `boot.spec.ts` が共有 storageState を使わないのと同じ)
+- **ログアウト導線のテストはプラットフォームごとに 1 本まで**。増やす場合はこの見積表を更新すること
+- **429 になったらリトライしない**。窓が 1 時間・上限変更不可のため、リトライは run を長引かせるだけ。
+  `globalSetup` は日本語の対処案内を出して即座に中断する(fail-fast)
+- **`maxWorkers: 1` が前提**。並列化すると同一 refresh token を複数プロセスが同時に使い、
+  Supabase の reuse 検知でセッションファミリごと失効しうる
+
+## ロケール(ja-JP)の担保
+
+アプリは `expo-localization` の結果でロケールを解決してリダイレクトし、検索チュートリアルは `isJapanese` で表示が分岐する。
+**デバイスのロケールが ja-JP でないとシナリオが再現しない**(「たまたま通る」状態になる)ため、`utils/locale.ts` に手段を集約している(#1031 確定 B4)。
+
+| プラットフォーム | 方法                                                                                                           |
+| ---------------- | -------------------------------------------------------------------------------------------------------------- |
+| iOS              | `device.launchApp({ languageAndLocale })`(Detox 公式 API。**iOS 専用**)。fixtures が自動で付与する             |
+| Android          | **エミュレータのシステムロケール**を ja-JP にする。fixtures は不一致なら警告を出す(設定自体は CI / AVD の責務) |
+
+```bash
+# Android: エミュレータ起動後に 1 回だけ実行する(ランタイム再起動を伴うため数十秒かかる)
+adb shell setprop persist.sys.locale ja-JP && adb shell setprop ctl.restart zygote
+```
+
+ロケール依存の画面へ入る場合は、システムロケールに頼らず `localeDeepLink("search/topics")`(= `nanitabeyo:///ja-JP/search/topics`)で
+**locale セグメントを直接指定**する方が決定論的。
+
+## ディレクトリ構成
+
+```
+e2e-mobile/
+├── .detoxrc.js            # 設定の中核(configurations / artifacts / behavior)
+├── jest.config.js         # テスト探索と Tier の安全弁
+├── .env.example
+├── fixtures/
+│   ├── e2e.ts             # 共通基盤(全 spec / Screen Object はここから import すること)
+│   ├── globalSetup.ts     # Detox 公式 globalSetup のラッパー + セッション事前確立
+│   └── globalTeardown.ts  # Detox 公式 globalTeardown のラッパー + セッション revoke
+├── utils/                 # 画面に紐づかない横断ヘルパ
+│   ├── locale.ts          # ロケール固定(iOS の launchArgs / Android の adb)
+│   ├── waits.ts           # 待機プリミティブとタイムアウト定数
+│   ├── sessionEnv.ts      # globalSetup ↔ ワーカー間のセッション受け渡し規約
+│   └── revokeSessions.ts  # signOut({ scope: "global" }) による後始末
+├── screens/               # Screen Object Model(1 画面 = 1 クラス)※ シナリオ実装 PR で追加
+└── tests/
+    ├── smoke/             # Tier 1
+    ├── navigation/ search/ review/ profile/ authenticated/   # Tier 2 ※ シナリオ実装 PR で追加
+    └── mutation/          # Tier 3(既定で除外)
+```
+
+**責務の境界**
+
+| ディレクトリ | 責務                                                                        | 禁止事項                                                         |
+| ------------ | --------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `fixtures/`  | 全 spec が共有する前提づくり(起動・セッション注入・ロケール・Tier の安全弁) | 画面固有のセレクタを持たない                                     |
+| `screens/`   | 1 画面のセレクタ定義と、その画面固有の操作 / 検証。testID を外へ漏らさない  | テストの意図を書かない。`device.launchApp` を直接呼ばない        |
+| `utils/`     | 画面に紐づかない横断ヘルパ(Supabase 直叩き・adb 操作・待機)                 | `screens/` を import しない(依存方向は screens → utils の一方向) |
+| `tests/`     | ユーザー視点の 1 シナリオ = 1 `it()`                                        | `by.id(...)` の直書き(必ず Screen Object 経由)                   |
 
 ## テスト追加ガイドライン
 
-e2e-web/README.md のガイドライン（1 spec = 1 画面 or 1 機能、testID 優先セレクタ、@mutation の原則）に従う。詳細な規約は設計確定後にこの README へ追記する。
+- **粒度**: 1 spec ファイル = 1 画面 or 1 機能。1 `it()` = ユーザー視点の 1 シナリオ。細かい UI 検証はシナリオ内の複数 expect に集約する
+- **import 規約**: spec / Screen Object は必ず `fixtures/e2e` から import する(**`detox` の直 import 禁止**)。
+  起動手順(セッション注入・ロケール・権限)と Tier の安全弁が効かなくなるため
+- **起動規約**:
+  - 通常の spec は `beforeAll` で `launchAppWithSession({ as: "anon" })`(ログイン必須なら `"authenticated"`)
+  - `launchAppWithoutSession()` は `tests/smoke/boot.test.ts` の専用(匿名クォータを消費するため)
+  - `device.reloadReactNative()` は使わない(RN 0.82 でのクラッシュ報告があるため、`launchApp({ newInstance: true })` で統一)
+- **セレクタ優先順位**: `by.id`(testID) > `by.text` の ja-JP 文字列
+  - `testID` が無ければ app-expo 側に追加してよい(挙動に影響しない)。追加箇所は #1031 のカタログを参照
+  - i18n 文字列セレクタは翻訳変更で壊れるため、コメントで参照元(`ja-JP.json` のキー)を明記する
+- **ログイン必須の spec**: `describeAuthenticated(...)` で囲む(creds 未設定の環境では自動 skip)
+- **書き込みの原則**(e2e-web のポリシーを踏襲):
+  - `tests/mutation/` 配下に置き、`describeMutation(...)` で囲む
+  - **必ず認証済みユーザーで実行する**(共有匿名ユーザーでは書き込まない)
+  - いいね/保存 ⇄ 解除はハッピーパスでは解除まで書くが、**保証されたロールバックではない**
+    (途中の expect が失敗するとその時点で終了し、以降の解除処理は走らない。`try/finally` は意図的に入れない)
+  - 削除 UI が無いレビュー投稿は本文冒頭に **`[E2E]` プレフィックス**を付ける
+  - フィードバック送信(GitHub issue が作られる)は**送信操作まで到達させない**
+  - **課金・外部連携の禁止**: AdMob 広告の実クリック、プッシュ通知の実登録、ストアレビュー要求は行わない
+- **フレーク対策**: 待機は `utils/waits.ts` のヘルパ経由にする。Detox にはネットワーク傍受 API が無いため、
+  「API 応答を待つ」目的の待機は**画面上の観測点**(要素の出現/消失)で表現する
+
+## 補足
+
+### `@types/jest` を採用している理由(#1028 m1)
+
+Detox 公式の TypeScript ガイドは「Jest の `expect` と Detox の `expect` の型が衝突する」既知問題を挙げ、
+**(a) `@jest/globals` からの明示 import** と **(b) `@types/jest` + `detox` からの `expect` import** の 2 案を示している。
+本ワークスペースは **(b)** を採用した。スパイク(#1027)で (b) が型衝突なく動作することを実測できたためで、
+`describe` / `it` / `beforeAll` をグローバルのまま使える分、spec の記述量が少なくなる。
+
+あわせて `.detoxrc.js` で `behavior.init.exposeGlobals: false` を指定している。
+これを有効(既定)のままにすると、**グローバルの `expect` は「型は Jest・実体は Detox」**という食い違いが起き、
+値のアサーションが静かに壊れる。グローバルを注入しないことで、この不整合を構造的に防いでいる。
+要素のアサーションは `fixtures/e2e` から import した `expect`(= Detox のマッチャ)を使うこと。
+
+### `detox` のバージョンを完全固定している理由(#1028 M2)
+
+`detox` の npm パッケージは Android の maven リポジトリ(`detox/Detox-android`)を同梱しており、
+Gradle 側は `com.wix:detox:+` でそのローカル maven から解決する。つまり **npm のバージョンが上がると native の aar も暗黙に上がる**。
+E2E 基盤のフレーク源を減らすため、`^` を付けず意図的な更新のみに限定している(`^` を使う他ワークスペースとはここだけ流儀が異なる)。
+
+### turbo との関係
+
+- `turbo run test` を使う場合は `--filter=!e2e-web --filter=!e2e-mobile` で除外すること
+  (E2E は実デバイス + 共有 dev 環境依存でキャッシュに不適なため、turbo タスクには組み込んでいない)
+- `pnpm typecheck`(ルート)では e2e-mobile の型チェックも turbo 経由で実行される

--- a/e2e-mobile/fixtures/e2e.ts
+++ b/e2e-mobile/fixtures/e2e.ts
@@ -1,0 +1,230 @@
+import { by, device, element, expect as detoxExpect, waitFor } from "detox";
+
+import { iosLanguageAndLocale, localeDeepLink, warnIfAndroidLocaleMismatch } from "../utils/locale";
+import {
+	isAuthenticatedAvailable,
+	isMutationEnabled,
+	readSessionFromEnv,
+	type SessionOwner,
+} from "../utils/sessionEnv";
+import {
+	DEFAULT_TIMEOUT,
+	LAUNCH_TIMEOUT,
+	existsNow,
+	waitUntilExists,
+	waitUntilGone,
+	waitUntilVisible,
+} from "../utils/waits";
+
+/**
+ * 🧩 e2e-mobile 共通基盤（e2e-web の fixtures/test.ts に相当）
+ *
+ * **すべての spec / Screen Object はこのファイルから import すること。**
+ * `detox` を直接 import すると、ここで定義した起動手順（セッション注入・ロケール固定・権限付与）や
+ * Tier の安全弁が効かなくなる。
+ *
+ * ## Playwright との違い
+ * Playwright のフィクスチャ（DI で `appPage` を注入する仕組み）は Detox + Jest には無い。
+ * そのため **「明示的に呼ぶヘルパ関数 + 再エクスポート」** で同等の効果を出し、
+ * 「`fixtures/e2e` から import する」という規約を e2e-web の「`@playwright/test` 直 import 禁止」と
+ * 同じ強度で運用する（#1028 §5-2）。
+ *
+ * ## expect の使い分け（#1028 m1 の確定に基づく）
+ * このワークスペースは `@types/jest` + `detox` からの明示 import 方式を採用している
+ * （スパイクで型衝突が起きないことを実測済み。詳細は README「@types/jest を採用している理由」）。
+ * - `expect`（このファイルからの import）… **Detox のマッチャ**。要素のアサーション用
+ *   （`await expect(element(by.id("x"))).toBeVisible()`）
+ * - 値（配列・文字列など）のアサーションは Detox の expect では行えない。
+ *   純粋な値を検証したい場合は `node:assert/strict` を使うこと（グローバルの `expect` は
+ *   .detoxrc.js の `behavior.init.exposeGlobals: false` により Jest 側のものになるが、
+ *   混同を避けるため spec では使わない規約とする）
+ */
+
+export { by, device, element, waitFor, detoxExpect as expect };
+export { DEFAULT_TIMEOUT, LAUNCH_TIMEOUT, existsNow, waitUntilExists, waitUntilGone, waitUntilVisible };
+export { localeDeepLink };
+export type { SessionOwner };
+
+/**
+ * アプリの「起動完了」を判定する観測点。
+ *
+ * #1028 【設計】e2e-web の「/ja-JP へのリダイレクト完了 + 匿名セッション確立」に相当するネイティブ側の観測点として、
+ * ボトムタブ（app-expo/app/[locale]/(tabs)/_layout.tsx の tabBarButtonTestID）の表示を使う。
+ * ここが見えている = 「JS バンドル読込 → ロケール解決 → 認証確立 → タブレイアウト描画」まで到達している。
+ */
+const APP_READY_TEST_ID = "tab-search";
+
+/** 起動ヘルパの共通オプション */
+type LaunchOptions = {
+	/**
+	 * 起動時に開くディープリンク。省略時はアプリの通常起動。
+	 * ロケール依存の画面へ直接飛ぶ場合は `localeDeepLink("search/topics")` を使うこと（#1031 B4）。
+	 */
+	url?: string;
+	/**
+	 * 起動前にアプリのストレージ（AsyncStorage）を消すか。
+	 * ⚠️ iOS の `resetAppState()` は **アンインストール + 再インストール相当**で高コスト（#1030 m-5）。
+	 * さらにセッションも消えるため、launchArgs を渡さない起動と組み合わせると
+	 * **匿名サインインのクォータ（30 回/時/IP）を 1 消費する**。既定 false。
+	 */
+	resetState?: boolean;
+	/** 起動後に「アプリ起動完了」まで待つか。既定 true */
+	waitForReady?: boolean;
+};
+
+/**
+ * 「セッションを注入した状態でアプリを起動し、操作可能になるまで待つ」。
+ * e2e-web の `appPage` フィクスチャに相当する、**全 spec の標準的な入口**。
+ *
+ * ## 仕組み（#1030 確定設計 A' 案）
+ * 1. globalSetup が Node 側 supabase client で 1 回だけセッションを確立し、`process.env` へ格納する
+ * 2. このヘルパがそれを `launchArgs`（`e2eAccessToken` / `e2eRefreshToken` / `e2eSessionOwner`）としてアプリへ渡す
+ * 3. アプリ側フック（app-expo。**別 PR で実装中**）が `supabase.auth.setSession()` で注入する
+ *
+ * これにより「アプリのデータを何度消しても匿名サインインを消費しない」状態を作り、
+ * 「テスト間の状態汚染を避けたい」と「レート制限を超えたくない」を両立させる（#1030 3-1）。
+ *
+ * ⚠️ **アプリ側フックが未実装の間**は、launchArgs は単に無視される（アプリは通常どおり自前で
+ * 匿名サインインする）。渡す側の契約はこの時点で確定させ、アプリ側 PR の合流で自動的に有効になる。
+ *
+ * @param opts.as 期待するセッションの持ち主。`authenticated` はテストユーザー、`anon` は匿名
+ * @失敗時 期待するセッションが環境変数に無い場合、日本語メッセージで例外を投げる（fail-loud。#1030 B-1）
+ */
+export async function launchAppWithSession(opts: { as: SessionOwner } & LaunchOptions): Promise<void> {
+	const { as, url, resetState = false, waitForReady = true } = opts;
+
+	const session = readSessionFromEnv(as);
+	if (!session) {
+		// #1030 【設計】B-1: 「注入できなかったので黙って通常起動へフォールバック」は絶対にしない。
+		// 匿名ユーザーのままログイン済みテストが走り、テストは緑なのに検証内容だけが嘘になるため
+		throw new Error(
+			[
+				`${as} セッションが確立されていないため、launchAppWithSession({ as: "${as}" }) を実行できません。`,
+				as === "authenticated"
+					? "  TEST_USER_EMAIL / TEST_USER_PASSWORD（e2e-mobile/.env または CI secrets）を設定してください。" +
+						"\n  設定できない環境では describeAuthenticated を使って spec ごと skip させること。"
+					: "  app-expo/.env の EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_ANON_KEY を確認してください" +
+						"\n  （CI では `eas env:pull development` が .env を生成します）。",
+			].join("\n"),
+		);
+	}
+
+	if (resetState) {
+		await device.resetAppState();
+	}
+
+	await device.launchApp({
+		newInstance: true,
+		url,
+		// #1030 【設計】キー名は `e2e` プレフィックスで統一する（Detox 自身が使う `detox*` 系と衝突させないため）。
+		// 値は **文字列のみ**（launchArgs の数値・真偽値の型変換はプラットフォーム差があるため踏まない。#1030 3-2）
+		launchArgs: {
+			e2eAccessToken: session.accessToken,
+			e2eRefreshToken: session.refreshToken,
+			// #1030 【設計】B-1: アプリ側は「セッションの有無」ではなく「期待ユーザーと現在ユーザーの一致」で
+			// 再注入を判断する。その期待値がこのキー
+			e2eSessionOwner: as,
+		},
+		...platformLaunchOptions(),
+	});
+
+	if (waitForReady) {
+		await waitForAppReady();
+	}
+}
+
+/**
+ * 「セッションを注入せずに」アプリを起動する。
+ *
+ * ⚠️ **原則としてこのヘルパは使わないこと。** アプリ自身の `signInAnonymously()` が走るため、
+ * 呼ぶたびに匿名サインインのクォータ（30 回/時/IP、dev/prod 共有プロジェクト）を消費する。
+ *
+ * #1030 【設計】3-1 の例外規約: 「匿名セッションの**自動確立そのもの**を検証する」
+ * tests/smoke/boot.test.ts だけがこの起動方法を使ってよい
+ * （e2e-web の boot.spec.ts が共有 storageState を使わずフレッシュな状態に戻しているのと同じ位置づけ）。
+ *
+ * @param opts.waitForReady 既定 false。起動シーケンスそのものを検証する spec が自分で待つため
+ */
+export async function launchAppWithoutSession(opts: LaunchOptions = {}): Promise<void> {
+	const { url, resetState = false, waitForReady = false } = opts;
+
+	if (resetState) {
+		await device.resetAppState();
+	}
+
+	await device.launchApp({
+		newInstance: true,
+		url,
+		...platformLaunchOptions(),
+	});
+
+	if (waitForReady) {
+		await waitForAppReady();
+	}
+}
+
+/**
+ * アプリが操作可能な状態（タブレイアウトの描画完了）になるまで待つ。
+ *
+ * @param timeout タイムアウト (ms)。既定は初回起動を見込んだ LAUNCH_TIMEOUT
+ * @失敗時 タイムアウト時に Detox の例外を投げる
+ */
+export async function waitForAppReady(timeout: number = LAUNCH_TIMEOUT): Promise<void> {
+	await waitUntilVisible(by.id(APP_READY_TEST_ID), timeout);
+}
+
+/**
+ * 認証済みテスト用の `describe`。
+ *
+ * #1030 【設計】3-3: TEST_USER_EMAIL / TEST_USER_PASSWORD が未設定の環境（fork PR・初見のローカル）では
+ * spec を丸ごと skip する。e2e-web の tests/authenticated/ が自動 skip されるのと同じ体験を Detox でも再現する。
+ *
+ * ⚠️ `describe` は Jest のグローバル（`@types/jest` 由来）を参照している。
+ * import 元をぶらさないため、この判定は必ずこの定数経由で行うこと（#1030 m-9）。
+ *
+ * @example
+ * describeAuthenticated("マイページ（ログイン済み）", () => { ... });
+ */
+export const describeAuthenticated: typeof describe = isAuthenticatedAvailable() ? describe : describe.skip;
+
+/**
+ * @mutation テスト用の `describe`。
+ *
+ * #1030 【設計】レビュー M-3: e2e-web は playwright.config.ts の `grepInvert` という
+ * **設定ファイル側**の安全弁を持つが、Jest には `testNamePattern` 相当の設定オプションが無い。
+ * そのため「実行コマンドに依存しない」ガードとして、コードレベルでも skip できるようにする。
+ *
+ * 実際には次の二重ガードになる:
+ * 1. 設定段（主防御）: jest.config.js の `testPathIgnorePatterns` が `tests/mutation/` を探索から外す
+ *    → RUN_MUTATION が無い限り **ファイルがロードされない**
+ * 2. コード段（二重ガード）: この `describeMutation` が `RUN_MUTATION !== "1"` なら skip する
+ *    → `--testPathPattern` 等で設定をバイパスされても共有 dev DB へ書き込まない
+ *
+ * @example
+ * describeMutation("いいね/保存 @mutation", () => { ... });
+ */
+export const describeMutation: typeof describe = isMutationEnabled() ? describe : describe.skip;
+
+/**
+ * プラットフォーム依存の launchApp オプションを組み立てる。
+ *
+ * #1028 【設計】`permissions` と `languageAndLocale` は **どちらも Detox の iOS 専用機能**。
+ * Android へ渡すと無視される（もしくはエラーになる）ため、プラットフォーム判定でここに閉じ込める。
+ * Android 側の等価物は次のとおりで、いずれも CI ワークフロー / AVD 側の責務になる（#1029）:
+ * - 実行時権限 … `adb shell pm grant <package> android.permission.ACCESS_FINE_LOCATION` 等
+ * - ロケール   … `adb shell setprop persist.sys.locale ja-JP`（utils/locale.ts のヘルパ参照）
+ */
+function platformLaunchOptions(): Detox.DeviceLaunchAppConfig {
+	if (device.getPlatform() === "ios") {
+		return {
+			// #1031 【設計】B4: iOS はここでロケールを固定できる（Android にはこの機能が無い）
+			languageAndLocale: iosLanguageAndLocale(),
+			// #1028 【設計】権限ダイアログは操作を止めるため事前に付与する
+			permissions: { location: "inuse", notifications: "YES", camera: "YES", photos: "YES" },
+		};
+	}
+
+	// #1031 【設計】B4: Android はロケールを起動時に指定できないため、ずれていれば警告だけ出して気付けるようにする
+	warnIfAndroidLocaleMismatch();
+	return {};
+}

--- a/e2e-mobile/fixtures/globalSetup.ts
+++ b/e2e-mobile/fixtures/globalSetup.ts
@@ -1,0 +1,182 @@
+import * as path from "node:path";
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import * as dotenv from "dotenv";
+
+import { revokeAllSessions } from "../utils/revokeSessions";
+import { AUTHENTICATED_AVAILABLE_ENV, writeSessionToEnv } from "../utils/sessionEnv";
+
+/**
+ * 🚦 Jest globalSetup（Detox 公式 globalSetup のラッパー）
+ *
+ * ## 役割
+ * 1. `.env` の読み込み（app-expo/.env → Supabase 接続情報 / e2e-mobile/.env → テストユーザー等）
+ * 2. **Node 側**の supabase client でセッションを 1 回だけ確立し、`process.env` 経由でテストへ渡す
+ *    - 匿名セッション … 全 spec が共有する（匿名サインインのクォータ消費を run あたり 1 回に抑える）
+ *    - 認証済みセッション … TEST_USER_EMAIL / TEST_USER_PASSWORD が設定されている場合のみ
+ * 3. Detox 公式の globalSetup を呼ぶ（デバイス割り当ての初期化）
+ *
+ * ## ⚠️ Detox の globalSetup は「置き換え」てはならない（#1030 レビュー M-6）
+ * Detox 公式の Jest 連携は `globalSetup` / `globalTeardown` / `testEnvironment` / `reporter` の
+ * 4 点セットで成立しており、独自ロジックが要る場合は **公式実装を import して呼んだうえで自前処理を足す**
+ * ことが公式に指示されている。素朴に差し替えるとデバイス割り当てが壊れる。
+ *
+ * ## 実行順序
+ * 「セッション確立 → Detox 初期化」の順にしている。認証情報の不備やレート制限は
+ * **エミュレータを起動する前**に気付けた方が速く、CI 時間も無駄にしないため（fail-fast）。
+ *
+ * ## セキュリティ（#1030 レビュー B-2）
+ * - トークンは **ディスクへ書かない**（`process.env` のみ）。Artifact 経由の漏洩面を作らないため
+ * - トークンそのものは **絶対にログへ出さない**（このファイルは成否だけを出力する）
+ * - run 終了時に fixtures/globalTeardown.ts が `signOut({ scope: "global" })` で revoke する
+ */
+
+// #1030 【設計】M-6: Detox 公式の globalSetup。型定義が提供されていないため require で読み込む
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const detoxGlobalSetup = require("detox/runners/jest/globalSetup") as () => Promise<void>;
+
+export default async function globalSetup(): Promise<void> {
+	loadEnvFiles();
+	try {
+		await establishSessions();
+	} catch (error) {
+		// #1030 【セキュリティ】B-2: 途中まで確立できたセッションを放置しない。
+		// globalSetup が失敗すると Jest は globalTeardown を実行しないため、ここで自前で revoke する
+		await revokeAllSessions();
+		throw error;
+	}
+	await detoxGlobalSetup();
+}
+
+/**
+ * `.env` を読み込む。
+ *
+ * #1030 【設計】3-3: Supabase の接続情報はアプリと同じものを使うため **app-expo/.env から読む**
+ * （e2e-web の tests/setup/auth.setup.ts と同じ「重複管理を避ける」方針。CI では
+ * `eas env:pull development --path .env` が app-expo/.env を生成する）。
+ * テストユーザーの認証情報はローカルでは e2e-mobile/.env、CI では GitHub Secrets（= 既に process.env にある）。
+ *
+ * @副作用 process.env を書き換える（既存の値は上書きしない = CI の secrets が常に優先される）
+ */
+function loadEnvFiles(): void {
+	dotenv.config({ path: path.resolve(__dirname, "../../app-expo/.env") });
+	dotenv.config({ path: path.resolve(__dirname, "../.env") });
+}
+
+/**
+ * 匿名セッションと（設定があれば）認証済みセッションを確立し、環境変数へ格納する。
+ *
+ * @失敗時
+ * - 匿名サインインが 429（レート制限）… **リトライせず**日本語案内付きで例外を投げる
+ * - テストユーザーの認証情報が設定済みなのにログインに失敗 … 例外を投げる（hard fail。#1030 m-8）
+ * - Supabase 接続情報が未設定 … 警告のみ（boot スモークは launchArgs 不要で動くため）
+ */
+async function establishSessions(): Promise<void> {
+	// #1030 【設計】3-3: 既定は「認証済みテストは実行不可」。ログイン成功時にだけ 1 を立てる
+	process.env[AUTHENTICATED_AVAILABLE_ENV] = "0";
+
+	const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+	const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+
+	if (!supabaseUrl || !supabaseAnonKey) {
+		console.warn(
+			[
+				"⚠️ EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_ANON_KEY が未設定のため、セッションの事前確立をスキップしました。",
+				"   launchAppWithSession() を使う spec は失敗します（launchArgs 無しで起動する tests/smoke/boot.test.ts のみ実行可能）。",
+				"   ローカルでは `cd app-expo && pnpx eas-cli env:pull development --path .env` を実行してください。",
+			].join("\n"),
+		);
+		return;
+	}
+
+	await establishAnonymousSession(supabaseUrl, supabaseAnonKey);
+	await establishAuthenticatedSession(supabaseUrl, supabaseAnonKey);
+}
+
+/**
+ * 匿名セッションを 1 回だけ確立する。
+ *
+ * #1030 【設計】3-1: 全 spec がこの 1 つの匿名セッションを launchArgs 経由で共有する。
+ * これにより「アプリのデータを何度消しても匿名サインインを消費しない」状態を作り、
+ * 30 回/時/IP のレート制限（dev/prod 共有プロジェクト）を安全側に保つ。
+ */
+async function establishAnonymousSession(supabaseUrl: string, supabaseAnonKey: string): Promise<void> {
+	const supabase = createNodeClient(supabaseUrl, supabaseAnonKey);
+	const { data, error } = await supabase.auth.signInAnonymously();
+
+	if (error || !data.session) {
+		// #1030 【設計】レビュー 3.2: 匿名サインインの 30 回/時/IP は Supabase 公式が「カスタマイズ不可」と
+		// 明記しており、窓が 1 時間なので **リトライは run を無駄に長引かせるだけ**。ここは fail-fast させる
+		if (error?.status === 429) {
+			throw new Error(
+				[
+					"匿名サインインがレート制限（429）に達しました。リトライせず中断します。",
+					"  Supabase の匿名サインインは 30 回/時/IP（カスタマイズ不可）で、dev/prod で同一プロジェクトを共有しています。",
+					"  対処:",
+					"    1. 他の E2E ワークフロー（e2e-web の nightly 等）が同時実行されていないか確認する",
+					"    2. GitHub ホストランナーの IP は他テナントと共有のため、1 時間ほど待ってから再実行する",
+				].join("\n"),
+			);
+		}
+		throw new Error(`匿名セッションの確立に失敗しました: ${error?.message ?? "session is null"}`);
+	}
+
+	writeSessionToEnv("anon", {
+		accessToken: data.session.access_token,
+		refreshToken: data.session.refresh_token,
+	});
+	console.log("✅ 匿名セッションを確立しました（全 spec で共有します）");
+}
+
+/**
+ * テストユーザーでログインし、認証済みセッションを確立する。
+ *
+ * #1030 【設計】3-3: 認証情報が未設定なら skip（`describeAuthenticated` が spec ごと skip する）。
+ * **設定済みなのに失敗した場合は hard fail**（m-8）。skip にすると認証済みテストが黙って消え、
+ * 「実行されていないのに緑」という最悪の状態になるため。
+ */
+async function establishAuthenticatedSession(supabaseUrl: string, supabaseAnonKey: string): Promise<void> {
+	const email = process.env.TEST_USER_EMAIL;
+	const password = process.env.TEST_USER_PASSWORD;
+
+	if (!email || !password) {
+		console.log(
+			"ℹ️ TEST_USER_EMAIL / TEST_USER_PASSWORD が未設定のため、tests/authenticated/ 配下は自動的にスキップされます",
+		);
+		return;
+	}
+
+	const supabase = createNodeClient(supabaseUrl, supabaseAnonKey);
+	const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+
+	if (error || !data.session) {
+		throw new Error(
+			[
+				`テストユーザーのログインに失敗しました: ${error?.message ?? "session is null"}`,
+				"確認事項:",
+				"  1. Supabase ダッシュボードで Email provider が ON になっているか（OFF だと 'Email logins are disabled' で失敗する）",
+				"  2. e2e-mobile/.env（CI では secrets）の TEST_USER_EMAIL / TEST_USER_PASSWORD が正しいか",
+			].join("\n"),
+		);
+	}
+
+	writeSessionToEnv("authenticated", {
+		accessToken: data.session.access_token,
+		refreshToken: data.session.refresh_token,
+	});
+	process.env[AUTHENTICATED_AVAILABLE_ENV] = "1";
+	console.log("✅ テストユーザーのセッションを確立しました（tests/authenticated/ を実行します）");
+}
+
+/**
+ * Node 側（テストランナー）専用の supabase client を作る。
+ *
+ * #1030 【設計】レビュー M-4: `persistSession: false` に加えて **`autoRefreshToken: false` が必須**。
+ * 既定（true）のままだと、この client が run 中にバックグラウンドでトークンをローテーションし、
+ * 端末へ渡した refresh_token を無効化してしまう（端末側との二重所有によるセッション失効）。
+ */
+function createNodeClient(supabaseUrl: string, supabaseAnonKey: string): SupabaseClient {
+	return createClient(supabaseUrl, supabaseAnonKey, {
+		auth: { persistSession: false, autoRefreshToken: false },
+	});
+}

--- a/e2e-mobile/fixtures/globalTeardown.ts
+++ b/e2e-mobile/fixtures/globalTeardown.ts
@@ -1,0 +1,25 @@
+import { revokeAllSessions } from "../utils/revokeSessions";
+
+/**
+ * 🧹 Jest globalTeardown（Detox 公式 globalTeardown のラッパー）
+ *
+ * ## 役割
+ * 1. この run で発行したセッションを **`signOut({ scope: "global" })` で revoke する**（#1030 レビュー B-2 の MUST）
+ * 2. Detox 公式の globalTeardown を呼ぶ（デバイスの後始末）
+ *
+ * ## ⚠️ Detox の globalTeardown は「置き換え」てはならない（#1030 レビュー M-6）
+ * Detox 公式の Jest 連携は globalSetup / globalTeardown / testEnvironment / reporter の 4 点セットで成立しており、
+ * 独自ロジックが要る場合は **公式実装を import して呼んだうえで自前処理を足す**ことが公式に指示されている。
+ * かつ **revoke が失敗しても必ず呼ぶ**（finally）— さもないとエミュレータが解放されずに残り、次の run を巻き込む。
+ */
+
+// #1030 【設計】M-6: Detox 公式の globalTeardown。型定義が提供されていないため require で読み込む
+const detoxGlobalTeardown = require("detox/runners/jest/globalTeardown") as () => Promise<void>;
+
+export default async function globalTeardown(): Promise<void> {
+	try {
+		await revokeAllSessions();
+	} finally {
+		await detoxGlobalTeardown();
+	}
+}

--- a/e2e-mobile/jest.config.js
+++ b/e2e-mobile/jest.config.js
@@ -1,16 +1,50 @@
-// #1027 【設計】Detox 公式の jest ランナー構成（globalSetup/testEnvironment が device 等を初期化する）
+/**
+ * 🃏 Detox + Jest ランナー設定
+ *
+ * ## テスト 3 層構造（e2e-web と同一の考え方）
+ * - Tier 1 `@smoke`   : tests/smoke/                              起動・タブ導線の最小確認
+ * - Tier 2 (無タグ)   : tests/navigation|search|review|profile|authenticated/
+ * - Tier 3 `@mutation`: tests/mutation/                           dev DB へ書き込む。**既定では読み込まれない**
+ *
+ * ## Tier の絞り込み方法（Playwright の --grep 相当）
+ * - Tier 1 のみ : `pnpm test:smoke:android`      (= `-- --testPathPattern 'tests/smoke/'`)
+ * - Tier 1+2    : `pnpm test:android`            (testPathIgnorePatterns が Tier 3 を弾く)
+ * - Tier 3 のみ : `pnpm test:mutation:android`   (RUN_MUTATION=1 + --testPathPattern 'tests/mutation/')
+ * - 全件        : `pnpm test:all:android`
+ *
+ * `detox test` の `--` 以降の引数はそのまま Jest へ転送される（Detox CLI の仕様）。
+ */
+
+// #1028 【設計】§6-1: Tier 3(@mutation) の主防御。RUN_MUTATION が無い限り tests/mutation/ を
+// **テスト探索の対象から外す**。テスト名フィルタ（--testNamePattern）ではなくパス除外にすることで、
+// 「ファイルがロードされること自体」を防ぎ、フィルタ漏れ時に fail-open しないようにしている
+// （e2e-web の playwright.config.ts の grepInvert に対応する位置づけ）。
+// #1030 【設計】レビュー M-3: これに加えて fixtures/e2e.ts の describeMutation がコード段でも塞ぐ（二重ガード）。
+const isMutationEnabled = process.env.RUN_MUTATION === "1";
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
 	rootDir: ".",
 	testMatch: ["<rootDir>/tests/**/*.test.ts"],
+	// 既定値（node_modules の除外）を失わないよう、除外パターンは必ず一緒に列挙する
+	testPathIgnorePatterns: isMutationEnabled ? ["/node_modules/"] : ["/node_modules/", "<rootDir>/tests/mutation/"],
+
 	// #1027 【設計】E2E は実機相当の起動・ネットワークを待つため単体テストより大幅に長くする
 	testTimeout: 300000,
 	// #1027 【設計】1 台のエミュレータを全テストで共有するため並列化しない
+	// #1030 【設計】レビュー 3.1: 並列化すると同一 refresh token を複数プロセスが同時に使うことになり、
+	// Supabase の reuse 検知でセッションファミリごと失効しうる。**maxWorkers: 1 が前提**
 	maxWorkers: 1,
-	globalSetup: "detox/runners/jest/globalSetup",
-	globalTeardown: "detox/runners/jest/globalTeardown",
+
+	// ── Detox 連携の必須設定（Detox Internals API との接続点） ────────────────
+	// #1030 【設計】レビュー M-6: globalSetup / globalTeardown は Detox 公式実装を **置き換えず**、
+	// fixtures/ 側で import してラップしている（セッションの事前確立と revoke を足すため）。
+	// testEnvironment / reporter は公式実装をそのまま使う
+	globalSetup: "<rootDir>/fixtures/globalSetup.ts",
+	globalTeardown: "<rootDir>/fixtures/globalTeardown.ts",
 	reporters: ["detox/runners/jest/reporter"],
 	testEnvironment: "detox/runners/jest/testEnvironment",
+
 	verbose: true,
 	transform: {
 		"^.+\\.tsx?$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.json" }],

--- a/e2e-mobile/package.json
+++ b/e2e-mobile/package.json
@@ -5,14 +5,21 @@
 	"description": "Detox によるモバイルネイティブ (iOS/Android) × api-development の E2E テスト",
 	"scripts": {
 		"build:android": "detox build --configuration android.emu.release",
+		"test": "detox test --configuration android.emu.release",
 		"test:android": "detox test --configuration android.emu.release",
-		"test:ci:android": "detox test --configuration android.emu.release --headless --record-logs failing --take-screenshots failing --artifacts-location artifacts",
+		"test:smoke:android": "detox test --configuration android.emu.release -- --testPathPattern 'tests/smoke/'",
+		"test:mutation:android": "RUN_MUTATION=1 detox test --configuration android.emu.release -- --testPathPattern 'tests/mutation/'",
+		"test:all:android": "RUN_MUTATION=1 detox test --configuration android.emu.release",
+		"test:ci:android": "detox test --configuration android.emu.release --headless --artifacts-location artifacts",
+		"test:ci:smoke:android": "detox test --configuration android.emu.release --headless --artifacts-location artifacts -- --testPathPattern 'tests/smoke/'",
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
+		"@supabase/supabase-js": "^2.49.4",
 		"@types/jest": "^29.5.14",
 		"@types/node": "^22.15.3",
-		"detox": "^20.51.4",
+		"detox": "20.51.4",
+		"dotenv": "^16.5.0",
 		"jest": "^29.7.0",
 		"ts-jest": "^29.4.12",
 		"typescript": "^5.4.3"

--- a/e2e-mobile/tests/smoke/boot.test.ts
+++ b/e2e-mobile/tests/smoke/boot.test.ts
@@ -1,4 +1,4 @@
-import { device, element, by, waitFor } from "detox";
+import { DEFAULT_TIMEOUT, LAUNCH_TIMEOUT, by, launchAppWithoutSession, waitUntilVisible } from "../../fixtures/e2e";
 
 /**
  * 🚀 起動スモークテスト @smoke
@@ -7,14 +7,23 @@ import { device, element, by, waitFor } from "detox";
  *       アプリの起動シーケンス全体が壊れていないことを最小の手数で保証する（e2e-web の boot.spec.ts に対応）。
  * 検証範囲: タブバーの表示のみ。個別機能には踏み込まない (Tier 1)。
  *
+ * ## この spec だけ launchArgs を渡さずに起動する理由（#1030 3-1 の例外規約）
+ * 他の spec は `launchAppWithSession()` で Node 側が確立済みのセッションを注入し、
+ * 匿名サインイン（30 回/時/IP、dev/prod 共有プロジェクト）の消費を run あたり 1 回に抑える。
+ * しかし本 spec は **「アプリが自力で匿名サインインを自動確立すること」自体が検証対象**なので、
+ * 意図的に `launchAppWithoutSession()` を使う。
+ * （e2e-web の boot.spec.ts が共有 storageState を使わずフレッシュな状態へ戻しているのと同じ判断。
+ *   この例外で匿名クォータを 1 消費することは #1030 3-1 の見積に織り込み済み）
+ *
  * 注意: tabBarButtonTestID は app-expo/app/[locale]/(tabs)/_layout.tsx で定義されている。
  * tab-notifications は匿名ユーザーには非表示、tab-map は常に非表示（内部遷移専用）のため、
  * ここでは匿名ユーザーでも必ず表示される 3 タブのみを検証する。
  */
 describe("起動 @smoke", () => {
 	beforeAll(async () => {
-		// #1027 【設計】クリーンな初回起動を検証するため新規インスタンスで起動する
-		await device.launchApp({ newInstance: true });
+		// #1030 【設計】3-1 の例外: セッションを注入せず、アプリ本来の signInAnonymously() を通す。
+		// 起動シーケンスそのものが検証対象なので、起動完了待ちは fixtures に任せずテスト本体で行う
+		await launchAppWithoutSession();
 	});
 
 	// ─ テストケース: 起動するとタブバー付きの検索画面が表示される ─
@@ -23,14 +32,9 @@ describe("起動 @smoke", () => {
 	//   2. さがす/レビュー/マイページの各タブが表示されることを検証
 	it("起動するとタブバー付きの検索画面が表示される", async () => {
 		// #1027 【パフォーマンス】初回起動は JS バンドル読込 + 匿名サインインの通信を含むため長めに待つ
-		await waitFor(element(by.id("tab-search")))
-			.toBeVisible()
-			.withTimeout(120000);
-		await waitFor(element(by.id("tab-review")))
-			.toBeVisible()
-			.withTimeout(15000);
-		await waitFor(element(by.id("tab-profile")))
-			.toBeVisible()
-			.withTimeout(15000);
+		await waitUntilVisible(by.id("tab-search"), LAUNCH_TIMEOUT);
+		// タブバーは同時に描画されるため、以降は通常のタイムアウトで足りる
+		await waitUntilVisible(by.id("tab-review"), DEFAULT_TIMEOUT);
+		await waitUntilVisible(by.id("tab-profile"), DEFAULT_TIMEOUT);
 	});
 });

--- a/e2e-mobile/utils/locale.ts
+++ b/e2e-mobile/utils/locale.ts
@@ -1,0 +1,129 @@
+import { execFileSync } from "node:child_process";
+
+import { device } from "detox";
+
+/**
+ * 🌏 デバイスロケール固定ヘルパ
+ *
+ * ## なぜ必要か（#1031 確定 B4）
+ * `app-expo/app/index.tsx` は `expo-localization.getLocales()[0].languageTag` から locale を解決して
+ * `/{locale}/...` へリダイレクトする。さらに検索チュートリアルは `isJapanese` ゲートで表示が分岐する。
+ * つまり **デバイスのロケールが ja-JP でないとテストが再現しない**（「たまたま通る」状態になる）。
+ * e2e-web は Playwright の `locale: "ja-JP"` 一発で固定できたが、Detox には同等の横断機能が無い。
+ *
+ * ## プラットフォーム別の担保方法（#1031 確定 B4 / #1028 R3）
+ * | プラットフォーム | 方法 |
+ * | --- | --- |
+ * | iOS | `device.launchApp({ languageAndLocale })`（Detox 公式 API。**iOS 専用**） |
+ * | Android | **AVD / エミュレータのシステムロケール**を ja-JP にする（CI は emulator 起動後に adb で設定する前提） |
+ *
+ * このモジュールは「iOS 用の launchApp 引数」と「Android 用の adb 操作 / 検証」をヘルパ化し、
+ * fixtures/e2e.ts の起動ヘルパから透過的に使えるようにする。
+ */
+
+/** テストが前提とするロケール（BCP 47）。app-expo の `locales/ja-JP.json` に対応する */
+export const E2E_LOCALE = "ja-JP";
+
+/** テストが前提とする言語コード */
+export const E2E_LANGUAGE = "ja";
+
+/** app.config.ts の `scheme`。ディープリンクの組み立てに使う */
+export const APP_SCHEME = "nanitabeyo";
+
+/**
+ * iOS の `device.launchApp()` へ渡すロケール指定を返す。
+ *
+ * #1028 【設計】Android では Detox が `languageAndLocale` を解釈しないため、
+ * 呼び出し側は必ず `device.getPlatform() === "ios"` のときだけ展開すること
+ * （このヘルパ自体はプラットフォーム判定を行わない純関数にしてある）。
+ */
+export function iosLanguageAndLocale(): Detox.LanguageAndLocale {
+	return { language: E2E_LANGUAGE, locale: E2E_LOCALE };
+}
+
+/**
+ * ロケールセグメント付きのディープリンク URL を組み立てる。
+ *
+ * #1031 【設計】expo-router は `/[locale]/...` 構成なので、ロケール依存の遷移は
+ * 「システムロケールに任せる」より「locale セグメントを直接指定して開く」方が決定論的になる。
+ *
+ * @param pathname 例: "search", "search/topics"（先頭のスラッシュは省略可）
+ * @returns 例: "nanitabeyo:///ja-JP/search"
+ */
+export function localeDeepLink(pathname = ""): string {
+	const normalized = pathname.replace(/^\/+/, "");
+	return `${APP_SCHEME}:///${E2E_LOCALE}${normalized ? `/${normalized}` : ""}`;
+}
+
+/**
+ * Android エミュレータの現在のシステムロケールを取得する。
+ *
+ * @returns 例: "ja-JP"。取得できなかった場合は null
+ * @失敗時 adb の実行に失敗しても例外は投げず null を返す（ロケール検証は fail-fast させない方針）
+ */
+export function getAndroidSystemLocale(): string | null {
+	try {
+		return adb(["shell", "getprop", "persist.sys.locale"]) || adb(["shell", "getprop", "ro.product.locale"]) || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Android エミュレータのシステムロケールを ja-JP に設定する。
+ *
+ * ⚠️ `persist.sys.locale` の変更は Android のランタイム再起動を伴うため **数十秒かかる**。
+ * CI では「エミュレータ起動直後に 1 回だけ」実行するのが正しい使い方で、
+ * spec から毎回呼ぶことは想定していない（#1029 のワークフロー側で実行する）。
+ *
+ * @returns 設定を実行できた場合 true / adb が使えない等で実行できなかった場合 false
+ */
+export function setAndroidSystemLocale(): boolean {
+	try {
+		adb(["shell", "setprop", "persist.sys.locale", E2E_LOCALE]);
+		// #1031 【設計】プロパティを反映させるには Android のランタイム（zygote）再起動が必要。
+		// `stop; start` 相当を ctl.restart で行う（adb root を必要としないため CI のエミュレータでも通る）
+		adb(["shell", "setprop", "ctl.restart", "zygote"]);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * 現在のデバイスが ja-JP ロケールで動いていることを確認する（Android 専用・非致命）。
+ *
+ * #1031 【設計】ロケール不一致は「テストは緑だが検証内容が嘘」という最悪の壊れ方をするため、
+ * 起動時に必ず警告を出して気付けるようにする。ただしロケール設定は CI ワークフロー（#1029）と
+ * AVD の責務なので、ここで例外を投げてテストを止めることはしない（責任分界を跨がない）。
+ *
+ * @returns 一致していれば true
+ */
+export function warnIfAndroidLocaleMismatch(): boolean {
+	const current = getAndroidSystemLocale();
+	if (current === E2E_LOCALE) return true;
+
+	console.warn(
+		[
+			`⚠️ Android デバイスのロケールが ${E2E_LOCALE} ではありません（現在: ${current ?? "取得不可"}）。`,
+			"  ja-JP 前提のシナリオ（チュートリアル表示・日本語文言セレクタ）が再現しない可能性があります。",
+			"  エミュレータ起動後に次を実行してください:",
+			`    adb shell setprop persist.sys.locale ${E2E_LOCALE} && adb shell setprop ctl.restart zygote`,
+		].join("\n"),
+	);
+	return false;
+}
+
+/**
+ * 現在の Detox デバイスに対して adb コマンドを実行する。
+ *
+ * @param args adb のサブコマンド（`-s <deviceId>` は自動で前置する）
+ * @returns 標準出力（前後の空白を除去したもの）
+ * @失敗時 adb が見つからない / コマンドが失敗した場合は例外を投げる（呼び出し側で握り潰すこと）
+ */
+function adb(args: string[]): string {
+	return execFileSync("adb", ["-s", device.id, ...args], {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+	}).trim();
+}

--- a/e2e-mobile/utils/revokeSessions.ts
+++ b/e2e-mobile/utils/revokeSessions.ts
@@ -1,0 +1,76 @@
+import { createClient } from "@supabase/supabase-js";
+
+import { SESSION_ENV_KEYS, readSessionFromEnv, type SessionOwner } from "./sessionEnv";
+
+/**
+ * 🔒 この run で発行したセッションの revoke
+ *
+ * ## なぜ必須なのか（#1030 レビュー B-2 / 確定設計の MUST）
+ * launchArgs でアプリへ渡す `refresh_token` は **長期資格情報**であり、access_token の 1 時間とは無関係に
+ * 交換可能なまま残る。このリポジトリは public で Actions の Artifact は実質誰でも取得できるため、
+ * 万一ログ等にトークンが載ると「有効な資格情報が公開状態で残る」ことになる。
+ * run 終了時にセッションファミリごと revoke することが、被害を **「run 終了まで」に構造的に限定する唯一の手段**。
+ *
+ * ## 既知の副作用
+ * テストユーザーは e2e-web と共用のため、`scope: "global"` の signOut は
+ * **同時実行中の e2e-web のセッションも失効させる**。両 nightly の cron 時刻は分離すること（#1029）。
+ */
+
+/**
+ * 環境変数に残っている全セッション（匿名 / 認証済み）を revoke する。
+ *
+ * globalTeardown（正常終了時）と globalSetup の失敗時の後始末の両方から呼ばれる。
+ *
+ * @失敗時 **例外を投げない**（警告のみ）。後始末の失敗で run を赤にしても得るものが無く、
+ *         呼び出し側（Detox の後始末・元の例外の再送出）を阻害しないことを優先する
+ */
+export async function revokeAllSessions(): Promise<void> {
+	for (const owner of ["anon", "authenticated"] as SessionOwner[]) {
+		await revokeSession(owner);
+	}
+}
+
+/**
+ * 指定した持ち主のセッションを `signOut({ scope: "global" })` で revoke する。
+ *
+ * @param owner セッションの持ち主
+ */
+async function revokeSession(owner: SessionOwner): Promise<void> {
+	const session = readSessionFromEnv(owner);
+	if (!session) return;
+
+	const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+	const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+	if (!supabaseUrl || !supabaseAnonKey) return;
+
+	try {
+		// #1030 【設計】M-4: 後始末用の client も persistSession / autoRefreshToken は必ず無効にする
+		const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+			auth: { persistSession: false, autoRefreshToken: false },
+		});
+
+		// signOut は「現在のセッション」に対して働くため、まず revoke 対象のセッションを client へ載せる
+		const { error: setSessionError } = await supabase.auth.setSession({
+			access_token: session.accessToken,
+			refresh_token: session.refreshToken,
+		});
+		if (setSessionError) {
+			// #1030 【セキュリティ】トークンそのものは絶対にログへ出さない（原因メッセージのみ）
+			console.warn(`⚠️ ${owner} セッションの復元に失敗したため revoke をスキップします: ${setSessionError.message}`);
+			return;
+		}
+
+		const { error } = await supabase.auth.signOut({ scope: "global" });
+		if (error) {
+			console.warn(`⚠️ ${owner} セッションの revoke に失敗しました: ${error.message}`);
+			return;
+		}
+		console.log(`🔒 ${owner} セッションを revoke しました（scope: global）`);
+	} catch (error) {
+		console.warn(`⚠️ ${owner} セッションの revoke 中に例外が発生しました: ${(error as Error).message}`);
+	} finally {
+		// #1030 【設計】revoke 済みのトークンを環境変数に残さない（後続処理からの誤用防止）
+		delete process.env[SESSION_ENV_KEYS[owner].accessToken];
+		delete process.env[SESSION_ENV_KEYS[owner].refreshToken];
+	}
+}

--- a/e2e-mobile/utils/sessionEnv.ts
+++ b/e2e-mobile/utils/sessionEnv.ts
@@ -1,0 +1,83 @@
+/**
+ * 🔑 Node 側で確立したセッションを「テストワーカーへ受け渡す」ための env 規約
+ *
+ * ## なぜ env なのか（#1030 3-3 / リスク2）
+ * globalSetup で取得したセッション（access_token / refresh_token）は **ディスクへ書かない**。
+ * ファイルに落とすと Detox の artifacts ごと GitHub Actions の Artifact にアップロードされ、
+ * public リポジトリでは実質誰でも取得できてしまう（#1030 レビュー B-2）。
+ * Jest の globalSetup はテストワーカーが fork される前に実行されるため、
+ * ここで `process.env` に代入した値はワーカー側からもそのまま読める。
+ *
+ * ## 命名規約
+ * - `E2E_` プレフィックスで統一する（アプリへ渡す launchArgs 側は `e2e` プレフィックス。#1030 3-2）
+ * - **値はトークン文字列そのもの**。ログへ出さないこと（このモジュールも一切 console 出力しない）
+ */
+
+/** セッションの持ち主。アプリ側フックが「期待ユーザーと現在ユーザーの一致」を判定するために使う（#1030 B-1） */
+export type SessionOwner = "anon" | "authenticated";
+
+/** globalSetup ↔ テストワーカー間で共有する環境変数名 */
+export const SESSION_ENV_KEYS = {
+	anon: {
+		accessToken: "E2E_ANON_ACCESS_TOKEN",
+		refreshToken: "E2E_ANON_REFRESH_TOKEN",
+	},
+	authenticated: {
+		accessToken: "E2E_AUTH_ACCESS_TOKEN",
+		refreshToken: "E2E_AUTH_REFRESH_TOKEN",
+	},
+} as const satisfies Record<SessionOwner, { accessToken: string; refreshToken: string }>;
+
+/**
+ * 認証済みテストが実行可能か（= TEST_USER_EMAIL / TEST_USER_PASSWORD が設定され、ログインに成功したか）。
+ * #1030 3-3 の「未設定時の自動 skip」を `describeAuthenticated` から判定するためのフラグ。
+ */
+export const AUTHENTICATED_AVAILABLE_ENV = "E2E_AUTHENTICATED_AVAILABLE";
+
+/** アプリへ渡すセッション（launchArgs の中身に 1:1 対応する） */
+export type E2ESession = {
+	accessToken: string;
+	refreshToken: string;
+};
+
+/**
+ * セッションを環境変数へ書き出す（globalSetup 専用）。
+ *
+ * @param owner セッションの持ち主
+ * @param session Node 側 supabase client が発行したセッション
+ * @副作用 process.env を書き換える（ディスクへは書かない）
+ */
+export function writeSessionToEnv(owner: SessionOwner, session: E2ESession): void {
+	const keys = SESSION_ENV_KEYS[owner];
+	process.env[keys.accessToken] = session.accessToken;
+	process.env[keys.refreshToken] = session.refreshToken;
+}
+
+/**
+ * 環境変数からセッションを読み出す。
+ *
+ * @param owner セッションの持ち主
+ * @returns 両方のトークンが揃っていればセッション / 1 つでも欠けていれば null
+ */
+export function readSessionFromEnv(owner: SessionOwner): E2ESession | null {
+	const keys = SESSION_ENV_KEYS[owner];
+	const accessToken = process.env[keys.accessToken];
+	const refreshToken = process.env[keys.refreshToken];
+	if (!accessToken || !refreshToken) return null;
+	return { accessToken, refreshToken };
+}
+
+/** 認証済みテストが実行可能かどうか（globalSetup が判定して立てたフラグを読むだけ） */
+export function isAuthenticatedAvailable(): boolean {
+	return process.env[AUTHENTICATED_AVAILABLE_ENV] === "1";
+}
+
+/**
+ * @mutation テストが明示的に許可されているか。
+ *
+ * #1030 レビュー M-3: 「実行コマンドに依存しない」安全弁にするため、
+ * jest.config.js の testPathIgnorePatterns（設定段）とこのフラグ（コード段）の二重ガードにしている。
+ */
+export function isMutationEnabled(): boolean {
+	return process.env.RUN_MUTATION === "1";
+}

--- a/e2e-mobile/utils/waits.ts
+++ b/e2e-mobile/utils/waits.ts
@@ -1,0 +1,75 @@
+import { element, waitFor } from "detox";
+
+/**
+ * ⏳ 待機ヘルパ
+ *
+ * Detox の `waitFor(...).toBeVisible().withTimeout(...)` は毎回 4 段のチェーンになり、
+ * spec / Screen Object に散らばると「どこにどのタイムアウトが効いているか」が読めなくなる。
+ * ここへ集約し、タイムアウトの既定値も 1 箇所で管理する。
+ *
+ * ⚠️ Detox には Playwright の `waitForResponse` に相当するネットワーク傍受 API が無い。
+ * 「API 応答を待つ」目的の待機は Detox の同期機構（ネットワークが落ち着くまで次の操作を
+ * ブロックする仕組み）に委ね、**画面上の観測点**（要素の出現/消失）で待つこと。
+ */
+
+/**
+ * 画面表示待ちの既定タイムアウト（ms）。
+ * 実 API（Cloud Run api-development）のコールドスタートを見込み、e2e-web の expect.timeout より長めに取る。
+ */
+export const DEFAULT_TIMEOUT = 15_000;
+
+/**
+ * アプリ起動待ちのタイムアウト（ms）。
+ * release APK の初回起動は「JS バンドル読込 → 匿名認証 or セッション注入 → 初回描画」を含むため長い。
+ */
+export const LAUNCH_TIMEOUT = 120_000;
+
+/**
+ * 要素が可視になるまで待つ。
+ *
+ * @param matcher 対象のマッチャ（例: `by.id("tab-search")`）
+ * @param timeout タイムアウト (ms)。既定 DEFAULT_TIMEOUT
+ * @失敗時 タイムアウト時に Detox の例外を投げる（失敗時スクリーンショットは .detoxrc.js の artifacts 設定で保存される）
+ */
+export async function waitUntilVisible(matcher: Detox.NativeMatcher, timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+	await waitFor(element(matcher)).toBeVisible().withTimeout(timeout);
+}
+
+/**
+ * 要素がビューツリーに存在するまで待つ（画面外にあってもよい場合はこちら）。
+ *
+ * @param matcher 対象のマッチャ
+ * @param timeout タイムアウト (ms)
+ */
+export async function waitUntilExists(matcher: Detox.NativeMatcher, timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+	await waitFor(element(matcher)).toExist().withTimeout(timeout);
+}
+
+/**
+ * 要素がビューツリーから消えるまで待つ（モーダル・スナックバーの閉じ待ちなど）。
+ *
+ * @param matcher 対象のマッチャ
+ * @param timeout タイムアウト (ms)
+ */
+export async function waitUntilGone(matcher: Detox.NativeMatcher, timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+	await waitFor(element(matcher)).not.toExist().withTimeout(timeout);
+}
+
+/**
+ * 要素が存在するかどうかを **待たずに** 判定する。
+ *
+ * 「出ていれば閉じる」といったベストエフォート処理に使う。
+ * ⚠️ 通常のアサーションには使わないこと（false は「まだ描画されていない」だけの可能性がある）。
+ *
+ * @param matcher 対象のマッチャ
+ * @param timeout 存在確認に費やす上限 (ms)。既定 2 秒（短くして無駄な待ちを避ける）
+ * @returns 存在すれば true / しなければ false（例外は投げない）
+ */
+export async function existsNow(matcher: Detox.NativeMatcher, timeout = 2_000): Promise<boolean> {
+	try {
+		await waitFor(element(matcher)).toExist().withTimeout(timeout);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"format": "prettier --write .",
 		"typecheck": "turbo run typecheck",
 		"test:e2e": "pnpm --filter e2e-web test",
+		"test:e2e:mobile": "pnpm --filter e2e-mobile test",
 		"deploy:api": "pnpm --workspace api run deploy",
 		"db:migration": "bash scripts/apply-migration.sh",
 		"db:pull": "bash scripts/db-pull.sh",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,6 +490,9 @@ importers:
 
   e2e-mobile:
     devDependencies:
+      "@supabase/supabase-js":
+        specifier: ^2.49.4
+        version: 2.84.0
       "@types/jest":
         specifier: ^29.5.14
         version: 29.5.14
@@ -497,8 +500,11 @@ importers:
         specifier: ^22.15.3
         version: 22.19.1
       detox:
-        specifier: ^20.51.4
+        specifier: 20.51.4
         version: 20.51.4(@jest/environment@29.7.0)(@jest/types@29.6.3)(@types/bunyan@1.8.11)(expect@29.7.0)(jest-environment-node@29.7.0)(jest@29.7.0(@types/node@22.19.1))
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.6.1
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@22.19.1)(typescript@5.8.3))
@@ -13384,7 +13390,7 @@ snapshots:
       getenv: 2.0.0
       glob: 10.5.0
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.5
       slash: 3.0.0
       slugify: 1.6.6
       xcode: 3.0.1
@@ -13465,7 +13471,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
       resolve-workspace-root: 2.0.0
-      semver: 7.7.3
+      semver: 7.8.5
       slugify: 1.6.6
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -13483,7 +13489,7 @@ snapshots:
     dependencies:
       "@expo/logger": 1.0.221
       joi: 17.13.3
-      semver: 7.7.3
+      semver: 7.8.5
       zod: 4.1.12
 
   "@expo/eas-build-job@1.0.243":
@@ -13553,7 +13559,7 @@ snapshots:
       jimp-compact: 0.16.1
       parse-png: 2.1.0
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.5
       temp-dir: 2.0.0
       unique-string: 2.0.0
 
@@ -13565,7 +13571,7 @@ snapshots:
       jimp-compact: 0.16.1
       parse-png: 2.1.0
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.5
       temp-dir: 2.0.0
       unique-string: 2.0.0
 
@@ -14982,7 +14988,7 @@ snapshots:
 
   "@npmcli/fs@4.0.0":
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.5
     optional: true
 
   "@npmcli/promise-spawn@3.0.0":
@@ -16642,7 +16648,7 @@ snapshots:
   bin-version-check@5.1.0:
     dependencies:
       bin-version: 6.0.0
-      semver: 7.7.3
+      semver: 7.8.5
       semver-truncate: 3.0.0
 
   bin-version@6.0.0:
@@ -17588,7 +17594,7 @@ snapshots:
       proper-lockfile: 3.2.0
       resolve-from: 5.0.0
       sanitize-filename: 1.6.4
-      semver: 7.7.3
+      semver: 7.8.5
       serialize-error: 8.1.0
       shell-quote: 1.8.3
       signal-exit: 3.0.7
@@ -18114,7 +18120,7 @@ snapshots:
       promise-breaker: 6.0.0
       qs: 6.14.0
       raw-body: 2.5.2
-      semver: 7.7.3
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -20019,7 +20025,7 @@ snapshots:
       "@babel/parser": 7.28.5
       "@istanbuljs/schema": 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.3
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -20335,7 +20341,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.7.3
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -20802,7 +20808,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.5
 
   make-error@1.3.6: {}
 
@@ -21406,7 +21412,7 @@ snapshots:
       make-fetch-happen: 14.0.3
       nopt: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.5
       tar: 7.5.2
       tinyglobby: 0.2.15
       which: 5.0.0
@@ -21454,7 +21460,7 @@ snapshots:
 
   npm-install-checks@6.3.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.5
 
   npm-normalize-package-bin@3.0.1: {}
 
@@ -21462,7 +21468,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.7.3
+      semver: 7.8.5
       validate-npm-package-name: 5.0.1
 
   npm-pick-manifest@9.1.0:
@@ -21470,7 +21476,7 @@ snapshots:
       npm-install-checks: 6.3.0
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 11.0.3
-      semver: 7.7.3
+      semver: 7.8.5
 
   npm-run-all@4.1.5:
     dependencies:
@@ -22739,7 +22745,7 @@ snapshots:
 
   semver-truncate@3.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.5
 
   semver@5.7.2: {}
 
@@ -23874,7 +23880,7 @@ snapshots:
       pupa: 2.1.1
       registry-auth-token: 5.1.0
       registry-url: 5.1.0
-      semver: 7.7.3
+      semver: 7.8.5
       semver-diff: 3.1.1
       xdg-basedir: 4.0.0
     transitivePeerDependencies:


### PR DESCRIPTION
## 対象 Issue

- #1028(Detox 基盤設計・確定コメント準拠)/ #1030(認証・セッション設計・確定コメントの MUST 反映)
- 親: #1027

## 概要

main のスパイクを確定設計の基盤へ拡張する(e2e-mobile/ とルート設定のみ。app-expo は別 PR #1030 実装が担当)。

- `fixtures/e2e.ts`: 全 spec 共通基盤(`launchAppWithSession`(launchArgs: e2eAccessToken/e2eRefreshToken/e2eSessionOwner)、`describeAuthenticated`、`describeMutation`)
- jest `globalSetup`/`globalTeardown`: **Detox 公式をラップ**(M-6)。Node 側 supabase client は `persistSession:false, autoRefreshToken:false`(M-4)、匿名は 429 で fail-fast、認証は creds 設定済み失敗で hard fail(m-8)、teardown で `signOut({scope:'global'})`(B-2)
- Tier 機構: `tests/mutation/` を `testPathIgnorePatterns` で既定除外(RUN_MUTATION=1 でのみ実行)、`test:smoke:*` 追加
- `utils/`: ロケール固定・待機ヘルパ、ルート `test:e2e:mobile`、README 完全版

## 検証

- worker run(issue-1028-impl-pra-foundation)にて typecheck / 設定ロード検証を実施。エビデンスは Actions Artifact 参照

## スクショ免除の理由

app-expo(UI)への変更なし(テスト基盤のみ)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8)_