### PR TITLE
ci: E2E Mobile へ scope=probe を追加し @probe を明示実行できるようにする (#1087)

### DIFF
--- a/.github/workflows/e2e-mobile-test.yml
+++ b/.github/workflows/e2e-mobile-test.yml
@@ -18,13 +18,14 @@ on:
           - android
           - ios
       scope:
-        description: "実行するテストの範囲（tier1 = smoke のみ / tier1-2 = 既定 / mutation = dev DB へ書き込む）"
+        description: "実行するテストの範囲（tier1 = smoke のみ / tier1-2 = 既定 / mutation = dev DB へ書き込む / probe = 不具合を数値で示す。落ちるのが正しい）"
         type: choice
         default: tier1-2
         options:
           - tier1-2
           - tier1
           - mutation
+          - probe
   schedule:
     # #1029 【設計】毎日 JST 4:00（UTC 19:00）。e2e-web(JST 3:00 / timeout 30分) と時間帯を分け、
     # テストユーザーと Supabase の匿名サインイン枠を取り合わないようにする
@@ -60,6 +61,9 @@ jobs:
           case "$SCOPE" in
             tier1)    android=test:ci:smoke:android; ios=test:ci:smoke:ios ;;
             mutation) android=test:ci:mutation:android; ios=test:ci:mutation:ios ;;
+            # #1087 @probe は「修正が入るまで落ちるのが正しい」spec。既定スコープにも
+            # schedule にも入らず、この scope を明示したときだけ走る（mutation と同じ扱い）
+            probe)    android=test:ci:probe:android;  ios=test:ci:probe:ios ;;
             *)        android=test:ci:android;       ios=test:ci:ios ;;
           esac
           echo "android_script=$android" >> "$GITHUB_OUTPUT"

--- a/e2e-mobile/package.json
+++ b/e2e-mobile/package.json
@@ -21,7 +21,9 @@
 		"test:ci:smoke:ios": "detox test --configuration ios.sim.release --retries 1 --take-screenshots all --artifacts-location artifacts -- --testPathPattern 'tests/smoke/'",
 		"typecheck": "tsc --noEmit",
 		"test:ci:mutation:android": "RUN_MUTATION=1 detox test --configuration android.emu.release --headless --take-screenshots all --artifacts-location artifacts -- --testPathPattern 'tests/mutation/'",
-		"test:ci:mutation:ios": "RUN_MUTATION=1 detox test --configuration ios.sim.release --take-screenshots all --artifacts-location artifacts -- --testPathPattern 'tests/mutation/'"
+		"test:ci:mutation:ios": "RUN_MUTATION=1 detox test --configuration ios.sim.release --take-screenshots all --artifacts-location artifacts -- --testPathPattern 'tests/mutation/'",
+		"test:ci:probe:android": "RUN_PROBE=1 detox test --configuration android.emu.release --headless --take-screenshots all --artifacts-location artifacts -- --testPathPattern 'tests/probe/'",
+		"test:ci:probe:ios": "RUN_PROBE=1 detox test --configuration ios.sim.release --take-screenshots all --artifacts-location artifacts -- --testPathPattern 'tests/probe/'"
 	},
 	"devDependencies": {
 		"@supabase/supabase-js": "^2.49.4",


### PR DESCRIPTION
対応 Issue: #1087（親 #1082）

## これは何か

`e2e-mobile` に新設した **`@probe` 層（`tests/probe/`）を CI から明示実行できるようにする**だけの、CI 設定の追加です。アプリのコードには一切触れていません。

`@probe` は「**修正が入るまで落ちるのが正しい**」spec の層です。不具合の存在を数値で示すことが目的なので、夜間 CI の既定スコープ（tier1-2）へ混ぜると常時赤くなり、本物の回帰が埋もれます。そのため `@mutation` と同じく、**scope を明示したときだけ**走らせます。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `.github/workflows/e2e-mobile-test.yml` | `scope` の選択肢に `probe` を追加し、`test:ci:probe:{android,ios}` へ解決する分岐を足した |
| `e2e-mobile/package.json` | `test:ci:probe:android` / `test:ci:probe:ios` を追加 |

`probe` は `RUN_PROBE=1` + `--testPathPattern 'tests/probe/'` で、`@mutation` と同じ二重ガード方式に揃えています（`jest.config.js` 側の `testPathIgnorePatterns` と `fixtures/e2e.ts` の `describeProbe`）。

**`--retries` は付けていません。** probe は失敗が期待値なので、リトライしても赤を 2 回引いて実行時間が倍になるだけです（`test:ci:mutation:*` に合わせた形でもあります）。

## 非回帰

- `scope` の既定値は `tier1-2` のまま。`schedule` 実行も従来どおり `tier1-2` にフォールバックする
- 既存の `tier1` / `tier1-2` / `mutation` の解決結果は 1 文字も変えていない
- `tests/probe/` は `RUN_PROBE=1` が無い限りテスト探索の対象外なので、既存スコープの実行内容は変わらない

## 検証

- `e2e-mobile/package.json` の JSON パース: ✅
- `.github/workflows/e2e-mobile-test.yml` の YAML パース: ✅（`scope.options` が `['tier1-2', 'tier1', 'mutation', 'probe']` になることを確認）

## なぜこの PR が要るか

`@probe` の spec 自体は `claude/1087-preload-probe` にありますが、**worker run は `.github/workflows/` を変更できない**ため、CI から起動する経路だけが欠けていました。この PR でそこを埋めます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019GW8FK6QMDcCXnHB36NvRL)_