### PR TITLE
#829 fix: bulk-import を跨いだ重複と failed の再課金ループを解消

### DIFF
--- a/api/src/v1/dishes/deterministic-id.spec.ts
+++ b/api/src/v1/dishes/deterministic-id.spec.ts
@@ -47,6 +47,17 @@ describe('Google import の決定論的 ID', () => {
     });
   });
 
+  describe('uuidV5 の名前空間検証', () => {
+    it.each([
+      'not-a-uuid',
+      '',
+      '8f2b1c94',
+      'zzzzzzzz-4d7e-5a13-9c60-2e4f8a1b3d57',
+    ])('不正な名前空間 %p は例外になる（黙って短いハッシュにしない）', (ns) => {
+      expect(() => uuidV5('name', ns)).toThrow(/Invalid UUID namespace/);
+    });
+  });
+
   describe('buildGoogleImportDishMediaId', () => {
     it('同じ place + category なら、別リクエストでも同じ ID になる', () => {
       // これが等しくないと、レースした2本の bulk-import が別 row を作る
@@ -82,8 +93,18 @@ describe('Google import の決定論的 ID', () => {
   });
 
   describe('buildGoogleImportDishReviewId', () => {
-    const build = (comment: string, author = 'https://example.com/u1') =>
-      buildGoogleImportDishReviewId(PLACE_ID, CATEGORY_ID, comment, author);
+    const build = (
+      comment: string,
+      author = 'https://example.com/u1',
+      rating = 5,
+    ) =>
+      buildGoogleImportDishReviewId(
+        PLACE_ID,
+        CATEGORY_ID,
+        comment,
+        author,
+        rating,
+      );
 
     it('同じレビューは、別リクエストでも同じ ID になる', () => {
       expect(build('美味しかった')).toBe(build('美味しかった'));
@@ -111,8 +132,13 @@ describe('Google import の決定論的 ID', () => {
 
     it('dish_media の名前空間と衝突しない', () => {
       expect(
-        buildGoogleImportDishReviewId(PLACE_ID, CATEGORY_ID, '', ''),
+        buildGoogleImportDishReviewId(PLACE_ID, CATEGORY_ID, '', '', 0),
       ).not.toBe(buildGoogleImportDishMediaId(PLACE_ID, CATEGORY_ID));
+    });
+
+    it('本文も投稿者も空な「評価のみ」のレビューを rating で区別する', () => {
+      // rating がキーに無いと、この 2 件が同一 ID に潰れて件数がズレる
+      expect(build('', '', 5)).not.toBe(build('', '', 1));
     });
 
     it('本文が空でも UUID として妥当', () => {
@@ -123,12 +149,11 @@ describe('Google import の決定論的 ID', () => {
   describe('レース時の重複防止（#829 の本質）', () => {
     it('DB を読めていない2本の bulk-import が同じ ID 集合を生成する', () => {
       const googleReviews = [
-        { text: 'レビュー1', author: 'https://example.com/a' },
-        { text: 'レビュー2', author: 'https://example.com/b' },
+        { text: 'レビュー1', author: 'https://example.com/a', rating: 5 },
+        { text: 'レビュー2', author: 'https://example.com/b', rating: 4 },
       ];
 
-      // 1本目: preflight lookup は「既存なし」
-      const first = {
+      const buildIds = () => ({
         mediaId: buildGoogleImportDishMediaId(PLACE_ID, CATEGORY_ID),
         reviewIds: googleReviews.map((r) =>
           buildGoogleImportDishReviewId(
@@ -136,22 +161,15 @@ describe('Google import の決定論的 ID', () => {
             CATEGORY_ID,
             r.text,
             r.author,
+            r.rating,
           ),
         ),
-      };
+      });
 
+      // 1本目: preflight lookup は「既存なし」
+      const first = buildIds();
       // 2本目: 1本目の handler がまだ commit していないので、やはり「既存なし」
-      const second = {
-        mediaId: buildGoogleImportDishMediaId(PLACE_ID, CATEGORY_ID),
-        reviewIds: googleReviews.map((r) =>
-          buildGoogleImportDishReviewId(
-            PLACE_ID,
-            CATEGORY_ID,
-            r.text,
-            r.author,
-          ),
-        ),
-      };
+      const second = buildIds();
 
       // ID が一致するので upsert / skipDuplicates がクロスリクエストでも効く
       expect(second.mediaId).toBe(first.mediaId);

--- a/api/src/v1/dishes/deterministic-id.spec.ts
+++ b/api/src/v1/dishes/deterministic-id.spec.ts
@@ -1,0 +1,161 @@
+import {
+  buildGoogleImportDishMediaId,
+  buildGoogleImportDishReviewId,
+  uuidV5,
+} from './deterministic-id';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+/**
+ * #829 【回帰防止】bulk-import を跨いだ dish_reviews の重複。
+ *
+ * preflight lookup は DB を読むが、その行を書くのは非同期の Cloud Tasks handler。
+ * 1本目の handler が commit する前に2本目の bulk-import が走ると、どちらも
+ * 「既存なし」と判定する。ID がリクエストごとに変わると、この窓で
+ * dish_reviews が二重登録され reviewCount / averageRating が水増しされる。
+ *
+ * ここが壊れると、その事故が静かに再発する。
+ */
+describe('Google import の決定論的 ID', () => {
+  const PLACE_ID = 'ChIJSzZlDRONGGARkKzJf-PF4m4';
+  const CATEGORY_ID = 'ramen';
+
+  describe('uuidV5', () => {
+    it('RFC 4122 の v5 形式になる', () => {
+      expect(uuidV5('name', '8f2b1c94-4d7e-5a13-9c60-2e4f8a1b3d57')).toMatch(
+        UUID_RE,
+      );
+    });
+
+    it('同じ入力からは常に同じ値が出る', () => {
+      const ns = '8f2b1c94-4d7e-5a13-9c60-2e4f8a1b3d57';
+
+      expect(uuidV5('a', ns)).toBe(uuidV5('a', ns));
+    });
+
+    it('名前が違えば別の値になる', () => {
+      const ns = '8f2b1c94-4d7e-5a13-9c60-2e4f8a1b3d57';
+
+      expect(uuidV5('a', ns)).not.toBe(uuidV5('b', ns));
+    });
+
+    it('名前空間が違えば別の値になる', () => {
+      expect(uuidV5('a', '8f2b1c94-4d7e-5a13-9c60-2e4f8a1b3d57')).not.toBe(
+        uuidV5('a', 'b41d7e26-9a83-5f04-8d15-6c9e2b7a4f80'),
+      );
+    });
+  });
+
+  describe('buildGoogleImportDishMediaId', () => {
+    it('同じ place + category なら、別リクエストでも同じ ID になる', () => {
+      // これが等しくないと、レースした2本の bulk-import が別 row を作る
+      expect(buildGoogleImportDishMediaId(PLACE_ID, CATEGORY_ID)).toBe(
+        buildGoogleImportDishMediaId(PLACE_ID, CATEGORY_ID),
+      );
+    });
+
+    it('category が違えば別 ID になる', () => {
+      expect(buildGoogleImportDishMediaId(PLACE_ID, 'ramen')).not.toBe(
+        buildGoogleImportDishMediaId(PLACE_ID, 'sushi'),
+      );
+    });
+
+    it('place が違えば別 ID になる', () => {
+      expect(buildGoogleImportDishMediaId('place-a', CATEGORY_ID)).not.toBe(
+        buildGoogleImportDishMediaId('place-b', CATEGORY_ID),
+      );
+    });
+
+    it('UUID として妥当な形式になる', () => {
+      expect(buildGoogleImportDishMediaId(PLACE_ID, CATEGORY_ID)).toMatch(
+        UUID_RE,
+      );
+    });
+
+    it('区切り文字の取り違えで衝突しない', () => {
+      // "a:b" + "c" と "a" + "b:c" が同じにならないこと
+      expect(buildGoogleImportDishMediaId('a:b', 'c')).not.toBe(
+        buildGoogleImportDishMediaId('a', 'b:c'),
+      );
+    });
+  });
+
+  describe('buildGoogleImportDishReviewId', () => {
+    const build = (comment: string, author = 'https://example.com/u1') =>
+      buildGoogleImportDishReviewId(PLACE_ID, CATEGORY_ID, comment, author);
+
+    it('同じレビューは、別リクエストでも同じ ID になる', () => {
+      expect(build('美味しかった')).toBe(build('美味しかった'));
+    });
+
+    it('本文が違えば別 ID になる', () => {
+      expect(build('美味しかった')).not.toBe(build('普通だった'));
+    });
+
+    it('投稿者が違えば別 ID になる（同じ本文でも別レビュー）', () => {
+      expect(build('美味しい', 'https://example.com/u1')).not.toBe(
+        build('美味しい', 'https://example.com/u2'),
+      );
+    });
+
+    it('Google が返す並び順が変わっても ID は変わらない', () => {
+      // index ベースだとここで破綻する
+      const reviews = ['一番目', '二番目', '三番目'];
+      const shuffled = ['三番目', '一番目', '二番目'];
+
+      expect(new Set(reviews.map((r) => build(r)))).toEqual(
+        new Set(shuffled.map((r) => build(r))),
+      );
+    });
+
+    it('dish_media の名前空間と衝突しない', () => {
+      expect(
+        buildGoogleImportDishReviewId(PLACE_ID, CATEGORY_ID, '', ''),
+      ).not.toBe(buildGoogleImportDishMediaId(PLACE_ID, CATEGORY_ID));
+    });
+
+    it('本文が空でも UUID として妥当', () => {
+      expect(build('')).toMatch(UUID_RE);
+    });
+  });
+
+  describe('レース時の重複防止（#829 の本質）', () => {
+    it('DB を読めていない2本の bulk-import が同じ ID 集合を生成する', () => {
+      const googleReviews = [
+        { text: 'レビュー1', author: 'https://example.com/a' },
+        { text: 'レビュー2', author: 'https://example.com/b' },
+      ];
+
+      // 1本目: preflight lookup は「既存なし」
+      const first = {
+        mediaId: buildGoogleImportDishMediaId(PLACE_ID, CATEGORY_ID),
+        reviewIds: googleReviews.map((r) =>
+          buildGoogleImportDishReviewId(
+            PLACE_ID,
+            CATEGORY_ID,
+            r.text,
+            r.author,
+          ),
+        ),
+      };
+
+      // 2本目: 1本目の handler がまだ commit していないので、やはり「既存なし」
+      const second = {
+        mediaId: buildGoogleImportDishMediaId(PLACE_ID, CATEGORY_ID),
+        reviewIds: googleReviews.map((r) =>
+          buildGoogleImportDishReviewId(
+            PLACE_ID,
+            CATEGORY_ID,
+            r.text,
+            r.author,
+          ),
+        ),
+      };
+
+      // ID が一致するので upsert / skipDuplicates がクロスリクエストでも効く
+      expect(second.mediaId).toBe(first.mediaId);
+      expect(second.reviewIds).toEqual(first.reviewIds);
+    });
+  });
+});

--- a/api/src/v1/dishes/deterministic-id.ts
+++ b/api/src/v1/dishes/deterministic-id.ts
@@ -1,0 +1,86 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * #829 【設計】Google import の ID を (placeId, categoryId) から決定論的に導出する。
+ *
+ * bulk-import は「既存 dish_media を DB から読んで再利用するか決める」が、その行を実際に
+ * 書くのは非同期の Cloud Tasks handler である。つまり 1 本目の handler が commit する前に
+ * 2 本目の bulk-import が走ると、どちらの preflight lookup も「既存なし」と判定し、
+ * それぞれ別の randomUUID を採番してしまう。結果として同じ Google レビューが
+ * dish_reviews へ二重登録され、reviewCount と averageRating が水増しされる。
+ *
+ * ID をリクエスト間で決定論的にすると、DB を先に読まなくても両者が同じ ID を出すため、
+ * 既存の `dish_media.upsert` と `dish_reviews.createMany({ skipDuplicates: true })` が
+ * そのままクロスリクエストの重複防止として機能する。
+ * preflight lookup は「Photo Media 課金を skip するための最適化」に純化でき、
+ * 正しさが実行タイミングに依存しなくなる。
+ *
+ * RFC 4122 の UUID v5（SHA-1 + 名前空間）に準拠する。
+ */
+
+/** UUID 文字列を 16 バイトへ変換する */
+const uuidToBytes = (uuid: string): Buffer =>
+  Buffer.from(uuid.replace(/-/g, ''), 'hex');
+
+/**
+ * RFC 4122 UUID v5 を生成する。
+ * 外部依存を増やさないため node:crypto だけで実装する。
+ */
+export function uuidV5(name: string, namespace: string): string {
+  const hash = createHash('sha1')
+    .update(uuidToBytes(namespace))
+    .update(Buffer.from(name, 'utf8'))
+    .digest();
+
+  const bytes = Buffer.from(hash.subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x50; // version 5
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+
+  const hex = bytes.toString('hex');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}
+
+/**
+ * 名前空間。値を変更すると既存レコードと ID が一致しなくなるため、変更しないこと。
+ */
+const NS_DISH_MEDIA = '8f2b1c94-4d7e-5a13-9c60-2e4f8a1b3d57';
+const NS_DISH_REVIEW = 'b41d7e26-9a83-5f04-8d15-6c9e2b7a4f80';
+
+/**
+ * 区切り文字の取り違えによる衝突を防ぐため、各要素を長さ接頭辞付きで連結する。
+ * 単純な `a:b` 連結だと ("a:b", "c") と ("a", "b:c") が同じキーになる。
+ */
+const joinKeyParts = (...parts: string[]): string =>
+  parts.map((part) => `${part.length}:${part}`).join('');
+
+/** Google import の dish_media.id を (placeId, categoryId) から導出する */
+export function buildGoogleImportDishMediaId(
+  placeId: string,
+  categoryId: string,
+): string {
+  return uuidV5(joinKeyParts(placeId, categoryId), NS_DISH_MEDIA);
+}
+
+/**
+ * Google import の dish_reviews.id を (placeId, categoryId, レビュー本文) から導出する。
+ *
+ * index ではなく本文でキーを作る。Google が返すレビューの並び順は保証されないため、
+ * index を使うと並びが変わっただけで別 ID になり重複してしまう。
+ */
+export function buildGoogleImportDishReviewId(
+  placeId: string,
+  categoryId: string,
+  reviewComment: string,
+  authorUri: string,
+): string {
+  return uuidV5(
+    joinKeyParts(placeId, categoryId, authorUri, reviewComment),
+    NS_DISH_REVIEW,
+  );
+}

--- a/api/src/v1/dishes/deterministic-id.ts
+++ b/api/src/v1/dishes/deterministic-id.ts
@@ -19,8 +19,15 @@ import { createHash } from 'node:crypto';
  */
 
 /** UUID 文字列を 16 バイトへ変換する */
-const uuidToBytes = (uuid: string): Buffer =>
-  Buffer.from(uuid.replace(/-/g, ''), 'hex');
+const uuidToBytes = (uuid: string): Buffer => {
+  const bytes = Buffer.from(uuid.replace(/-/g, ''), 'hex');
+  // Buffer.from(..., 'hex') は不正な文字で静かに打ち切るため、長さを必ず検証する。
+  // 検証しないと 0〜15 バイトの名前空間で黙ってハッシュしてしまう。
+  if (bytes.length !== 16) {
+    throw new Error(`Invalid UUID namespace: ${uuid}`);
+  }
+  return bytes;
+};
 
 /**
  * RFC 4122 UUID v5 を生成する。
@@ -72,15 +79,20 @@ export function buildGoogleImportDishMediaId(
  *
  * index ではなく本文でキーを作る。Google が返すレビューの並び順は保証されないため、
  * index を使うと並びが変わっただけで別 ID になり重複してしまう。
+ *
+ * 本文・投稿者が空でも区別できるよう rating まで含める。
  */
 export function buildGoogleImportDishReviewId(
   placeId: string,
   categoryId: string,
   reviewComment: string,
   authorUri: string,
+  rating: number,
 ): string {
+  // rating も含める。本文も authorAttribution.uri も無い「評価のみ」のレビューが
+  // 複数返ると、rating が無いキーでは同一 ID に潰れて件数がズレる。
   return uuidV5(
-    joinKeyParts(placeId, categoryId, authorUri, reviewComment),
+    joinKeyParts(placeId, categoryId, authorUri, reviewComment, String(rating)),
     NS_DISH_REVIEW,
   );
 }

--- a/api/src/v1/dishes/dishes.controller.ts
+++ b/api/src/v1/dishes/dishes.controller.ts
@@ -20,6 +20,8 @@ import { CreateDishDto, BulkImportDishesDto } from '@shared/v1/dto';
 import { CreateDishResponse, BulkImportDishesResponse } from '@shared/v1/res';
 
 // 横串 (Auth)
+import { CurrentUser } from '../../core/auth/current-user.decorator';
+import { RequestUser } from '../../core/auth/auth.types';
 import { AuthAnonGuard } from '../../core/auth/auth.guard';
 
 // ドメイン Service
@@ -52,7 +54,11 @@ export class DishesController {
   @ApiResponse({ status: 201, description: '一括登録成功' })
   async bulkImportDishes(
     @Body() dto: BulkImportDishesDto,
+    @CurrentUser() user: RequestUser,
   ): Promise<BulkImportDishesResponse> {
-    return this.dishesService.bulkImportFromGoogle(dto);
+    // #829 【バグ】既存 entry を返すようになったため、viewer を渡さないと
+    // isMine/isSaved/isLiked が常に false になり、保存済みの dish を
+    // 未保存として表示 → タップで unique 制約違反の 500 を招く。
+    return this.dishesService.bulkImportFromGoogle(dto, user.id);
   }
 }

--- a/api/src/v1/dishes/dishes.repository.ts
+++ b/api/src/v1/dishes/dishes.repository.ts
@@ -21,6 +21,12 @@ export type ReusableGoogleImportDishMedia = {
   reuseKind: 'completed' | 'google-import-non-completed';
 };
 
+/**
+ * #829 再処理して意味があるステータス。`failed` は恒久エラーなので含めない。
+ * 片方が completed でもう片方が processing、という状態は再処理対象なので completed も含む。
+ */
+const NON_FAILED_PROCESSING_STATUSES = ['idle', 'processing', 'completed'];
+
 @Injectable()
 export class DishesRepository {
   constructor(
@@ -169,6 +175,10 @@ export class DishesRepository {
         id: true,
         dish_media: {
           where: {
+            // #829 【バグ】docstring どおり Google import 由来だけを再利用する。
+            // ユーザー投稿を bulk-import の結果として返すと、投稿者以外の画面に
+            // isMine/isSaved/isLiked が壊れた状態で出てしまう。
+            user_id: null,
             media_processing_status: 'completed',
             thumbnail_processing_status: 'completed',
           },
@@ -212,6 +222,13 @@ export class DishesRepository {
           dish_media: {
             where: {
               user_id: null,
+              // #829 【バグ】failed は恒久エラー（元画像が sharp で扱えない等）なので
+              // 再利用対象にすると、その place で毎回 Photo Media を課金し続けてしまう。
+              // 再試行して意味があるのは processing / idle のときだけ。
+              media_processing_status: { in: NON_FAILED_PROCESSING_STATUSES },
+              thumbnail_processing_status: {
+                in: NON_FAILED_PROCESSING_STATUSES,
+              },
               OR: [
                 { media_processing_status: { not: 'completed' } },
                 { thumbnail_processing_status: { not: 'completed' } },

--- a/api/src/v1/dishes/dishes.repository.ts
+++ b/api/src/v1/dishes/dishes.repository.ts
@@ -21,12 +21,6 @@ export type ReusableGoogleImportDishMedia = {
   reuseKind: 'completed' | 'google-import-non-completed';
 };
 
-/**
- * #829 再処理して意味があるステータス。`failed` は恒久エラーなので含めない。
- * 片方が completed でもう片方が processing、という状態は再処理対象なので completed も含む。
- */
-const NON_FAILED_PROCESSING_STATUSES = ['idle', 'processing', 'completed'];
-
 @Injectable()
 export class DishesRepository {
   constructor(
@@ -222,13 +216,19 @@ export class DishesRepository {
           dish_media: {
             where: {
               user_id: null,
-              // #829 【バグ】failed は恒久エラー（元画像が sharp で扱えない等）なので
-              // 再利用対象にすると、その place で毎回 Photo Media を課金し続けてしまう。
-              // 再試行して意味があるのは processing / idle のときだけ。
-              media_processing_status: { in: NON_FAILED_PROCESSING_STATUSES },
-              thumbnail_processing_status: {
-                in: NON_FAILED_PROCESSING_STATUSES,
-              },
+              // #829 【設計】failed も必ず lookup 対象に含める。
+              //
+              // failed を除外すると、その place は新規作成パスへ落ちて決定論 ID が
+              // 新たに採番される。既存行は randomUUID 由来なので ID が一致せず、
+              // skipDuplicates が効かないまま同じ Google レビューが二重登録される。
+              // ID の再利用（重複防止）と Photo Media 課金の抑止は別の関心事であり、
+              // ここで status を絞ると前者が壊れる。
+              //
+              // failed の place で Photo Media を毎回課金してしまう件は、
+              // tryGetPhotoMedia が reuse 判定より前にある構造の問題なので、
+              // 別途 handler 側の download skip 判定とあわせて対応する。
+              // 再利用が起きたことは ExistingGoogleImportDishMediaReused ログの
+              // mediaProcessingStatus で数えられる。
               OR: [
                 { media_processing_status: { not: 'completed' } },
                 { thumbnail_processing_status: { not: 'completed' } },

--- a/api/src/v1/dishes/dishes.service.ts
+++ b/api/src/v1/dishes/dishes.service.ts
@@ -40,12 +40,13 @@ import {
   getExt,
 } from 'src/core/storage/storage.utils';
 import { randomUUID } from 'node:crypto';
+import {
+  buildGoogleImportDishMediaId,
+  buildGoogleImportDishReviewId,
+} from './deterministic-id';
 
 // Google Maps types for photo handling
 import { protos } from '@googlemaps/places';
-
-// #829 bulk-import は viewer を受け取らないが、既存 entry 組み立てでは UUID 条件が必要になる。
-const DUMMY_VIEWER_ID = '593e6eff-34b3-4293-90e4-b0e61d66f761';
 
 @Injectable()
 export class DishesService {
@@ -133,6 +134,7 @@ export class DishesService {
   /* ------------------------------------------------------------------ */
   async bulkImportFromGoogle(
     dto: BulkImportDishesDto,
+    viewerId: string,
   ): Promise<BulkImportDishesResponse> {
     this.logger.debug('BulkImportFromGoogle', 'bulkImportFromGoogle', dto);
 
@@ -202,7 +204,7 @@ export class DishesService {
     // #829 【互換性】bulk-import は viewer を受け取らないため、既存 entry 組み立てだけ固定 viewer で既存 assembler に寄せる。
     const existingEntries =
       await this.dishMediaService.fetchDishMediaEntryItems(reusableMediaIds, {
-        userId: DUMMY_VIEWER_ID,
+        userId: viewerId,
       });
     const existingEntryByMediaId = new Map(
       existingEntries.items.map((entry) => [
@@ -228,7 +230,28 @@ export class DishesService {
     }
 
     // 各レストランに対してデータ登録処理（並列処理）
-    const processPromises = googlePlaces.places.map(async (place, index) => {
+    // #829 【バグ】Text Search が同じ place を2件返すと、ID が決定論的になった今は
+    // 同一 dish_media.id が2件レスポンスに載り、Cloud Task も二重に積まれる。
+    // contextualContents は元の places と index で対応するため、
+    // 重複除去後も必ず「元の index」を保持すること。
+    const seenPlaceIds = new Set<string>();
+    const uniquePlaces = googlePlaces.places
+      .map((place, index) => ({ place, index }))
+      .filter(({ place, index }) => {
+        if (!place.id) return true;
+        if (seenPlaceIds.has(place.id)) {
+          this.logger.warn(
+            'DuplicatePlaceInTextSearch',
+            'bulkImportFromGoogle',
+            { placeId: place.id, index },
+          );
+          return false;
+        }
+        seenPlaceIds.add(place.id);
+        return true;
+      });
+
+    const processPromises = uniquePlaces.map(async ({ place, index }) => {
       try {
         const contextualContent = canUseContextual
           ? contextualContents[index]
@@ -394,7 +417,13 @@ export class DishesService {
         };
 
         const dishMedia: SupabaseDishMedia = {
-          id: existingGoogleImportEntry?.dish_media.id ?? randomUUID(),
+          // #829 【バグ】randomUUID だと、1本目の handler が commit する前に2本目の
+          // bulk-import が走った場合に別 ID が採番され、dish_reviews が二重登録される。
+          // (placeId, categoryId) から決定論的に導出し、upsert / skipDuplicates を
+          // リクエスト間でも効かせる。
+          id:
+            existingGoogleImportEntry?.dish_media.id ??
+            buildGoogleImportDishMediaId(place.id!, dto.categoryId),
           dish_id: dish.id,
           user_id: null, // Google からのインポートなので null
           media_path: mediaPath,
@@ -412,11 +441,38 @@ export class DishesService {
           lock_no: existingGoogleImportEntry?.dish_media.lock_no ?? 0,
         };
 
+        if (existingGoogleImportEntry) {
+          // #829 【設計】この経路は既存 ID・既存 media_path・既存 review を payload へ
+          // 注入するため副作用が大きい。件数と status を必ず残し、failed ループや
+          // 課金残存を後からログで数えられるようにする。
+          this.logger.log(
+            'ExistingGoogleImportDishMediaReused',
+            'bulkImportFromGoogle',
+            {
+              placeId: place.id!,
+              categoryId: dto.categoryId,
+              dishMediaId: existingGoogleImportEntry.dish_media.id,
+              mediaProcessingStatus:
+                existingGoogleImportEntry.dish_media.media_processing_status,
+              thumbnailProcessingStatus:
+                existingGoogleImportEntry.dish_media
+                  .thumbnail_processing_status,
+              reusedReviewCount: existingGoogleImportEntry.dish_reviews.length,
+            },
+          );
+        }
+
         // #829 【設計】未完了 Google import の再処理では既存 review ID を渡し、handler 側の skipDuplicates と合わせて retry を no-op 化する。
         const dishReviews: SupabaseDishReviews[] = existingGoogleImportEntry
           ? this.toSupabaseDishReviews(existingGoogleImportEntry.dish_reviews)
           : reviews.map((review) => ({
-              id: randomUUID(),
+              // #829 【バグ】review ID も決定論的に導出し、リクエストを跨いだ重複を防ぐ
+              id: buildGoogleImportDishReviewId(
+                place.id!,
+                dto.categoryId,
+                review.originalText?.text || '',
+                review.authorAttribution?.uri || '',
+              ),
               dish_id: dish.id,
               user_id: null, // Google からのインポートなので null
               comment: review.originalText?.text || '',

--- a/api/src/v1/dishes/dishes.service.ts
+++ b/api/src/v1/dishes/dishes.service.ts
@@ -39,7 +39,6 @@ import {
   buildFullPath,
   getExt,
 } from 'src/core/storage/storage.utils';
-import { randomUUID } from 'node:crypto';
 import {
   buildGoogleImportDishMediaId,
   buildGoogleImportDishReviewId,
@@ -472,6 +471,7 @@ export class DishesService {
                 dto.categoryId,
                 review.originalText?.text || '',
                 review.authorAttribution?.uri || '',
+                review.rating || 0,
               ),
               dish_id: dish.id,
               user_id: null, // Google からのインポートなので null


### PR DESCRIPTION
PR #844 のレビュー指摘への対応。**base は #844 のブランチ**（stacked PR）なので、#844 → 本 PR の順にマージしてください。

対象 Issue: #829 ／ レビュー: [#844 のコメント](https://github.com/Ayato-kosaka/nanitabeyo/pull/844#issuecomment-5109881942)、[#1051 のコメント](https://github.com/Ayato-kosaka/nanitabeyo/pull/1051#issuecomment-5110824711)

## 指摘①【高】dish_reviews の重複は解消していなかった

`skipDuplicates` が効くのは「同一 payload の Cloud Tasks retry」だけで、**bulk-import リクエストを跨いだ重複**は防げていませんでした。

preflight lookup は DB を**読む**が、その行を**書く**のは非同期の Cloud Tasks handler です。1本目の handler が commit する前に2本目の bulk-import が走ると、どちらも「既存なし」と判定して別の `randomUUID()` を採番します。

| 時刻 | 動作 | 結果 |
|---|---|---|
| T0 | bulk-import #1 → preflight「既存なし」 | `M_A` / `R1..R5` を採番 |
| T1 | bulk-import #2 → preflight **まだ「既存なし」** | `M_B` / `R6..R10` を採番 |
| T2 | handler #1 → insert | dish_media 1行 / dish_reviews 5行 |
| T3 | handler #2 → insert（id が全く別） | **dish_media 2行 / dish_reviews 10行** |

`dish_media.id` と `dish_reviews.id` を `(placeId, categoryId)` から**決定論的に導出**する方式へ変更しました（RFC 4122 UUID v5、`node:crypto` のみで実装し依存追加なし）。DB を先に読まなくても両者が同じ ID を出すため、既存の `upsert` と `skipDuplicates` が**そのままクロスリクエストの重複防止として機能**します。

レビュー案1をほぼ採用しましたが、3点変えています。

- **review ID のキーは index ではなく本文＋投稿者＋rating** — Google が返す並び順は保証されないので index だと重複します。rating を含めるのは、本文も `authorAttribution.uri` も無い「評価のみ」のレビューが複数返ったときに同一 ID へ潰れるのを防ぐためです
- **キーの連結に長さ接頭辞** — 単純な `a:b` 連結だと `("a:b","c")` と `("a","b:c")` が衝突します（この衝突は自分で書いたテストが検出しました）
- **`uuidToBytes` に長さ検証** — `Buffer.from(..., 'hex')` は不正な文字で静かに打ち切るため、検証しないと 0〜15 バイトの名前空間で黙ってハッシュしてしまいます

UUID v5 実装は RFC 4122 の既知ベクタと Python `uuid.uuid5` の両方でクロスチェック済みです（レビュアーによる検証）。

## 指摘②【高】`failed` の無限再課金 → **本 PR では対応しません**

当初 `failed` を再利用対象から除外しましたが、**これは誤りだったので取り消しました**。理由は2つあります。

1. **課金削減の効果が無い**。`tryGetPhotoMedia` は reuse 判定より**前**で呼ばれるため、`failed` を除外しても「completed に到達しない place は毎回課金」は変わりません
2. **指摘①と同じクラスの事故を新たに作る**。除外するとその place は新規作成パスへ落ちて決定論 ID が新たに採番され、randomUUID 由来の既存 review 行と ID が一致せず、**同じ Google レビューが二重登録**されます（`dish_reviews` の unique 制約は PK のみで、本文が同じ別 ID の行は弾けません）

ID の再利用（重複防止）と Photo Media 課金の抑止は別の関心事であり、lookup 側で status を絞ると前者が壊れます。**正しい対処は `tryGetPhotoMedia` の呼び出し位置の見直し**（指摘③と同根）なので、#1053 へ最優先項目として送りました。

`failed` の place で再利用が起きたことは、⑥ で追加した `ExistingGoogleImportDishMediaReused` ログの `mediaProcessingStatus` で数えられます。

## 指摘④【中】分岐①にユーザー投稿の除外が無い

docstring は「ユーザー投稿は Google import の冪等性対象に巻き込まない」と書いているのに、completed 分岐に `user_id: null` が無く実装と矛盾していました。docstring 側に合わせて filter を追加しています。

## 指摘⑤【中】`DUMMY_VIEWER_ID` で `isMine`/`isSaved`/`isLiked` が常に false

既存 entry を返すようになったため、保存済みの dish が未保存として表示され、タップすると `reactions` の unique 制約違反で 500 になっていました。`bulk-import` は認証済みエンドポイントなので、`@CurrentUser()` から実 viewer を渡すようにしました。

`AuthAnonGuard` が `user` を必ず返すこと（token 無し／検証失敗はいずれも `UnauthorizedException`）はレビューで確認済みです。

## 指摘⑥【中】未完了再利用ブランチのログが皆無

`ExistingGoogleImportDishMediaReused` を追加し、`mediaProcessingStatus` を含めました。

## 指摘⑦【中】同一 placeId が複数返ると `dish_media.id` が重複する

ID が決定論的になったことで**新たに顕在化する**問題です。placeId で重複除去しました。`contextualContents` は元の `places` と index で対応するため、**除去後も元の index を保持**しています（素朴に filter すると index がズレて写真とレビューの対応が壊れます）。

## 検証

- `pnpm turbo run typecheck`: **2/2 成功**
- 新規単体テスト **21 件成功**（`api/src/v1/dishes/deterministic-id.spec.ts`）
  - レースした2本の bulk-import が同じ ID 集合を生成すること
  - Google の並び順が変わっても ID が変わらないこと
  - 評価のみのレビューが rating で区別されること
  - 不正な名前空間で例外になること
- `eslint`: base（#844）と同じ 9 errors。回帰なし

## 残課題 → #1053

未完了再利用パスの Photo Media 課金、`media_path` の決定論化、Cloud Tasks の `task.name` dedup、分岐テスト、feature flag などをまとめてあります。