### PR TITLE
#1077 fix: E2E ワークフローで EXPO_PUBLIC_COMMIT_ID を注入する

### DIFF
--- a/.github/workflows/e2e-mobile-test.yml
+++ b/.github/workflows/e2e-mobile-test.yml
@@ -65,6 +65,19 @@ jobs:
         working-directory: app-expo
         run: pnpx eas-cli env:pull development --non-interactive --path .env
 
+      # #1076 この run のビルドにだけ commit SHA を焼き込む（e2e-web-test.yml と同一方針・同一内容）。
+      # eas-cli env:update は使わない: EAS 側の共有 development 環境そのものを書き換えるため、
+      # CI の SHA が全開発者の env:pull に降ってくるうえ、E2E Web / E2E Mobile の同時実行で競合する。
+      # prebuild ではなく Gradle ビルド時に効く: expo-constants の createExpoConfig タスクが
+      # preBuild で @expo/env.load(projectRoot) を呼び、この .env を読んで assets の app.config を生成する。
+      # printf の先頭 \n は、env:pull の出力が改行で終わっていない場合に前行と連結して
+      # 「前行の値まで壊す」事故を防ぐ保険（echo では防げない）。
+      - name: 🔖 Inject commit id into .env
+        working-directory: app-expo
+        env:
+          COMMIT_ID: ${{ github.sha }}
+        run: printf '\nEXPO_PUBLIC_COMMIT_ID=%s\n' "$COMMIT_ID" >> .env
+
       # Gradle (AGP 8.x) は JDK 17 を要求する
       - name: ☕ Setup JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/e2e-web-test.yml
+++ b/.github/workflows/e2e-web-test.yml
@@ -56,6 +56,19 @@ jobs:
         working-directory: app-expo
         run: pnpx eas-cli env:pull development --non-interactive --path .env
 
+      # #1076 この run のビルドにだけ commit SHA を焼き込む。
+      # eas-cli env:update は使わない: EAS 側の共有 development 環境そのものを書き換えるため、
+      # CI の SHA が全開発者の env:pull に降ってくるうえ、E2E Web / E2E Mobile の同時実行で競合する。
+      # env:pull が生成した .env の末尾へ追記する。dotenv は同一ファイル内で後勝ちなので、
+      # env:pull 側が同名キーを出力していてもこの行が最終値になる。
+      # printf の先頭 \n は、env:pull の出力が改行で終わっていない場合に前行と連結して
+      # 「前行の値まで壊す」事故を防ぐ保険（echo では防げない）。
+      - name: 🔖 Inject commit id into .env
+        working-directory: app-expo
+        env:
+          COMMIT_ID: ${{ github.sha }}
+        run: printf '\nEXPO_PUBLIC_COMMIT_ID=%s\n' "$COMMIT_ID" >> .env
+
       - name: 🏗️ Build Web App
         run: pnpm --filter app-expo build:web
 


### PR DESCRIPTION
## 対象 Issue

- Closes #1077 — E2E ワークフローへ `EXPO_PUBLIC_COMMIT_ID` を注入する
- 親 Issue: #1076（完了条件 1・2）

#1076 の完了条件 3・4（欠落耐性・バッチ部分受理）は #1080 が担当します。本 PR は `.github/workflows/` の 2 ファイルしか変更しません。

## 何が起きていたか

E2E Web / E2E Mobile は `eas-cli env:pull development` でしか環境変数を用意しておらず、`EXPO_PUBLIC_COMMIT_ID` が空のままバンドルへ焼き込まれていました。`app.config.ts:245` → `Env.ts:8` → `useLogger.ts:71` と一本道で流れる値なので、未設定だと `created_commit_id` が JSON からキーごと消え、`@IsString()` が落ちて 400。ログ系エンドポイントの 400 は **100% がこの 1 原因**でした（#1076 の集計）。

本番系 4 ワークフローは `env:update` で注入済みのため、production では 0 件です。

## 変更内容

`.github/workflows/e2e-web-test.yml` と `.github/workflows/e2e-mobile-test.yml` の `🛠️ Sync environment variables from EAS CLI` の直後に、`.env` へ追記するステップを 1 つずつ追加しました。

```yaml
- name: 🔖 Inject commit id into .env
  working-directory: app-expo
  env:
    COMMIT_ID: ${{ github.sha }}
  run: printf '\nEXPO_PUBLIC_COMMIT_ID=%s\n' "$COMMIT_ID" >> .env
```

### なぜ `eas-cli env:update` を使わないか

EAS 側の共有 development 環境**そのもの**を書き換えるため、CI の SHA が全開発者の `env:pull` に降ってきます。さらに E2E Web / E2E Mobile が同時に走ると競合します。ここで欲しいのは「この run のビルドにだけ焼き込む」ことなので `.env` 追記で足ります。

### なぜ `echo` ではなく `printf` で先頭に改行を入れるか

`env:pull` の出力が改行で終わっていない場合、`echo` だと前行と連結して **前行の値まで壊します**。実際に確かめた挙動:

```
# echo の場合（前行が壊れる）
EXPO_PUBLIC_BACKEND_BASE_URL=https://api-dev.exampleEXPO_PUBLIC_COMMIT_ID=1eb3a21...

# printf '\n...' の場合
EXPO_PUBLIC_BACKEND_BASE_URL=https://api-dev.example
EXPO_PUBLIC_COMMIT_ID=1eb3a21...
```

余分な空行は dotenv が無視するので、追記が常に安全側に倒れます。

### なぜ step の `env:` ではなく `.env` か

mobile 側は `expo prebuild` と Gradle が spawn する node の両方で config を評価するため、step の `env:` だと複数箇所へ書く必要があり漏れやすい。`.env` なら 1 箇所で web の `expo export` と mobile の両方を賄えます。

### 値がバンドルへ到達する経路

- **web**: `expo export` が `@expo/env.load()` → `babel-preset-expo` の `expo-inline-manifest-plugin` が `process.env.APP_MANIFEST` をビルド時に置換 → `Constants.expoConfig.extra`
- **mobile**: prebuild 時ではなく **Gradle ビルド時**に効きます。`expo-constants` の `createExpoConfig` タスクが `preBuild` に紐付き（`outputs.upToDateWhen { false }` で毎回再生成）、`getAppConfig.js` が `@expo/env.load(projectRoot)` でこの `.env` を読んで assets の `app.config` を生成します

同じ経路で供給されている `EXPO_PUBLIC_BACKEND_BASE_URL` が現に両バンドルへ届いている（E2E が `api-development` に到達して 400 を記録している）ことが、経路そのものの実測証明になっています。**欠けていたのはキーが `.env` に無かったことだけ**です。

## `github.sha` について

web は `workflow_dispatch` + `schedule`、mobile は `workflow_dispatch` のみで、**どちらにも `pull_request` トリガーはありません**。したがって `github.sha` は checkout した commit と一致し、完了条件 2（BigQuery の `created_commit_id` に当該 run の SHA が入る）を満たします。本番系（`firebase-hosting-deploy.yml`）も `github.sha` を使っており、prod / dev で同じ 40 桁 hex 形式に揃うので横断クエリできます。

将来 `pull_request` を足す場合はマージコミット SHA になる点の検討が必要です（追跡性を取るかビルド同一性を取るか）。

## 検証したこと

- 両 YAML が `yaml.safe_load` でパースできること ✅
- 追加ステップが `Sync environment variables from EAS CLI` の直後にあること（web の次は `Build Web App`、mobile の次は `Setup JDK 17`）✅
- mobile の挿入位置が `Expo prebuild` / Detox build より前であること ✅
- `printf` が改行なし `.env` に対して前行を壊さないこと（上記の実出力）✅
- `assert:no-e2e-hook` への副作用がないこと（SENTINEL は `__E2E_TEST_SESSION_HOOK__` で 40 桁 hex と衝突しない）✅

## 未検証

- **実際の E2E 実行はしていません。** 完了条件 1・2 の最終確認はマージ後に E2E Web / E2E Mobile を 1 回ずつ実行し、`nanitabeyo_logs_dev` で (a) その時間帯に `created_commit_id` 起因の 400 が 0 件、(b) `created_commit_id = <SHA>` のログが 1 件以上、を確認する必要があります。
- Detox 実行中に expo-updates が EAS Update を取得して manifest を差し替える可能性。`eas.json` の `development` プロファイルに `channel` 指定が無いため解決されない見込みですが、`android/` 未生成の状態では AndroidManifest の `EXPO_UPDATES_*` を読めず未確認です。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZGA9DKbLS581TrAygJh5K


---
_Generated by [Claude Code](https://claude.ai/code/session_01RZGA9DKbLS581TrAygJh5K)_