### PR TITLE
fix: evidence-collect の元run検証が必ず失敗する問題を修正

### DIFF
--- a/.github/workflows/evidence-collect.yml
+++ b/.github/workflows/evidence-collect.yml
@@ -38,6 +38,8 @@ jobs:
       SOURCE_RUN_ID: ${{ inputs.run_id }}
       ARTIFACT_NAME: ${{ inputs.artifact_name }}
       SOURCE_SHA: ${{ inputs.source_sha }}
+      # 元runがClaude Workerであることを .path で判定する（.name は run-name のため使えない）
+      EXPECTED_WORKFLOW_PATH: .github/workflows/claude-worker.yml
 
     steps:
       - name: 入力値を検証
@@ -69,14 +71,20 @@ jobs:
           set -euo pipefail
 
           RUN_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}")"
-          WORKFLOW_NAME="$(jq -r '.name' <<<"$RUN_JSON")"
+          # 【バグ】run オブジェクトの .name は workflow 名ではなく run-name を返す。
+          # claude-worker.yml は run-name を定義しているため .name は
+          # "Claude Worker / <task_key> / <model> / <access>" になり、
+          # "Claude Worker" と完全一致することは無い（＝この検証は必ず落ちていた）。
+          # workflow ファイルを一意に指す .path で判定する。
+          WORKFLOW_PATH="$(jq -r '.path' <<<"$RUN_JSON")"
+          RUN_NAME="$(jq -r '.name' <<<"$RUN_JSON")"
           EVENT="$(jq -r '.event' <<<"$RUN_JSON")"
           STATUS="$(jq -r '.status' <<<"$RUN_JSON")"
           CONCLUSION="$(jq -r '.conclusion' <<<"$RUN_JSON")"
           SOURCE_URL="$(jq -r '.html_url' <<<"$RUN_JSON")"
 
-          if [[ "$WORKFLOW_NAME" != "Claude Worker" || "$EVENT" != "workflow_dispatch" ]]; then
-            echo "::error::元runはClaude Workerのworkflow_dispatchではありません（name=$WORKFLOW_NAME, event=$EVENT）。"
+          if [[ "$WORKFLOW_PATH" != "$EXPECTED_WORKFLOW_PATH" || "$EVENT" != "workflow_dispatch" ]]; then
+            echo "::error::元runはClaude Workerのworkflow_dispatchではありません（path=$WORKFLOW_PATH, event=$EVENT, run-name=$RUN_NAME）。"
             exit 1
           fi
 
@@ -192,6 +200,12 @@ jobs:
               output.write(f"video_count={len(videos)}\n")
               output.write(f"manifest_url={manifest['publicManifestUrl']}\n")
           PY
+
+      # ubuntu-24.04 ランナーへの gcloud 同梱は保証されていないため、
+      # api-deploy.yml と同様に SDK のセットアップを明示する。
+      # 既に入っていても害はない。
+      - name: Google Cloud SDKをセットアップ
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Google Cloudへ認証
         shell: bash


### PR DESCRIPTION
#1054 で追加された `evidence-collect.yml` の元run検証が、**あらゆる Claude Worker run に対して必ず失敗する**状態だったので修正します。

## バグ

Actions API の workflow **run** オブジェクトの `.name` は、workflow 名ではなく **run-name** を返します。`claude-worker.yml` は run-name を定義しているため:

```yaml
run-name: >-
  Claude Worker / ${{ inputs.task_key }} / ${{ inputs.model }} / ${{ inputs.access }}
```

`.name` の実際の値は `Claude Worker / issue-817-playwright-evidence / opus / observe` になり、`"Claude Worker"` と完全一致することは永久にありません。

実際の失敗: https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/30439685165

```
##[error]元runはClaude Workerのworkflow_dispatchではありません
（name=Claude Worker / issue-817-playwright-evidence / opus / observe, event=workflow_dispatch）
```

`event=workflow_dispatch` は合っているのに `name` だけが原因で落ちているのが分かります。

## 修正

workflow ファイルを一意に指す `.path` で判定するようにしました。`.path` は run-name の影響を受けません。

```
name : Claude Worker / issue-817-playwright-evidence / opus / observe   ← run-name
path : .github/workflows/claude-worker.yml                              ← これで判定
event: workflow_dispatch
```

期待値は job の `env` に `EXPECTED_WORKFLOW_PATH` として切り出し、エラーメッセージには run-name も併記して切り分けしやすくしました。

## あわせて（防御的な変更）

`ubuntu-24.04` ランナーに gcloud / gsutil が同梱されている保証がないため、同リポジトリの `api-deploy.yml` と同じく `google-github-actions/setup-gcloud@v2` を明示しました。既に入っていても害はありません。

**元runの検証で落ちていたため、その先の gcloud 認証・gsutil アップロード・manifest 生成の各ステップは一度も実行されておらず未検証です。** マージ後の初回実行でそこが通るかは別途確認が必要です。

## 検証

- YAML を PyYAML で parse し、ステップ構成を確認
- 実際の Claude Worker run オブジェクトで `.path` が `.github/workflows/claude-worker.yml` になることを確認（2 run で確認）

## 経緯

#817 の Playwright スクリーンショットを公開しようとして踏みました。マージいただければ再実行します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNtBY7eogNKTRf4d91sqCd)_