### PR TITLE
fix: Claude Workerの権限拒否を安全に要約する

### DIFF
--- a/.github/scripts/summarize-claude-output.sh
+++ b/.github/scripts/summarize-claude-output.sh
@@ -9,13 +9,29 @@ if [[ ! -f "$OUT" ]]; then
   exit 0
 fi
 
-# Claude Codeの実行ファイルはJSONL（改行区切りJSON）。全体をslurpし、
-# 最後のresultイベントから公開して問題ない集計値だけを取り出す。
-SUBTYPE=$(jq -rs '[.[] | select(.type == "result")] | last | .subtype // "unknown"' "$OUT" 2>/dev/null || echo unknown)
-IS_ERROR=$(jq -rs '[.[] | select(.type == "result")] | last | .is_error // false' "$OUT" 2>/dev/null || echo unknown)
-NUM_TURNS=$(jq -rs '[.[] | select(.type == "result")] | last | .num_turns // "?"' "$OUT" 2>/dev/null || echo "?")
-COST=$(jq -rs '[.[] | select(.type == "result")] | last | .total_cost_usd // "?"' "$OUT" 2>/dev/null || echo "?")
-DENIALS=$(jq -rs '[.[] | select(.type == "result")] | last | .permission_denials_count // 0' "$OUT" 2>/dev/null || echo 0)
+TMP_EVENTS=$(mktemp)
+TMP_DENIALS=$(mktemp)
+trap 'rm -f "$TMP_EVENTS" "$TMP_DENIALS"' EXIT
+
+# claude-code-actionは通常JSON配列を書き出すが、旧形式のJSONLも読めるよう
+# jqのslurp結果をイベント配列へ正規化する。
+if ! jq -s '
+  if length == 1 and (.[0] | type) == "array" then
+    .[0]
+  else
+    .
+  end
+' "$OUT" > "$TMP_EVENTS" 2>/dev/null; then
+  echo "::warning::Claude Codeの実行結果をJSONとして解析できませんでした。"
+  exit 0
+fi
+
+# 最後のresultイベントから、公開して問題ない集計値だけを取り出す。
+SUBTYPE=$(jq -r '[.[] | select(.type == "result")] | last | .subtype // "unknown"' "$TMP_EVENTS")
+IS_ERROR=$(jq -r '[.[] | select(.type == "result")] | last | .is_error // false' "$TMP_EVENTS")
+NUM_TURNS=$(jq -r '[.[] | select(.type == "result")] | last | .num_turns // "?"' "$TMP_EVENTS")
+COST=$(jq -r '[.[] | select(.type == "result")] | last | .total_cost_usd // "?"' "$TMP_EVENTS")
+DENIALS=$(jq -r '[.[] | select(.type == "result")] | last | (.permission_denials // []) | length' "$TMP_EVENTS")
 
 {
   echo "### Claude Code 実行結果"
@@ -27,7 +43,7 @@ sanitize() {
   local value="$1"
   local max_length="$2"
 
-  # permissionエラーにコマンド断片が含まれても、代表的な認証情報を公開しない。
+  # permission情報にコマンド断片が含まれても、代表的な認証情報を公開しない。
   value=$(printf '%s' "$value" \
     | tr '\r\n' '  ' \
     | sed -E \
@@ -46,76 +62,80 @@ sanitize() {
   printf '%s' "$value"
 }
 
-if [[ "$DENIALS" != "0" && "$DENIALS" != "null" ]]; then
-  echo "::warning::permission_denials_count=$DENIALS。拒否されたツールと理由をStep Summaryへ限定表示します。"
+if (( DENIALS > 0 )); then
+  echo "::warning::permission_denials_count=$DENIALS。拒否されたツールと安全な概要をStep Summaryへ限定表示します。"
 
-  TMP_DENIALS=$(mktemp)
-  trap 'rm -f "$TMP_DENIALS"' EXIT
+  # result.permission_denialsが権限拒否の一次情報。tool_resultのエラーが存在する場合だけ
+  # tool_use_idで関連付けて理由を補い、なければ一般的な説明を表示する。
+  jq -r '
+    def content_text:
+      if type == "string" then .
+      elif type == "array" then
+        map(if type == "object" then (.text // tostring) else tostring end) | join("\n")
+      else tostring
+      end;
 
-  # assistant側のtool_useとuser側のtool_resultをtool_use_idで関連付ける。
-  # 全ツール出力は公開せず、permission系かつis_error=trueの結果だけを最大20件抽出する。
-  jq -rs -r '
     . as $events
-    | [
-      $events[]
-      | select(.type == "assistant")
-      | (.message.content // [])[]?
-      | select(.type == "tool_use" and (.id // "") != "")
-      | {key: .id, value: {tool: (.name // "unknown"), input: (.input // {})}}
-    ]
-    | from_entries as $uses
-    | [
+    | ([
         $events[]
         | select(.type == "user")
         | (.message.content // [])[]?
-        | select(.type == "tool_result" and (.is_error // false) == true)
+        | select(.type == "tool_result" and (.is_error // false) == true and (.tool_use_id // "") != "")
         | . as $result
-        | (
-            ($result.content // "")
-            | if type == "string" then .
-              elif type == "array" then map(if type == "object" then (.text // tostring) else tostring end) | join("\n")
-              else tostring
-              end
-          ) as $reason
-        | select($reason | test("permission|denied|not allowed|not permitted|requires approval|approval required|blocked"; "i"))
-        | ($uses[$result.tool_use_id] // {tool: "unknown", input: {}}) as $use
-        | {
-            tool: $use.tool,
-            command: (if $use.tool == "Bash" then ($use.input.command // "") else "" end),
-            reason: $reason
-          }
-      ]
-    | .[:20][]
+        | {key: $result.tool_use_id, value: (($result.content // "") | content_text)}
+      ] | from_entries) as $errors
+    | ([.[] | select(.type == "result")] | last | (.permission_denials // []))[:20][]
+    | {
+        tool: (.tool_name // "unknown"),
+        tool_use_id: (.tool_use_id // ""),
+        command: (if .tool_name == "Bash" then (.tool_input.command // "") else "" end),
+        parameter_names: (if .tool_name == "Bash" then [] else ((.tool_input // {}) | keys) end),
+        reason: ($errors[.tool_use_id] // "Claude Codeの権限設定により拒否されました。SDK resultには詳細理由が含まれていません。")
+      }
     | @base64
-  ' "$OUT" > "$TMP_DENIALS" 2>/dev/null || true
+  ' "$TMP_EVENTS" > "$TMP_DENIALS" 2>/dev/null || true
 
   {
     echo
     echo "### 権限拒否の詳細（機密情報をマスク済み）"
 
     if [[ ! -s "$TMP_DENIALS" ]]; then
-      echo "permission系のtool resultを抽出できませんでした。Claude Codeの出力形式が想定と異なる可能性があります。"
+      echo "permission_denialsの詳細を抽出できませんでした。Claude Codeの出力形式が想定と異なる可能性があります。"
     else
       INDEX=0
       while IFS= read -r denial_b64; do
         INDEX=$((INDEX + 1))
         DENIAL_JSON=$(printf '%s' "$denial_b64" | base64 --decode 2>/dev/null || echo '{}')
         TOOL=$(jq -r '.tool // "unknown"' <<< "$DENIAL_JSON" 2>/dev/null || echo unknown)
+        TOOL_USE_ID=$(jq -r '.tool_use_id // ""' <<< "$DENIAL_JSON" 2>/dev/null || true)
         COMMAND=$(jq -r '.command // ""' <<< "$DENIAL_JSON" 2>/dev/null || true)
-        REASON=$(jq -r '.reason // "decode error"' <<< "$DENIAL_JSON" 2>/dev/null || echo "decode error")
+        PARAMETER_NAMES=$(jq -r '(.parameter_names // []) | join(", ")' <<< "$DENIAL_JSON" 2>/dev/null || true)
+        REASON=$(jq -r '.reason // "詳細理由を取得できませんでした。"' <<< "$DENIAL_JSON" 2>/dev/null || echo "詳細理由を取得できませんでした。")
 
         TOOL=$(sanitize "$TOOL" 100)
+        TOOL_USE_ID=$(sanitize "$TOOL_USE_ID" 100)
         COMMAND=$(sanitize "$COMMAND" 500)
+        PARAMETER_NAMES=$(sanitize "$PARAMETER_NAMES" 300)
         REASON=$(sanitize "$REASON" 1000)
 
         echo "#### $INDEX. \`$TOOL\`"
+        if [[ -n "$TOOL_USE_ID" ]]; then
+          echo "- tool_use_id: \`$TOOL_USE_ID\`"
+        fi
         if [[ -n "$COMMAND" ]]; then
           echo "- command（先頭500文字）:"
           echo "    $COMMAND"
+        elif [[ -n "$PARAMETER_NAMES" ]]; then
+          echo "- parameters（値は非表示）: \`$PARAMETER_NAMES\`"
         fi
         echo "- reason（先頭1000文字）:"
         echo "    $REASON"
       done < "$TMP_DENIALS"
+
+      if (( DENIALS > 20 )); then
+        echo
+        echo "先頭20件のみ表示しています。残り$((DENIALS - 20))件は省略しました。"
+      fi
     fi
   } >> "$SUMMARY"
 fi

--- a/.github/scripts/summarize-claude-output.sh
+++ b/.github/scripts/summarize-claude-output.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT="${CLAUDE_EXECUTION_OUTPUT:-/home/runner/work/_temp/claude-execution-output.json}"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+if [[ ! -f "$OUT" ]]; then
+  echo "::warning::実行結果ログ($OUT)が見つかりません。"
+  exit 0
+fi
+
+# Claude Codeの実行ファイルはJSONL（改行区切りJSON）。全体をslurpし、
+# 最後のresultイベントから公開して問題ない集計値だけを取り出す。
+SUBTYPE=$(jq -rs '[.[] | select(.type == "result")] | last | .subtype // "unknown"' "$OUT" 2>/dev/null || echo unknown)
+IS_ERROR=$(jq -rs '[.[] | select(.type == "result")] | last | .is_error // false' "$OUT" 2>/dev/null || echo unknown)
+NUM_TURNS=$(jq -rs '[.[] | select(.type == "result")] | last | .num_turns // "?"' "$OUT" 2>/dev/null || echo "?")
+COST=$(jq -rs '[.[] | select(.type == "result")] | last | .total_cost_usd // "?"' "$OUT" 2>/dev/null || echo "?")
+DENIALS=$(jq -rs '[.[] | select(.type == "result")] | last | .permission_denials_count // 0' "$OUT" 2>/dev/null || echo 0)
+
+{
+  echo "### Claude Code 実行結果"
+  echo "- subtype: \`$SUBTYPE\` / is_error: \`$IS_ERROR\`"
+  echo "- turns: $NUM_TURNS / cost: \$$COST / permission denials: $DENIALS"
+} >> "$SUMMARY"
+
+sanitize() {
+  local value="$1"
+  local max_length="$2"
+
+  # permissionエラーにコマンド断片が含まれても、代表的な認証情報を公開しない。
+  value=$(printf '%s' "$value" \
+    | tr '\r\n' '  ' \
+    | sed -E \
+      -e 's/sk-ant-[A-Za-z0-9_-]+/[REDACTED_ANTHROPIC_KEY]/g' \
+      -e 's/github_pat_[A-Za-z0-9_]+/[REDACTED_GITHUB_TOKEN]/g' \
+      -e 's/gh[pousr]_[A-Za-z0-9_]+/[REDACTED_GITHUB_TOKEN]/g' \
+      -e 's/(AKIA|ASIA)[A-Z0-9]{16}/[REDACTED_AWS_ACCESS_KEY]/g' \
+      -e 's/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/[REDACTED_JWT]/g' \
+      -e 's/Bearer[[:space:]]+[A-Za-z0-9._~+\/-]+/Bearer [REDACTED]/Ig' \
+      -e 's#https://[^/@[:space:]]+:[^/@[:space:]]+@#https://[REDACTED]@#g' \
+      -e 's/((TOKEN|KEY|SECRET|PASSWORD|PASSWD|AUTHORIZATION)[A-Za-z0-9_ -]*[=:][[:space:]]*)[^ ,;]+/\1[REDACTED]/Ig')
+
+  if (( ${#value} > max_length )); then
+    value="${value:0:max_length}…"
+  fi
+  printf '%s' "$value"
+}
+
+if [[ "$DENIALS" != "0" && "$DENIALS" != "null" ]]; then
+  echo "::warning::permission_denials_count=$DENIALS。拒否されたツールと理由をStep Summaryへ限定表示します。"
+
+  TMP_DENIALS=$(mktemp)
+  trap 'rm -f "$TMP_DENIALS"' EXIT
+
+  # assistant側のtool_useとuser側のtool_resultをtool_use_idで関連付ける。
+  # 全ツール出力は公開せず、permission系かつis_error=trueの結果だけを最大20件抽出する。
+  jq -rs -r '
+    . as $events
+    | [
+      $events[]
+      | select(.type == "assistant")
+      | (.message.content // [])[]?
+      | select(.type == "tool_use" and (.id // "") != "")
+      | {key: .id, value: {tool: (.name // "unknown"), input: (.input // {})}}
+    ]
+    | from_entries as $uses
+    | [
+        $events[]
+        | select(.type == "user")
+        | (.message.content // [])[]?
+        | select(.type == "tool_result" and (.is_error // false) == true)
+        | . as $result
+        | (
+            ($result.content // "")
+            | if type == "string" then .
+              elif type == "array" then map(if type == "object" then (.text // tostring) else tostring end) | join("\n")
+              else tostring
+              end
+          ) as $reason
+        | select($reason | test("permission|denied|not allowed|not permitted|requires approval|approval required|blocked"; "i"))
+        | ($uses[$result.tool_use_id] // {tool: "unknown", input: {}}) as $use
+        | {
+            tool: $use.tool,
+            command: (if $use.tool == "Bash" then ($use.input.command // "") else "" end),
+            reason: $reason
+          }
+      ]
+    | .[:20][]
+    | @base64
+  ' "$OUT" > "$TMP_DENIALS" 2>/dev/null || true
+
+  {
+    echo
+    echo "### 権限拒否の詳細（機密情報をマスク済み）"
+
+    if [[ ! -s "$TMP_DENIALS" ]]; then
+      echo "permission系のtool resultを抽出できませんでした。Claude Codeの出力形式が想定と異なる可能性があります。"
+    else
+      INDEX=0
+      while IFS= read -r denial_b64; do
+        INDEX=$((INDEX + 1))
+        DENIAL_JSON=$(printf '%s' "$denial_b64" | base64 --decode 2>/dev/null || echo '{}')
+        TOOL=$(jq -r '.tool // "unknown"' <<< "$DENIAL_JSON" 2>/dev/null || echo unknown)
+        COMMAND=$(jq -r '.command // ""' <<< "$DENIAL_JSON" 2>/dev/null || true)
+        REASON=$(jq -r '.reason // "decode error"' <<< "$DENIAL_JSON" 2>/dev/null || echo "decode error")
+
+        TOOL=$(sanitize "$TOOL" 100)
+        COMMAND=$(sanitize "$COMMAND" 500)
+        REASON=$(sanitize "$REASON" 1000)
+
+        echo "#### $INDEX. \`$TOOL\`"
+        if [[ -n "$COMMAND" ]]; then
+          echo "- command（先頭500文字）:"
+          echo "    $COMMAND"
+        fi
+        echo "- reason（先頭1000文字）:"
+        echo "    $REASON"
+      done < "$TMP_DENIALS"
+    fi
+  } >> "$SUMMARY"
+fi
+
+if [[ "$SUBTYPE" == "error_max_turns" ]]; then
+  echo "::warning::max_turns($NUM_TURNS)に到達して打ち切られました。タスクを分割するか max_turns を増やして再実行してください。"
+fi

--- a/.github/scripts/summarize-claude-output.sh
+++ b/.github/scripts/summarize-claude-output.sh
@@ -39,65 +39,24 @@ DENIALS=$(jq -r '[.[] | select(.type == "result")] | last | (.permission_denials
   echo "- turns: $NUM_TURNS / cost: \$$COST / permission denials: $DENIALS"
 } >> "$SUMMARY"
 
-sanitize() {
-  local value="$1"
-  local max_length="$2"
-
-  # permission情報にコマンド断片が含まれても、代表的な認証情報を公開しない。
-  value=$(printf '%s' "$value" \
-    | tr '\r\n' '  ' \
-    | sed -E \
-      -e 's/sk-ant-[A-Za-z0-9_-]+/[REDACTED_ANTHROPIC_KEY]/g' \
-      -e 's/github_pat_[A-Za-z0-9_]+/[REDACTED_GITHUB_TOKEN]/g' \
-      -e 's/gh[pousr]_[A-Za-z0-9_]+/[REDACTED_GITHUB_TOKEN]/g' \
-      -e 's/(AKIA|ASIA)[A-Z0-9]{16}/[REDACTED_AWS_ACCESS_KEY]/g' \
-      -e 's/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/[REDACTED_JWT]/g' \
-      -e 's/Bearer[[:space:]]+[A-Za-z0-9._~+\/-]+/Bearer [REDACTED]/Ig' \
-      -e 's#https://[^/@[:space:]]+:[^/@[:space:]]+@#https://[REDACTED]@#g' \
-      -e 's/((TOKEN|KEY|SECRET|PASSWORD|PASSWD|AUTHORIZATION)[A-Za-z0-9_ -]*[=:][[:space:]]*)[^ ,;]+/\1[REDACTED]/Ig')
-
-  if (( ${#value} > max_length )); then
-    value="${value:0:max_length}…"
-  fi
-  printf '%s' "$value"
-}
-
 if (( DENIALS > 0 )); then
-  echo "::warning::permission_denials_count=$DENIALS。拒否されたツールと安全な概要をStep Summaryへ限定表示します。"
+  echo "::warning::permission_denials_count=$DENIALS。拒否されたツールの安全なメタデータだけをStep Summaryへ表示します。"
 
-  # result.permission_denialsが権限拒否の一次情報。tool_resultのエラーが存在する場合だけ
-  # tool_use_idで関連付けて理由を補い、なければ一般的な説明を表示する。
+  # result.permission_denialsから、値を含まないメタデータだけを最大20件抽出する。
+  # tool_inputの値・Bashコマンド・tool_result本文は、未知の機密情報を含み得るため公開しない。
   jq -r '
-    def content_text:
-      if type == "string" then .
-      elif type == "array" then
-        map(if type == "object" then (.text // tostring) else tostring end) | join("\n")
-      else tostring
-      end;
-
-    . as $events
-    | ([
-        $events[]
-        | select(.type == "user")
-        | (.message.content // [])[]?
-        | select(.type == "tool_result" and (.is_error // false) == true and (.tool_use_id // "") != "")
-        | . as $result
-        | {key: $result.tool_use_id, value: (($result.content // "") | content_text)}
-      ] | from_entries) as $errors
-    | ([.[] | select(.type == "result")] | last | (.permission_denials // []))[:20][]
+    ([.[] | select(.type == "result")] | last | (.permission_denials // []))[:20][]
     | {
         tool: (.tool_name // "unknown"),
         tool_use_id: (.tool_use_id // ""),
-        command: (if .tool_name == "Bash" then (.tool_input.command // "") else "" end),
-        parameter_names: (if .tool_name == "Bash" then [] else ((.tool_input // {}) | keys) end),
-        reason: ($errors[.tool_use_id] // "Claude Codeの権限設定により拒否されました。SDK resultには詳細理由が含まれていません。")
+        parameter_names: ((.tool_input // {}) | keys)
       }
     | @base64
   ' "$TMP_EVENTS" > "$TMP_DENIALS" 2>/dev/null || true
 
   {
     echo
-    echo "### 権限拒否の詳細（機密情報をマスク済み）"
+    echo "### 権限拒否の詳細（引数値は非表示）"
 
     if [[ ! -s "$TMP_DENIALS" ]]; then
       echo "permission_denialsの詳細を抽出できませんでした。Claude Codeの出力形式が想定と異なる可能性があります。"
@@ -108,28 +67,18 @@ if (( DENIALS > 0 )); then
         DENIAL_JSON=$(printf '%s' "$denial_b64" | base64 --decode 2>/dev/null || echo '{}')
         TOOL=$(jq -r '.tool // "unknown"' <<< "$DENIAL_JSON" 2>/dev/null || echo unknown)
         TOOL_USE_ID=$(jq -r '.tool_use_id // ""' <<< "$DENIAL_JSON" 2>/dev/null || true)
-        COMMAND=$(jq -r '.command // ""' <<< "$DENIAL_JSON" 2>/dev/null || true)
         PARAMETER_NAMES=$(jq -r '(.parameter_names // []) | join(", ")' <<< "$DENIAL_JSON" 2>/dev/null || true)
-        REASON=$(jq -r '.reason // "詳細理由を取得できませんでした。"' <<< "$DENIAL_JSON" 2>/dev/null || echo "詳細理由を取得できませんでした。")
-
-        TOOL=$(sanitize "$TOOL" 100)
-        TOOL_USE_ID=$(sanitize "$TOOL_USE_ID" 100)
-        COMMAND=$(sanitize "$COMMAND" 500)
-        PARAMETER_NAMES=$(sanitize "$PARAMETER_NAMES" 300)
-        REASON=$(sanitize "$REASON" 1000)
 
         echo "#### $INDEX. \`$TOOL\`"
         if [[ -n "$TOOL_USE_ID" ]]; then
           echo "- tool_use_id: \`$TOOL_USE_ID\`"
         fi
-        if [[ -n "$COMMAND" ]]; then
-          echo "- command（先頭500文字）:"
-          echo "    $COMMAND"
-        elif [[ -n "$PARAMETER_NAMES" ]]; then
+        if [[ -n "$PARAMETER_NAMES" ]]; then
           echo "- parameters（値は非表示）: \`$PARAMETER_NAMES\`"
+        else
+          echo "- parameters: なし"
         fi
-        echo "- reason（先頭1000文字）:"
-        echo "    $REASON"
+        echo "- 詳細理由・コマンド・引数値は、機密情報保護のため公開しません。"
       done < "$TMP_DENIALS"
 
       if (( DENIALS > 20 )); then

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -229,31 +229,7 @@ jobs:
       - name: 実行結果を要約
         if: always()
         shell: bash
-        run: |
-          set -euo pipefail
-          OUT=/home/runner/work/_temp/claude-execution-output.json
-          if [[ ! -f "$OUT" ]]; then
-            echo "::warning::実行結果ログ($OUT)が見つかりません。"
-            exit 0
-          fi
-          # ファイルはJSONL（改行区切りJSON）。-s で1つの配列にslurpしてから
-          # type=result の最後の要素（実行全体のサマリ）を取り出す。
-          SUBTYPE=$(jq -rs '[.[] | select(.type=="result")] | last | .subtype // "unknown"' "$OUT" 2>/dev/null || echo unknown)
-          IS_ERROR=$(jq -rs '[.[] | select(.type=="result")] | last | .is_error // false' "$OUT" 2>/dev/null || echo unknown)
-          NUM_TURNS=$(jq -rs '[.[] | select(.type=="result")] | last | .num_turns // "?"' "$OUT" 2>/dev/null || echo "?")
-          COST=$(jq -rs '[.[] | select(.type=="result")] | last | .total_cost_usd // "?"' "$OUT" 2>/dev/null || echo "?")
-          DENIALS=$(jq -rs '[.[] | select(.type=="result")] | last | .permission_denials_count // 0' "$OUT" 2>/dev/null || echo 0)
-          {
-            echo "### Claude Code 実行結果"
-            echo "- subtype: \`$SUBTYPE\` / is_error: \`$IS_ERROR\`"
-            echo "- turns: $NUM_TURNS / cost: \$$COST / permission denials: $DENIALS"
-          } >> "$GITHUB_STEP_SUMMARY"
-          if [[ "$DENIALS" != "0" && "$DENIALS" != "null" ]]; then
-            echo "::warning::permission_denials_count=$DENIALS。allowedToolsのBashパターンが実際のコマンドと一致していない可能性があります（複合コマンドはprefixパターンに丸ごと弾かれます）。"
-          fi
-          if [[ "$SUBTYPE" == "error_max_turns" ]]; then
-            echo "::warning::max_turns($NUM_TURNS)に到達して打ち切られました。タスクを分割するか max_turns を増やして再実行してください。"
-          fi
+        run: bash .github/scripts/summarize-claude-output.sh
 
       - name: テストエビデンスを保存
         if: always()
@@ -380,35 +356,14 @@ jobs:
             pull_requests: write
             issues: write
             actions: read
+          # 公開リポジトリのログへツール出力や機密情報を露出させない。
           show_full_output: false
           display_report: false
 
       - name: 実行結果を要約
         if: always()
         shell: bash
-        run: |
-          set -euo pipefail
-          OUT=/home/runner/work/_temp/claude-execution-output.json
-          if [[ ! -f "$OUT" ]]; then
-            echo "::warning::実行結果ログ($OUT)が見つかりません。"
-            exit 0
-          fi
-          SUBTYPE=$(jq -rs '[.[] | select(.type=="result")] | last | .subtype // "unknown"' "$OUT" 2>/dev/null || echo unknown)
-          IS_ERROR=$(jq -rs '[.[] | select(.type=="result")] | last | .is_error // false' "$OUT" 2>/dev/null || echo unknown)
-          NUM_TURNS=$(jq -rs '[.[] | select(.type=="result")] | last | .num_turns // "?"' "$OUT" 2>/dev/null || echo "?")
-          COST=$(jq -rs '[.[] | select(.type=="result")] | last | .total_cost_usd // "?"' "$OUT" 2>/dev/null || echo "?")
-          DENIALS=$(jq -rs '[.[] | select(.type=="result")] | last | .permission_denials_count // 0' "$OUT" 2>/dev/null || echo 0)
-          {
-            echo "### Claude Code 実行結果"
-            echo "- subtype: \`$SUBTYPE\` / is_error: \`$IS_ERROR\`"
-            echo "- turns: $NUM_TURNS / cost: \$$COST / permission denials: $DENIALS"
-          } >> "$GITHUB_STEP_SUMMARY"
-          if [[ "$DENIALS" != "0" && "$DENIALS" != "null" ]]; then
-            echo "::warning::permission_denials_count=$DENIALS。allowedToolsのBashパターンが実際のコマンドと一致していない可能性があります（複合コマンドはprefixパターンに丸ごと弾かれます）。"
-          fi
-          if [[ "$SUBTYPE" == "error_max_turns" ]]; then
-            echo "::warning::max_turns($NUM_TURNS)に到達して打ち切られました。タスクを分割するか max_turns を増やして再実行してください。"
-          fi
+        run: bash .github/scripts/summarize-claude-output.sh
 
       - name: commit・pushされたことを検証
         # このstepは常に実行し、Claude Codeが権限拒否やturn切れで行き詰まり

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -229,6 +229,8 @@ jobs:
       - name: 実行結果を要約
         if: always()
         shell: bash
+        env:
+          CLAUDE_EXECUTION_OUTPUT: ${{ steps.claude.outputs.execution_file }}
         run: bash .github/scripts/summarize-claude-output.sh
 
       - name: テストエビデンスを保存
@@ -363,6 +365,8 @@ jobs:
       - name: 実行結果を要約
         if: always()
         shell: bash
+        env:
+          CLAUDE_EXECUTION_OUTPUT: ${{ steps.claude.outputs.execution_file }}
         run: bash .github/scripts/summarize-claude-output.sh
 
       - name: commit・pushされたことを検証

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -226,12 +226,23 @@ jobs:
           show_full_output: false
           display_report: false
 
+      - name: 信頼済み要約スクリプトを取得
+        if: always()
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .claude-worker-trusted
+          sparse-checkout: .github/scripts/summarize-claude-output.sh
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: 実行結果を要約
         if: always()
         shell: bash
         env:
           CLAUDE_EXECUTION_OUTPUT: ${{ steps.claude.outputs.execution_file }}
-        run: bash .github/scripts/summarize-claude-output.sh
+        run: bash .claude-worker-trusted/.github/scripts/summarize-claude-output.sh
 
       - name: テストエビデンスを保存
         if: always()
@@ -362,12 +373,23 @@ jobs:
           show_full_output: false
           display_report: false
 
+      - name: 信頼済み要約スクリプトを取得
+        if: always()
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .claude-worker-trusted
+          sparse-checkout: .github/scripts/summarize-claude-output.sh
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: 実行結果を要約
         if: always()
         shell: bash
         env:
           CLAUDE_EXECUTION_OUTPUT: ${{ steps.claude.outputs.execution_file }}
-        run: bash .github/scripts/summarize-claude-output.sh
+        run: bash .claude-worker-trusted/.github/scripts/summarize-claude-output.sh
 
       - name: commit・pushされたことを検証
         # このstepは常に実行し、Claude Codeが権限拒否やturn切れで行き詰まり


### PR DESCRIPTION
## 概要

Claude Workerで`show_full_output`と`display_report`を有効化せず、権限拒否の安全なメタデータだけをStep Summaryへ出すようにします。

- `show_full_output: false` / `display_report: false`を維持
- observe/writeで重複していた要約処理を`.github/scripts/summarize-claude-output.sh`へ共通化
- claude-code-actionの`execution_file`出力を要約スクリプトへ渡す
- 通常のJSON配列と旧形式のJSONLをどちらも読み取れるように正規化
- 最後の`result.permission_denials`から、拒否されたツールを最大20件表示
- 公開するのはツール名・`tool_use_id`・引数名だけ
- Bashコマンド、全ツールの引数値、tool result本文、詳細理由は公開しない

## 背景

Actions run `30396673385`ではClaude Code自体は成功しましたが、`permission_denials_count: 9`のままcommitが作られず、後段の成果物検証で失敗しました。

また、既存の要約処理は実行ファイルをJSONLとして`jq -rs`で読んでいましたが、現在のclaude-code-actionは実行メッセージをJSON配列として保存します。そのため、既存要約が集計値を正しく取得できない可能性も併せて修正しています。

## セキュリティ

全会話・全ツール結果は公開しません。ブラックリスト方式のマスクには依存せず、値を一切出さない許可リスト方式でメタデータだけを表示します。

## 確認内容

- `bash -n .github/scripts/summarize-claude-output.sh`
- Workflow YAMLのパース
- JSON配列形式のサンプルでpermission denialを抽出
- JSONL形式でも同一のSummaryになることを確認
- Bashを含む全ツールで引数値・コマンド・tool result本文が出力されないことを確認
