### PR TITLE
e2e-mobile: TabBar Screen Object を追加(Wave 2 の共通基盤)#1031

### DIFF
--- a/e2e-mobile/screens/TabBar.ts
+++ b/e2e-mobile/screens/TabBar.ts
@@ -1,0 +1,67 @@
+import { DEFAULT_TIMEOUT, by, element, existsNow, waitUntilVisible } from "../fixtures/e2e";
+
+/**
+ * 🧭 ボトムタブバーの Screen Object（e2e-web の pages/TabBar.ts に対応）
+ *
+ * testID は `app-expo/app/[locale]/(tabs)/_layout.tsx` の `tabBarButtonTestID` に対応する。
+ *
+ * ## タブ可視性の注意点（アサーション時に必ず考慮すること）
+ * - お知らせ (`tab-notifications`): 匿名ユーザーには非表示（`href: null`）。
+ *   `describeAuthenticated` 配下でのみ表示をアサートできる
+ * - マップ (`tab-map`) / posts: 常に非表示（内部遷移専用の隠しルート）
+ *
+ * ## Detox と Playwright の違い
+ * Detox の `element()` はグローバル API で、Page Object のように `page` を保持する必要が無い。
+ * そのため e2e-web の Page Object と違いコンストラクタ引数を取らず、**インスタンスは使い捨てでよい**
+ * （#1031 §2）。
+ */
+export class TabBar {
+	/** さがすタブ */
+	readonly searchTab = by.id("tab-search");
+	/** レビュータブ */
+	readonly reviewTab = by.id("tab-review");
+	/** マイページタブ */
+	readonly profileTab = by.id("tab-profile");
+	/** お知らせタブ（ログイン済みユーザーのみ表示） */
+	readonly notificationsTab = by.id("tab-notifications");
+	/** マップタブ（常に非表示 — 存在しないことのアサート用） */
+	readonly mapTab = by.id("tab-map");
+
+	/** さがすタブへ遷移する */
+	async gotoSearch(): Promise<void> {
+		await element(this.searchTab).tap();
+	}
+
+	/** レビュータブへ遷移する */
+	async gotoReview(): Promise<void> {
+		await element(this.reviewTab).tap();
+	}
+
+	/** マイページタブへ遷移する */
+	async gotoProfile(): Promise<void> {
+		await element(this.profileTab).tap();
+	}
+
+	/** お知らせタブへ遷移する（ログイン済みユーザー専用） */
+	async gotoNotifications(): Promise<void> {
+		await element(this.notificationsTab).tap();
+	}
+
+	/**
+	 * 匿名ユーザーでも必ず表示される 3 タブが見えていることを検証する。
+	 * 「タブレイアウトまで描画が到達した」ことの共通観測点として使う。
+	 */
+	async expectLoaded(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await waitUntilVisible(this.searchTab, timeout);
+		await waitUntilVisible(this.reviewTab, timeout);
+		await waitUntilVisible(this.profileTab, timeout);
+	}
+
+	/**
+	 * お知らせタブが表示されているかを **待たずに** 判定する。
+	 * 匿名/ログイン済みで可視性が変わるため、アサーションの分岐に使う。
+	 */
+	async hasNotificationsTab(): Promise<boolean> {
+		return existsNow(this.notificationsTab);
+	}
+}


### PR DESCRIPTION
## 対象 Issue

- #1031(Screen Object 設計 §2)/ 親: #1027

## 概要

Wave 2 の各実装 PR(search / profile / review / authenticated)が共通で依存するタブ導線の Screen Object を先行投入する。**これを先に main へ入れることで、後続 PR を同じファイルへ触らせずに並列実装できる。**

- `e2e-mobile/screens/TabBar.ts`: e2e-web の `pages/TabBar.ts` に対応
- Detox の `element()` はグローバル API のため、Page Object と違いコンストラクタ引数を取らない設計(#1031 §2 の方針どおり)
- 匿名では非表示の `tab-notifications`、常に非表示の `tab-map` の扱いを JSDoc に明記

## 検証

- `pnpm --filter e2e-mobile typecheck` OK(`tsconfig.json` の include に `screens/**/*.ts` が含まれることも確認)
- 実行時の検証は Wave 2 の各テスト PR で行う(本 PR 時点では利用者がいないため)

## スクショ免除の理由

app-expo(UI)への変更なし。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8)_