### PR TITLE
e2e-mobile: review(ゲスト導線)テストと Screen Object を追加(PR-5)#1031

### DIFF
--- a/e2e-mobile/screens/ReviewScreen.ts
+++ b/e2e-mobile/screens/ReviewScreen.ts
@@ -1,0 +1,68 @@
+import { DEFAULT_TIMEOUT, by, element, waitUntilVisible } from "../fixtures/e2e";
+
+/**
+ * ✏️ 「レビュー」タブの Screen Object（e2e-web の pages/ReviewPage.ts に対応）
+ *
+ * 対応画面:
+ * - `app-expo/app/[locale]/(tabs)/review/index.tsx`（タブ本体。ログイン状態で表示が分岐する）
+ * - `app-expo/app/[locale]/(tabs)/review/restaurant/[restaurantId]/review.tsx`
+ *   （`features/map/components/ReviewForm.tsx`。レビュー投稿フォーム本体）
+ *
+ * 表示内容はログイン状態で分岐する（index.tsx）:
+ * - 匿名ユーザー: ゲスト向け説明 + ログイン CTA（`Review.guest.*`）
+ * - ログイン済み: レビュー投稿 CTA（`Review.authenticated.postButton`）→ SelectRestaurantScreen へ
+ *
+ * ## このクラスがカバーする範囲（#1031 B6 確定 / このリーダー指示の範囲）
+ * この PR（PR-5）で実際にテストから使うのは **ゲスト向け表示 2 要素のみ**。
+ * フォーム部分（comment/dishCategory/price/star/submit）は認証済み前提のため、
+ * この PR のテストからは使わない。**将来のレビュー投稿テスト（別 PR・認証済みセッション利用）が
+ * 迷わず使えるよう、実在する testID を調べたうえで定義だけ用意する**（#1031 B6 レビュー指摘の反映）。
+ *
+ * ## 写真付きレビュー投稿はスコープ外（#1031 B6 確定）
+ * フォトピッカーは OS のアプリ外プロセスで動作するため、Detox からは操作できない。
+ * そのため `ReviewForm` が起動直後に呼ぶメディア選択（`selectMedia`）を伴う画面遷移そのものを
+ * この Screen Object / この PR のテストでは検証しない。テキスト入力欄（comment/dishCategory/price/star/submit）の
+ * 定義だけを残しておき、実装は「メディア選択をアプリ側テストフックで固定画像に差し替える」方式が
+ * 決まった将来の PR に委ねる。
+ */
+export class ReviewScreen {
+	// ── ゲスト向け表示（この PR のテストで実際に使う） ──────────────────────────
+	/** ゲスト向け説明文（ja-JP: `Review.guest.description` = "ログインしてレビューを書こう"） */
+	readonly guestDescription = by.id("review-guest-description");
+	/** ゲスト向けログイン CTA（ja-JP: `Review.guest.loginButton` = "ログインする"） */
+	readonly guestLoginButton = by.id("review-guest-login-button");
+
+	// ── ログイン済み向け表示（#1031 B6: 定義のみ。認証済みセッションが前提のため別 PR で使用） ──
+	/** レビュー投稿 CTA（ja-JP: `Review.authenticated.postButton`）。タップで SelectRestaurantScreen へ遷移 */
+	readonly postButton = by.id("review-post-button");
+
+	// ── レビュー投稿フォーム（#1031 B6: 定義のみ。`ReviewForm.tsx` 由来、認証済み専用） ──────
+	/** レビュー本文入力欄（`ReviewForm.tsx:578`） */
+	readonly commentInput = by.id("review-comment-input");
+	/** 料理カテゴリ選択行（`ReviewForm.tsx:596`）。タップで dishCategorySearch モーダルが開く */
+	readonly dishCategoryRow = by.id("review-dish-category-row");
+	/** 料理カテゴリ検索モーダル本体（`ReviewForm.tsx:722`, `DishCategorySearchForm`） */
+	readonly dishCategorySearch = by.id("dish-category-search");
+	/** 価格入力欄（`ReviewForm.tsx:635,646`） */
+	readonly priceInput = by.id("review-price-input");
+	/** 投稿ボタン（`ReviewForm.tsx:706`） */
+	readonly submitButton = by.id("review-submit-button");
+
+	/**
+	 * 星評価ボタン（`ReviewForm.tsx:671`）。1〜5 の整数を渡す。
+	 * @param star 1〜5
+	 */
+	star(star: 1 | 2 | 3 | 4 | 5) {
+		return by.id(`review-star-${star}`);
+	}
+
+	/** ゲスト向けログイン CTA が表示されるまで待つ */
+	async expectGuestViewLoaded(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await waitUntilVisible(this.guestLoginButton, timeout);
+	}
+
+	/** ゲスト向けログイン CTA をタップする */
+	async tapGuestLogin(): Promise<void> {
+		await element(this.guestLoginButton).tap();
+	}
+}

--- a/e2e-mobile/screens/SelectRestaurantScreen.ts
+++ b/e2e-mobile/screens/SelectRestaurantScreen.ts
@@ -1,0 +1,29 @@
+import { by } from "../fixtures/e2e";
+
+/**
+ * 📍 レビュー投稿用の「お店選択」Screen Object。
+ *
+ * 対応画面:
+ * - `app-expo/app/[locale]/(tabs)/review/selectRestaurant.tsx`（地図 + 検索でお店を選ぶ画面）
+ * - `app-expo/app/[locale]/(tabs)/review/restaurant/[restaurantId].tsx`
+ *   （`features/review/components/SelectedRestaurantDetails.tsx`。選択後の詳細画面）
+ *
+ * ## この PR（PR-5）では定義のみ（#1031 B6 レビュー指摘の反映）
+ * この画面へ到達する唯一の UI 導線は `ReviewScreen.postButton`（レビュータブの投稿 CTA）で、
+ * ログイン済みユーザーにしか表示されない（`app-expo/.../review/index.tsx` の
+ * `user?.is_anonymous !== false` 分岐）。つまり **匿名ユーザーはこの画面へ到達する手段が無い**ため、
+ * この PR（匿名のみで検証する PR-5）のテストからは使わない。
+ * 将来の認証済みレビュー投稿テスト（別 PR）がそのまま使えるよう、実在する testID を確認したうえで
+ * 定義だけ用意しておく。
+ */
+export class SelectRestaurantScreen {
+	/** 検索バー内の現在地ボタン（`selectRestaurant.tsx:480`） */
+	readonly currentLocationButton = by.id("review-select-restaurant-current-location-button");
+
+	/**
+	 * 選択したお店の詳細画面にある「写真・動画を投稿」ボタン（`SelectedRestaurantDetails.tsx:137`）。
+	 * ログイン済みなら ReviewScreen（フォーム）へ、匿名ならログインモーダルへ遷移する
+	 * （`handleReviewButtonPress`、`SelectedRestaurantDetails.tsx:68-88`）。
+	 */
+	readonly postPhotoButton = by.id("restaurant-detail-post-photo-button");
+}

--- a/e2e-mobile/tests/review/review-guest.test.ts
+++ b/e2e-mobile/tests/review/review-guest.test.ts
@@ -1,0 +1,61 @@
+import { by, element, expect, launchAppWithSession, waitUntilVisible } from "../../fixtures/e2e";
+import { ReviewScreen } from "../../screens/ReviewScreen";
+import { TabBar } from "../../screens/TabBar";
+
+/**
+ * ✏️ レビュータブ（匿名ユーザー）のテスト（e2e-web の tests/review/review-guest.spec.ts に対応）
+ *
+ * 目的: 匿名ユーザーに対する「ログインへの導線」が機能していることを保証する。
+ *
+ * ## スコープ（#1031 B6 確定 / このリーダー指示の範囲）
+ * - 対象は **匿名ユーザーで検証できる範囲のみ**（ゲスト向け表示 + ログイン導線）。
+ * - レビュー投稿（書き込み）は認証済み前提のため、このテストでは扱わない（別 PR 担当）。
+ * - 写真付きレビュー投稿はフォトピッカーがアプリ外プロセスのため Detox から操作できず、
+ *   初期スコープ外（#1031 B6）。そもそもこの画面（お店選択・投稿フォーム）へは
+ *   匿名ユーザーが到達する UI 導線自体が無い（`ReviewScreen.postButton` はログイン済みのみ表示）。
+ *
+ * ## ログインモーダルの検証について
+ * `LoginModal` の Screen Object（`login-modal` / `login-google-button` / `login-apple-button`）は
+ * 別 PR（PR-4: profile+settings 系）が所有するファイルのため、この PR ではファイルを増やさず
+ * `by.id(...)` を直接使って最小限の検証だけ行う。
+ */
+describe("レビュータブ（匿名ユーザー）", () => {
+	const tabBar = new TabBar();
+	const reviewScreen = new ReviewScreen();
+
+	beforeAll(async () => {
+		// #1030 【設計】確定設計（A' 案）どおり、Node 側で確立済みの匿名セッションを注入して起動する。
+		// 匿名サインインのクォータ（30 回/時/IP）を消費しない
+		await launchAppWithSession({ as: "anon" });
+	});
+
+	// ─ テストケース: ゲスト向け説明とログイン CTA が表示される ─
+	// 手順:
+	//   1. レビュータブへ遷移する
+	//   2. ゲスト説明文（testID: review-guest-description。ja-JP: Review.guest.description）が
+	//      表示されることを検証
+	//   3. ログイン CTA（testID: review-guest-login-button。ja-JP: Review.guest.loginButton）が
+	//      表示されることを検証
+	it("ゲスト向け説明とログイン CTA が表示される", async () => {
+		await tabBar.gotoReview();
+
+		await reviewScreen.expectGuestViewLoaded();
+		await expect(element(reviewScreen.guestDescription)).toBeVisible();
+	});
+
+	// ─ テストケース: ログイン CTA タップでログインモーダルが開く ─
+	// 手順:
+	//   1. レビュータブのゲスト表示を開く
+	//   2. ログイン CTA をタップする
+	//   3. ログインモーダル（testID: login-modal）が開き、Google/Apple ボタンが表示されることを検証
+	it("ログイン CTA タップでログインモーダルが開く", async () => {
+		await tabBar.gotoReview();
+		await reviewScreen.expectGuestViewLoaded();
+
+		await reviewScreen.tapGuestLogin();
+
+		await waitUntilVisible(by.id("login-modal"));
+		await expect(element(by.id("login-google-button"))).toBeVisible();
+		await expect(element(by.id("login-apple-button"))).toBeVisible();
+	});
+});


### PR DESCRIPTION
## 対象 Issue

- #1031(PR-5: review 系)/ 親: #1027

## 概要

- `screens/ReviewScreen.ts` / `screens/SelectRestaurantScreen.ts`: レビュー画面の Screen Object(フォーム部分の定義は将来の投稿テスト用に用意、本 PR のテストからは未使用)
- `tests/review/review-guest.test.ts`: 匿名(ゲスト)ユーザーでのレビュータブ表示とログイン導線を検証

## スコープ外(設計確定 B6 に従う)

- **写真付きレビュー投稿**: フォトピッカーはアプリ外プロセスのため Detox から操作できない
- **レビュー投稿(書き込み)**: 認証済み前提のため別 PR。`tests/mutation/` には何も追加していない
- 共有 dev DB への書き込みは一切なし

## 検証

- 使用している testID 13 件すべてが app-expo に実在することをリーダー側で grep 確認済み
- worker run(issue-1031-impl-pr5-review)で `pnpm --filter e2e-mobile typecheck` 実施

## スクショ免除の理由

app-expo(UI)への変更なし(E2E テストの追加のみ)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8)_