### PR TITLE
e2e-mobile: TabBar / DeepLink ナビゲーションテストを追加(PR-2)#1031

### DIFF
--- a/e2e-mobile/tests/navigation/tab-bar.test.ts
+++ b/e2e-mobile/tests/navigation/tab-bar.test.ts
@@ -1,0 +1,56 @@
+import { by, launchAppWithSession, waitUntilGone, waitUntilVisible } from "../../fixtures/e2e";
+import { TabBar } from "../../screens/TabBar";
+
+/**
+ * 🧭 タブバー ナビゲーションテスト
+ *
+ * 目的: ボトムタブの可視性ルール(匿名ユーザーでの表示制御)と、
+ *       タブ遷移で各画面が表示されることを保証する(e2e-web の tests/navigation/tab-bar.spec.ts に対応)。
+ * 検証範囲: 匿名ユーザーでのタブ可視性 + タブ遷移時の到達画面確認のみ。
+ *          個別画面の機能検証には踏み込まない(Tier 2)。
+ *
+ * ## この spec での起動方法
+ * #1030 【設計】3-1 の原則どおり、匿名サインインのレート制限(30 回/時/IP)を避けるため
+ * `launchAppWithSession({ as: "anon" })` でセッションを注入して起動する
+ * (launchAppWithoutSession は起動シーケンス自体を検証する tests/smoke/boot.test.ts のみの例外)。
+ */
+describe("タブバー(匿名ユーザー)", () => {
+	const tabBar = new TabBar();
+
+	beforeAll(async () => {
+		await launchAppWithSession({ as: "anon" });
+	});
+
+	// ─ テストケース: 匿名時に表示されるタブが正しい ─
+	// 手順:
+	//   1. launchAppWithSession({ as: "anon" }) で起動済み(beforeAll)
+	//   2. さがす/レビュー/マイページの 3 タブが表示されることを検証
+	//   3. お知らせタブ(tab-notifications)が存在しないことを検証
+	//      (app-expo/app/[locale]/(tabs)/_layout.tsx で匿名時 href: null のため非マウント)
+	//   4. マップタブ(tab-map)が存在しないことを検証(内部遷移専用の隠しルートで常時非表示)
+	it("匿名時に表示されるタブが正しい", async () => {
+		await tabBar.expectLoaded();
+		// #1031 【設計】existsNow は「待たない・分岐用」のため、確定的なアサートには waitUntilGone を使う
+		await waitUntilGone(tabBar.notificationsTab);
+		await waitUntilGone(tabBar.mapTab);
+	});
+
+	// ─ テストケース: タブ遷移で各画面が表示される ─
+	// 手順:
+	//   1. レビュータブへ遷移 → ゲスト向けログイン導線が表示されることを検証
+	//      testID: review-guest-login-button (ja-JP: Review.guest.loginButton)
+	//   2. マイページタブへ遷移 → ゲスト向けログインボタンが表示されることを検証
+	//      testID: profile-login-button (ja-JP: auth.btn_login)
+	//   3. さがすタブへ戻る → 検索ヘッダが再表示されることを検証
+	//      testID: search-header-title (ja-JP: Search.headerTitle)
+	it("タブ遷移で各画面が表示される", async () => {
+		await tabBar.gotoReview();
+		await waitUntilVisible(by.id("review-guest-login-button"));
+
+		await tabBar.gotoProfile();
+		await waitUntilVisible(by.id("profile-login-button"));
+
+		await tabBar.gotoSearch();
+		await waitUntilVisible(by.id("search-header-title"));
+	});
+});

--- a/e2e-mobile/tests/smoke/deep-link.test.ts
+++ b/e2e-mobile/tests/smoke/deep-link.test.ts
@@ -1,0 +1,44 @@
+import { by, launchAppWithSession, localeDeepLink, waitUntilVisible } from "../../fixtures/e2e";
+
+/**
+ * 🔗 ディープリンクスモークテスト @smoke
+ *
+ * 目的: ロケールセグメント付きディープリンク(`nanitabeyo:///ja-JP/...`)からの直接起動で、
+ *       expo-router のルーティングが素通しで機能していることを保証する
+ *       (e2e-web の tests/smoke/deep-link.spec.ts に対応)。
+ * 検証範囲: 代表的な直リンク 2 画面(検索 / マイページ)。
+ *
+ * ## URL の組み立て方(#1031 確定 B4)
+ * expo-router は `/[locale]/...` 構成のため、システムロケールに任せず
+ * `localeDeepLink()` で ja-JP セグメントを明示したディープリンクを組み立てて起動する。
+ *
+ * ## e2e-web との差分(NotFound 画面を対象外とした理由)
+ * e2e-web は「存在しないパスで NotFound 画面が表示される」も検証しているが、
+ * ネイティブの NotFound 画面(app-expo/app/[locale]/+not-found.tsx)には
+ * testID が実装されていない(grep 済み)。本規約(セレクタは testID 最優先、
+ * 存在しない testID は使わない)に従い、本 spec ではこのシナリオを対象外とする。
+ * testID 追加(#1031 レビュー m8 で指摘済み)は別 PR のスコープとする。
+ */
+describe("ディープリンク @smoke", () => {
+	// ─ テストケース: 検索画面への直リンクが表示される ─
+	// 手順:
+	//   1. localeDeepLink("search") で "nanitabeyo:///ja-JP/search" を組み立てる
+	//   2. launchAppWithSession({ as: "anon", url }) でそのディープリンクから直接起動する
+	//   3. 検索ヘッダが表示されることを検証
+	//      testID: search-header-title (ja-JP: Search.headerTitle)
+	it("検索画面への直リンクが表示される", async () => {
+		await launchAppWithSession({ as: "anon", url: localeDeepLink("search") });
+		await waitUntilVisible(by.id("search-header-title"));
+	});
+
+	// ─ テストケース: マイページへの直リンクが表示される ─
+	// 手順:
+	//   1. localeDeepLink("profile") で "nanitabeyo:///ja-JP/profile" を組み立てる
+	//   2. launchAppWithSession({ as: "anon", url }) でそのディープリンクから直接起動する
+	//   3. ゲスト向けログインボタンが表示されることを検証
+	//      testID: profile-login-button (ja-JP: auth.btn_login)
+	it("マイページへの直リンクが表示される", async () => {
+		await launchAppWithSession({ as: "anon", url: localeDeepLink("profile") });
+		await waitUntilVisible(by.id("profile-login-button"));
+	});
+});


### PR DESCRIPTION
## 対象 Issue

- #1031(PR-2: navigation 系)/ 親: #1027

## 概要

- `tests/navigation/tab-bar.test.ts`(Tier 2): 匿名ユーザーでのタブ可視性(`tab-notifications` 非表示 / `tab-map` 常時非表示)とタブ遷移で各画面へ到達することを検証
- `tests/smoke/deep-link.test.ts`(Tier 1): `localeDeepLink()` でロケールセグメント付き URL を組み立て、直リンク起動で対象画面が表示されることを検証(#1031 確定 B4)

いずれも `launchAppWithSession({ as: "anon" })` で起動し、匿名サインインのレート制限(30 回/時/IP)を消費しない(#1030 3-1)。

## 設計確定への追従

- NotFound 画面の直リンク検証は、ネイティブ側に testID が無いため**対象外**とし理由をコメントに明記(testID 追加は #1031 レビュー m8 として別スコープ)

## 検証

- worker run(issue-1031-impl-pr2-navigation)で `pnpm --filter e2e-mobile typecheck` 実施
- エミュレータ/シミュレータでの実行検証は、Wave 2 の各 PR を統合後にまとめて CI で行う

## スクショ免除の理由

app-expo(UI)への変更なし(E2E テストの追加のみ)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8)_