### PR TITLE
fix: 該当店舗0件の bulk-import が 500 INTERNAL_ERROR になる問題を修正

### DIFF
--- a/api/src/v1/dishes/dishes.service.spec.ts
+++ b/api/src/v1/dishes/dishes.service.spec.ts
@@ -1,0 +1,101 @@
+// api/src/v1/dishes/dishes.service.spec.ts
+//
+// ❶ bulkImportFromGoogle の「該当店舗なし」経路を固定する
+// ❷ searchRestaurants は3段フォールバックを尽くしたうえで空レスポンスを返す契約なので、
+//    ここを throw にすると該当なしの検索がすべて 500 INTERNAL_ERROR になる
+//
+
+// core/config/env は import 時に process.env をバリデーションして throw するため、
+// 実DB・実APIに触れない単体テストでも .env が無いと suite ごと落ちる。
+// dishes.service.ts は repository / logger 経由でこれを推移的に読み込むので、
+// DI で差し替えるより手前、モジュール解決の段階で無害化する。
+jest.mock('../../core/config/env', () => ({
+  env: new Proxy(
+    {},
+    {
+      get: (_target, key: string) => (key === 'DB_POOL_MAX' ? 1 : `test-${key}`),
+    },
+  ),
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { DishesService } from './dishes.service';
+import { DishesRepository } from './dishes.repository';
+import { AppLoggerService } from '../../core/logger/logger.service';
+import { LocationsService } from '../locations/locations.service';
+import { RemoteConfigService } from '../../core/remote-config/remote-config.service';
+import { CloudTasksService } from '../../core/cloud-tasks/cloud-tasks.service';
+import { DishCategoriesRepository } from '../dish-categories/dish-categories.repository';
+import { RestaurantsRepository } from '../restaurants/restaurants.repository';
+import { PrismaService } from '../../prisma/prisma.service';
+import type { BulkImportDishesDto } from '@shared/v1/dto';
+
+describe('DishesService', () => {
+  let service: DishesService;
+  let mockLocationsService: { searchRestaurants: jest.Mock };
+  let mockCloudTasksService: { createTask: jest.Mock };
+
+  const dto = {
+    location: '35.68944,139.69167',
+    radius: 500,
+    categoryId: 'category-uuid',
+    categoryName: 'ラーメン',
+    minRating: 3.0,
+    languageCode: 'ja',
+  } as BulkImportDishesDto;
+
+  beforeEach(async () => {
+    mockLocationsService = { searchRestaurants: jest.fn() };
+    mockCloudTasksService = { createTask: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DishesService,
+        { provide: DishesRepository, useValue: {} },
+        {
+          provide: AppLoggerService,
+          useValue: {
+            debug: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+            log: jest.fn(),
+          },
+        },
+        { provide: LocationsService, useValue: mockLocationsService },
+        {
+          provide: RemoteConfigService,
+          useValue: {
+            getRemoteConfigValue: jest.fn().mockResolvedValue('5'),
+          },
+        },
+        { provide: CloudTasksService, useValue: mockCloudTasksService },
+        { provide: DishCategoriesRepository, useValue: {} },
+        { provide: RestaurantsRepository, useValue: {} },
+        { provide: PrismaService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<DishesService>(DishesService);
+  });
+
+  describe('bulkImportFromGoogle: 該当店舗なし', () => {
+    // searchRestaurants は全フォールバックが0件だったとき {} を返す
+    // (api/src/v1/locations/locations.service.ts の GoogleMapsTextSearchAllFallbacksFailed 経路)
+    it.each([
+      ['placesを持たない空レスポンス', {}],
+      ['placesが空配列', { places: [] }],
+    ])('%s のとき 500 ではなく空配列を返す', async (_label, response) => {
+      mockLocationsService.searchRestaurants.mockResolvedValue(response);
+
+      await expect(service.bulkImportFromGoogle(dto)).resolves.toEqual([]);
+    });
+
+    it('該当なしのとき Cloud Task を enqueue しない', async () => {
+      mockLocationsService.searchRestaurants.mockResolvedValue({});
+
+      await service.bulkImportFromGoogle(dto);
+
+      expect(mockCloudTasksService.createTask).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/v1/dishes/dishes.service.ts
+++ b/api/src/v1/dishes/dishes.service.ts
@@ -146,8 +146,18 @@ export class DishesService {
     });
 
     // #636 【バグ】contextualContents は experimental で返却保証が弱いため、places のみ必須とする
-    if (!googlePlaces || !googlePlaces?.places) {
-      throw new Error('No places found from Google Maps API');
+    // 【設計】0件は異常ではなく「その地点・カテゴリに該当店舗が無かった」という正常な結果。
+    // searchRestaurants は3段のフォールバック（full → relaxed → minimal）を尽くしたうえで
+    // places を持たない空レスポンスを返す契約なので、ここを throw にすると
+    // 該当なしの検索がすべて 500 INTERNAL_ERROR になる。空配列を返してクライアントへ委ねる。
+    if (!googlePlaces?.places || googlePlaces.places.length === 0) {
+      this.logger.warn('BulkImportNoPlacesFound', 'bulkImportFromGoogle', {
+        location: dto.location,
+        radius: dto.radius,
+        categoryName: dto.categoryName,
+        categoryId: dto.categoryId,
+      });
+      return [];
     }
 
     const contextualContents = googlePlaces?.contextualContents;


### PR DESCRIPTION
#829 の冪等性 E2E 検証（run [30452844584](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/30452844584)）が `POST /v1/dishes/bulk-import` の **HTTP 500** で完走できず、原因を追ったところ **main に存在する既存バグ**でした。#844 / #1051 の変更とは無関係です。

## 何が起きるか

`searchRestaurants` は 0 件のとき、**3段のフォールバックを尽くしたうえで** `places` を持たない空レスポンス `{}` を返す契約です（`locations.service.ts` の `GoogleMapsTextSearchAllFallbacksFailed` 経路）。

```
Step 1 full_conditions        (minRating + priceLevels + rankPreference)  → 0件
Step 2 without_rating_and_price                                            → 0件
Step 3 minimal_conditions                                                  → 0件
→ return response   // places 自体が存在しない
```

これを `bulkImportFromGoogle` が `throw new Error(...)` で受けていました。

```ts
if (!googlePlaces || !googlePlaces?.places) {
  throw new Error('No places found from Google Maps API');
}
```

`Error` は `HttpException` ではないため Nest の例外フィルタで **500 INTERNAL_ERROR** になります。つまり **「その地点・カテゴリに該当店舗が無い」という正常な検索結果が、クライアントにはサーバ障害として見えていました。**

`{ places: [] }`（空配列）が返るケースでは truthy なので throw されず、後続が空回りして `[]` を返します。**同じ「0件」でも Google のレスポンス形状次第で 500 と 200 に分かれる**、という一貫性の無さもありました。

## 課金面

この経路は Text Search を **3 回**消費したうえで 500 を返します。#829（コスト削減）の文脈では、0 件になりやすい地点・カテゴリの組み合わせでこれが繰り返されると、成果ゼロのまま Text Search 課金だけが積み上がります。

## 変更内容

0 件を正常な結果として扱い、空配列を返します。あわせて `BulkImportNoPlacesFound` の warn ログを追加し、0 件がどの地点・カテゴリで起きているかを追跡できるようにしました（従来この分岐は例外メッセージだけで、`location` / `categoryId` が残りませんでした）。

`{}` と `{ places: [] }` の両方を同じ分岐で拾うようにして、上記の不一致も解消しています。

**フロント側の変更は不要です。** `app-expo/lib/dishMediaSearch.ts` の `createDishItemsForCategory` は `importResponse` をそのまま `concat` するため、空配列でも「検索結果なし」として正しく表示されます。

## 検証

- `pnpm --filter api typecheck` ✅
- 新規単体テスト `api/src/v1/dishes/dishes.service.spec.ts` **3/3 成功**
  - `{}` / `{ places: [] }` のいずれでも throw せず `[]` を返すこと
  - 0 件のとき Cloud Task を enqueue しないこと
- **ミューテーション確認済み**: 修正を元の `throw` へ差し戻すと 3 件中 2 件が失敗します（`{ places: [] }` のケースは元コードでも throw しないため、意図どおり通過します）。回帰検出器として機能します。

### テストの補足

`dishes.service.ts` は repository / logger 経由で `core/config/env` を推移的に読み込み、これが import 時に `process.env` を検証して throw します。そのため実 DB・実 API に触れない単体テストでも `.env` が無いと suite ごと落ちます。本 PR では spec 内で `jest.mock('../../core/config/env', ...)` して無害化しました。

これは `api/src/v1/dish-media/dish-media.assembler.spec.ts` が main で失敗しているのと同じ原因です。jest の `setupFiles` でテスト用 env 既定値を入れれば一括で解消できますが、本 PR のスコープ外としています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNtBY7eogNKTRf4d91sqCd)_