### PR TITLE
fix: 角括弧を含むファイル名が gsutil の glob 解釈で公開に失敗する問題を修正

### DIFF
--- a/.github/workflows/evidence-collect.yml
+++ b/.github/workflows/evidence-collect.yml
@@ -117,6 +117,7 @@ jobs:
           import json
           import mimetypes
           import os
+          import re
           import shutil
           import urllib.parse
           from datetime import datetime, timezone
@@ -138,6 +139,37 @@ jobs:
           bucket = os.environ["GCS_BUCKET"]
           prefix = f"e2e-evidence/{repository}/runs/{run_id}/{artifact_name}"
 
+          used_object_paths = set()
+
+          def safe_object_path(relative, used):
+              """GCS オブジェクト名として安全な相対パスを返す。
+
+              gsutil の glob 解釈と URL エンコード肥大を避けるため、
+              各セグメントを [A-Za-z0-9._-] だけに落とす。
+              衝突したら連番を付ける。
+              """
+              segments = []
+              for segment in relative.parts[:-1]:
+                  segments.append(re.sub(r"[^A-Za-z0-9._-]+", "_", segment) or "_")
+
+              stem = relative.stem
+              suffix = relative.suffix.lower()
+              safe_stem = re.sub(r"[^A-Za-z0-9._-]+", "_", stem).strip("_") or "file"
+              safe_suffix = re.sub(r"[^A-Za-z0-9.]+", "", suffix) or ".bin"
+
+              candidate = "/".join(segments + [f"{safe_stem}{safe_suffix}"])
+              if candidate not in used:
+                  used.add(candidate)
+                  return candidate
+
+              counter = 2
+              while True:
+                  candidate = "/".join(segments + [f"{safe_stem}-{counter}{safe_suffix}"])
+                  if candidate not in used:
+                      used.add(candidate)
+                      return candidate
+                  counter += 1
+
           images = []
           videos = []
 
@@ -150,14 +182,20 @@ jobs:
                   continue
 
               relative = path.relative_to(source)
-              destination = publish / relative
+              # 【バグ】gsutil は `[` `]` `*` `?` を glob として解釈するため、
+              # これらを含むファイル名は「該当なし」となり転送に失敗する。
+              # 日本語ファイル名も URL が %エンコードで肥大する。
+              # 公開名は安全な文字だけへ正規化し、元の名前は manifest に残す。
+              safe_relative = safe_object_path(relative, used_object_paths)
+              destination = publish / safe_relative
               destination.parent.mkdir(parents=True, exist_ok=True)
               shutil.copy2(path, destination)
 
-              object_name = f"{prefix}/{relative.as_posix()}"
+              object_name = f"{prefix}/{safe_relative}"
               encoded_object = urllib.parse.quote(object_name, safe="/")
               entry = {
                   "path": relative.as_posix(),
+                  "publishedPath": safe_relative,
                   "url": f"https://storage.googleapis.com/{bucket}/{encoded_object}",
                   "contentType": mimetypes.guess_type(path.name)[0] or "application/octet-stream",
               }


### PR DESCRIPTION
#1056 で元run検証を直した結果、その先の GCS アップロードまで到達できるようになり、**次のバグが顕在化しました**。

## バグ

`gsutil cp` は引数の `[` `]` `*` `?` を glob として解釈します。Playwright のスクリーンショット名に `[ja-ja-en]` のような言語ラベルを含めていたため、gsutil が文字クラスとして展開してリテラルのファイルを見つけられず、転送に失敗していました。

実際の失敗: https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/30445836567

```
Operation completed over 6 objects/1.5 MiB.
CommandException: 4 files/objects could not be transferred.
```

10 件中 6 件だけ成功し、**落ちた 4 件がちょうど日英混在レビューのスクリーンショット**でした。#817 の証跡としていちばん価値が高いものが、名前に `[...]` を含むという理由だけで公開されなかったことになります。

⚠️ `Operation completed over 6 objects` の直後に `CommandException` が出るため、**ログを流し読みすると成功に見えます**。部分失敗である点に注意が必要です（`set -euo pipefail` のおかげで job 自体は失敗しました）。

## 修正

公開するオブジェクト名を `[A-Za-z0-9._-]` だけに正規化します。元のファイル名は manifest の `path` に残し、正規化後の名前を `publishedPath` として併記します。

これにより 2 つを同時に解消します。

- gsutil の glob 解釈による転送失敗
- 日本語ファイル名による URL の %エンコード肥大（`loc2-銀座-01-fullpage.png` のような名前は URL が読めなくなっていました）

正規化で衝突した場合は連番を付けます。

## 検証

実際に失敗したファイル名を含むケースで正規化ロジックを実行し、glob 文字・非 ASCII が残らず、衝突もしないことを確認しました。

| 元のファイル名 | 公開名 |
|---|---|
| `mixed-0-やきとりの名門秋吉_渋谷桜丘店-[ja-ja-en]-fullpage.png` | `mixed-0-___-_ja-ja-en_-fullpage.png` |
| `a/b/[x].png` | `a/b/x.png` |
| `sub dir/with space*.png` | `sub_dir/with_space.png` |
| `同じ名前.png` / `同じ_名前.png` | `file.png` / `file-2.png`（衝突回避） |

YAML は PyYAML で parse して構造を確認済みです。

## 補足: #1056 の `setup-gcloud` は効いていました

防御的に追加した `google-github-actions/setup-gcloud@v2` は正しく機能しています。失敗ログに `CLOUDSDK_METRICS_ENVIRONMENT: github-actions-setup-gcloud` が出ており、gcloud が action 経由で入っていることが確認できます。

## 既知の残課題

ファイル名が全て非 ASCII の場合、公開名が `file.png` のように情報を失います。manifest の `path` に元名が残るので追跡は可能ですが、ワーカー側で**最初から英数字のファイル名を付けさせる**のが本筋です（`.claude/skills/parallel-development/SKILL.md` への追記候補）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNtBY7eogNKTRf4d91sqCd)_