### PR TITLE
feat: publish test evidence to public GCS

### DIFF
--- a/.claude/skills/parallel-development/SKILL.md
+++ b/.claude/skills/parallel-development/SKILL.md
@@ -57,7 +57,7 @@ description: CSVまたはGitHubの親Issueから複数課題を読み取り、�
 
 1. 対象リポジトリ、既定ブランチ、現在の作業ツリー、既存Issue、Sub-issue、PRを確認する。
 2. `gh auth status` と `gh workflow view claude-worker.yml` を確認する。
-3. `gh secret list` で `CLAUDE_CODE_OAUTH_TOKEN` の名前が存在することを確認する。秘密値は読まない。
+3. `gh secret list` で `CLAUDE_CODE_OAUTH_TOKEN` の名前が存在することだけを確認する。値を取得、表示、コピーしない。
 4. 公式Claude GitHub Appが対象リポジトリへインストール済みであることを確認する。未導入なら、ユーザーへ導入を依頼して停止する。
 5. 既定ブランチのrulesetでPR経由と必要な人間レビューを必須にし、Claude GitHub Appをbypass対象にしていないことを確認する。
 6. ユーザーが指定したCSVまたは親Issueを全件読み、未解決範囲を把握する。
@@ -287,7 +287,31 @@ Workerへ、実行したテストの生データを `/tmp/claude-artifacts/` 配
 
 秘密値、`.env`、認証情報、個人情報をArtifactへ含めない。Artifactは必ず対象PRの最新commit SHAに対応させる。新しいcommitがpushされたら、古いエビデンスだけで完了判定しない。
 
-`gh run download` で必要なArtifactを取得し、要約だけでなく中身を確認する。人間にはrun URL、Artifact名、対象SHA、成功・失敗、未実施項目をまとめて提示する。
+実装runのエビデンスは暫定確認に使い、人間へ公開する最終エビデンスは、原則として独立レビューrunまたは専用validation runのArtifactを使う。UI変更では `access=observe`、`setup_playwright=true`、`base_ref=<PRの最新HEAD SHA>` で検証runを起動し、レビュー指摘の修正後は新しいHEAD SHAで再実行する。
+
+レビューがApprove相当で、必須テストが成功し、未解決の重大指摘がなく、レビューrunへ渡した `base_ref` と現在のPR HEAD SHAが一致した場合だけ、`.github/workflows/evidence-collect.yml` を起動する。`workflow_dispatch` の `--ref main` は信頼済みWorkflowを選ぶためのrefであり、Actions APIのrun `head_sha` はテスト対象SHAを表さないことがある。したがって、リーダー自身がdispatch時に記録した `base_ref` と現在のPR HEADを照合し、そのSHAを `source_sha` として渡す。
+
+```bash
+PR_HEAD_SHA="$(gh pr view <pr-number> --json headRefOid --jq .headRefOid)"
+
+gh workflow run evidence-collect.yml \
+  --ref main \
+  -f run_id=<review-or-validation-run-id> \
+  -f artifact_name=<claude-worker-artifact-name> \
+  -f source_sha="$PR_HEAD_SHA"
+```
+
+`evidence-collect.yml` は元runが成功したClaude Workerであることを確認し、Artifact内の画像・動画だけを `nanitabeyo-public` へ公開する。Playwright trace、HTML report、ログ、JUnit等の生データは元Artifactに残す。公開後は、GCS上とActions Artifactの両方へ `manifest.json` を保存する。このWorkflow自身にはIssue・PRコメントをさせない。
+
+収集runの完了後、`evidence-manifest-<source-run-id>` Artifactまたは公開manifestを読み、`repository`、`sourceRunId`、`sourceCommitSha`、`artifactName` が期待値と一致することを確認する。リーダーがIssueまたはPRへ、画像はMarkdown画像、動画はリンクとしてコメントし、元run URL、Artifact名、対象SHAも併記する。
+
+```markdown
+![画面名](https://storage.googleapis.com/nanitabeyo-public/...)
+
+🎥 [動画名](https://storage.googleapis.com/nanitabeyo-public/...)
+```
+
+`gh run download` で元Artifactも必要に応じて取得し、要約だけでなく中身を確認する。人間にはrun URL、Artifact名、対象SHA、成功・失敗、未実施項目をまとめて提示する。
 
 ## runを追跡する
 

--- a/.codex/bigquery/access.md
+++ b/.codex/bigquery/access.md
@@ -5,12 +5,15 @@
 ```bash
 export PATH=/home/ubuntu/.local/google-cloud-sdk/bin:$PATH
 export GOOGLE_APPLICATION_CREDENTIALS=~/.config/service-account-key/food-scroll-2bc35f43cfea.json
-export BQ_DATASET=food-scroll.nanitabeyo_logs_prod
+export BQ_DATASET=food-scroll.nanitabeyo_logs_dev
 ```
 
-Dataset:
+Datasets:
 
-- `food-scroll.nanitabeyo_logs_prod`
+- `food-scroll.nanitabeyo_logs_dev` — development APIの検証・ログ調査で使用する既定dataset
+- `food-scroll.nanitabeyo_logs_prod` — production調査を明示的に依頼された場合だけ使用する
+
+APIの開発・レビュー・検証では、必ず `food-scroll.nanitabeyo_logs_dev` を使用する。`nanitabeyo_logs_prod`へ切り替えない。
 
 Primary command shape:
 

--- a/.github/workflows/evidence-collect.yml
+++ b/.github/workflows/evidence-collect.yml
@@ -1,49 +1,94 @@
 name: Evidence Collect
 
-# 📸 テストエビデンス回収ワークフロー（#1027）
-# - 指定した workflow run の Artifact（Detox のスクリーンショット等）をダウンロードし、
-#   エビデンス用ブランチへ commit する
-# - Actions の Artifact ダウンロード URL(Azure blob)へ直接アクセスできない環境からでも、
-#   git 経由でエビデンスを取得できるようにするための決定的な補助ワークフロー
+# 📸 テストエビデンス公開ワークフロー
+# - 指定した Claude Worker run の Artifact をダウンロードする
+# - オーケストレーターが照合した対象commit SHAとrun結果を記録する
+# - 画像・動画を nanitabeyo-public へ公開する
+# - オーケストレーターがIssue/PRコメントを作れるようmanifestを生成する
+#
+# このWorkflow自身はIssue/PRへコメントしない。
 on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: "Artifact を持つ workflow run の ID"
+        description: "Artifactを持つClaude Worker workflow run ID"
         required: true
         type: string
       artifact_name:
-        description: "ダウンロードする Artifact 名（例: detox-report-android）"
+        description: "ダウンロードするArtifact名（例: claude-issue-123-review-123456789-1）"
         required: true
         type: string
-      dest_dir:
-        description: "リポジトリ内の格納先ディレクトリ"
+      source_sha:
+        description: "オーケストレーターが照合済みのテスト対象commit SHA"
         required: true
-        default: "docs/e2e-evidence"
-        type: string
-      branch:
-        description: "commit 先のエビデンスブランチ"
-        required: true
-        default: "e2e-evidence/boot-screenshots"
         type: string
 
 permissions:
-  contents: write
+  contents: read
   actions: read
 
 jobs:
   collect:
-    name: Collect ${{ inputs.artifact_name }} from run ${{ inputs.run_id }}
-    runs-on: ubuntu-latest
+    name: Publish ${{ inputs.artifact_name }} from run ${{ inputs.run_id }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
+    env:
+      GCS_BUCKET: nanitabeyo-public
+      GCP_KEY: ${{ secrets.GCP_SA_KEY }}
+      SOURCE_RUN_ID: ${{ inputs.run_id }}
+      ARTIFACT_NAME: ${{ inputs.artifact_name }}
+      SOURCE_SHA: ${{ inputs.source_sha }}
 
     steps:
-      - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: 入力値を検証
+        shell: bash
+        run: |
+          set -euo pipefail
 
-      - name: 📥 Download artifact
+          if [[ ! "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "::error::run_idは数字のみで指定してください。"
+            exit 1
+          fi
+
+          if [[ ! "$ARTIFACT_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::artifact_nameは英数字・._-のみで指定してください。"
+            exit 1
+          fi
+
+          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-fA-F]{40,64}$ ]]; then
+            echo "::error::source_shaは40〜64桁の16進commit SHAで指定してください。"
+            exit 1
+          fi
+
+      - name: 元runを検証
+        id: source
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RUN_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}")"
+          WORKFLOW_NAME="$(jq -r '.name' <<<"$RUN_JSON")"
+          EVENT="$(jq -r '.event' <<<"$RUN_JSON")"
+          STATUS="$(jq -r '.status' <<<"$RUN_JSON")"
+          CONCLUSION="$(jq -r '.conclusion' <<<"$RUN_JSON")"
+          SOURCE_URL="$(jq -r '.html_url' <<<"$RUN_JSON")"
+
+          if [[ "$WORKFLOW_NAME" != "Claude Worker" || "$EVENT" != "workflow_dispatch" ]]; then
+            echo "::error::元runはClaude Workerのworkflow_dispatchではありません（name=$WORKFLOW_NAME, event=$EVENT）。"
+            exit 1
+          fi
+
+          if [[ "$STATUS" != "completed" || "$CONCLUSION" != "success" ]]; then
+            echo "::error::元runが成功完了していません（status=$STATUS, conclusion=$CONCLUSION）。"
+            exit 1
+          fi
+
+          echo "sha=${SOURCE_SHA,,}" >> "$GITHUB_OUTPUT"
+          echo "url=$SOURCE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Artifactをダウンロード
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ inputs.run_id }}
@@ -51,33 +96,166 @@ jobs:
           path: /tmp/evidence
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # 既存のエビデンスブランチがあれば継続し、無ければ main から新規作成する
-      - name: 💾 Commit evidence to branch
+      - name: 画像・動画とmanifestを準備
+        id: prepare
         env:
-          BRANCH: ${{ inputs.branch }}
-          DEST: ${{ inputs.dest_dir }}/${{ inputs.artifact_name }}
-          RUN_ID: ${{ inputs.run_id }}
-          ARTIFACT: ${{ inputs.artifact_name }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          SOURCE_URL: ${{ steps.source.outputs.url }}
+        shell: bash
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" 2>/dev/null; then
-            git switch --create "$BRANCH" --track "origin/$BRANCH" || git switch "$BRANCH"
-          else
-            git switch --create "$BRANCH"
+          python3 <<'PY'
+          import json
+          import mimetypes
+          import os
+          import shutil
+          import urllib.parse
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          source = Path("/tmp/evidence")
+          publish = Path("/tmp/public-evidence")
+          manifest_dir = Path("/tmp/evidence-manifest")
+          publish.mkdir(parents=True, exist_ok=True)
+          manifest_dir.mkdir(parents=True, exist_ok=True)
+
+          image_extensions = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
+          video_extensions = {".mp4", ".webm", ".mov", ".m4v"}
+          allowed_extensions = image_extensions | video_extensions
+
+          repository = os.environ["GITHUB_REPOSITORY"]
+          run_id = os.environ["SOURCE_RUN_ID"]
+          artifact_name = os.environ["ARTIFACT_NAME"]
+          bucket = os.environ["GCS_BUCKET"]
+          prefix = f"e2e-evidence/{repository}/runs/{run_id}/{artifact_name}"
+
+          images = []
+          videos = []
+
+          for path in sorted(source.rglob("*")):
+              if not path.is_file() or path.is_symlink():
+                  continue
+
+              extension = path.suffix.lower()
+              if extension not in allowed_extensions:
+                  continue
+
+              relative = path.relative_to(source)
+              destination = publish / relative
+              destination.parent.mkdir(parents=True, exist_ok=True)
+              shutil.copy2(path, destination)
+
+              object_name = f"{prefix}/{relative.as_posix()}"
+              encoded_object = urllib.parse.quote(object_name, safe="/")
+              entry = {
+                  "path": relative.as_posix(),
+                  "url": f"https://storage.googleapis.com/{bucket}/{encoded_object}",
+                  "contentType": mimetypes.guess_type(path.name)[0] or "application/octet-stream",
+              }
+
+              if extension in image_extensions:
+                  images.append(entry)
+              else:
+                  videos.append(entry)
+
+          if not images and not videos:
+              raise SystemExit("公開対象の画像・動画がArtifact内にありません。")
+
+          manifest = {
+              "schemaVersion": 1,
+              "generatedAt": datetime.now(timezone.utc).isoformat(),
+              "repository": repository,
+              "sourceRunId": int(run_id),
+              "sourceRunUrl": os.environ["SOURCE_URL"],
+              "sourceCommitSha": os.environ["SOURCE_SHA"],
+              "artifactName": artifact_name,
+              "bucket": bucket,
+              "gcsPrefix": f"gs://{bucket}/{prefix}",
+              "publicManifestUrl": (
+                  f"https://storage.googleapis.com/{bucket}/"
+                  f"{urllib.parse.quote(prefix, safe='/')}/manifest.json"
+              ),
+              "images": images,
+              "videos": videos,
+          }
+
+          manifest_path = manifest_dir / "manifest.json"
+          manifest_path.write_text(
+              json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8",
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"prefix={prefix}\n")
+              output.write(f"image_count={len(images)}\n")
+              output.write(f"video_count={len(videos)}\n")
+              output.write(f"manifest_url={manifest['publicManifestUrl']}\n")
+          PY
+
+      - name: Google Cloudへ認証
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$GCP_KEY" ]]; then
+            echo "::error::Repository Secret GCP_SA_KEYが設定されていません。"
+            exit 1
           fi
 
-          rm -rf "$DEST"
-          mkdir -p "$DEST"
-          # ディレクトリ構造ごとコピーする（before/after 等の同名ファイルの衝突を避ける）
-          cp -r /tmp/evidence/. "$DEST"/
+          KEY_FILE="$RUNNER_TEMP/gcp-key.json"
+          printf '%s' "$GCP_KEY" > "$KEY_FILE"
+          chmod 600 "$KEY_FILE"
+          gcloud auth activate-service-account --key-file="$KEY_FILE"
+          gcloud config set project "$(jq -r '.project_id' "$KEY_FILE")"
 
-          git add "$DEST"
-          if git diff --cached --quiet; then
-            echo "変更なし（Artifact が空、または既存と同一）"
-            exit 0
-          fi
-          git commit -m "docs: テストエビデンス回収 ($ARTIFACT / run $RUN_ID) #1027"
-          git push -u origin "$BRANCH"
+      - name: 画像・動画とmanifestをGCSへ公開
+        env:
+          GCS_PREFIX: ${{ steps.prepare.outputs.prefix }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob dotglob
+
+          media=(/tmp/public-evidence/*)
+          gsutil -m \
+            -h "Cache-Control:public,max-age=31536000,immutable" \
+            cp -r "${media[@]}" "gs://${GCS_BUCKET}/${GCS_PREFIX}/"
+
+          gsutil \
+            -h "Cache-Control:public,max-age=300" \
+            -h "Content-Type:application/json; charset=utf-8" \
+            cp /tmp/evidence-manifest/manifest.json \
+            "gs://${GCS_BUCKET}/${GCS_PREFIX}/manifest.json"
+
+      - name: manifestをArtifactとして保存
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-manifest-${{ inputs.run_id }}
+          path: /tmp/evidence-manifest/manifest.json
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: 結果をJob summaryへ出力
+        env:
+          SOURCE_URL: ${{ steps.source.outputs.url }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          IMAGE_COUNT: ${{ steps.prepare.outputs.image_count }}
+          VIDEO_COUNT: ${{ steps.prepare.outputs.video_count }}
+          MANIFEST_URL: ${{ steps.prepare.outputs.manifest_url }}
+        shell: bash
+        run: |
+          {
+            echo "## Evidence published"
+            echo
+            echo "- Source run: $SOURCE_URL"
+            echo "- Commit: \`$SOURCE_SHA\`"
+            echo "- Images: $IMAGE_COUNT"
+            echo "- Videos: $VIDEO_COUNT"
+            echo "- Manifest: $MANIFEST_URL"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: 一時的な認証ファイルを削除
+        if: always()
+        shell: bash
+        run: rm -f "$RUNNER_TEMP/gcp-key.json"


### PR DESCRIPTION
## 概要

`evidence-collect.yml` を、エビデンス用ブランチへcommitする方式から、画像・動画を `nanitabeyo-public` へ公開してmanifestを生成する方式へ変更します。

Issue / PRへのコメントはWorkflow内では行わず、parallel-developmentのオーケストレーターがレビュー通過後にmanifestを読み、画像・動画URLをコメントします。

## 変更内容

- `evidence-collect.yml`
  - Claude Workerの成功済み`workflow_dispatch` runだけを収集対象にする
  - `run_id`、`artifact_name`、オーケストレーターが照合済みの`source_sha`を入力にする
  - Artifactから画像（PNG/JPEG/WebP/GIF）と動画（MP4/WebM/MOV/M4V）を抽出する
  - `gs://nanitabeyo-public/e2e-evidence/<repo>/runs/<run-id>/<artifact>/`へアップロードする
  - 公開URL、元run、対象SHAを含む`manifest.json`をGCSとActions Artifactへ保存する
  - Issue / PR書込権限と、エビデンスブランチへのcommit処理を削除する
- `parallel-development/SKILL.md`
  - 独立レビューまたはvalidation runのArtifactを最終エビデンスにする流れを追記する
  - PR HEADとレビューrunへ渡した`base_ref`をオーケストレーターが照合することを明記する
  - Evidence Collect完了後、manifestを検証してIssue / PRへ画像・動画をコメントする責務を明記する

## 想定フロー

1. `claude-worker.yml`のwrite runで実装・テスト・Artifact生成
2. 最新PR HEADを`base_ref`にしたobserve runで独立レビュー・再テスト
3. Approve相当、必須テスト成功、重大指摘なし、PR HEAD一致を確認
4. `evidence-collect.yml`を起動してGCSへ公開
5. オーケストレーターがmanifestを読み、Issue / PRへコメント

## 検証

- YAMLをローカルでparse
- サンプルArtifactを使い、次をスモークテスト
  - 画像・動画だけが抽出されること
  - ディレクトリ構造が維持されること
  - 空白を含むファイル名がURL encodeされること
  - 画像・動画別のmanifestが生成されること

## 注意事項

- 実際のGCSアップロードを伴うend-to-end実行は未実施です。
- 既存のRepository Secret `GCP_SA_KEY`に`nanitabeyo-public`への書込権限が必要です。
- バケット側で公開読み取りが有効であることを前提とします。
- Playwright trace、HTML report、ログ、JUnitなどは公開せず、元のActions Artifactに残します。