### PR TITLE
e2e-mobile: profile / settings / login-modal テストを追加(PR-4)#1031

### DIFF
--- a/e2e-mobile/screens/LoginModal.ts
+++ b/e2e-mobile/screens/LoginModal.ts
@@ -1,0 +1,47 @@
+import { DEFAULT_TIMEOUT, by, element, expect, waitUntilVisible } from "../fixtures/e2e";
+
+/**
+ * 🔑 ログインモーダル（BlurModal）の Screen Object（e2e-web の pages/LoginModal.ts に対応）
+ *
+ * 対応コンポーネント: app-expo/features/profile/components/LoginbackModal.tsx
+ *
+ * ## テスト範囲の注意
+ * ログイン手段は Google/Apple OAuth のみ。実際の OAuth 遷移は外部 IdP（Google/Apple）の
+ * ログイン画面に進むため E2E テストの対象外とする（bot 検知・利用規約の観点でもアンチパターン。
+ * e2e-web の LoginModal と同じ判断）。このモーダルでは「表示・ボタンの存在・リーガルリンク」までを検証する。
+ *
+ * ## #1031 【設計確定】B2: リーガルモーダル検証方法の変更
+ * e2e-web（`login-modal.spec.ts`）は「プライバシーポリシー」という同一文字列の出現数（1→3）で
+ * リーガルモーダルの表示を判定しているが、Detox に要素数アサーション API（`toHaveCount` 相当）は無い。
+ * そのため PR #1033 で追加された `login-privacy-link` / `legal-document-modal` の testID を使い、
+ * 「リンクをタップ → モーダルの testID が出現する」という直接検証に置き換える。
+ */
+export class LoginModal {
+	/** モーダルのコンテナ（既存 testID） */
+	readonly container = by.id("login-modal");
+	/** Google ログインボタン（既存 testID） */
+	readonly googleButton = by.id("login-google-button");
+	/** Apple ログインボタン（既存 testID） */
+	readonly appleButton = by.id("login-apple-button");
+	/** 同意文言内のプライバシーポリシーリンク（#1031 確定 B2。PR #1033 で testID 追加） */
+	readonly privacyLink = by.id("login-privacy-link");
+	/** プライバシーポリシーのリーガルドキュメントモーダル（#1031 確定 B2。PR #1033 で testID 追加） */
+	readonly legalDocumentModal = by.id("legal-document-modal");
+
+	/** ログインモーダルが開いていることを検証する */
+	async expectOpened(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await waitUntilVisible(this.container, timeout);
+		await expect(element(this.googleButton)).toBeVisible();
+		await expect(element(this.appleButton)).toBeVisible();
+	}
+
+	/** プライバシーポリシーリンクをタップしてリーガルモーダルを開く */
+	async openPrivacyPolicy(): Promise<void> {
+		await element(this.privacyLink).tap();
+	}
+
+	/** リーガルドキュメントモーダルが開いていることを検証する */
+	async expectLegalDocumentOpened(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await waitUntilVisible(this.legalDocumentModal, timeout);
+	}
+}

--- a/e2e-mobile/screens/ProfileScreen.ts
+++ b/e2e-mobile/screens/ProfileScreen.ts
@@ -1,0 +1,63 @@
+import { DEFAULT_TIMEOUT, by, element, existsNow, waitUntilVisible } from "../fixtures/e2e";
+
+/**
+ * 👤 マイページの Screen Object（e2e-web の pages/ProfilePage.ts に対応）
+ *
+ * 対応画面: app-expo/app/[locale]/(tabs)/profile/index.tsx（実体は features/profile/ProfileTabsLayout）
+ *
+ * タブ構成はログイン状態で分岐する（#1031 【設計】§2）:
+ * - 匿名ユーザー: 保存系タブのみ（save-post / save-topic / like）+ ログインボタン表示
+ * - ログイン済み: 上記に加えて reviews（投稿）タブ ※ログイン済み前提のテストは別 PR 担当
+ *
+ * ゲスト時は `features/profile/containers/ProfileTabsLayout.tsx` の `!isGuest ? <Tabs.Tab name="reviews">...`
+ * により reviews タブの Tabs.Tab 自体がレンダリングされない。つまり `review-tab-grid` は
+ * 「非表示」ではなく「存在しない」ため、可視性ではなく存在有無で検証する。
+ */
+export class ProfileScreen {
+	/** 匿名ユーザーに表示されるログインボタン（既存 testID） */
+	readonly loginButton = by.id("profile-login-button");
+	/**
+	 * 設定画面への唯一の UI 導線（歯車ボタン）。
+	 * #1031 【設計確定】B2 に関連する実装メモ: e2e-web の ProfilePage.gotoSettings() は
+	 * このボタンに testID が無いため URL 直遷移（page.goto）で代替しているが、
+	 * ネイティブには URL 直遷移の代替経路が無いため実 UI 導線のタップを正とする。
+	 * testID（`profile-settings-button`）は PR #1033 で追加済み。
+	 */
+	readonly settingsButton = by.id("profile-settings-button");
+	/** 保存した投稿グリッド（既存 testID） */
+	readonly savedPostsGrid = by.id("save-post-tab-grid");
+	/** 保存したトピックグリッド（既存 testID） */
+	readonly savedTopicsGrid = by.id("save-topic-tab-grid");
+	/** いいねした投稿グリッド（既存 testID） */
+	readonly likedGrid = by.id("like-tab-grid");
+	/** 自分のレビュー投稿グリッド（ログイン済みのみ表示。ゲスト時は Tabs.Tab ごと未マウント） */
+	readonly reviewsGrid = by.id("review-tab-grid");
+
+	/** 匿名ユーザー向けのゲスト表示（ログインボタン）が出ていることを検証する */
+	async expectGuestViewLoaded(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await waitUntilVisible(this.loginButton, timeout);
+	}
+
+	/** 保存した投稿グリッドが表示されていることを検証する */
+	async expectSavedPostsGridVisible(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await waitUntilVisible(this.savedPostsGrid, timeout);
+	}
+
+	/** ログインボタンをタップしてログインモーダルを開く（匿名ユーザーのみ） */
+	async openLoginModal(): Promise<void> {
+		await element(this.loginButton).tap();
+	}
+
+	/** 歯車ボタンをタップして設定画面へ遷移する（#1031 確定: URL 直遷移ではなく実 UI 導線のタップ） */
+	async gotoSettings(): Promise<void> {
+		await element(this.settingsButton).tap();
+	}
+
+	/**
+	 * レビュー投稿グリッドが存在するかを **待たずに** 判定する。
+	 * ゲスト時は Tabs.Tab ごと未マウントなので、TabBar.hasNotificationsTab() と同じ考え方で使う。
+	 */
+	async hasReviewsGrid(): Promise<boolean> {
+		return existsNow(this.reviewsGrid);
+	}
+}

--- a/e2e-mobile/screens/SettingsScreen.ts
+++ b/e2e-mobile/screens/SettingsScreen.ts
@@ -16,6 +16,10 @@ export class SettingsScreen {
 	 * 画面タイトル（ja-JP: Settings.title＝「設定」）。
 	 * ナビゲーションヘッダー（ScreenHeader）のため testID 化は見送られている（#1031 確定 §3-P3）。
 	 * i18n 文字列セレクタのため、翻訳キー変更時はここも見直すこと。
+	 *
+	 * ⚠️ 本 Screen Object で唯一のロケール依存セレクタ。**Android 端末のロケールが ja-JP でない場合、
+	 * expectLoaded() がここで最初に落ちる**（iOS は launchApp の languageAndLocale で固定できるが、
+	 * Android は CI 側で `adb shell setprop persist.sys.locale ja-JP` を実行する前提。#1031 B4）。
 	 */
 	readonly title = by.text("設定");
 	/** ご意見・不具合（フィードバック）行（既存 testID） */

--- a/e2e-mobile/screens/SettingsScreen.ts
+++ b/e2e-mobile/screens/SettingsScreen.ts
@@ -1,0 +1,50 @@
+import { DEFAULT_TIMEOUT, by, existsNow, waitUntilVisible } from "../fixtures/e2e";
+
+/**
+ * ⚙️ 設定画面の Screen Object（e2e-web の pages/SettingsPage.ts に対応）
+ *
+ * 対応画面: app-expo/app/[locale]/(tabs)/profile/settings.tsx
+ *
+ * - 「レビューを書く」（ストア誘導・settings-leave-review）は Web では非表示（`Platform.OS !== "web"` 条件）だが、
+ *   ネイティブでは表示される（#1031 §1-1 の反転分類）。
+ *   #1031 【設計確定】M2: 共有 dev 環境・外部ストアへの書き込みを避けるため、このボタンは
+ *   **表示のみ検証しタップしない**（タップすると実際に Linking.openURL が走り外部アプリへ遷移してしまう）。
+ * - 「ログアウト」はログイン済み（非匿名）ユーザーのみ表示。このワークスペースは匿名固定のテストのみを扱う（別 PR がログイン済みを担当）ため非表示側のみ検証する。
+ */
+export class SettingsScreen {
+	/**
+	 * 画面タイトル（ja-JP: Settings.title＝「設定」）。
+	 * ナビゲーションヘッダー（ScreenHeader）のため testID 化は見送られている（#1031 確定 §3-P3）。
+	 * i18n 文字列セレクタのため、翻訳キー変更時はここも見直すこと。
+	 */
+	readonly title = by.text("設定");
+	/** ご意見・不具合（フィードバック）行（既存 testID） */
+	readonly feedbackItem = by.id("settings-feedback");
+	/** レビューを書く（ストア誘導）行。ネイティブのみ表示（既存 testID） */
+	readonly leaveReviewItem = by.id("settings-leave-review");
+	/** ブロック済みの料理トピック行（既存 testID） */
+	readonly blockedTopicsItem = by.id("settings-blocked-topics");
+	/** コミュニティガイドライン行（既存 testID） */
+	readonly guidelinesItem = by.id("settings-guidelines");
+	/** 利用規約行（既存 testID） */
+	readonly termsItem = by.id("settings-terms");
+	/** プライバシーポリシー行（既存 testID） */
+	readonly privacyItem = by.id("settings-privacy");
+	/** 著作権行（既存 testID） */
+	readonly copyrightItem = by.id("settings-copyright");
+	/** ログアウト行（ログイン済みユーザーのみ表示・既存 testID） */
+	readonly logoutItem = by.id("settings-logout");
+
+	/** 設定画面が表示されていることを検証する */
+	async expectLoaded(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await waitUntilVisible(this.title, timeout);
+	}
+
+	/**
+	 * ログアウト行が表示されているかを **待たずに** 判定する。
+	 * 匿名/ログイン済みで可視性が変わるため、TabBar.hasNotificationsTab() と同じ考え方で使う。
+	 */
+	async hasLogoutItem(): Promise<boolean> {
+		return existsNow(this.logoutItem);
+	}
+}

--- a/e2e-mobile/tests/profile/login-modal.test.ts
+++ b/e2e-mobile/tests/profile/login-modal.test.ts
@@ -15,7 +15,10 @@ import { LoginModal } from "../../screens/LoginModal";
  * ログイン済み状態のテストは別 PR（launchAppWithSession({ as: "authenticated" })）が担当する。
  */
 describe("ログインモーダル", () => {
-	beforeAll(async () => {
+	// #1031 【バグ】beforeAll だと前のテストが残した画面状態(開いたままのモーダル等)を次が引き継ぎ、
+	// タップがオーバーレイに阻まれて落ちる。セッション注入起動は匿名クォータを消費しないため
+	// (fixtures/e2e.ts の launchAppWithSession)、テストごとに起動し直して独立性を担保する
+	beforeEach(async () => {
 		await launchAppWithSession({ as: "anon" });
 	});
 

--- a/e2e-mobile/tests/profile/login-modal.test.ts
+++ b/e2e-mobile/tests/profile/login-modal.test.ts
@@ -1,0 +1,58 @@
+import { launchAppWithSession } from "../../fixtures/e2e";
+import { TabBar } from "../../screens/TabBar";
+import { ProfileScreen } from "../../screens/ProfileScreen";
+import { LoginModal } from "../../screens/LoginModal";
+
+/**
+ * 🔑 ログインモーダルのテスト（e2e-web の tests/profile/login-modal.spec.ts に対応）
+ *
+ * 目的: ログイン導線の入口（モーダル表示・OAuth ボタン・リーガルリンク）を保証する。
+ *
+ * ## なぜ実 OAuth はテストしないのか
+ * ログイン手段は Google/Apple OAuth のみで、外部 IdP のログイン画面は bot 検知により
+ * 自動化がブロックされる上、プロバイダの利用規約にも抵触しうる。e2e-web と同じ方針で
+ * 「自分のアプリの責務（モーダル表示・遷移開始）」までをテストする。
+ * ログイン済み状態のテストは別 PR（launchAppWithSession({ as: "authenticated" })）が担当する。
+ */
+describe("ログインモーダル", () => {
+	beforeAll(async () => {
+		await launchAppWithSession({ as: "anon" });
+	});
+
+	// ─ テストケース: モーダルに Google/Apple ボタンが表示される ─
+	// 手順:
+	//   1. マイページのログインボタンをタップする
+	//   2. モーダル（login-modal）が開き、login-google-button・login-apple-button が
+	//      表示されることを検証
+	it("Google/Apple ボタンが表示される", async () => {
+		const tabBar = new TabBar();
+		const profileScreen = new ProfileScreen();
+		const loginModal = new LoginModal();
+
+		await tabBar.gotoProfile();
+		await profileScreen.openLoginModal();
+		await loginModal.expectOpened();
+	});
+
+	// ─ テストケース: プライバシーポリシーリンクでリーガルモーダルが開く ─
+	// 手順:
+	//   1. ログインモーダルを開く
+	//   2. 同意文言内のプライバシーポリシーリンク（login-privacy-link）をタップする
+	//   3. リーガルドキュメントモーダル（legal-document-modal）が表示されることを検証
+	//
+	// #1031 【設計確定】B2: e2e-web は「プライバシーポリシー」という同一文字列の出現数（1→3）で
+	// 判定しているが、Detox に要素数アサーション API は無いため、PR #1033 で追加された
+	// testID（login-privacy-link / legal-document-modal）を使って直接検証する。
+	it("プライバシーポリシーリンクでリーガルモーダルが開く", async () => {
+		const tabBar = new TabBar();
+		const profileScreen = new ProfileScreen();
+		const loginModal = new LoginModal();
+
+		await tabBar.gotoProfile();
+		await profileScreen.openLoginModal();
+		await loginModal.expectOpened();
+
+		await loginModal.openPrivacyPolicy();
+		await loginModal.expectLegalDocumentOpened();
+	});
+});

--- a/e2e-mobile/tests/profile/profile-guest.test.ts
+++ b/e2e-mobile/tests/profile/profile-guest.test.ts
@@ -12,7 +12,10 @@ import { ProfileScreen } from "../../screens/ProfileScreen";
  * ログイン済み前提のテスト（reviews タブの表示等）はこの PR では扱わない（別 PR 担当）。
  */
 describe("マイページ（匿名ユーザー）", () => {
-	beforeAll(async () => {
+	// #1031 【バグ】beforeAll だと前のテストが残した画面状態(開いたままのモーダル等)を次が引き継ぎ、
+	// タップがオーバーレイに阻まれて落ちる。セッション注入起動は匿名クォータを消費しないため
+	// (fixtures/e2e.ts の launchAppWithSession)、テストごとに起動し直して独立性を担保する
+	beforeEach(async () => {
 		// #1031 【設計】通常の spec は launchAppWithSession({ as: "anon" }) で
 		// 匿名サインインのクォータを消費せずに起動する
 		await launchAppWithSession({ as: "anon" });

--- a/e2e-mobile/tests/profile/profile-guest.test.ts
+++ b/e2e-mobile/tests/profile/profile-guest.test.ts
@@ -1,0 +1,50 @@
+import { strict as assert } from "node:assert";
+
+import { launchAppWithSession } from "../../fixtures/e2e";
+import { TabBar } from "../../screens/TabBar";
+import { ProfileScreen } from "../../screens/ProfileScreen";
+
+/**
+ * 👤 マイページ（匿名ユーザー）のテスト（e2e-web の tests/profile/profile-guest.spec.ts に対応）
+ *
+ * 目的: 匿名ユーザーのマイページが「ゲスト表示 + 保存系タブのみ」という
+ *       仕様どおりの構成になっていることを保証する。
+ * ログイン済み前提のテスト（reviews タブの表示等）はこの PR では扱わない（別 PR 担当）。
+ */
+describe("マイページ（匿名ユーザー）", () => {
+	beforeAll(async () => {
+		// #1031 【設計】通常の spec は launchAppWithSession({ as: "anon" }) で
+		// 匿名サインインのクォータを消費せずに起動する
+		await launchAppWithSession({ as: "anon" });
+	});
+
+	// ─ テストケース: ゲスト表示（ログインボタン等）が表示される ─
+	// 手順:
+	//   1. TabBar.gotoProfile() でマイページタブへ遷移する
+	//   2. ログインボタン（profile-login-button）が表示されることを検証
+	it("ゲスト表示が表示される", async () => {
+		const tabBar = new TabBar();
+		const profileScreen = new ProfileScreen();
+
+		await tabBar.gotoProfile();
+		await profileScreen.expectGuestViewLoaded();
+	});
+
+	// ─ テストケース: タブが保存系のみで構成される ─
+	// 手順:
+	//   1. マイページを表示する（デフォルトタブ = 保存した投稿）
+	//   2. 保存した投稿タブ（save-post-tab-grid）が表示されることを検証
+	//   3. レビュー投稿タブ（review-tab-grid）が存在しないことを検証
+	//      （features/profile/containers/ProfileTabsLayout.tsx で isGuest 時は
+	//      Tabs.Tab 自体がレンダリングされない仕様。Web 版の toHaveCount(0) に相当）
+	it("タブが保存系のみで構成される", async () => {
+		const tabBar = new TabBar();
+		const profileScreen = new ProfileScreen();
+
+		await tabBar.gotoProfile();
+		await profileScreen.expectSavedPostsGridVisible();
+
+		const hasReviewsGrid = await profileScreen.hasReviewsGrid();
+		assert.equal(hasReviewsGrid, false, "ゲスト時は review-tab-grid が存在しないはず");
+	});
+});

--- a/e2e-mobile/tests/profile/settings.test.ts
+++ b/e2e-mobile/tests/profile/settings.test.ts
@@ -19,7 +19,10 @@ import { SettingsScreen } from "../../screens/SettingsScreen";
  *   Linking.openURL が実際に走ってしまうため）。
  */
 describe("設定画面（匿名ユーザー）", () => {
-	beforeAll(async () => {
+	// #1031 【バグ】beforeAll だと前のテストが残した画面状態(開いたままのモーダル等)を次が引き継ぎ、
+	// タップがオーバーレイに阻まれて落ちる。セッション注入起動は匿名クォータを消費しないため
+	// (fixtures/e2e.ts の launchAppWithSession)、テストごとに起動し直して独立性を担保する
+	beforeEach(async () => {
 		await launchAppWithSession({ as: "anon" });
 	});
 

--- a/e2e-mobile/tests/profile/settings.test.ts
+++ b/e2e-mobile/tests/profile/settings.test.ts
@@ -1,0 +1,66 @@
+import { strict as assert } from "node:assert";
+
+import { launchAppWithSession, waitUntilVisible } from "../../fixtures/e2e";
+import { TabBar } from "../../screens/TabBar";
+import { ProfileScreen } from "../../screens/ProfileScreen";
+import { SettingsScreen } from "../../screens/SettingsScreen";
+
+/**
+ * ⚙️ 設定画面（匿名ユーザー）のテスト（e2e-web の tests/profile/settings.spec.ts に対応）
+ *
+ * 目的: 設定メニューの項目構成と、匿名ユーザーへの表示制御を保証する。
+ * 表示・遷移の検証に留め、フィードバック送信・アカウント削除等の共有 dev 環境へ書き込む操作は行わない。
+ *
+ * ## Web 版からの変更点（#1031 確定）
+ * - e2e-web は `page.goto("/ja-JP/profile/settings")` で URL 直遷移するが、ネイティブには
+ *   その代替経路が無いため、マイページの歯車ボタン（profile-settings-button）を実際にタップして遷移する。
+ * - 「レビューを書く」（settings-leave-review）は Web では非表示だが、ネイティブでは表示される
+ *   （`Platform.OS !== "web"` 条件、#1031 §1-1 の反転）。表示のみ検証し、タップはしない（M2: ストア誘導の
+ *   Linking.openURL が実際に走ってしまうため）。
+ */
+describe("設定画面（匿名ユーザー）", () => {
+	beforeAll(async () => {
+		await launchAppWithSession({ as: "anon" });
+	});
+
+	// ─ テストケース: 設定メニューの各項目が表示される ─
+	// 手順:
+	//   1. マイページタブ→歯車ボタンの実導線で設定画面へ遷移する
+	//   2. 以下の項目が表示されることを検証:
+	//      - ご意見・不具合(settings-feedback) / レビューを書く(settings-leave-review、ネイティブのみ)
+	//      - ブロック済みの料理トピック(settings-blocked-topics) / 利用規約(settings-terms)
+	//      - プライバシーポリシー(settings-privacy)
+	it("設定メニューの各項目が表示される", async () => {
+		const tabBar = new TabBar();
+		const profileScreen = new ProfileScreen();
+		const settingsScreen = new SettingsScreen();
+
+		await tabBar.gotoProfile();
+		await profileScreen.gotoSettings();
+		await settingsScreen.expectLoaded();
+
+		await waitUntilVisible(settingsScreen.feedbackItem);
+		await waitUntilVisible(settingsScreen.leaveReviewItem);
+		await waitUntilVisible(settingsScreen.blockedTopicsItem);
+		await waitUntilVisible(settingsScreen.termsItem);
+		await waitUntilVisible(settingsScreen.privacyItem);
+	});
+
+	// ─ テストケース: 匿名時はログアウトが表示されない ─
+	// 手順:
+	//   1. 設定画面を表示する（匿名状態）
+	//   2. ログアウト行（settings-logout）が存在しないことを検証
+	//      （ログアウトは非匿名ユーザーのみに表示される仕様）
+	it("匿名時はログアウトが表示されない", async () => {
+		const tabBar = new TabBar();
+		const profileScreen = new ProfileScreen();
+		const settingsScreen = new SettingsScreen();
+
+		await tabBar.gotoProfile();
+		await profileScreen.gotoSettings();
+		await settingsScreen.expectLoaded();
+
+		const hasLogoutItem = await settingsScreen.hasLogoutItem();
+		assert.equal(hasLogoutItem, false, "匿名ユーザーには settings-logout が表示されないはず");
+	});
+});


### PR DESCRIPTION
## 対象 Issue

- #1031(PR-4: profile + settings 系)/ 親: #1027

## 概要

Screen Object 3種(`ProfileScreen` / `SettingsScreen` / `LoginModal`)と、匿名ユーザーで検証できる spec 3本(profile-guest / settings / login-modal)を追加。

## 設計確定への追従(B2)

- リーガルモーダルの検証は「同じ文字列の出現数」(Detox に要素数 API が無い)ではなく、PR #1033 で追加した `login-privacy-link` / `legal-document-modal` を使って**直接検証**
- マイページ → 設定は URL 直遷移ではなく `profile-settings-button` の**実導線タップ**で遷移

## 安全性

- 設定画面では共有 dev 環境へ書き込む操作(フィードバック送信・アカウント削除等)を一切行わず、表示・遷移の検証に留めている

## 検証

- 使用している testID 19 件すべてが app-expo に実在することをリーダー側で grep 確認済み
- worker run(issue-1031-impl-pr4-profile)で `pnpm --filter e2e-mobile typecheck` 実施
- 実機実行の検証は Wave 2 統合後に CI でまとめて行う

## スクショ免除の理由

app-expo(UI)への変更なし(E2E テストの追加のみ)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8)_