### PR TITLE
#1053 fix: 未完了再利用パスの Photo Media 課金を止め、冪等性の穴を塞ぐ

### DIFF
--- a/api/src/core/cloud-tasks/cloud-tasks.service.ts
+++ b/api/src/core/cloud-tasks/cloud-tasks.service.ts
@@ -4,6 +4,7 @@
 // 責務: ジョブのエンキューのみ
 //
 
+import { createHash } from 'node:crypto';
 import { Injectable } from '@nestjs/common';
 import { CloudTasksClient } from '@google-cloud/tasks';
 import { env } from '../config/env';
@@ -26,8 +27,16 @@ export class CloudTasksService {
     payload: unknown;
     queueName: string;
     logAction: string; // 例: 'enqueueCreateDishMediaEntry'
+    /**
+     * #1053 指定すると Cloud Tasks の名前付きタスクとして積み、
+     * 同名タスクの再 enqueue を ALREADY_EXISTS で弾く（完了後およそ1時間保持）。
+     *
+     * これが防ぐのは「enqueue の重複」だけで、handler retry の冪等性にはならない。
+     * handler 側の既存チェックと併用すること。
+     */
+    dedupeKey?: string;
   }): Promise<void> {
-    const { url, payload, queueName, logAction } = params;
+    const { url, payload, queueName, logAction, dedupeKey } = params;
     const audience = env.CLOUD_RUN_URL; // OIDC audience
 
     if (env.CLOUD_RUN_URL.startsWith('http://localhost')) {
@@ -57,6 +66,15 @@ export class CloudTasksService {
           audience,
         },
       },
+      // #1053 タスク名は queuePath 配下の相対名で、使える文字は [A-Za-z0-9_-] のみ。
+      // 任意文字列を含む dedupeKey をそのまま置けないため sha256 の hex に潰す。
+      ...(dedupeKey
+        ? {
+            name: `${queuePath}/tasks/${createHash('sha256')
+              .update(dedupeKey)
+              .digest('hex')}`,
+          }
+        : {}),
     };
 
     try {
@@ -67,14 +85,33 @@ export class CloudTasksService {
       this.logger.log('CloudTaskEnqueued', logAction, {
         taskName: response.name,
         queueName,
+        deduped: !!dedupeKey,
       });
     } catch (error) {
+      // #1053 名前付きタスクの ALREADY_EXISTS は「既に積まれている」という
+      // 正常な重複排除であって失敗ではない。ここで throw すると、呼び出し元は
+      // enqueue できなかったと誤解する。
+      if (dedupeKey && this.isAlreadyExistsError(error)) {
+        this.logger.log('CloudTaskDeduplicated', logAction, {
+          queueName,
+          dedupeKey,
+        });
+        return;
+      }
       this.logger.error('CloudTaskEnqueueError', logAction, {
         queueName,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
       throw error;
     }
+  }
+
+  /** gRPC の ALREADY_EXISTS (code 6) を判定する */
+  private isAlreadyExistsError(error: unknown): boolean {
+    const code = (error as { code?: unknown })?.code;
+    if (code === 6) return true;
+    const message = error instanceof Error ? error.message : '';
+    return message.includes('ALREADY_EXISTS');
   }
 
   /** create dish media entry ジョブをキューに追加 */
@@ -87,6 +124,9 @@ export class CloudTasksService {
       payload: { ...payload },
       queueName: 'dish-queue',
       logAction: 'enqueueCreateDishMediaEntry',
+      // #1053 同じ (placeId, categoryId) の重複 enqueue を Cloud Tasks 側で弾く。
+      // handler 側の既存チェックは引き続き必要（retry には効かないため）。
+      dedupeKey: payload.idempotencyKey,
     });
   }
 

--- a/api/src/internal/dishes/create-dish-media-entry.service.ts
+++ b/api/src/internal/dishes/create-dish-media-entry.service.ts
@@ -88,6 +88,16 @@ export class CreateDishMediaEntryService {
   private async downloadAndStorePhotos(
     payload: CreateDishMediaEntryJobPayload,
   ): Promise<void> {
+    // #1053 【課金】bulk-import が「GCS に実体あり」と判定した再利用パスでは photoUri が空。
+    // その場合 download は不要で、upsert と resize のやり直しだけが目的になる。
+    if (payload.photoUri.length === 0) {
+      this.logger.debug('PhotoDownloadSkipped', 'downloadAndStorePhotos', {
+        jobId: payload.jobId,
+        mediaPath: payload.dish_media.media_path,
+      });
+      return;
+    }
+
     const downloadPromises = payload.photoUri.map(async (photoUri, index) => {
       try {
         // 写真データを取得
@@ -133,45 +143,67 @@ export class CreateDishMediaEntryService {
     dishMedia: PrismaDishMedia,
     restaurants: PrismaRestaurants,
   ) {
+    // #1053 【設計】分岐判定は media/thumbnail の AND なので、
+    // 「media=completed / thumbnail=processing」は未完了に倒れて handler が再実行される。
+    // そのとき completed 側まで再 enqueue すると、resize-image 側が fileExists で
+    // 早期 return するため画像処理自体は走らないものの、Cloud Tasks の実行回数と
+    // Cloud Run のリクエスト数だけが二重に増える。completed の列は skip する。
+    const skipMedia = dishMedia.media_processing_status === 'completed';
+    const skipThumbnail = dishMedia.thumbnail_processing_status === 'completed';
+
+    if (skipMedia || skipThumbnail) {
+      this.logger.debug('ResizeEnqueueSkipped', 'enqueueResizeImageJob', {
+        dishMediaId: dishMedia.id,
+        skipMedia,
+        skipThumbnail,
+      });
+    }
+
     return Promise.all([
       // メイン画像リサイズジョブ
-      this.cloudTasksService
-        .enqueueResizeImage({
-          table: 'dish_media',
-          column: 'media_path',
-          recordId: dishMedia.id,
-          size: 1024,
-          aspectRatio: 9 / 16,
-          originalPath: dishMedia.media_path,
-        })
-        .catch((error) => {
-          this.logger.error('EnqueueResizeImageError', 'createDishMediaEntry', {
-            dishMediaId: dishMedia.id,
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
-          throw error;
-        }),
+      !skipMedia &&
+        this.cloudTasksService
+          .enqueueResizeImage({
+            table: 'dish_media',
+            column: 'media_path',
+            recordId: dishMedia.id,
+            size: 1024,
+            aspectRatio: 9 / 16,
+            originalPath: dishMedia.media_path,
+          })
+          .catch((error) => {
+            this.logger.error(
+              'EnqueueResizeImageError',
+              'createDishMediaEntry',
+              {
+                dishMediaId: dishMedia.id,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              },
+            );
+            throw error;
+          }),
       // サムネイル画像リサイズジョブ
-      this.cloudTasksService
-        .enqueueResizeImage({
-          table: 'dish_media',
-          column: 'thumbnail_path',
-          recordId: dishMedia.id,
-          size: 256,
-          aspectRatio: 9 / 16,
-          originalPath: dishMedia.thumbnail_path,
-        })
-        .catch((error) => {
-          this.logger.error(
-            'EnqueueResizeThumbnailError',
-            'createDishMediaEntry',
-            {
-              dishMediaId: dishMedia.id,
-              error: error instanceof Error ? error.message : 'Unknown error',
-            },
-          );
-          throw error;
-        }),
+      !skipThumbnail &&
+        this.cloudTasksService
+          .enqueueResizeImage({
+            table: 'dish_media',
+            column: 'thumbnail_path',
+            recordId: dishMedia.id,
+            size: 256,
+            aspectRatio: 9 / 16,
+            originalPath: dishMedia.thumbnail_path,
+          })
+          .catch((error) => {
+            this.logger.error(
+              'EnqueueResizeThumbnailError',
+              'createDishMediaEntry',
+              {
+                dishMediaId: dishMedia.id,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              },
+            );
+            throw error;
+          }),
       restaurants.image_path &&
         this.cloudTasksService
           .enqueueResizeImage({

--- a/api/src/v1/dishes/dishes.service.spec.ts
+++ b/api/src/v1/dishes/dishes.service.spec.ts
@@ -1,8 +1,7 @@
 // api/src/v1/dishes/dishes.service.spec.ts
 //
-// ❶ bulkImportFromGoogle の「該当店舗なし」経路を固定する
-// ❷ searchRestaurants は3段フォールバックを尽くしたうえで空レスポンスを返す契約なので、
-//    ここを throw にすると該当なしの検索がすべて 500 INTERNAL_ERROR になる
+// ❶ bulkImportFromGoogle の分岐を固定する
+// ❷ とくに「Photo Media を呼ばないこと」はコスト削減(#829/#1053)の回帰テスト
 //
 
 // core/config/env は import 時に process.env をバリデーションして throw するため、
@@ -13,7 +12,8 @@ jest.mock('../../core/config/env', () => ({
   env: new Proxy(
     {},
     {
-      get: (_target, key: string) => (key === 'DB_POOL_MAX' ? 1 : `test-${key}`),
+      get: (_target, key: string) =>
+        key === 'DB_POOL_MAX' ? 1 : `test-${key}`,
     },
   ),
 }));
@@ -28,30 +28,129 @@ import { CloudTasksService } from '../../core/cloud-tasks/cloud-tasks.service';
 import { DishCategoriesRepository } from '../dish-categories/dish-categories.repository';
 import { RestaurantsRepository } from '../restaurants/restaurants.repository';
 import { PrismaService } from '../../prisma/prisma.service';
+import { DishMediaService } from '../dish-media/dish-media.service';
+import { StorageService } from '../../core/storage/storage.service';
+import { buildGoogleImportDishMediaId } from './deterministic-id';
 import type { BulkImportDishesDto } from '@shared/v1/dto';
 
-describe('DishesService', () => {
-  let service: DishesService;
-  let mockLocationsService: { searchRestaurants: jest.Mock };
-  let mockCloudTasksService: { createTask: jest.Mock };
+const VIEWER_ID = 'viewer-uuid';
+const CATEGORY_ID = 'category-uuid';
+const PLACE_ID = 'ChIJplace1';
 
-  const dto = {
-    location: '35.68944,139.69167',
-    radius: 500,
-    categoryId: 'category-uuid',
-    categoryName: 'ラーメン',
-    minRating: 3.0,
-    languageCode: 'ja',
-  } as BulkImportDishesDto;
+const dto = {
+  location: '35.68944,139.69167',
+  radius: 500,
+  categoryId: CATEGORY_ID,
+  categoryName: 'ラーメン',
+  minRating: 3.0,
+  languageCode: 'ja',
+} as BulkImportDishesDto;
+
+/** Text Search が返す最小限の place */
+const buildPlace = (id: string) => ({
+  id,
+  displayName: { text: `店舗 ${id}` },
+  location: { latitude: 35.6, longitude: 139.7 },
+  addressComponents: [{ longText: '東京都', shortText: 'Tokyo', types: [] }],
+  photos: [{ name: `places/${id}/photos/abc`, widthPx: 1200, heightPx: 900 }],
+  reviews: [
+    {
+      originalText: { text: 'おいしい', languageCode: 'ja' },
+      rating: 5,
+      authorAttribution: { displayName: '太郎', uri: 'https://example.com/1' },
+    },
+  ],
+});
+
+/** 既存 dish_media を返す assembler 相当のダミー entry */
+const buildExistingEntry = (
+  dishMediaId: string,
+  overrides: Record<string, unknown> = {},
+) => ({
+  restaurant: {
+    id: 'restaurant-uuid',
+    google_place_id: PLACE_ID,
+    name: '既存店舗',
+    name_language_code: 'ja',
+    latitude: 35.6,
+    longitude: 139.7,
+    location: null,
+    image_url: 'https://cdn.example.com/existing.jpg',
+    image_path: 'google-maps/photo/existing.jpg',
+    address_components: [],
+    plus_code: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    imageUrls: { sm: '', md: '' },
+  },
+  dish: {
+    id: 'dish-uuid',
+    restaurant_id: 'restaurant-uuid',
+    category_id: CATEGORY_ID,
+    name: 'ラーメン',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    lock_no: 0,
+    reviewCount: 1,
+    averageRating: 5,
+  },
+  dish_media: {
+    id: dishMediaId,
+    dish_id: 'dish-uuid',
+    user_id: null,
+    media_path: 'google-maps/photo/existing.jpg',
+    media_type: 'image',
+    thumbnail_path: 'google-maps/photo/existing.jpg',
+    video_duration_ms: null,
+    media_processing_status: 'processing',
+    thumbnail_processing_status: 'processing',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    lock_no: 0,
+    isMine: false,
+    isSaved: false,
+    isLiked: false,
+    likeCount: 0,
+    mediaUrl: 'https://cdn.example.com/existing.jpg',
+    thumbnailImageUrl: 'https://cdn.example.com/existing.jpg',
+    ...(overrides.dish_media as object),
+  },
+  dish_reviews: (overrides.dish_reviews as unknown[]) ?? [],
+});
+
+describe('DishesService.bulkImportFromGoogle', () => {
+  let service: DishesService;
+  let locations: { searchRestaurants: jest.Mock; tryGetPhotoMedia: jest.Mock };
+  let cloudTasks: { enqueueCreateDishMediaEntry: jest.Mock };
+  let repo: {
+    findReusableGoogleImportDishMediaByPlaceIdsAndCategory: jest.Mock;
+  };
+  let dishMediaService: { fetchDishMediaEntryItems: jest.Mock };
+  let storage: { fileExists: jest.Mock };
 
   beforeEach(async () => {
-    mockLocationsService = { searchRestaurants: jest.fn() };
-    mockCloudTasksService = { createTask: jest.fn() };
+    locations = {
+      searchRestaurants: jest.fn(),
+      tryGetPhotoMedia: jest
+        .fn()
+        .mockResolvedValue({ photoUri: 'https://google/photo.jpg' }),
+    };
+    cloudTasks = {
+      enqueueCreateDishMediaEntry: jest.fn().mockResolvedValue(undefined),
+    };
+    repo = {
+      findReusableGoogleImportDishMediaByPlaceIdsAndCategory: jest
+        .fn()
+        .mockResolvedValue(new Map()),
+    };
+    dishMediaService = {
+      fetchDishMediaEntryItems: jest.fn().mockResolvedValue({ items: [] }),
+    };
+    storage = { fileExists: jest.fn().mockResolvedValue(false) };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DishesService,
-        { provide: DishesRepository, useValue: {} },
+        { provide: DishesRepository, useValue: repo },
         {
           provide: AppLoggerService,
           useValue: {
@@ -61,41 +160,201 @@ describe('DishesService', () => {
             log: jest.fn(),
           },
         },
-        { provide: LocationsService, useValue: mockLocationsService },
+        { provide: LocationsService, useValue: locations },
         {
           provide: RemoteConfigService,
-          useValue: {
-            getRemoteConfigValue: jest.fn().mockResolvedValue('5'),
-          },
+          useValue: { getRemoteConfigValue: jest.fn().mockResolvedValue('5') },
         },
-        { provide: CloudTasksService, useValue: mockCloudTasksService },
+        { provide: CloudTasksService, useValue: cloudTasks },
         { provide: DishCategoriesRepository, useValue: {} },
         { provide: RestaurantsRepository, useValue: {} },
         { provide: PrismaService, useValue: {} },
+        { provide: DishMediaService, useValue: dishMediaService },
+        { provide: StorageService, useValue: storage },
       ],
     }).compile();
 
     service = module.get<DishesService>(DishesService);
   });
 
-  describe('bulkImportFromGoogle: 該当店舗なし', () => {
+  describe('該当店舗なし', () => {
     // searchRestaurants は全フォールバックが0件だったとき {} を返す
-    // (api/src/v1/locations/locations.service.ts の GoogleMapsTextSearchAllFallbacksFailed 経路)
+    // (locations.service.ts の GoogleMapsTextSearchAllFallbacksFailed 経路)
     it.each([
       ['placesを持たない空レスポンス', {}],
       ['placesが空配列', { places: [] }],
     ])('%s のとき 500 ではなく空配列を返す', async (_label, response) => {
-      mockLocationsService.searchRestaurants.mockResolvedValue(response);
+      locations.searchRestaurants.mockResolvedValue(response);
 
-      await expect(service.bulkImportFromGoogle(dto)).resolves.toEqual([]);
+      await expect(
+        service.bulkImportFromGoogle(dto, VIEWER_ID),
+      ).resolves.toEqual([]);
     });
 
     it('該当なしのとき Cloud Task を enqueue しない', async () => {
-      mockLocationsService.searchRestaurants.mockResolvedValue({});
+      locations.searchRestaurants.mockResolvedValue({});
 
-      await service.bulkImportFromGoogle(dto);
+      await service.bulkImportFromGoogle(dto, VIEWER_ID);
 
-      expect(mockCloudTasksService.createTask).not.toHaveBeenCalled();
+      expect(cloudTasks.enqueueCreateDishMediaEntry).not.toHaveBeenCalled();
+    });
+
+    it('該当なしのとき Photo Media を呼ばない', async () => {
+      locations.searchRestaurants.mockResolvedValue({});
+
+      await service.bulkImportFromGoogle(dto, VIEWER_ID);
+
+      expect(locations.tryGetPhotoMedia).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#829 completed 再利用', () => {
+    beforeEach(() => {
+      locations.searchRestaurants.mockResolvedValue({
+        places: [buildPlace(PLACE_ID)],
+      });
+      repo.findReusableGoogleImportDishMediaByPlaceIdsAndCategory.mockResolvedValue(
+        new Map([
+          [PLACE_ID, { dishMediaId: 'existing-media', reuseKind: 'completed' }],
+        ]),
+      );
+      dishMediaService.fetchDishMediaEntryItems.mockResolvedValue({
+        items: [
+          buildExistingEntry('existing-media', {
+            dish_media: {
+              media_processing_status: 'completed',
+              thumbnail_processing_status: 'completed',
+            },
+          }),
+        ],
+      });
+    });
+
+    // これが #829 のコスト削減そのものの回帰テスト
+    it('Photo Media を呼ばない', async () => {
+      await service.bulkImportFromGoogle(dto, VIEWER_ID);
+
+      expect(locations.tryGetPhotoMedia).not.toHaveBeenCalled();
+    });
+
+    it('Cloud Task を enqueue しない', async () => {
+      await service.bulkImportFromGoogle(dto, VIEWER_ID);
+
+      expect(cloudTasks.enqueueCreateDishMediaEntry).not.toHaveBeenCalled();
+    });
+
+    it('既存 entry をそのまま返す', async () => {
+      const result = await service.bulkImportFromGoogle(dto, VIEWER_ID);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].dish_media.id).toBe('existing-media');
+    });
+  });
+
+  describe('#1053 未完了再利用と Photo Media 課金', () => {
+    beforeEach(() => {
+      locations.searchRestaurants.mockResolvedValue({
+        places: [buildPlace(PLACE_ID)],
+      });
+      repo.findReusableGoogleImportDishMediaByPlaceIdsAndCategory.mockResolvedValue(
+        new Map([
+          [
+            PLACE_ID,
+            {
+              dishMediaId: 'existing-media',
+              reuseKind: 'google-import-non-completed',
+            },
+          ],
+        ]),
+      );
+      dishMediaService.fetchDishMediaEntryItems.mockResolvedValue({
+        items: [buildExistingEntry('existing-media')],
+      });
+    });
+
+    it('GCS に実体があれば Photo Media を呼ばない', async () => {
+      storage.fileExists.mockResolvedValue(true);
+
+      await service.bulkImportFromGoogle(dto, VIEWER_ID);
+
+      expect(storage.fileExists).toHaveBeenCalledWith(
+        'google-maps/photo/existing.jpg',
+      );
+      expect(locations.tryGetPhotoMedia).not.toHaveBeenCalled();
+    });
+
+    it('GCS に実体があれば photoUri 空で enqueue し、handler に download を skip させる', async () => {
+      storage.fileExists.mockResolvedValue(true);
+
+      await service.bulkImportFromGoogle(dto, VIEWER_ID);
+
+      expect(cloudTasks.enqueueCreateDishMediaEntry).toHaveBeenCalledTimes(1);
+      const payload = cloudTasks.enqueueCreateDishMediaEntry.mock.calls[0][0];
+      expect(payload.photoUri).toEqual([]);
+      // resize をやり直させるため、同じ dish_media.id で積み直すこと
+      expect(payload.dish_media.id).toBe('existing-media');
+    });
+
+    it('GCS に実体が無ければ Photo Media を取り直す', async () => {
+      storage.fileExists.mockResolvedValue(false);
+
+      await service.bulkImportFromGoogle(dto, VIEWER_ID);
+
+      expect(locations.tryGetPhotoMedia).toHaveBeenCalledTimes(1);
+      const payload = cloudTasks.enqueueCreateDishMediaEntry.mock.calls[0][0];
+      expect(payload.photoUri).toEqual(['https://google/photo.jpg']);
+    });
+
+    it('今回 Google が返した新しいレビューが捨てられない', async () => {
+      storage.fileExists.mockResolvedValue(true);
+
+      await service.bulkImportFromGoogle(dto, VIEWER_ID);
+
+      const payload = cloudTasks.enqueueCreateDishMediaEntry.mock.calls[0][0];
+      // 既存 review 0 件 + Google の新規 1 件 = 1 件が payload に載る
+      expect(payload.dish_reviews).toHaveLength(1);
+      expect(payload.dish_reviews[0].comment).toBe('おいしい');
+    });
+  });
+
+  describe('#1053 その他の分岐', () => {
+    it('同一 placeId が2件返ってもレスポンスの dish_media.id は重複しない', async () => {
+      locations.searchRestaurants.mockResolvedValue({
+        places: [buildPlace(PLACE_ID), buildPlace(PLACE_ID)],
+      });
+
+      const result = await service.bulkImportFromGoogle(dto, VIEWER_ID);
+
+      const ids = result.map((entry) => entry.dish_media.id);
+      expect(new Set(ids).size).toBe(ids.length);
+      expect(cloudTasks.enqueueCreateDishMediaEntry).toHaveBeenCalledTimes(1);
+    });
+
+    it('media_path が dish_media.id から決定論的に導出される', async () => {
+      locations.searchRestaurants.mockResolvedValue({
+        places: [buildPlace(PLACE_ID)],
+      });
+
+      await service.bulkImportFromGoogle(dto, VIEWER_ID);
+
+      const payload = cloudTasks.enqueueCreateDishMediaEntry.mock.calls[0][0];
+      const expectedId = buildGoogleImportDishMediaId(PLACE_ID, CATEGORY_ID);
+      expect(payload.dish_media.id).toBe(expectedId);
+      // Date.now() 由来のファイル名だとレース時に食い違う
+      expect(payload.dish_media.media_path).toContain(expectedId);
+    });
+
+    it('enqueue が reject しても unhandled rejection にならず処理が続く', async () => {
+      locations.searchRestaurants.mockResolvedValue({
+        places: [buildPlace(PLACE_ID)],
+      });
+      cloudTasks.enqueueCreateDishMediaEntry.mockRejectedValue(
+        new Error('Cloud Tasks unavailable'),
+      );
+
+      await expect(
+        service.bulkImportFromGoogle(dto, VIEWER_ID),
+      ).resolves.toHaveLength(1);
     });
   });
 });

--- a/api/src/v1/dishes/dishes.service.ts
+++ b/api/src/v1/dishes/dishes.service.ts
@@ -23,6 +23,7 @@ import { DishCategoriesRepository } from '../dish-categories/dish-categories.rep
 import { RestaurantsRepository } from '../restaurants/restaurants.repository';
 import { PrismaService } from '../../prisma/prisma.service';
 import { DishMediaService } from '../dish-media/dish-media.service';
+import { StorageService } from '../../core/storage/storage.service';
 
 // Import converters
 import {
@@ -34,11 +35,7 @@ import { SupabaseRestaurants } from '../../../../shared/converters/convert_resta
 import { SupabaseDishMedia } from '../../../../shared/converters/convert_dish_media';
 import { SupabaseDishReviews } from '../../../../shared/converters/convert_dish_reviews';
 import { CreateDishMediaEntryJobPayload } from '../../internal/dishes/create-dish-media-entry.interface';
-import {
-  buildFileName,
-  buildFullPath,
-  getExt,
-} from 'src/core/storage/storage.utils';
+import { buildFullPath, getExt } from 'src/core/storage/storage.utils';
 import {
   buildGoogleImportDishMediaId,
   buildGoogleImportDishReviewId,
@@ -59,6 +56,7 @@ export class DishesService {
     private readonly restaurantsRepository: RestaurantsRepository,
     private readonly prisma: PrismaService,
     private readonly dishMediaService: DishMediaService,
+    private readonly storage: StorageService,
   ) {}
 
   /* ------------------------------------------------------------------ */
@@ -196,13 +194,32 @@ export class DishesService {
       .map((place) => place.id)
       .filter((placeId): placeId is string => Boolean(placeId));
 
+    // #1053 【退避】preflight を Remote Config で無効化できるようにする。
+    // DB 由来の不具合が出たときに、コードデプロイなしで従来の「常に新規作成」へ戻す。
+    const preflightEnabled =
+      (await this.remoteConfigService.getRemoteConfigValue(
+        'v1_bulk_import_preflight_enabled',
+      )) !== 'false';
+
     // #829 【性能】Photo Media 前に、Text Search 結果の place/category だけを batch lookup する。
     // completed は課金削減のため即再利用し、未完了 Google import は同じ ID で再処理してレスポンス ID の不整合を避ける。
-    const reusableMediaByPlaceId =
-      await this.repo.findReusableGoogleImportDishMediaByPlaceIdsAndCategory(
-        placeIds,
-        dto.categoryId,
-      );
+    const reusableMediaByPlaceId = preflightEnabled
+      ? await this.repo.findReusableGoogleImportDishMediaByPlaceIdsAndCategory(
+          placeIds,
+          dto.categoryId,
+        )
+      : new Map<
+          string,
+          {
+            dishMediaId: string;
+            reuseKind: 'completed' | 'google-import-non-completed';
+          }
+        >();
+    if (!preflightEnabled) {
+      this.logger.warn('BulkImportPreflightDisabled', 'bulkImportFromGoogle', {
+        categoryId: dto.categoryId,
+      });
+    }
     const reusableMediaIds = [
       ...new Set(
         [...reusableMediaByPlaceId.values()].map(
@@ -243,6 +260,15 @@ export class DishesService {
     // 同一 dish_media.id が2件レスポンスに載り、Cloud Task も二重に積まれる。
     // contextualContents は元の places と index で対応するため、
     // 重複除去後も必ず「元の index」を保持すること。
+    // #1053 【観測】重複削減の効果は external_api_logs の Photo Media 呼び出し数で測るのが
+    // 最も直接的だが、それだけだと「何件を再利用して減らせたのか」が分からない。
+    // 分岐の内訳をレスポンス側にも残し、突き合わせられるようにする。
+    let reusedCompletedCount = 0;
+    let reusedNonCompletedCount = 0;
+    let newlyCreatedCount = 0;
+    let photoMediaCallCount = 0;
+    let photoMediaSkippedCount = 0;
+
     const seenPlaceIds = new Set<string>();
     const uniquePlaces = googlePlaces.places
       .map((place, index) => ({ place, index }))
@@ -350,10 +376,46 @@ export class DishesService {
               dishMediaId: existingReusableEntry.entry.dish_media.id,
             },
           );
+          reusedCompletedCount++;
           return existingReusableEntry.entry;
         }
 
-        if (!photos || photos.length === 0) {
+        const existingGoogleImportEntry =
+          existingReusableEntry?.reuseKind === 'google-import-non-completed'
+            ? existingReusableEntry.entry
+            : undefined;
+
+        // #1053 【課金】未完了再利用パスは、既存 media_path の実体が GCS にある限り
+        // Photo Media を取り直す必要がない。写真バイナリは既に保存済みで、
+        // 未完了なのは「その後の resize」だからである。
+        //
+        // ここを見落とすと、恒久的に resize 失敗して failed に張り付いた place が
+        // bulk-import のたびに Photo Media を課金し続ける（#829 の目的に反する）。
+        // 実体があるなら photoUri 無しで enqueue し、handler には download を skip させて
+        // resize だけやり直させる。
+        const reusableMediaPath = existingGoogleImportEntry?.dish_media
+          .media_path as string | undefined;
+        const canSkipPhotoMedia = reusableMediaPath
+          ? await this.storage.fileExists(reusableMediaPath)
+          : false;
+
+        if (canSkipPhotoMedia) {
+          this.logger.log(
+            'PhotoMediaSkippedForStoredMedia',
+            'bulkImportFromGoogle',
+            {
+              placeId: place.id!,
+              categoryId: dto.categoryId,
+              dishMediaId: existingGoogleImportEntry!.dish_media.id,
+              mediaPath: reusableMediaPath,
+              mediaProcessingStatus:
+                existingGoogleImportEntry!.dish_media.media_processing_status,
+            },
+          );
+          photoMediaSkippedCount++;
+        }
+
+        if (!canSkipPhotoMedia && (!photos || photos.length === 0)) {
           this.logger.warn('NoPhotoForPlace', 'bulkImportFromGoogle', {
             placeId: place.id!,
           });
@@ -361,23 +423,31 @@ export class DishesService {
         }
 
         // PhotoMediaUri を複数候補から取得（バイナリ取得は行わない）
-        const photoMedia = await this.locationsService.tryGetPhotoMedia(photos);
-        if (!photoMedia) {
-          throw new Error(`No photo URL found for place: ${place.id!}`);
+        const photoMedia = canSkipPhotoMedia
+          ? null
+          : await this.locationsService.tryGetPhotoMedia(photos);
+        if (!canSkipPhotoMedia) {
+          if (!photoMedia) {
+            throw new Error(`No photo URL found for place: ${place.id!}`);
+          }
+          photoMediaCallCount++;
         }
-
-        const existingGoogleImportEntry =
-          existingReusableEntry?.reuseKind === 'google-import-non-completed'
-            ? existingReusableEntry.entry
-            : undefined;
         const ext = getExt('image/jpeg');
+        const dishMediaId =
+          existingGoogleImportEntry?.dish_media.id ??
+          buildGoogleImportDishMediaId(place.id!, dto.categoryId);
         // #829 【設計】未完了 Google import は既存 GCS path を維持し、同じ dish_media.id の resize 完了を目指す。
+        // #1053 【バグ】新規パスの buildFileName は `${Date.now()}_${slug}` を返すため、
+        // レース中の2本は dish_media.id が一致するのに media_path だけ食い違う。
+        // upsert の update は空なので DB は先勝ちの path のまま残り、後勝ちが
+        // アップロードした GCS オブジェクトは誰からも参照されない孤児になる。
+        // dish_media.id から導出して media_path も決定論的にする。
         const mediaPath =
           existingGoogleImportEntry?.dish_media.media_path ??
           buildFullPath({
             resourceType: 'google-maps',
             usageType: 'photo',
-            finalFileName: buildFileName(place.id!, ext),
+            finalFileName: `${dishMediaId}.${ext}`,
           });
 
         const restaurant: SupabaseRestaurants = {
@@ -396,7 +466,11 @@ export class DishesService {
             existingGoogleImportEntry?.restaurant.longitude ??
             place.location!.longitude!,
           location: existingGoogleImportEntry?.restaurant.location ?? null,
-          image_url: photoMedia.photoUri,
+          // #1053 Photo Media を skip したときは新しい photoUri が無いので既存値を維持する。
+          image_url:
+            photoMedia?.photoUri ??
+            existingGoogleImportEntry?.restaurant.image_url ??
+            '',
           image_path: mediaPath,
           address_components:
             existingGoogleImportEntry?.restaurant.address_components ??
@@ -430,9 +504,7 @@ export class DishesService {
           // bulk-import が走った場合に別 ID が採番され、dish_reviews が二重登録される。
           // (placeId, categoryId) から決定論的に導出し、upsert / skipDuplicates を
           // リクエスト間でも効かせる。
-          id:
-            existingGoogleImportEntry?.dish_media.id ??
-            buildGoogleImportDishMediaId(place.id!, dto.categoryId),
+          id: dishMediaId,
           dish_id: dish.id,
           user_id: null, // Google からのインポートなので null
           media_path: mediaPath,
@@ -471,56 +543,78 @@ export class DishesService {
           );
         }
 
+        const googleReviews: SupabaseDishReviews[] = reviews.map((review) => ({
+          // #829 【バグ】review ID も決定論的に導出し、リクエストを跨いだ重複を防ぐ
+          id: buildGoogleImportDishReviewId(
+            place.id!,
+            dto.categoryId,
+            review.originalText?.text || '',
+            review.authorAttribution?.uri || '',
+            review.rating || 0,
+          ),
+          dish_id: dish.id,
+          user_id: null, // Google からのインポートなので null
+          comment: review.originalText?.text || '',
+          comment_tsv: null,
+          original_language_code: review.originalText?.languageCode || '',
+          rating: review.rating || 0,
+          price_cents: null,
+          currency_code: null,
+          created_dish_media_id: dishMedia.id,
+          imported_user_name: review.authorAttribution?.displayName || null,
+          imported_user_avatar: review.authorAttribution?.photoUri || null,
+          created_at: new Date().toISOString(),
+        }));
+
         // #829 【設計】未完了 Google import の再処理では既存 review ID を渡し、handler 側の skipDuplicates と合わせて retry を no-op 化する。
+        // #1053 【バグ】既存 review だけを渡すと、今回 Google が返した新しいレビューが毎回捨てられる。
+        // 既存 entry の dish_reviews は `take: reviewLimit`（既定 6）で切られてもいるため、
+        // 前回インポート時に Google が 0 件を返していた place は、以後レビューが付いても永久に登録されない。
+        // ID は決定論的なので、両者を id で union すれば skipDuplicates が既存分を no-op にし、
+        // 差分だけが追加される。
         const dishReviews: SupabaseDishReviews[] = existingGoogleImportEntry
-          ? this.toSupabaseDishReviews(existingGoogleImportEntry.dish_reviews)
-          : reviews.map((review) => ({
-              // #829 【バグ】review ID も決定論的に導出し、リクエストを跨いだ重複を防ぐ
-              id: buildGoogleImportDishReviewId(
-                place.id!,
-                dto.categoryId,
-                review.originalText?.text || '',
-                review.authorAttribution?.uri || '',
-                review.rating || 0,
+          ? this.mergeDishReviewsById(
+              this.toSupabaseDishReviews(
+                existingGoogleImportEntry.dish_reviews,
               ),
-              dish_id: dish.id,
-              user_id: null, // Google からのインポートなので null
-              comment: review.originalText?.text || '',
-              comment_tsv: null,
-              original_language_code: review.originalText?.languageCode || '',
-              rating: review.rating || 0,
-              price_cents: null,
-              currency_code: null,
-              created_dish_media_id: dishMedia.id,
-              imported_user_name: review.authorAttribution?.displayName || null,
-              imported_user_avatar: review.authorAttribution?.photoUri || null,
-              created_at: new Date().toISOString(),
-            }));
+              googleReviews,
+            )
+          : googleReviews;
 
         // 非同期ジョブをキューに投入
+        // #1053 photoUri が空配列なら handler は download を skip し、upsert と resize だけやり直す。
         await this.enqueueCreateDishMediaEntryJob({
           restaurant,
           dish,
           dishMedia,
           dishReviews,
           placeId: place.id!,
-          photoUri: photoMedia.photoUri,
+          photoUri: photoMedia?.photoUri,
         });
 
         if (existingGoogleImportEntry) {
+          reusedNonCompletedCount++;
           // #829 【互換性】未完了 row はフロントの polling 条件に乗りにくいため、同期レスポンスだけ Google Photo URL で completed 相当にする。
-          return this.buildGoogleImportRetryEntry(
-            existingGoogleImportEntry,
-            photoMedia.photoUri,
-          );
+          // #1053 Photo Media を skip した場合は新しい URL が無いが、GCS に実体がある
+          // ことは確認済みなので、assembler が組み立てた既存 URL をそのまま返せばよい。
+          return photoMedia
+            ? this.buildGoogleImportRetryEntry(
+                existingGoogleImportEntry,
+                photoMedia.photoUri,
+              )
+            : existingGoogleImportEntry;
         }
+
+        newlyCreatedCount++;
 
         const BulkImportDishesResponseEntry: BulkImportDishesResponse[0] = {
           restaurant: {
             ...restaurant,
             imageUrls: {
-              sm: photoMedia.photoUri,
-              md: photoMedia.photoUri,
+              // canSkipPhotoMedia は existingGoogleImportEntry がある場合のみ true になるため、
+              // 新規作成パスに到達した時点で photoMedia は必ず取得済み。
+              sm: photoMedia!.photoUri,
+              md: photoMedia!.photoUri,
             },
           },
           dish: {
@@ -536,8 +630,8 @@ export class DishesService {
             ...dishMedia,
             media_processing_status: 'completed', // クライアント側には処理済みの画像を返す
             thumbnail_processing_status: 'completed',
-            mediaUrl: photoMedia.photoUri,
-            thumbnailImageUrl: photoMedia.photoUri,
+            mediaUrl: photoMedia!.photoUri,
+            thumbnailImageUrl: photoMedia!.photoUri,
             isMine: false, // インポートなので自分のものではない
             isSaved: false, // 初期状態では保存されていない
             isLiked: false, // 初期状態ではいいねされていない
@@ -574,9 +668,18 @@ export class DishesService {
 
     results.push(...successfulResults);
 
+    // #1053 【観測】削減効果は external_api_logs の Photo Media 呼び出し数と
+    // 突き合わせて評価する。内訳が無いと「減ったのは再利用のおかげか、
+    // そもそも検索結果が少なかっただけか」を区別できない。
     this.logger.log('BulkImportCompleted', 'bulkImportFromGoogle', {
       importedCount: results.length,
       totalPlaces: googlePlaces.places?.length,
+      categoryId: dto.categoryId,
+      reusedCompletedCount,
+      reusedNonCompletedCount,
+      newlyCreatedCount,
+      photoMediaCallCount,
+      photoMediaSkippedCount,
     });
 
     return results;
@@ -633,7 +736,7 @@ export class DishesService {
     dishMedia: SupabaseDishMedia;
     dishReviews: SupabaseDishReviews[];
     placeId: string;
-    photoUri: string;
+    photoUri?: string;
   }) {
     // 非同期ジョブ用のペイロード作成
     const jobId = `dish-create-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
@@ -642,7 +745,8 @@ export class DishesService {
     const jobPayload: CreateDishMediaEntryJobPayload = {
       jobId,
       idempotencyKey,
-      photoUri: [photoUri],
+      // #1053 GCS に実体がある再利用パスでは空配列。handler は download を skip する。
+      photoUri: photoUri ? [photoUri] : [],
       restaurants: restaurant,
       dishes: dish,
       dish_media: dishMedia,
@@ -650,20 +754,44 @@ export class DishesService {
     };
 
     // 非同期ジョブをキューに投入（写真の実体取得・保存のため）
+    // #1053 【バグ】以前は Promise を await も catch もしていなかった。
+    // enqueueCreateDishMediaEntry は createTask 失敗時に reject するため、
+    // 同期 try/catch では捕まえられず unhandled rejection になる
+    // （Node 15+ の既定ではプロセスが落ちる）。必ず await して握る。
     try {
-      this.cloudTasksService.enqueueCreateDishMediaEntry(jobPayload).then(() =>
-        this.logger.debug('AsyncJobEnqueued', 'bulkImportFromGoogle', {
-          jobId,
-          placeId,
-        }),
-      );
+      await this.cloudTasksService.enqueueCreateDishMediaEntry(jobPayload);
+      this.logger.debug('AsyncJobEnqueued', 'bulkImportFromGoogle', {
+        jobId,
+        placeId,
+        hasPhotoUri: !!photoUri,
+      });
     } catch (error) {
+      // #1053 enqueue に失敗すると「レスポンスで返した dish_media.id が永久に DB に存在しない」
+      // orphan response になる。同期レスポンスは継続するが、必ず error として残す。
       this.logger.error('AsyncJobEnqueueError', 'bulkImportFromGoogle', {
         jobId,
         placeId,
+        dishMediaId: dishMedia.id,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
-      // エンキューエラーでも同期レスポンスは継続
     }
+  }
+
+  /**
+   * #1053 既存 review と Google の新規 review を id で union する。
+   *
+   * ID は (placeId, categoryId, 本文, 投稿者, rating) から決定論的に導出されるため、
+   * 同じレビューは必ず同じ id になる。既存を優先して残し（created_at 等の
+   * DB 側の値を壊さない）、未知の id だけを追加する。
+   */
+  private mergeDishReviewsById(
+    existing: SupabaseDishReviews[],
+    incoming: SupabaseDishReviews[],
+  ): SupabaseDishReviews[] {
+    const byId = new Map(existing.map((review) => [review.id, review]));
+    for (const review of incoming) {
+      if (!byId.has(review.id)) byId.set(review.id, review);
+    }
+    return [...byId.values()];
   }
 }

--- a/shared/remoteConfig/remoteConfig.schema.ts
+++ b/shared/remoteConfig/remoteConfig.schema.ts
@@ -35,6 +35,19 @@ export const remoteConfigSchema = z.object({
 	dish_category_recommendation_penalty_weight_core_ingredient: z.string(),
 	dish_category_recommendation_penalty_weight_taste: z.string(),
 	dish_category_recommendation_penalty_weight_cooking_method: z.string(),
+	/**
+	 * #1053 bulk-import の preflight lookup（既存 dish_media の再利用）を on/off する。
+	 *
+	 * `"false"` で従来の「常に新規作成」へ戻せる。DB 由来の不具合が出たときに
+	 * コードデプロイなしで退避するための逃げ道。
+	 *
+	 * ⚠️ 必ず optional + default にすること。このスキーマは要求されたキーだけでなく
+	 * config 全体を safeParse するため、**必須キーを1つでも足すと、GCS の config.json を
+	 * 同時に更新するまで「実在する他のキーの読み取りまで全部 throw する」**。
+	 * バックエンドは全 RemoteConfig 呼び出しが落ち、一方フロントは Zod を通さず
+	 * キャストしているだけなので無症状のまま——という気づきにくい壊れ方をする。
+	 */
+	v1_bulk_import_preflight_enabled: z.string().optional().default("true"),
 });
 
 export type RemoteConfigValues = z.infer<typeof remoteConfigSchema>;


### PR DESCRIPTION
Closes #1053

#1053 の 9 項目のうち、コードで閉じられる 8 項目に対応しました。見送った 1 項目とその理由も下に書いています。

## 1.【最優先】未完了再利用パスの Photo Media 課金を止める

`tryGetPhotoMedia` は completed の early return より**後ろ**にあるため、completed に到達しない place は bulk-import のたびに Photo Media を課金し続けていました。とくに恒久的に resize 失敗して `failed` に張り付いた行は**永久に毎回課金**されます。

**着眼点**: 未完了なのは「写真の取得」ではなく「その後の resize」です。既存 `media_path` の実体が GCS にある限り、Photo Media を取り直す理由がありません。

```ts
const canSkipPhotoMedia = reusableMediaPath
  ? await this.storage.fileExists(reusableMediaPath)
  : false;
```

skip したときは `photoUri` を**空配列**で enqueue し、handler 側は download を飛ばして upsert と resize のやり直しだけを行います。同期レスポンスは、assembler が組み立てた既存 URL（実体があることは確認済み）をそのまま返します。

これにより #1051 で一度試して取り消した「`failed` を除外する」案が不要になります。あの案は課金削減効果がないうえ、既存 place を新規パスへ落として**同じ Google レビューを二重登録**する副作用がありました。

### TTL 判定は入れていません

Issue には「`created_at` が N 分より古い `processing` は `failed` とみなす TTL」の案がありましたが、これは**「張り付き行が毎回課金される」ことへの対策**でした。上記で課金が発生しなくなったため、再処理は無害になり TTL の根拠が消えます。件数の監視が必要なら観測（項目 8）側で足すのが筋だと考え、入れていません。

## 2. `media_path` の決定論化

`buildFileName` は `${Date.now()}_${slug}` を返すため、レースした 2 本は `dish_media.id` が一致するのに `media_path` だけ食い違います。`upsert` の update は空なので DB は先勝ちの path のまま残り、**後勝ちがアップロードした GCS オブジェクトは誰からも参照されない孤児**になります。

`dish_media.id` から導出するよう変更しました。

## 3. Cloud Tasks の名前付きタスクによる enqueue dedup

`task.name` を `${queuePath}/tasks/${sha256(idempotencyKey)}` にしました（タスク名に使える文字は `[A-Za-z0-9_-]` のみなので hex へ潰しています）。`ALREADY_EXISTS` は失敗ではなく正常な重複排除なので、握って `CloudTaskDeduplicated` を出し、呼び出し元へは成功として返します。

### ⚠️ 項目 1 との相互作用（レビュー時にご確認ください）

名前付きタスクは**完了後およそ 1 時間保持**されます。`idempotencyKey` は `${placeId}-${categoryId}` で永続的に同じ値なので、**項目 1 の「resize をやり直すための再 enqueue」は 1 時間のあいだ dedup で弾かれます**。

これは「無意味な resize リトライを 1 時間に 1 回へ throttle する」動作になり、望ましい方向だと判断して採用しましたが、**意図しない挙動であればここは外せます**。名前付きタスクにはスループット制約もあるため、`pageSize` を大きく増やす場合は再検討が必要です。

## 4. completed の列を resize 再 enqueue しない

分岐判定が media/thumbnail の AND なので `media=completed / thumbnail=processing` は未完了に倒れ、handler 再実行時に completed 側まで再 enqueue されていました。`resize-image` 側が `fileExists` で早期 return するため画像処理は走りませんが、Cloud Tasks の実行回数と Cloud Run のリクエスト数だけが二重に増えます。

## 5. 再利用時に新しいレビューが捨てられる問題

`existingGoogleImportEntry.dish_reviews` は `take: reviewLimit`（既定 6）で切られた既存分のみで、今回 Google が返したレビューは丸ごと無視されていました。**前回インポート時に Google が 0 件を返していた place は、以後レビューが付いても永久に登録されません。**

ID が決定論的なので、既存と新規を id で union すれば `skipDuplicates` が既存分を no-op にし、差分だけが追加されます。

## 6. enqueue の unhandled rejection

```ts
// 変更前: await も .catch() も無い
this.cloudTasksService.enqueueCreateDishMediaEntry(jobPayload).then(...)
```

`createTask` 失敗時に Promise が reject しますが、同期 `try/catch` では捕捉できず **unhandled rejection**（Node 15+ の既定ではプロセス停止）になります。`await` して握るようにしました。enqueue 失敗は「レスポンスで返した `dish_media.id` が永久に DB に存在しない」orphan response を意味するため、`dishMediaId` 付きで error ログに残します。

## 7. 分岐テスト

`api/src/v1/dishes/dishes.service.spec.ts` に **14 件**追加しました。

とくに **「completed 再利用時に `tryGetPhotoMedia` が呼ばれないこと」は #829 のコスト削減そのものの回帰テスト**です。

- 該当なし（`{}` / `{places: []}`）で 500 にならず Photo Media も enqueue もしない
- completed 再利用で Photo Media / Cloud Task を呼ばない
- 未完了再利用 × GCS 実体あり → Photo Media を呼ばず `photoUri: []` で enqueue
- 未完了再利用 × GCS 実体なし → Photo Media を取り直す
- 再利用時に新規レビューが捨てられない
- 同一 placeId 2 件でレスポンスの `dish_media.id` が重複しない
- `media_path` が `dish_media.id` から導出される
- enqueue が reject しても処理が続く

**ミューテーション確認済み**: `canSkipPhotoMedia` を `false` 固定にすると 2 件が失敗します。

## 8. 観測

`BulkImportCompleted` に `reusedCompletedCount` / `reusedNonCompletedCount` / `newlyCreatedCount` / `photoMediaCallCount` / `photoMediaSkippedCount` を追加しました。`external_api_logs` の Photo Media 呼び出し数と突き合わせると、「減ったのは再利用のおかげか、そもそも検索結果が少なかっただけか」を区別できます。

skip した個別ケースは `PhotoMediaSkippedForStoredMedia` で追えます。

## 9. feature flag

`v1_bulk_import_preflight_enabled` を追加し、`"false"` で従来の「常に新規作成」へ戻せるようにしました。

### ⚠️ optional + default にしている理由

`remoteConfigSchema` は要求されたキーだけでなく **config 全体**を `safeParse` します。そのため**必須キーを 1 つでも足すと、GCS の `config.json` を同時に更新するまで「実在する他のキーの読み取りまで全部 throw する」**という壊れ方をします。

しかもフロントは同じ JSON を Zod に通さず単にキャストしている（`app-expo/lib/remoteConfig.ts`）ため、**アプリは無症状のままバックエンドだけが全滅**します。非常に気づきにくいので、`.optional().default("true")` にして `config.json` 未更新でも安全に動くようにしました。

有効化したい場合のみ `config.json` にキーを足してください。**足さなくても現状どおり動きます。**

## 検証

- `pnpm turbo run typecheck`: **4/4 成功**
- 新規単体テスト **14 件成功**
- ミューテーション確認済み（上記）
- `pnpm exec jest`（api 全体）: 失敗数は main と**完全に同一**（6 suites / 3 tests）。いずれも `core/config/env` の import 時バリデーションに起因する既存の失敗で、本 PR とは無関係です

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNtBY7eogNKTRf4d91sqCd)_