### PR TITLE
e2e-mobile: search 系テストと Screen Object を追加(PR-3)#1031

### DIFF
--- a/e2e-mobile/fixtures/e2e.ts
+++ b/e2e-mobile/fixtures/e2e.ts
@@ -1,6 +1,12 @@
 import { by, device, element, expect as detoxExpect, waitFor } from "detox";
 
-import { iosLanguageAndLocale, localeDeepLink, warnIfAndroidLocaleMismatch } from "../utils/locale";
+import {
+	E2E_LOCALE,
+	getAndroidSystemLocale,
+	iosLanguageAndLocale,
+	localeDeepLink,
+	warnIfAndroidLocaleMismatch,
+} from "../utils/locale";
 import {
 	isAuthenticatedAvailable,
 	isMutationEnabled,
@@ -204,6 +210,31 @@ export const describeAuthenticated: typeof describe = isAuthenticatedAvailable()
  * describeMutation("いいね/保存 @mutation", () => { ... });
  */
 export const describeMutation: typeof describe = isMutationEnabled() ? describe : describe.skip;
+
+/**
+ * ja-JP ロケール前提のテスト用の `describe`。
+ *
+ * #1031 【設計】B4: 検索チュートリアルの自動表示は app-expo 側が `isJapanese` でゲートしており、
+ * 端末ロケールが ja-JP でないとそもそも開かない。CI は Android のシステムロケールを ja-JP へ固定するが
+ * （e2e-mobile-test.yml の adb setprop）、ローカルの手元エミュレータでは固定されていないことがある。
+ * その場合に **120 秒待ってから失敗する**のは調査コストが高いので、spec ごと skip して理由を明示する。
+ *
+ * 判定は Android のシステムロケールのみを見る（iOS は launchApp の `languageAndLocale` で
+ * 常に固定されるため。`getAndroidSystemLocale()` は iOS / adb 不在時に null を返すので skip しない）。
+ *
+ * @example
+ * describeJapaneseLocale("検索チュートリアル", () => { ... });
+ */
+export const describeJapaneseLocale: typeof describe = (() => {
+	const androidLocale = getAndroidSystemLocale();
+	if (androidLocale !== null && androidLocale !== E2E_LOCALE) {
+		console.warn(
+			`⚠️ Android ロケールが ${E2E_LOCALE} ではない（現在: ${androidLocale}）ため、ja-JP 前提の spec を skip します。`,
+		);
+		return describe.skip;
+	}
+	return describe;
+})();
 
 /**
  * プラットフォーム依存の launchApp オプションを組み立てる。

--- a/e2e-mobile/screens/ResultScreen.ts
+++ b/e2e-mobile/screens/ResultScreen.ts
@@ -1,0 +1,72 @@
+import { by, element, waitFor } from "../fixtures/e2e";
+
+/**
+ * 🍽 検索結果フィード画面（料理メディアのフィード / マップ）の Screen Object
+ *
+ * 対応画面: app-expo/app/[locale]/(tabs)/search/result.tsx
+ * 対応する e2e-web の Page Object: e2e-web/pages/ResultPage.ts
+ *
+ * ## 画面表示の観測点
+ * この画面には静的な見出しテキストが無く（表示されるのは動的な料理メディアのみ）、
+ * 画面到達の判定は閉じるボタン (`result-close-button`) の可視性で行う（e2e-web と同じ判断）。
+ *
+ * ## 閉じたときの戻り先
+ * `useSearchResult.handleClose` は `router.back()` を呼ぶ。ナビゲーション履歴は
+ * 検索 → トピック → 結果 と積まれているため、**1 回閉じた戻り先はトピック画面**になる。
+ *
+ * ## いいね / 保存の状態検証について（#1031 確定判断 B1）
+ * `dish-action-like` / `dish-action-save` の **選択状態**（いいね済みかどうか）は、app-expo 側で
+ * `aria-selected` と SVG の塗り色でしか表現されておらず、Detox には
+ * `accessibilityState` を検証する API が無いため現時点では検証できない。
+ * 状態を反映する testID の追加後に、@mutation テスト（PR-6）側で検証する。
+ * ここではフィード上のアクションを**タップできる**ところまでをヘルパとして提供する。
+ */
+export class ResultScreen {
+	/** 結果画面を閉じるボタン（トピック画面へ戻る） */
+	readonly closeButton = by.id("result-close-button");
+	/** いいねボタン（⚠️ フィードには複数カードが積まれるため atIndex で絞ること） */
+	readonly likeButton = by.id("dish-action-like");
+	/** 保存ボタン（⚠️ 同上） */
+	readonly saveButton = by.id("dish-action-save");
+
+	/**
+	 * 結果フィードの読み込み待ちタイムアウト (ms)。
+	 * トピック選択後は店舗 5 件分のリストとサムネイルの事前読み込みが走るため長めに取る。
+	 */
+	static readonly RESULT_TIMEOUT = 90_000;
+
+	/**
+	 * 結果画面が表示されていることを検証する。
+	 *
+	 * @param timeout タイムアウト (ms)
+	 * @失敗時 期限内に閉じるボタンが見えなければ Detox の例外を投げる
+	 */
+	async expectLoaded(timeout: number = ResultScreen.RESULT_TIMEOUT): Promise<void> {
+		await waitFor(element(this.closeButton)).toBeVisible().withTimeout(timeout);
+	}
+
+	/** 結果画面を閉じてトピック画面へ戻る */
+	async close(): Promise<void> {
+		await element(this.closeButton).tap();
+	}
+
+	/**
+	 * 表示中の料理メディアの「いいね」をタップする。
+	 * ⚠️ 書き込みを伴うため @mutation（Tier 3）でのみ使うこと。
+	 *
+	 * @param index フィード内の何枚目のカードか（既定 0 = 表示中のカード）
+	 */
+	async like(index = 0): Promise<void> {
+		await element(this.likeButton).atIndex(index).tap();
+	}
+
+	/**
+	 * 表示中の料理メディアの「保存」をタップする。
+	 * ⚠️ 書き込みを伴うため @mutation（Tier 3）でのみ使うこと。
+	 *
+	 * @param index フィード内の何枚目のカードか（既定 0 = 表示中のカード）
+	 */
+	async save(index = 0): Promise<void> {
+		await element(this.saveButton).atIndex(index).tap();
+	}
+}

--- a/e2e-mobile/screens/SearchScreen.ts
+++ b/e2e-mobile/screens/SearchScreen.ts
@@ -1,0 +1,304 @@
+import {
+	DEFAULT_TIMEOUT,
+	by,
+	element,
+	existsNow,
+	expect,
+	waitFor,
+	waitUntilGone,
+	waitUntilVisible,
+} from "../fixtures/e2e";
+
+/**
+ * 🔍 「さがす」タブ（検索フォーム画面）の Screen Object
+ *
+ * 対応画面: app-expo/app/[locale]/(tabs)/search/index.tsx
+ * 対応する e2e-web の Page Object: e2e-web/pages/SearchPage.ts
+ *
+ * ## 検索の必須項目
+ * 検索実行には 場所 / 時間帯 / 同行者（シーン）の 3 つが必要。
+ * 時間帯（既定 `lunch`）と同行者（既定 `solo`）には初期値があるため、**未確定なのは場所だけ**になる。
+ * #973 以降、検索ボタン (`search-submit-button`) は常にタップ可能で、未充足のまま押すと
+ * `handleSearch` 内のバリデーションが `global-snackbar` を出したうえで遷移をガードする。
+ *
+ * ## Detox と Playwright の違い（#1031 §2）
+ * `element()` はグローバル API なので、e2e-web の Page Object と違いコンストラクタ引数を取らない。
+ * TabBar.ts と同じく **by.id をそのまま readonly フィールドに持ち、操作メソッドで element() に包む**。
+ *
+ * ## 移植を落とした検証（#1031 確定判断 / testID ギャップ）
+ * - **B1**: `accessibilityRole="radiogroup"` / `accessibilityState.selected` 等の a11y 属性検証は
+ *   Detox に対応 API が無いため対象外。時間帯・同行者の「選択状態」は Web 側の a11y テストで担保する。
+ *   ネイティブでは「タップできること」と「その結果として検索が成立すること」までを検証範囲とする
+ * - **B3**: 距離に応じたおすすめ移動時間は **順序検証を落とし、表示有無のみ**を検証する
+ *   （Detox には子孫の前方一致セレクタも要素数アサーション（toHaveCount 相当）も無いため）
+ * - **距離スライダーの値変更**（e2e-web の distance-slider.spec.ts）は移植していない。
+ *   `search-distance-slider` は PanResponder ベースの自作スライダーで、現在値は `aria-valuenow`
+ *   （= web 専用属性）にしか出ておらず、**値を反映する testID が app-expo に無い**ため
+ *   Detox からは操作後の値を検証できない。値検証用の testID が追加されたら移植すること
+ * - **現在地取得**（e2e-web の current-location.spec.ts）は移植していない。
+ *   「拒否」「タイムアウト」の再現には起動時の権限設定を spec ごとに切り替える必要があるが、
+ *   fixtures/e2e.ts の `platformLaunchOptions()` は権限を常に付与する固定実装のため、
+ *   拒否ケースを表現できない。fixtures 側に権限を切り替える起動オプションが入ったら移植すること
+ */
+export class SearchScreen {
+	/** 画面ヘッダのタイトル（i18n: Search.headerTitle） */
+	readonly headerTitle = by.id("search-header-title");
+	/** ヘッダーの「？」ボタン（チュートリアル再表示。ja-JP のときのみ表示される） */
+	readonly helpButton = by.id("search-help-button");
+
+	/** 場所オートコンプリートの入力欄 */
+	readonly locationInput = by.id("search-location-autocomplete-input");
+	/** 場所入力のクリアボタン（入力が 1 文字以上あるときだけ描画される） */
+	readonly locationClearButton = by.id("search-location-autocomplete-clear");
+	/** 場所サジェストのリスト */
+	readonly locationSuggestions = by.id("search-location-autocomplete-suggestions");
+	/** 入力欄右端の「現在地を使う」ボタン */
+	readonly currentLocationButton = by.id("search-current-location-button");
+
+	/** 詳細条件の展開トグル */
+	readonly advancedToggle = by.id("search-advanced-toggle");
+	/** 距離スライダー */
+	readonly distanceSlider = by.id("search-distance-slider");
+	/** おすすめの移動時間チップの並び（#1031 B3: 表示有無のみ検証する） */
+	readonly distanceRecommendedEstimates = by.id("search-distance-recommended-estimates");
+	/** おすすめ外の移動時間を開閉するトグル */
+	readonly distanceEstimatesToggle = by.id("search-distance-estimates-toggle");
+	/** おすすめ外の移動時間チップの並び（トグルを開いたときだけ描画される） */
+	readonly distanceOtherEstimates = by.id("search-distance-other-estimates");
+
+	/** 検索実行ボタン（画面下部固定の FAB） */
+	readonly submitButton = by.id("search-submit-button");
+	/** グローバルスナックバー（バリデーションエラー等の通知） */
+	readonly snackbar = by.id("global-snackbar");
+
+	/** 検索チュートリアル（BottomSheet）のコンテンツ全体 */
+	readonly tutorialOverlay = by.id("search-tutorial-overlay");
+	/** チュートリアルの「つぎへ」（最終ページ以外で描画される） */
+	readonly tutorialNextButton = by.id("search-tutorial-next");
+	/** チュートリアルの「はじめよう」（最終ページのプライマリ CTA。押すと現在地取得が走る） */
+	readonly tutorialFinishButton = by.id("search-tutorial-finish");
+	/** チュートリアルの「あとで」（最終ページのセカンダリ CTA。現在地取得を伴わずに完了する） */
+	readonly tutorialLaterButton = by.id("search-tutorial-later");
+
+	/**
+	 * スクロール操作の起点にする要素。
+	 *
+	 * #1031 【設計】検索画面の `ScrollView` には testID が無いため、Detox の
+	 * `whileElement(...).scroll()` が使えない。代わりに **スクロール領域の内側にある実在の要素**を
+	 * 掴んで swipe することで同等のスクロールを行う（`search-scene-solo` は同行者グリッドの先頭項目）。
+	 * ⚠️ app-expo に `search-scroll-view` 相当の testID が追加されたら `whileElement().scroll()` へ置き換えること。
+	 */
+	private readonly scrollAnchor = by.id("search-scene-solo");
+
+	/** n 番目の場所サジェスト（0 始まり） */
+	locationSuggestion(index: number): Detox.NativeMatcher {
+		return by.id(`search-location-autocomplete-suggestion-${index}`);
+	}
+
+	/** 時間帯グリッドの項目（id は app-expo/features/search/constants.ts の timeSlots の値） */
+	timeSlot(id: "morning" | "lunch" | "dinner" | "late_night"): Detox.NativeMatcher {
+		return by.id(`search-time-slot-${id}`);
+	}
+
+	/** 同行者（シーン）グリッドの項目（id は sceneOptions の値） */
+	scene(id: "solo" | "date" | "friends" | "family" | "drinking"): Detox.NativeMatcher {
+		return by.id(`search-scene-${id}`);
+	}
+
+	/** 予算帯チップ（value は priceLevelOptions の値） */
+	priceLevel(value: string): Detox.NativeMatcher {
+		return by.id(`search-price-level-${value}`);
+	}
+
+	/** 交通手段ごとの所要時間チップ */
+	distanceEstimate(mode: "walk" | "bike" | "car" | "train"): Detox.NativeMatcher {
+		return by.id(`search-distance-estimate-${mode}`);
+	}
+
+	/**
+	 * 検索画面が表示されていることを検証する。
+	 *
+	 * ⚠️ チュートリアルが自動表示されていた場合は **先に閉じてから**検証する。
+	 * ネイティブのチュートリアルは BottomSheet（Android では別ウィンドウの Modal）として
+	 * 描画され、その間は背後の検索フォームが Detox から見えなくなるため、
+	 * 「チュートリアルが出ているせいで画面表示の検証に失敗する」誤検知を防ぐ必要がある。
+	 * チュートリアルそのものを検証する spec は expectLoaded を呼ぶ前に検証すること。
+	 *
+	 * @param timeout タイムアウト (ms)
+	 */
+	async expectLoaded(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await this.dismissTutorialIfPresent();
+		await waitUntilVisible(this.headerTitle, timeout);
+	}
+
+	/**
+	 * 場所入力欄へ文字を入力する。
+	 *
+	 * #1031 【設計】`typeText` ではなく `replaceText` を使う。Android の Detox は Espresso の
+	 * `typeTextIntoFocusedView` を使うため **ASCII 以外（= 日本語）を入力できない**。
+	 * `replaceText` はプラットフォームを問わず任意の文字列を入れられ、RN の `onChangeText` も発火する。
+	 *
+	 * また `LocationAutocomplete` は `showSuggestions = 入力あり && フォーカス中` で候補を出すため、
+	 * **入力前に必ずタップしてフォーカスを与える**（フォーカスが無いと候補パネルが開かない）。
+	 *
+	 * @param query 入力する地名（例: "渋谷"）
+	 */
+	async typeLocation(query: string): Promise<void> {
+		await element(this.locationInput).tap();
+		await element(this.locationInput).replaceText(query);
+	}
+
+	/**
+	 * 入力済みの場所をクリアする（入力が無ければ何もしない）。
+	 *
+	 * チュートリアル完了済みの状態では画面表示時に現在地が自動取得され、場所が確定済みになることがある。
+	 * 「場所未確定」を前提にする検証の前処理として使う（e2e-web の search-form.spec.ts と同じ考え方）。
+	 * クリアボタンの押下は入力文字列だけでなく確定済みの location（検索の必須項目）も null に戻す。
+	 *
+	 * @returns クリアを実行した場合 true
+	 */
+	async clearLocationIfPresent(): Promise<boolean> {
+		if (!(await existsNow(this.locationClearButton))) return false;
+
+		await element(this.locationClearButton).tap();
+		return true;
+	}
+
+	/**
+	 * n 番目の場所サジェストを選択する。
+	 *
+	 * ⚠️ サジェスト選択（handleLocationSelect）は、候補の文言を入力欄へ反映した**あとで非同期に**
+	 * 詳細取得 API (v1/locations/details) を呼び、その完了後にはじめて検索の必須項目である
+	 * `location` が確定する。Detox には Playwright の `waitForResponse` に相当する API が無いが、
+	 * Detox の同期機構が **未完了のネットワークリクエストがある間は次の操作をブロックする**ため、
+	 * この直後に `submit()` してもリクエスト完了後にタップが実行される（utils/waits.ts の方針）。
+	 *
+	 * @param index 0 始まりのサジェスト番号
+	 */
+	async selectLocationSuggestion(index: number): Promise<void> {
+		await waitUntilVisible(this.locationSuggestion(index));
+		await element(this.locationSuggestion(index)).tap();
+	}
+
+	/** 時間帯を選択する */
+	async selectTimeSlot(id: "morning" | "lunch" | "dinner" | "late_night"): Promise<void> {
+		await element(this.timeSlot(id)).tap();
+	}
+
+	/** 同行者（シーン）を選択する */
+	async selectScene(id: "solo" | "date" | "friends" | "family" | "drinking"): Promise<void> {
+		await element(this.scene(id)).tap();
+	}
+
+	/** 詳細条件（距離・フードスタイル等）を展開する。画面外にある場合はスクロールしてから押す */
+	async openAdvancedFilters(): Promise<void> {
+		await this.scrollUntilVisible(this.advancedToggle, this.scrollAnchor);
+		await element(this.advancedToggle).tap();
+	}
+
+	/** おすすめ外の移動時間チップの開閉を切り替える */
+	async toggleOtherDistanceEstimates(): Promise<void> {
+		await this.scrollUntilVisible(this.distanceEstimatesToggle, this.advancedToggle);
+		await element(this.distanceEstimatesToggle).tap();
+	}
+
+	/** 検索を実行する */
+	async submit(): Promise<void> {
+		await element(this.submitButton).tap();
+	}
+
+	/**
+	 * チュートリアルが自動表示されていることを検証する。
+	 * ja-JP かつ未視聴（AsyncStorage の `search_tutorial_seen_v1` が未設定）のときだけ成立する。
+	 */
+	async expectTutorialShown(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await waitUntilVisible(this.tutorialOverlay, timeout);
+	}
+
+	/**
+	 * チュートリアルが表示されていないことを検証する。
+	 *
+	 * #1031 【設計】m6: e2e-web は `page.evaluate` で localStorage のフラグを直接読んでいるが、
+	 * Detox からアプリの AsyncStorage は読めない。**「再訪問しても表示されない」という
+	 * ユーザー観測可能な事実**で代替する。
+	 */
+	async expectTutorialAbsent(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await waitUntilVisible(this.headerTitle, timeout);
+		await expect(element(this.tutorialOverlay)).not.toExist();
+	}
+
+	/**
+	 * チュートリアルを最後まで進めて完了させる。
+	 *
+	 * 最終ページのプライマリ CTA「はじめよう」は現在地取得（OS の位置情報アクセス）を伴うため、
+	 * e2e-web と同じくセカンダリ CTA「あとで」で完了させる。どちらも `markTutorialAsSeen()` を通る。
+	 *
+	 * @param maxPages ページ送りの上限（無限ループ防止。現在のページ数は 4）
+	 */
+	async completeTutorial(maxPages = 10): Promise<void> {
+		await waitUntilVisible(this.tutorialOverlay);
+
+		// #1031 【設計】§4-1: ページ送りは FlatList のスクロールアニメーションを伴う。
+		// プライマリ CTA の testID が「つぎへ」→「はじめよう」に切り替わることを毎回待ち合わせることで、
+		// アニメーション完了を明示的に待つ（Detox の idle 同期だけに頼らない）
+		for (let page = 0; page < maxPages; page += 1) {
+			if (await existsNow(this.tutorialFinishButton, 1_000)) break;
+			if (!(await existsNow(this.tutorialNextButton, 1_000))) break;
+
+			await element(this.tutorialNextButton).tap();
+		}
+
+		await waitUntilVisible(this.tutorialFinishButton);
+		await element(this.tutorialLaterButton).tap();
+		await waitUntilGone(this.tutorialOverlay);
+	}
+
+	/**
+	 * チュートリアルが出ていれば閉じる（ベストエフォート）。
+	 *
+	 * #1031 【設計】§4-3: e2e-web は fixtures が localStorage へ視聴済みフラグをシードして抑止しているが、
+	 * ネイティブ側の AsyncStorage シード手段は共通基盤（#1030 の launchArgs 経路）にまだ無い。
+	 * そのため各 spec は「出ていたら閉じる」で吸収する。
+	 * シード方式が基盤に入ったらこの前処理は不要になる。
+	 *
+	 * @returns 閉じた場合 true / そもそも出ていなかった場合 false
+	 */
+	async dismissTutorialIfPresent(): Promise<boolean> {
+		// チュートリアルは AsyncStorage の読み込み完了後に開くため、起動直後は少し遅れて現れる。
+		// 「出ていない」と誤判定して後続の操作がブロックされないよう、既定より長めに様子を見る
+		if (!(await existsNow(this.tutorialOverlay, 3_000))) return false;
+
+		await this.completeTutorial();
+		return true;
+	}
+
+	/**
+	 * 対象が画面内に入るまでスクロールする。
+	 *
+	 * #1031 【設計】検索画面の ScrollView に testID が無く `whileElement().scroll()` を使えないため、
+	 * スクロール領域内の実在要素を掴んで swipe することで代替する。
+	 *
+	 * @param target 画面内に入れたい要素
+	 * @param anchor swipe の起点にする、スクロール領域内の要素
+	 * @param maxSwipes swipe の上限回数
+	 * @失敗時 上限まで swipe しても見えない場合、最後に Detox の waitFor で失敗させる（失敗理由を残すため）
+	 */
+	private async scrollUntilVisible(
+		target: Detox.NativeMatcher,
+		anchor: Detox.NativeMatcher,
+		maxSwipes = 5,
+	): Promise<void> {
+		for (let i = 0; i < maxSwipes; i += 1) {
+			const visible = await waitFor(element(target))
+				.toBeVisible()
+				.withTimeout(1_000)
+				.then(() => true)
+				.catch(() => false);
+			if (visible) return;
+
+			await element(anchor).swipe("up", "slow", 0.6);
+		}
+
+		await waitUntilVisible(target);
+	}
+}

--- a/e2e-mobile/screens/SearchScreen.ts
+++ b/e2e-mobile/screens/SearchScreen.ts
@@ -196,9 +196,17 @@ export class SearchScreen {
 		await element(this.advancedToggle).tap();
 	}
 
-	/** おすすめ外の移動時間チップの開閉を切り替える */
+	/**
+	 * おすすめ外の移動時間チップの開閉を切り替える。
+	 *
+	 * #1031 【バグ】スクロール起点に `search-advanced-toggle` を使ってはいけない。
+	 * この要素は `showAdvancedFilters === false` のときだけ描画される（app-expo の
+	 * search/index.tsx）ため、`openAdvancedFilters()` が成功した時点でツリーから消えており、
+	 * スワイプが必要な画面サイズでは "no elements found" で確実に落ちる。
+	 * 展開後も残る `scrollAnchor`（search-scene-solo）を起点にする。
+	 */
 	async toggleOtherDistanceEstimates(): Promise<void> {
-		await this.scrollUntilVisible(this.distanceEstimatesToggle, this.advancedToggle);
+		await this.scrollUntilVisible(this.distanceEstimatesToggle, this.scrollAnchor);
 		await element(this.distanceEstimatesToggle).tap();
 	}
 

--- a/e2e-mobile/screens/TopicsScreen.ts
+++ b/e2e-mobile/screens/TopicsScreen.ts
@@ -1,0 +1,136 @@
+import { DEFAULT_TIMEOUT, by, element, existsNow, waitFor, waitUntilGone, waitUntilVisible } from "../fixtures/e2e";
+
+/**
+ * 🃏 トピック提案画面（検索結果のカードカルーセル）の Screen Object
+ *
+ * 対応画面: app-expo/app/[locale]/(tabs)/search/topics.tsx
+ * 対応する e2e-web の Page Object: e2e-web/pages/TopicsPage.ts
+ *
+ * ## 「この料理にする！」ボタンに atIndex(0) が要る理由（#1031 §2）
+ * カードは `react-native-reanimated-carousel` で描画され、**前後のカードも同時にマウントされる**。
+ * そのため `topics-choose-button` は常に複数一致しうる。Detox は複数一致した状態で
+ * `element(matcher)` を操作すると例外になるため、必ず `atIndex(0)`（= 先頭のカード）で絞る。
+ *
+ * ## スポットライトチュートリアルの扱い
+ * この画面は初回訪問時にスポットライトチュートリアル（`topics-tutorial-overlay`）を自動表示する。
+ * Modal として最前面に出るため、開いている間は背後のカードを Detox から操作できない。
+ * `expectLoaded()` は「チュートリアルが出ていれば閉じてからカードを待つ」形にしてある。
+ * チュートリアル自体の検証（e2e-web の topics-tutorial.spec.ts 相当）は本 PR のスコープ外。
+ */
+export class TopicsScreen {
+	/** 画面ヘッダのタイトル（ScreenHeader の testID 由来。i18n: Topics.headerTitle） */
+	readonly headerTitle = by.id("topics-header-title");
+	/** ヘッダーの戻るボタン */
+	readonly backButton = by.id("screen-header-back");
+	/** 「この料理にする！」ボタン（⚠️ 複数一致するため必ず atIndex で絞ること） */
+	readonly chooseButton = by.id("topics-choose-button");
+	/** ヘッダーのグループ投票ボタン */
+	readonly groupVoteButton = by.id("topics-group-vote");
+
+	/** ヘッダーの「？」ボタン（チュートリアル再表示） */
+	readonly tutorialHelpButton = by.id("topics-tutorial-help");
+	/** スポットライトを含む最前面オーバーレイ */
+	readonly tutorialOverlay = by.id("topics-tutorial-overlay");
+	/** チュートリアルの「つぎへ」（最終ステップ以外） */
+	readonly tutorialNextButton = by.id("topics-tutorial-next");
+	/** チュートリアルの「使ってみる」（最終ステップ） */
+	readonly tutorialFinishButton = by.id("topics-tutorial-finish");
+	/** チュートリアルの「スキップ」（最終ステップ以外で描画される） */
+	readonly tutorialSkipButton = by.id("topics-tutorial-skip");
+
+	/**
+	 * トピック生成待ちのタイムアウト (ms)。
+	 *
+	 * #1031 【設計】§4-1: 検索実行後の AI によるトピック生成は実測で数十秒かかる。
+	 * e2e-web が topics-flow.spec.ts へ `test.setTimeout(90_000)` を置いているのと同じ位置づけで、
+	 * ネイティブは実機/エミュレータの遅さを見込んでさらに余裕を持たせる。
+	 */
+	static readonly TOPICS_TIMEOUT = 120_000;
+
+	/** チュートリアルのステップ要素（id は TopicsSpotlightTutorial のステップ id） */
+	tutorialStep(id: string): Detox.NativeMatcher {
+		return by.id(`topics-tutorial-step-${id}`);
+	}
+
+	/**
+	 * トピック提案画面が表示され、カードが操作可能になるまで待つ。
+	 *
+	 * 「トピック生成の完了待ち」と「自動表示されるチュートリアルの解消」が同時に絡むため、
+	 * どちらが先に起きても破綻しないよう **交互にポーリングする**形にしている。
+	 *
+	 * @param timeout タイムアウト (ms)。既定はトピック生成待ちを見込んだ TOPICS_TIMEOUT
+	 * @失敗時 期限内にカードが表示されなければ Detox の例外を投げる
+	 */
+	async expectLoaded(timeout: number = TopicsScreen.TOPICS_TIMEOUT): Promise<void> {
+		const deadline = Date.now() + timeout;
+
+		while (Date.now() < deadline) {
+			if (await existsNow(this.tutorialOverlay, 1_000)) {
+				await this.dismissTutorialIfPresent();
+				continue;
+			}
+			if (await this.isFirstChooseButtonVisible(2_000)) return;
+		}
+
+		// 期限切れ。失敗理由（何が見えていないか）を Detox のメッセージとして残すため、最後に一度だけ待ち直す
+		await waitFor(this.firstChooseButton()).toBeVisible().withTimeout(DEFAULT_TIMEOUT);
+	}
+
+	/** 先頭のトピックカードを選択して結果フィードへ進む */
+	async chooseFirstTopic(): Promise<void> {
+		await this.firstChooseButton().tap();
+	}
+
+	/** ヘッダーの戻るボタンで検索画面へ戻る */
+	async goBack(): Promise<void> {
+		await element(this.backButton).tap();
+	}
+
+	/**
+	 * スポットライトチュートリアルが出ていれば閉じる（ベストエフォート）。
+	 *
+	 * 最終ステップではスキップ導線が消え「使ってみる」だけになるため、両方を見て閉じる。
+	 *
+	 * @returns 閉じた場合 true / そもそも出ていなかった場合 false
+	 */
+	async dismissTutorialIfPresent(): Promise<boolean> {
+		if (!(await existsNow(this.tutorialOverlay, 1_000))) return false;
+
+		if (await existsNow(this.tutorialSkipButton, 1_000)) {
+			await element(this.tutorialSkipButton).tap();
+		} else {
+			await element(this.tutorialFinishButton).tap();
+		}
+
+		// #1031 【設計】§4-1: 閉じる動作は Reanimated のフェードアウトを伴うため、
+		// 消えるまで明示的に待ってから次の操作へ進む
+		await waitUntilGone(this.tutorialOverlay);
+		return true;
+	}
+
+	/** ヘッダーのタイトルが表示されていることを検証する */
+	async expectHeaderVisible(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await waitUntilVisible(this.headerTitle, timeout);
+	}
+
+	/** 先頭カードの「この料理にする！」ボタン（カルーセルの多重マウント対策で atIndex(0) 固定） */
+	private firstChooseButton(): Detox.NativeElement {
+		return element(this.chooseButton).atIndex(0);
+	}
+
+	/**
+	 * 先頭カードのボタンが見えているかを判定する。
+	 *
+	 * ⚠️ utils/waits.ts の `existsNow` は `element(matcher)` を使うため、複数一致する
+	 * `topics-choose-button` には使えない（「複数一致」の例外を「存在しない」と誤判定してしまう）。
+	 * そのため atIndex 付きで自前に判定する。
+	 */
+	private async isFirstChooseButtonVisible(timeout: number): Promise<boolean> {
+		try {
+			await waitFor(this.firstChooseButton()).toBeVisible().withTimeout(timeout);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}

--- a/e2e-mobile/tests/search/location-autocomplete.test.ts
+++ b/e2e-mobile/tests/search/location-autocomplete.test.ts
@@ -1,0 +1,49 @@
+import { element, expect, launchAppWithSession, waitUntilGone, waitUntilVisible } from "../../fixtures/e2e";
+import { SearchScreen } from "../../screens/SearchScreen";
+
+/**
+ * 📍 場所オートコンプリートのテスト（実 API / Tier 2）
+ *
+ * 目的: 「ネイティブアプリ → Supabase 匿名 JWT → NestJS API → Google Places」というフル E2E 経路が
+ *       疎通していることを保証する、最重要のスモーク的機能テスト。
+ *       （e2e-web の tests/search/location-autocomplete.spec.ts に対応）
+ * 前提: api-development が稼働していること。Web と違い CORS には依存しない（ネイティブに同一生成元制約が無いため）。
+ *
+ * ## e2e-web から落とした検証（#1031 §1-1）
+ * - 「mousedown を 250ms 保持するスロークリック」は **C（対象外）**。
+ *   Web の mousedown/blur 競合バグの回帰専用テストであり、
+ *   タッチイベント（onPressIn/onPressOut）には対応概念が無い
+ * - 入力欄の**値**のアサーション（`toHaveValue("")` 等）は行わない。
+ *   Detox の `toHaveText`/`toHaveValue` は TextInput に対する挙動がプラットフォームで揺れるため、
+ *   「クリアボタンが消える（= 入力が空になった）」という等価で安定した観測点に置き換えている
+ */
+describe("場所オートコンプリート（実 API）", () => {
+	const search = new SearchScreen();
+
+	beforeAll(async () => {
+		await launchAppWithSession({ as: "anon" });
+		await search.expectLoaded();
+	});
+
+	// ─ テストケース: 地名を入力するとサジェストが表示され、クリアでリセットされる ─
+	// 手順:
+	//   1. 場所入力欄をタップしてフォーカスし、「渋谷」を入力する
+	//      （LocationAutocomplete は「入力あり && フォーカス中」で候補を出すため、フォーカスが必須）
+	//   2. 300ms のデバウンス → API 応答を経て、サジェストリストと先頭項目が表示されることを検証
+	//   3. クリアボタン（search-location-autocomplete-clear）を押す
+	//   4. サジェストリストが消え、クリアボタン自体も消える（= 入力が空になった）ことを検証
+	it("地名を入力するとサジェストが表示され、クリアでリセットされる", async () => {
+		await search.clearLocationIfPresent();
+
+		await search.typeLocation("渋谷");
+
+		await waitUntilVisible(search.locationSuggestions);
+		await waitUntilVisible(search.locationSuggestion(0));
+
+		await element(search.locationClearButton).tap();
+
+		await waitUntilGone(search.locationSuggestions);
+		// クリアボタンは「入力が 1 文字以上ある」ときだけ描画される。消えていれば入力欄は空
+		await expect(element(search.locationClearButton)).not.toExist();
+	});
+});

--- a/e2e-mobile/tests/search/search-form.test.ts
+++ b/e2e-mobile/tests/search/search-form.test.ts
@@ -1,0 +1,86 @@
+import { element, expect, launchAppWithSession, waitUntilExists, waitUntilVisible } from "../../fixtures/e2e";
+import { SearchScreen } from "../../screens/SearchScreen";
+
+/**
+ * 📝 検索フォームのロジックテスト（API 不要 / Tier 2）
+ *
+ * 目的: 検索フォームの必須項目制御・選択操作・詳細条件の展開という、
+ *       クライアント内で完結するロジックがネイティブでも成立することを保証する。
+ *       （e2e-web の tests/search/search-form.spec.ts に対応）
+ * 前提: 実 API を呼ばないシナリオのみを扱う。実 API を伴う検索実行は topics-flow.test.ts が担当する。
+ *
+ * ## e2e-web から落とした検証（#1031 確定判断）
+ * - **B1**: 時間帯・同行者の「選択されている」状態（Web は `toHaveCSS("border-color")` で検証）は
+ *   Detox に `accessibilityState` / role を検証する API が無いため対象外。
+ *   ネイティブでは「タップが通り、その条件で検索が成立する」ことまでを検証範囲とする
+ * - **B3**: 距離に応じたおすすめ移動時間は **順序検証（`toHaveCount` + `nth()`）を落とし**、
+ *   おすすめ行と「もっと見る」で開くおすすめ外の行の**表示有無のみ**を検証する
+ * - スナックバーの**文言**は検証しない。UI 文字列の直書きは i18n ポリシーで禁止されており、
+ *   e2e-mobile から ja-JP.json を引くヘルパ（#1031 M3）はまだ共通基盤に無いため。
+ *   代わりに「通知が出ること」＋「トピック画面へ遷移していないこと」で回帰を検知する
+ */
+describe("検索フォーム", () => {
+	const search = new SearchScreen();
+
+	beforeAll(async () => {
+		// #1030 【設計】3-1: 匿名サインインのクォータを消費しないよう、確立済みセッションを注入して起動する
+		await launchAppWithSession({ as: "anon" });
+		// #1031 【設計】§4-3: チュートリアルの AsyncStorage シード手段が共通基盤に無いため、
+		// 出ていれば閉じてからフォームの検証に入る（expectLoaded の中で吸収される）
+		await search.expectLoaded();
+	});
+
+	// ─ テストケース: 場所が未確定のまま検索すると通知が出て遷移しない ─
+	// 手順:
+	//   1. 自動取得された現在地が入っている可能性があるため、明示的にクリアして「場所未確定」を作る
+	//   2. 検索ボタン（search-submit-button）をタップする
+	//      #973 以降ボタンは常にタップ可能で、未充足時は handleSearch 内のバリデーションが
+	//      global-snackbar を出したうえで遷移をガードする
+	//   3. スナックバーが表示されることを検証
+	//   4. トピック画面へ遷移しておらず、検索画面に留まっていることを検証
+	it("場所が未確定のまま検索するとバリデーション通知が出て遷移しない", async () => {
+		await search.clearLocationIfPresent();
+
+		await search.submit();
+
+		await waitUntilVisible(search.snackbar);
+		// 遷移していないこと = 検索画面のヘッダが出続けていること（トピック画面には別のヘッダ testID がある）
+		await expect(element(search.headerTitle)).toBeVisible();
+	});
+
+	// ─ テストケース: 時間帯・同行者を選び、詳細条件を開くと距離まわりの UI が現れる ─
+	// 手順:
+	//   1. 時間帯（dinner）と同行者（friends）をタップする
+	//      → #1031 B1 により「選択状態」そのものは検証できないため、タップが通ることまでを見る
+	//   2. 詳細条件トグル（search-advanced-toggle）を開く
+	//   3. 距離スライダーと、距離に応じたおすすめ移動時間の行が現れることを検証（#1031 B3: 表示有無のみ）
+	//   4. 既定の 500m では自転車・徒歩だけがおすすめされ、車・電車は「もっと見る」でだけ現れることを検証
+	//      （#987 の仕様。e2e-web は所要時間の分数と並び順まで見ているが、B3 の確定判断により順序検証は落とす）
+	it("時間帯と同行者を選び、詳細条件を開くと距離とおすすめ移動時間が表示される", async () => {
+		await search.selectTimeSlot("dinner");
+		await search.selectScene("friends");
+
+		await search.openAdvancedFilters();
+
+		await waitUntilVisible(search.distanceSlider);
+		// #1031 【設計】チップ行の可視性ではなく存在を見る。距離セクションは画面下部固定の検索 FAB と
+		// 重なる位置に来ることがあり、`toBeVisible`（既定 75% 以上の露出が必要）はスクロール位置に
+		// 左右されてフレークになる。おすすめ / おすすめ外の出し分けは**条件付きレンダリング**なので、
+		// 存在の有無で仕様どおりに切り替わっていることを検証できる
+		await waitUntilExists(search.distanceRecommendedEstimates);
+		await expect(element(search.distanceEstimate("bike"))).toExist();
+		await expect(element(search.distanceEstimate("walk"))).toExist();
+		await expect(element(search.distanceEstimate("car"))).not.toExist();
+		await expect(element(search.distanceEstimate("train"))).not.toExist();
+
+		// おすすめ外の移動時間は明示操作したときだけ表示される
+		await expect(element(search.distanceOtherEstimates)).not.toExist();
+		await search.toggleOtherDistanceEstimates();
+		await waitUntilExists(search.distanceOtherEstimates);
+		await expect(element(search.distanceEstimate("car"))).toExist();
+		await expect(element(search.distanceEstimate("train"))).toExist();
+
+		await search.toggleOtherDistanceEstimates();
+		await expect(element(search.distanceOtherEstimates)).not.toExist();
+	});
+});

--- a/e2e-mobile/tests/search/search-tutorial.test.ts
+++ b/e2e-mobile/tests/search/search-tutorial.test.ts
@@ -1,0 +1,61 @@
+import { LAUNCH_TIMEOUT, launchAppWithSession } from "../../fixtures/e2e";
+import { SearchScreen } from "../../screens/SearchScreen";
+
+/**
+ * 🎓 検索チュートリアルの表示テスト（Tier 2）
+ *
+ * 目的: ja-JP 初回起動時のチュートリアル自動表示と、完了後の再表示抑止
+ *       （AsyncStorage フラグ `search_tutorial_seen_v1`）を保証する。
+ *       （e2e-web の tests/search/search-tutorial.spec.ts に対応。#1031 確定判断 B5 で PR-3 のスコープ）
+ *
+ * ## e2e-web との差分
+ * - **未視聴状態の作り方**: e2e-web は `test.use({ seedTutorialSeen: false })` でシードを外す。
+ *   ネイティブには AsyncStorage のシード手段がまだ無いため、`resetState: true` でアプリのストレージごと
+ *   消して「初回起動」を再現する。⚠️ `resetState` は iOS ではアンインストール相当で高コストなため
+ *   （#1030 m-5）、**このシナリオでだけ**使う。セッションは launchArgs で再注入されるので
+ *   匿名サインインのクォータは消費しない
+ * - **完了フラグの検証**（#1031 m6）: e2e-web は `page.evaluate` で localStorage を直接読んでいるが、
+ *   Detox からアプリの AsyncStorage は読めない。**「アプリを再起動しても表示されない」**という
+ *   ユーザーから観測できる事実に置き換える。ストレージへの永続化まで含めて検証できるため、
+ *   タブ切り替えによる再訪問で代替するより強い検証になっている
+ * - **完了操作**: 最終ページのプライマリ CTA「はじめよう」は現在地取得（OS の位置情報アクセス）を伴うため、
+ *   e2e-web と同じくセカンダリ CTA「あとで」で完了させる（どちらも markTutorialAsSeen を通る）
+ *
+ * ## 前提
+ * チュートリアルは `isJapanese` のときだけ自動表示される（app-expo の search/index.tsx）。
+ * デバイスロケールの ja-JP 固定は fixtures/e2e.ts + utils/locale.ts の責務（#1031 確定判断 B4）。
+ */
+describe("検索チュートリアル（初回起動）", () => {
+	const search = new SearchScreen();
+
+	beforeAll(async () => {
+		// アプリのストレージを消して「チュートリアル未視聴」を再現する。
+		// セッションは launchArgs で注入し直されるため、匿名サインインは追加で発生しない。
+		//
+		// ⚠️ `waitForReady: false` にしているのは、起動完了の観測点がタブバー (`tab-search`) だから。
+		// チュートリアルは BottomSheet（Android では別ウィンドウの Modal）として最前面に出るため、
+		// 先にシートが開くと背後のタブバーが Detox から見えず、起動待ちがタイムアウトしうる。
+		// この spec では「チュートリアルが出ること」自体が起動完了の観測点になるので、それを直接待つ
+		await launchAppWithSession({ as: "anon", resetState: true, waitForReady: false });
+	});
+
+	// ─ テストケース: 初回起動で自動表示され、完了すると次回以降は表示されない ─
+	// 手順:
+	//   1. ストレージを消した状態で起動する（beforeAll）
+	//   2. チュートリアル（search-tutorial-overlay）が自動表示されることを検証
+	//   3. 「つぎへ」で最終ページまで進め、「あとで」で完了させる
+	//   4. チュートリアルが閉じ、検索画面が操作できる状態になることを検証
+	//   5. アプリを再起動する（ストレージは消さない）
+	//   6. チュートリアルが自動表示されないことを検証（= 視聴済みフラグが永続化されている）
+	it("初回起動で自動表示され、完了すると再起動しても表示されない", async () => {
+		// 初回起動は JS バンドル読込 + セッション注入を含むため、起動待ちと同じスケールで待つ
+		await search.expectTutorialShown(LAUNCH_TIMEOUT);
+
+		await search.completeTutorial();
+		await search.expectLoaded();
+
+		// ストレージを保持したまま起動し直す（resetState は既定 false）
+		await launchAppWithSession({ as: "anon" });
+		await search.expectTutorialAbsent();
+	});
+});

--- a/e2e-mobile/tests/search/search-tutorial.test.ts
+++ b/e2e-mobile/tests/search/search-tutorial.test.ts
@@ -1,4 +1,4 @@
-import { LAUNCH_TIMEOUT, launchAppWithSession } from "../../fixtures/e2e";
+import { LAUNCH_TIMEOUT, describeJapaneseLocale, launchAppWithSession } from "../../fixtures/e2e";
 import { SearchScreen } from "../../screens/SearchScreen";
 
 /**
@@ -25,7 +25,10 @@ import { SearchScreen } from "../../screens/SearchScreen";
  * チュートリアルは `isJapanese` のときだけ自動表示される（app-expo の search/index.tsx）。
  * デバイスロケールの ja-JP 固定は fixtures/e2e.ts + utils/locale.ts の責務（#1031 確定判断 B4）。
  */
-describe("検索チュートリアル（初回起動）", () => {
+// #1031 【設計】B4: チュートリアルは app-expo 側が isJapanese でゲートしているため、
+// 端末ロケールが ja-JP でない環境（ロケール未固定のローカルエミュレータ等）では spec ごと skip する
+// （CI は e2e-mobile-test.yml の adb setprop で ja-JP に固定済み）
+describeJapaneseLocale("検索チュートリアル（初回起動）", () => {
 	const search = new SearchScreen();
 
 	beforeAll(async () => {

--- a/e2e-mobile/tests/search/topics-flow.test.ts
+++ b/e2e-mobile/tests/search/topics-flow.test.ts
@@ -1,0 +1,67 @@
+import { launchAppWithSession } from "../../fixtures/e2e";
+import { ResultScreen } from "../../screens/ResultScreen";
+import { SearchScreen } from "../../screens/SearchScreen";
+import { TopicsScreen } from "../../screens/TopicsScreen";
+
+/**
+ * 🍜 検索 → トピック提案 → 結果フィードのハッピーパス（実 API・最重要 / Tier 2）
+ *
+ * 目的: アプリの中核体験である「条件を入れて検索 → AI のトピック提案 → 料理フィード閲覧 → 戻る」の
+ *       一連のフローが、ネイティブでも実データで成立することを保証する。
+ *       （e2e-web の tests/search/topics-flow.spec.ts に対応）
+ *
+ * ## 検索の実行を beforeAll に置いている理由
+ * e2e-web の同 spec は 3 つの test それぞれで検索からやり直しているが、トピック生成は AI 応答待ちで
+ * 実測数十秒かかる。ネイティブは起動もエミュレータ上で遅いため、同じ構成にすると
+ * 「1 つのシナリオを検証するのに毎回 1 分待つ」ことになり、CI 時間とフレークの両方が悪化する。
+ * ここでは **検索の実行を beforeAll で 1 回だけ**行い、その後の画面遷移を it 単位で検証する。
+ * Jest は 1 ファイル内の it を宣言順に直列実行するため（jest.config.js の maxWorkers: 1 も前提）、
+ * 「トピック画面に到達している」という前提を後続の it が共有できる。
+ *
+ * ## Detox 固有の待ち合わせ（#1031 §4-1 / §4-2）
+ * 「場所サジェストの詳細取得」「トピック生成」「結果フィードの事前読み込み」はいずれもネットワーク待ちを含む。
+ * Detox には Playwright の `waitForResponse` に相当する API が無いため、
+ * Detox の同期機構（未完了リクエスト中は操作をブロックする）＋ **画面上の観測点**で待つ。
+ */
+describe("検索フロー（実 API）", () => {
+	const search = new SearchScreen();
+	const topics = new TopicsScreen();
+	const result = new ResultScreen();
+
+	beforeAll(async () => {
+		await launchAppWithSession({ as: "anon" });
+		await search.expectLoaded();
+
+		// 場所だけを確定させる（時間帯 lunch / 同行者 solo には初期値があるため追加選択は不要）
+		await search.clearLocationIfPresent();
+		await search.typeLocation("渋谷");
+		await search.selectLocationSuggestion(0);
+		await search.submit();
+	});
+
+	// ─ テストケース: 検索実行でトピック提案カードが表示される ─
+	// 手順:
+	//   1. beforeAll で「渋谷」を確定して検索を実行済み
+	//   2. トピック画面のヘッダとカードの選択ボタンが表示されることを検証
+	//      （初回訪問時はスポットライトチュートリアルが自動表示されるため、expectLoaded が閉じてから待つ）
+	it("検索実行でトピック提案カードが表示される", async () => {
+		await topics.expectLoaded();
+		await topics.expectHeaderVisible();
+	});
+
+	// ─ テストケース: トピックを選ぶと結果フィードが表示され、閉じるとトピック画面へ戻る ─
+	// 手順:
+	//   1. 先頭カードの「この料理にする！」をタップする（カルーセルの多重マウント対策で atIndex(0)）
+	//   2. 結果フィード画面（result-close-button）が表示されることを検証
+	//   3. 閉じるボタンを押す
+	//   4. 履歴は 検索 → トピック → 結果 と積まれているため、戻り先はトピック画面であることを検証
+	it("トピックを選ぶと結果フィードが表示され、閉じるとトピック画面へ戻る", async () => {
+		await topics.expectLoaded();
+
+		await topics.chooseFirstTopic();
+		await result.expectLoaded();
+
+		await result.close();
+		await topics.expectLoaded();
+	});
+});


### PR DESCRIPTION
## 対象 Issue

- #1031(PR-3: search 系)/ 親: #1027

## 概要

Screen Object 3種(`SearchScreen` / `TopicsScreen` / `ResultScreen`)と spec 4本を追加。

- `search-form.test.ts`: 検索フォームの基本操作(場所・時間帯・同行者・検索実行)
- `location-autocomplete.test.ts`: 場所入力のオートコンプリート
- `topics-flow.test.ts`: topics 画面への遷移とトピック選択 → result 表示
- `search-tutorial.test.ts`: 検索チュートリアル(#1031 確定 B5 の testID を使用)

## 設計確定への追従

- **B3**: 距離おすすめ表示は順序検証を落とし、表示有無のみ検証(Detox に要素数・順序 API が無いため)
- **B1**: role / checked 等の a11y 属性検証は Detox に API が無いため対象外(Web 側の axe / aria で担保)

## 検証

- 使用 testID をリーダー側で全件確認。うち 5 件(`search-scene-solo` / `topics-header-title` / `search-location-autocomplete-{input,suggestions,clear}`)は**動的生成**のため単純 grep では出ないが、以下のとおり実在することを確認済み:
  - `search/index.tsx:532` `` testID={`search-scene-${option.id}`} `` + `constants.ts` の `id: "solo"`
  - `topics.tsx:586` `testID="topics-header"` + PR #1033 の `ScreenHeader` が `` `${testID}-title` `` を描画
  - `search/index.tsx:496` `testID="search-location-autocomplete"` + `LocationAutocomplete.tsx:319/329/393` が `` `${testID}-input` / `-clear` / `-suggestions` `` を描画
- worker run(issue-1031-impl-pr3-search)で `pnpm --filter e2e-mobile typecheck` 実施

## スクショ免除の理由

app-expo(UI)への変更なし(E2E テストの追加のみ)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KieDKaXxd3Mf7d4hnm23d8)_