### PR TITLE
perf: 認証の完了を待たずに UI を描画する（isAppReady から !!user を外す / #1092 PR4b）

### DIFF
--- a/app-expo/__tests__/tabsNotificationsHref.test.tsx
+++ b/app-expo/__tests__/tabsNotificationsHref.test.tsx
@@ -1,0 +1,90 @@
+import React, { act } from "react";
+import TestRenderer from "react-test-renderer";
+
+/**
+ * #1092 PR4b の振る舞いテスト: **通知タブがログイン済みユーザーから消えない**。
+ *
+ * タブの表示判定は `user?.is_anonymous !== false ? null : undefined` だった。
+ * `@supabase/auth-js` の型では `User["is_anonymous"]` は **optional** なので、
+ * この式は「値が欠けている」を「匿名（ゲスト）」に倒す。ゲートを外して
+ * 認証未確定の状態から画面が動き出すようになった今、`user` は居るのに `is_anonymous` が
+ * 付いていないセッションで **ログイン済みなのに通知タブが出ない** が実際に起こりうる。
+ *
+ * ここでは 4 状態すべてを固定する。`!== false` に戻すと undefined のケースが赤くなる。
+ *
+ * `app/` 配下に置いたテストは expo-router がルートとして拾ってしまうため、ここに置いている。
+ */
+
+let mockUser: { is_anonymous?: boolean } | null = null;
+jest.mock("@/contexts/AuthProvider", () => ({
+	useAuth: () => ({ user: mockUser }),
+}));
+
+jest.mock("@/lib/i18n", () => ({
+	__esModule: true,
+	default: { t: (key: string) => key },
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+	useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// アイコンは表示判定に関係しないので、素の host 要素へ差し替える（ESM の変換を避ける狙いもある）
+jest.mock("lucide-react-native", () => {
+	const icon = () => require("react").createElement("Icon");
+	return { MapPinned: icon, Bell: icon, User: icon, Search: icon, Pencil: icon };
+});
+
+// `Tabs.Screen` に渡された options をそのまま観測できるようにする
+jest.mock("expo-router", () => {
+	const react = require("react");
+	const Tabs = ({ children }: { children: React.ReactNode }) => react.createElement("Tabs", null, children);
+	Tabs.Screen = ({ name, options }: { name: string; options?: Record<string, unknown> }) =>
+		react.createElement("TabsScreen", { name, options: options ?? {} });
+	return { Tabs };
+});
+
+import TabLayout from "@/app/[locale]/(tabs)/_layout";
+
+/**
+ * 通知タブの `href` を取り出す。
+ * expo-router では `href: null` が「タブバーに出さない」、`undefined` が「既定どおり出す」。
+ */
+const getNotificationsHref = (user: { is_anonymous?: boolean } | null) => {
+	mockUser = user;
+	let renderer: TestRenderer.ReactTestRenderer;
+	act(() => {
+		renderer = TestRenderer.create(React.createElement(TabLayout));
+	});
+	const screen = renderer!.root
+		.findAll((node) => String(node.type) === "TabsScreen")
+		.find((node) => node.props.name === "notifications");
+	if (!screen) throw new Error("notifications タブが見つからない（テストの前提が壊れている）");
+	return screen.props.options.href;
+};
+
+describe("#1092 通知タブの表示判定", () => {
+	beforeEach(() => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		mockUser = null;
+	});
+
+	it("is_anonymous === undefined のログイン済みユーザーには通知タブを出す", () => {
+		// 型上ありうる欠落。ここを「ゲスト」に倒すと、ログイン済みの人から通知機能が丸ごと消える
+		expect(getNotificationsHref({})).toBeUndefined();
+	});
+
+	it("is_anonymous === false（ログイン済み）には通知タブを出す", () => {
+		expect(getNotificationsHref({ is_anonymous: false })).toBeUndefined();
+	});
+
+	it("is_anonymous === true（ゲスト）には通知タブを出さない", () => {
+		expect(getNotificationsHref({ is_anonymous: true })).toBeNull();
+	});
+
+	it("user === null（認証未確定）では通知タブを出さない", () => {
+		// 「出てから消える」とタブ本数が 5→4 に変わりタブバー全体が再レイアウトするため、
+		// 未確定はゲスト側へ倒す（出ない→出る の方が害が小さい）
+		expect(getNotificationsHref(null)).toBeNull();
+	});
+});

--- a/app-expo/app/[locale]/(tabs)/_layout.tsx
+++ b/app-expo/app/[locale]/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@ import { Tabs } from "expo-router";
 import { MapPinned, Bell, User, Search, Pencil } from "lucide-react-native";
 import i18n from "@/lib/i18n";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { View } from "react-native";
 
@@ -94,8 +95,11 @@ export default function TabLayout() {
 					// **出てから消える**（タブ本数が 5→4 に変わりタブバー全体が再レイアウトする）。
 					// 出てから消えるより、出ない→出るの方が害が小さい。web の SSG は
 					// user === null の状態を出力するので、その観点でもこちらが安全。
-					// 判定は features/profile の isGuest と同じ `!== false` に揃えている。
-					href: user?.is_anonymous !== false ? null : undefined,
+					//
+					// #1092 PR4b 【修正】判定を `user?.is_anonymous !== false` から `isGuestUser()` へ寄せた。
+					// 旧式は `is_anonymous` が undefined（型の上では optional）のときもゲストへ倒れるため、
+					// **ログイン済みなのに通知タブが出ない**が起こりうる。判定の中身と理由は lib/authGuest.ts。
+					href: isGuestUser(user) ? null : undefined,
 				}}
 			/>
 			<Tabs.Screen

--- a/app-expo/app/[locale]/(tabs)/notifications/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/notifications/index.tsx
@@ -10,6 +10,7 @@ import { useMarkNotificationsRead } from "@/features/notifications/hooks/useMark
 import { useRouter } from "expo-router";
 import type { NotificationItem, NotificationResponse } from "@shared/api/v1/res";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import { useFocusEffect } from "expo-router";
 import { useNotificationUnreadCount } from "@/features/notifications/hooks/useNotificationUnreadCount";
 import { useDishMediaEntriesStore } from "@/stores/useDishMediaEntriesStore";
@@ -42,7 +43,10 @@ export default function NotificationsScreen() {
 	const inFlightRef = React.useRef(false);
 	useFocusEffect(
 		React.useCallback(() => {
-			if (!user || user.is_anonymous) return;
+			// #1092 PR4b `!user || user.is_anonymous` から共通判定（lib/authGuest.ts）へ寄せた。
+			// 判定内容は同じだが、通知タブの表示可否（app/[locale]/(tabs)/_layout.tsx）と
+			// 同じ式であることをコードで保証しておく
+			if (isGuestUser(user)) return;
 			if (inFlightRef.current) return;
 			inFlightRef.current = true;
 			(async () => {
@@ -196,7 +200,8 @@ export default function NotificationsScreen() {
 	);
 
 	// #通知機能 【設計】匿名ユーザーまたは未認証ユーザーは空画面を表示
-	if (!user || user.is_anonymous) {
+	// #1092 PR4b 判定は共通化（lib/authGuest.ts）。タブの表示可否と同じ式にしておく
+	if (isGuestUser(user)) {
 		return (
 			<SafeAreaView style={styles.container}>
 				<View style={styles.header}>

--- a/app-expo/app/[locale]/(tabs)/profile/blocked-topics.tsx
+++ b/app-expo/app/[locale]/(tabs)/profile/blocked-topics.tsx
@@ -17,6 +17,7 @@ import { useLogger } from "@/hooks/useLogger";
 
 import { QueryMeBlockedDishCategoriesResponse, UnblockDishCategoryResponse } from "@shared/api/v1/res";
 import type { SupabaseDishCategories } from "@shared/converters/convert_dish_categories";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 type BlockedCategory = SupabaseDishCategories;
 
@@ -130,7 +131,7 @@ export default function BlockedTopicsScreen() {
 					event_name: "fetch_blocked_categories_failed",
 					error_level: "error",
 					payload: {
-						error: error instanceof Error ? error.message : String(error),
+						error: toErrorLogMessage(error),
 					},
 				});
 				showSnackbar(i18n.t("Common.error"));
@@ -194,7 +195,7 @@ export default function BlockedTopicsScreen() {
 							event_name: "unblock_category_failed",
 							error_level: "error",
 							payload: {
-								error: error instanceof Error ? error.message : String(error),
+								error: toErrorLogMessage(error),
 								category_id: category.id,
 							},
 						});

--- a/app-expo/app/[locale]/(tabs)/profile/settings.tsx
+++ b/app-expo/app/[locale]/(tabs)/profile/settings.tsx
@@ -15,6 +15,7 @@ import { ChevronRight } from "lucide-react-native";
 import { Card } from "@/components/Card";
 import i18n from "@/lib/i18n";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import { useBlurModal } from "@/features/blurModal/hooks/useBlurModal";
 import { LegalDocument } from "@/features/settings/components/LegalDocument";
 import { useHaptics } from "@/hooks/useHaptics";
@@ -296,8 +297,8 @@ export default function SettingsScreen() {
 	// #1092 【設計】auth 未確定(user === null)を「ログイン済み」と誤解させない。
 	// `!user?.is_anonymous` は未確定でも true になるため、下のログアウト行が
 	// 一瞬出てから消える（押せてしまう瞬間もある）。確定するまではゲスト側に寄せる。
-	// 判定は features/profile の isGuest と同じ `!== false` に揃えている。
-	const isGuest = !isAuthResolved || user?.is_anonymous !== false;
+	// 判定は features/profile の isGuest と同じ共通関数（lib/authGuest.ts）へ揃えている。
+	const isGuest = !isAuthResolved || isGuestUser(user);
 
 	return (
 		<LinearGradient colors={["#FFFFFF", "#F8F9FA"]} style={styles.container}>

--- a/app-expo/app/[locale]/(tabs)/review/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/review/index.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet } from "react-native";
 import { Image } from "expo-image";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import { useBlurModal } from "@/features/blurModal/hooks/useBlurModal";
 import { LoginbackModal } from "@/features/profile/components/LoginbackModal";
 import { useHaptics } from "@/hooks/useHaptics";
@@ -97,7 +98,10 @@ export default function ReviewScreen() {
 			{/* CTA セクション */}
 			<View style={styles.ctaSection}>
 				<View style={styles.actionButtonContainer}>
-					{user?.is_anonymous !== false ? (
+					{/* #1092 PR4b 【修正】`user?.is_anonymous !== false` から共通判定（lib/authGuest.ts）へ寄せた。
+					    旧式は is_anonymous が undefined のときもゲストへ倒れるため、通知タブ・レビュータブは
+					    見えるのに、この画面だけログイン導線が出る、という食い違いになっていた */}
+					{isGuestUser(user) ? (
 						// #644 【設計】ゲスト状態：ログイン導線を表示
 						<>
 							{/* #1031 【設計】Detox から表示確認できるよう testID を追加 */}

--- a/app-expo/app/[locale]/(tabs)/search/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/index.tsx
@@ -20,6 +20,7 @@ import type { AutocompleteLocation, LocationDetailsResponse } from "@shared/api/
 import { useLocationSearch } from "@/hooks/useLocationSearch";
 import { LocationPermissionError, type LocationPermissionErrorKind } from "@/hooks/locationPermissionError";
 import { useSnackbar } from "@/contexts/SnackbarProvider";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 import {
 	LocationAutocomplete,
 	type LocationAutocompleteHandle,
@@ -169,7 +170,7 @@ export default function SearchScreen() {
 			logFrontendEvent({
 				event_name: "location_selection_failed",
 				error_level: "error",
-				payload: { placeId: prediction.place_id, error: String(error) },
+				payload: { placeId: prediction.place_id, error: toErrorLogMessage(error) },
 			});
 			showSnackbar(i18n.t("Search.errors.fetchLocation"));
 		}
@@ -226,7 +227,7 @@ export default function SearchScreen() {
 			logFrontendEvent({
 				event_name: "current_location_failed",
 				error_level: "error",
-				payload: { error: String(error), kind },
+				payload: { error: toErrorLogMessage(error), kind },
 			});
 			showSnackbar(getCurrentLocationErrorMessage(kind));
 

--- a/app-expo/app/[locale]/(tabs)/search/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/index.tsx
@@ -20,7 +20,7 @@ import type { AutocompleteLocation, LocationDetailsResponse } from "@shared/api/
 import { useLocationSearch } from "@/hooks/useLocationSearch";
 import { LocationPermissionError, type LocationPermissionErrorKind } from "@/hooks/locationPermissionError";
 import { useSnackbar } from "@/contexts/SnackbarProvider";
-import { toErrorLogMessage } from "@/lib/errorMessage";
+import { toErrorLogString } from "@/lib/errorMessage";
 import {
 	LocationAutocomplete,
 	type LocationAutocompleteHandle,
@@ -170,7 +170,7 @@ export default function SearchScreen() {
 			logFrontendEvent({
 				event_name: "location_selection_failed",
 				error_level: "error",
-				payload: { placeId: prediction.place_id, error: toErrorLogMessage(error) },
+				payload: { placeId: prediction.place_id, error: toErrorLogString(error) },
 			});
 			showSnackbar(i18n.t("Search.errors.fetchLocation"));
 		}
@@ -227,7 +227,7 @@ export default function SearchScreen() {
 			logFrontendEvent({
 				event_name: "current_location_failed",
 				error_level: "error",
-				payload: { error: toErrorLogMessage(error), kind },
+				payload: { error: toErrorLogString(error), kind },
 			});
 			showSnackbar(getCurrentLocationErrorMessage(kind));
 

--- a/app-expo/app/[locale]/contribution-tasks/dish-category-manual-image-supply.tsx
+++ b/app-expo/app/[locale]/contribution-tasks/dish-category-manual-image-supply.tsx
@@ -32,6 +32,7 @@ import { Env } from "@/constants/Env";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useSnackbar } from "@/contexts/SnackbarProvider";
 import { Dimensions } from "react-native";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 /* -------------------------------------------------------------------------- */
 /*                                    型定義                                   */
@@ -351,7 +352,7 @@ export default function DishCategoryManualImageSupplyScreen() {
 				logFrontendEvent({
 					event_name: "dish_manual_image_supply_upload_failed",
 					error_level: "error",
-					payload: { targetId: item.category_id, error: err instanceof Error ? err.message : String(err) },
+					payload: { targetId: item.category_id, error: toErrorLogMessage(err) },
 				});
 			}
 		},

--- a/app-expo/app/[locale]/contribution-tasks/dish-category-manual-text-supply.tsx
+++ b/app-expo/app/[locale]/contribution-tasks/dish-category-manual-text-supply.tsx
@@ -40,6 +40,7 @@ import { useSnackbar } from "@/contexts/SnackbarProvider";
 import { useHaptics } from "@/hooks/useHaptics";
 import { SkeletonShimmer } from "@/components/SkeletonShimmer";
 import { useImageLoadWithRetry } from "@/hooks/useImageLoadWithRetry";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 /* -------------------------------------------------------------------------- */
 /*                                    型定義                                   */
@@ -175,7 +176,7 @@ export default function DishCategoryManualTextSupplyScreen() {
 			logFrontendEvent({
 				event_name: "dish_manual_text_supply_data_load_error",
 				error_level: "error",
-				payload: { error: err instanceof Error ? err.message : String(err) },
+				payload: { error: toErrorLogMessage(err) },
 			});
 		} finally {
 			setIsLoadingCandidates(false);
@@ -455,7 +456,7 @@ export default function DishCategoryManualTextSupplyScreen() {
 				error_level: "error",
 				payload: {
 					targetId: editingItem.item_qid,
-					error: err instanceof Error ? err.message : String(err),
+					error: toErrorLogMessage(err),
 				},
 			});
 		} finally {

--- a/app-expo/components/HealthCheckInitializer.tsx
+++ b/app-expo/components/HealthCheckInitializer.tsx
@@ -1,6 +1,7 @@
 import { useAPICall } from "@/hooks/useAPICall";
 import { useAuth } from "@/contexts/AuthProvider";
 import { useLogger } from "@/hooks/useLogger";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 interface HealthCheckState {
@@ -71,7 +72,7 @@ export const HealthCheckInitializer: React.FC<{ children: React.ReactNode }> = (
 				event_name: "health_check_error",
 				error_level: "error",
 				payload: {
-					error: error?.message ? String(error.message) : String(error),
+					error: toErrorLogMessage(error),
 					code: error?.code,
 					status: error?.status,
 					requestId: error?.requestId,

--- a/app-expo/components/PushTokenRegistration.tsx
+++ b/app-expo/components/PushTokenRegistration.tsx
@@ -5,6 +5,7 @@ import { Platform } from "react-native";
 import * as SecureStore from "expo-secure-store";
 import { useAPICall } from "../hooks/useAPICall";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import { useLogger } from "../hooks/useLogger";
 import type { CreateDeviceTokenResponse } from "@shared/api/v1/res";
 import { Env } from "@/constants/Env";
@@ -35,7 +36,10 @@ export function PushTokenRegistration() {
 
 	useEffect(() => {
 		// #通知機能 【設計】匿名ユーザーは Push Token を登録しない
-		if (!user || user.is_anonymous) return;
+		// #1092 PR4b 判定は共通化（lib/authGuest.ts）。通知タブの表示可否と同じ式にしておく。
+		// `!user` を残しているのは判定のためではなく、この後の user.id 参照を TS に絞り込ませるため
+		// （isGuestUser は boolean を返すだけなので null を除いてくれない）
+		if (!user || isGuestUser(user)) return;
 
 		const registerPushToken = async () => {
 			try {

--- a/app-expo/components/SplashHandler.test.tsx
+++ b/app-expo/components/SplashHandler.test.tsx
@@ -9,11 +9,14 @@ import { SplashHandler } from "./SplashHandler";
  * 匿名サインインは起動のたびにネットワーク往復を伴うため、回線が細い端末では
  * 「アプリが 1 ピクセルも描画されない」時間がそのまま初回起動の体感速度になっていた。
  *
- * ここで固定するのは 3 つ。どれも「ゲートを戻すと赤くなる」形にしてある:
+ * ここで固定するのは 4 つ。どれも「ゲートを戻すと赤くなる」形にしてある:
  * 1. `user === null`（認証未確定）でも children がマウントされる
  * 2. 認証が未確定のままでもスプラッシュが解除される
  * 3. 匿名サインインが失敗しても必ずスプラッシュが解除される（#1089 の非退行。
  *    hideAsync() が呼ばれないと native はスプラッシュが張り付いたまま操作不能になる）
+ * 4. hideAsync() 自体が失敗しても再試行される（同じくスプラッシュ張り付きの防止）。
+ *    ゲートを外して effect の依存から auth が消えた結果、「失敗したらフラグを戻す」だけでは
+ *    誰も呼び直さなくなったため、再試行の経路そのものをテストで固定する
  */
 
 const mockHideAsync = jest.fn(async () => true);
@@ -97,6 +100,11 @@ describe("#1092 SplashHandler は認証の完了を待たずに描画する", ()
 		});
 	};
 
+	/** 保留中の Promise（hideAsync の失敗 → 再試行）を消化するためだけの空 act */
+	const flushPendingWork = async () => {
+		await act(async () => {});
+	};
+
 	const isChildrenMounted = () => renderer.root.findAllByType(AppChildren).length > 0;
 	const isAuthErrorFallbackShown = () =>
 		renderer.root.findAll((node) => String(node.type) === "AuthErrorFallback").length > 0;
@@ -148,6 +156,71 @@ describe("#1092 SplashHandler は認証の完了を待たずに描画する", ()
 
 		expect(mockHideAsync).toHaveBeenCalledTimes(1);
 		expect(isChildrenMounted()).toBe(true);
+	});
+
+	it("hideAsync が失敗したら呼び直す（フラグを戻すだけで終わらせない）", async () => {
+		// 1 回目だけ失敗させる。フラグを戻すコードはあっても「戻した後に呼び直す者」が居ないと、
+		// canRenderFirstFrame は一度 true になったら変わらないので二度と再試行されず、
+		// native はスプラッシュが張り付いたまま操作不能になる（#1089 と同種の事故）
+		mockHideAsync.mockRejectedValueOnce(new Error("Splash screen is not registered"));
+
+		await mount();
+		await finishRemoteConfig();
+		await flushPendingWork();
+
+		expect(mockHideAsync).toHaveBeenCalledTimes(2);
+	});
+
+	it("再試行が成功したらそれ以上は呼ばない", async () => {
+		mockHideAsync.mockRejectedValueOnce(new Error("Splash screen is not registered"));
+
+		await mount();
+		await finishRemoteConfig();
+		await flushPendingWork();
+		expect(mockHideAsync).toHaveBeenCalledTimes(2);
+
+		// 認証の解決など、その後の再レンダリングで 3 回目が走らないこと
+		await updateAuth({ ...AUTH_PENDING, loading: false, user: { id: "anon-1" } });
+		await flushPendingWork();
+
+		expect(mockHideAsync).toHaveBeenCalledTimes(2);
+	});
+
+	it("失敗し続けても有限回で打ち切る（レンダリングループにしない）", async () => {
+		mockHideAsync.mockRejectedValue(new Error("Splash screen is not registered"));
+
+		await mount();
+		await finishRemoteConfig();
+		await flushPendingWork();
+		await flushPendingWork();
+
+		// MAX_SPLASH_HIDE_ATTEMPTS と一致させること。ここが青天井だと
+		// 「失敗 → setState → 再レンダリング → 失敗」で CPU を焼き続ける
+		expect(mockHideAsync).toHaveBeenCalledTimes(3);
+	});
+
+	it("hideAsync の解決を待っている間に再レンダリングされても二重に呼ばない", async () => {
+		// フラグを await の前に立てているか（立てる位置を戻すと 2 回呼ばれて赤くなる）
+		let finishHide: () => void = () => {};
+		mockHideAsync.mockImplementationOnce(
+			() =>
+				new Promise<boolean>((resolve) => {
+					finishHide = () => resolve(true);
+				}),
+		);
+
+		await mount();
+		await finishRemoteConfig();
+		expect(mockHideAsync).toHaveBeenCalledTimes(1);
+
+		// hideAsync が未解決のまま認証が進む
+		await updateAuth({ ...AUTH_PENDING, loading: false, user: { id: "anon-1" } });
+		expect(mockHideAsync).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			finishHide();
+		});
+		expect(mockHideAsync).toHaveBeenCalledTimes(1);
 	});
 
 	it("認証が失敗している間は children ではなくエラー UI を出す", async () => {

--- a/app-expo/components/SplashHandler.test.tsx
+++ b/app-expo/components/SplashHandler.test.tsx
@@ -1,0 +1,161 @@
+import React, { act } from "react";
+import TestRenderer from "react-test-renderer";
+import { SplashHandler } from "./SplashHandler";
+
+/**
+ * #1092 PR4b の振る舞いテスト: **認証の完了を待たずに UI を出す**。
+ *
+ * `SplashHandler` は `isRemoteConfigReady && !isAuthLoading && !!user` が揃うまで `return null` していた。
+ * 匿名サインインは起動のたびにネットワーク往復を伴うため、回線が細い端末では
+ * 「アプリが 1 ピクセルも描画されない」時間がそのまま初回起動の体感速度になっていた。
+ *
+ * ここで固定するのは 3 つ。どれも「ゲートを戻すと赤くなる」形にしてある:
+ * 1. `user === null`（認証未確定）でも children がマウントされる
+ * 2. 認証が未確定のままでもスプラッシュが解除される
+ * 3. 匿名サインインが失敗しても必ずスプラッシュが解除される（#1089 の非退行。
+ *    hideAsync() が呼ばれないと native はスプラッシュが張り付いたまま操作不能になる）
+ */
+
+const mockHideAsync = jest.fn(async () => true);
+jest.mock("expo-splash-screen", () => ({
+	hideAsync: () => mockHideAsync(),
+}));
+
+/** Remote Config の初期化。テストごとに解決タイミングを手で制御する */
+let mockRemoteConfigPromise: Promise<void>;
+let resolveRemoteConfig: () => void;
+jest.mock("@/lib/remoteConfig", () => ({
+	initRemoteConfig: () => mockRemoteConfigPromise,
+}));
+
+// Env は expo-constants 経由で app.config を読むため、テストでは値だけ差し替える
+jest.mock("@/constants/Env", () => ({ Env: { NODE_ENV: "test" } }));
+
+// エラー UI 本体（i18n / PrimaryButton）はこのテストの対象ではないので、識別できる箱に差し替える
+jest.mock("@/components/AuthErrorFallback", () => ({
+	AuthErrorFallback: () => require("react").createElement("AuthErrorFallback"),
+}));
+
+type MockAuth = {
+	loading: boolean;
+	user: { id: string } | null;
+	authError: { isRateLimited: boolean; message: string } | null;
+	retryAuth: () => void;
+	isRetryingAuth: boolean;
+};
+
+let mockAuth: MockAuth;
+jest.mock("@/contexts/AuthProvider", () => ({
+	useAuth: () => mockAuth,
+}));
+
+/** children がマウントされたかを識別するためだけのマーカー */
+const AppChildren = () => React.createElement("AppChildren");
+
+/** 匿名サインインがまだ終わっていない、起動直後の状態 */
+const AUTH_PENDING: MockAuth = {
+	loading: true,
+	user: null,
+	authError: null,
+	retryAuth: () => {},
+	isRetryingAuth: false,
+};
+
+/** 匿名サインインが有限回のリトライを使い切って失敗した状態（#1089） */
+const AUTH_FAILED: MockAuth = {
+	loading: false,
+	user: null,
+	authError: { isRateLimited: false, message: "signInAnonymously returned no session" },
+	retryAuth: () => {},
+	isRetryingAuth: false,
+};
+
+describe("#1092 SplashHandler は認証の完了を待たずに描画する", () => {
+	let renderer: TestRenderer.ReactTestRenderer;
+
+	const element = () => React.createElement(SplashHandler, null, React.createElement(AppChildren));
+
+	const mount = async () => {
+		await act(async () => {
+			renderer = TestRenderer.create(element());
+		});
+	};
+
+	/** 認証状態を変えて再レンダリングする */
+	const updateAuth = async (next: MockAuth) => {
+		mockAuth = next;
+		await act(async () => {
+			renderer.update(element());
+		});
+	};
+
+	/** Remote Config の初期化を完了させる（成功・失敗いずれでも finally で ready になる） */
+	const finishRemoteConfig = async () => {
+		await act(async () => {
+			resolveRemoteConfig();
+			await mockRemoteConfigPromise;
+		});
+	};
+
+	const isChildrenMounted = () => renderer.root.findAllByType(AppChildren).length > 0;
+	const isAuthErrorFallbackShown = () =>
+		renderer.root.findAll((node) => String(node.type) === "AuthErrorFallback").length > 0;
+
+	beforeEach(() => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		mockRemoteConfigPromise = new Promise<void>((resolve) => {
+			resolveRemoteConfig = () => resolve();
+		});
+		mockAuth = AUTH_PENDING;
+	});
+
+	it("user === null（認証未確定）でも children をマウントする", async () => {
+		await mount();
+		await finishRemoteConfig();
+
+		// ここが false になるなら `!!user` / `!isAuthLoading` のゲートが復活している。
+		// その状態では匿名サインインのネットワーク往復が終わるまでアプリが何も描画しない
+		expect(mockAuth.user).toBeNull();
+		expect(mockAuth.loading).toBe(true);
+		expect(isChildrenMounted()).toBe(true);
+	});
+
+	it("認証が未確定のままでもスプラッシュを解除する", async () => {
+		await mount();
+		// Remote Config が終わるまでは描画できないので、まだ解除しない
+		expect(mockHideAsync).not.toHaveBeenCalled();
+
+		await finishRemoteConfig();
+
+		expect(mockHideAsync).toHaveBeenCalledTimes(1);
+	});
+
+	it("匿名サインインが失敗してもスプラッシュを解除する（#1089 の非退行）", async () => {
+		await mount();
+		// Remote Config は敢えて完了させない。認証の失敗だけでも解除されることを見る
+		await updateAuth(AUTH_FAILED);
+
+		expect(mockHideAsync).toHaveBeenCalledTimes(1);
+		expect(isAuthErrorFallbackShown()).toBe(true);
+	});
+
+	it("認証が後から成功しても hideAsync を呼び直さない", async () => {
+		await mount();
+		await finishRemoteConfig();
+		expect(mockHideAsync).toHaveBeenCalledTimes(1);
+
+		await updateAuth({ ...AUTH_PENDING, loading: false, user: { id: "anon-1" } });
+
+		expect(mockHideAsync).toHaveBeenCalledTimes(1);
+		expect(isChildrenMounted()).toBe(true);
+	});
+
+	it("認証が失敗している間は children ではなくエラー UI を出す", async () => {
+		await mount();
+		await finishRemoteConfig();
+		await updateAuth(AUTH_FAILED);
+
+		expect(isAuthErrorFallbackShown()).toBe(true);
+		expect(isChildrenMounted()).toBe(false);
+	});
+});

--- a/app-expo/components/SplashHandler.tsx
+++ b/app-expo/components/SplashHandler.tsx
@@ -1,10 +1,19 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import * as SplashScreen from "expo-splash-screen";
 import { useAuth } from "@/contexts/AuthProvider";
 import { initRemoteConfig } from "@/lib/remoteConfig";
 import { Env } from "@/constants/Env";
 import { retry } from "@/lib/retry";
 import { AuthErrorFallback } from "@/components/AuthErrorFallback";
+
+/**
+ * 🔁 `SplashScreen.hideAsync()` を試す最大回数。
+ *
+ * 失敗したまま諦めると native はスプラッシュが張り付いて操作不能になる（#1089）ので必ず再試行するが、
+ * 無条件に繰り返すと「常に reject する端末」でレンダリングループになるため上限を置く。
+ * hideAsync() の失敗はスプラッシュがまだ登録されていない等の一過性が主なので、数回で十分。
+ */
+const MAX_SPLASH_HIDE_ATTEMPTS = 3;
 
 /**
  * 🧯 アプリ起動時の Splash 画面を制御するコンポーネント。
@@ -21,6 +30,11 @@ export const SplashHandler = ({ children }: { children: React.ReactNode }) => {
 
 	const [isRemoteConfigReady, setIsRemoteConfigReady] = useState(false);
 	const hasSplashBeenHiddenRef = useRef(false);
+	/**
+	 * 🔁 hideAsync() が失敗した回数。**再試行のトリガを兼ねる**ので ref ではなく state。
+	 * ここを ref にすると値は増えても再レンダリングが起きず、下の effect が再発火しない = 再試行されない。
+	 */
+	const [splashHideAttempt, setSplashHideAttempt] = useState(0);
 
 	/**
 	 * 🔧 Remote Config の初期化処理
@@ -67,7 +81,7 @@ export const SplashHandler = ({ children }: { children: React.ReactNode }) => {
 	 *    Remote Config の初期化は失敗しても finally で必ず ready になるので、
 	 *    ここが永久に false のまま止まることはない。
 	 */
-	const isAppReady = useMemo(() => isRemoteConfigReady, [isRemoteConfigReady]);
+	const isAppReady = isRemoteConfigReady;
 
 	/**
 	 * #1089 認証が確立できないまま確定した状態。children ではなくエラー UI を出す。
@@ -85,7 +99,7 @@ export const SplashHandler = ({ children }: { children: React.ReactNode }) => {
 
 	/**
 	 * 🎬 Splash 非表示ロジック
-	 * - 一度だけ実行されるようフラグで制御
+	 * - **成功したら一度だけ**で済むようフラグで制御し、失敗したら上限まで再試行する
 	 *
 	 * #1092 【修正】条件を「認証が確定したか」から「最初のフレームを描画できるか」へ変えた。
 	 * ゲートを外して UI を先に出すようにした以上、スプラッシュも同じ時点で解除しないと、
@@ -96,22 +110,38 @@ export const SplashHandler = ({ children }: { children: React.ReactNode }) => {
 	 * 永久に呼ばれず、native はスプラッシュが張り付いたままになっていた。
 	 * 今の条件は `isRemoteConfigReady`（initializeRemoteConfig の finally で必ず true になる）を
 	 * 含むので、認証がどうなろうと解除される。**認証の状態を必須条件に戻さないこと。**
+	 *
+	 * #1092 【非退行】hideAsync() が reject した場合も必ず呼び直されること。
+	 * 「呼んだ」フラグを戻すだけでは不十分で、**戻した後に誰かが呼び直す経路**が要る。
+	 * この effect の依存は `canRenderFirstFrame`（一度 true になると変わらない）由来なので、
+	 * 失敗した回数を state に載せて自分で再発火させている。ここを ref にしたり
+	 * `setSplashHideAttempt` を消したりすると、フラグを戻す処理が黙って死にコードになり、
+	 * hideAsync() の失敗＝スプラッシュ張り付き（操作不能）が復活する。
 	 */
 	const hideSplashScreenIfReady = useCallback(async () => {
-		if (canRenderFirstFrame && !hasSplashBeenHiddenRef.current) {
-			// hideAsync() の解決を待たずにフラグを立てる。await の間に再レンダリングが挟まると
-			// 二重に hideAsync() を呼んでしまうため（失敗時は下の catch で戻す）
-			hasSplashBeenHiddenRef.current = true;
-			try {
-				await SplashScreen.hideAsync();
-			} catch (err: any) {
-				hasSplashBeenHiddenRef.current = false;
-				if (Env.NODE_ENV === "development") {
-					console.warn("[SplashHandler] Failed to hide splash screen:", err?.message ?? err);
-				}
+		if (!canRenderFirstFrame) return;
+		if (hasSplashBeenHiddenRef.current) return;
+		// 🛑 再試行の打ち切り。ここが無いと hideAsync() が常に reject する端末で
+		//    「失敗 → setState → 再レンダリング → 失敗」の無限ループになる
+		if (splashHideAttempt >= MAX_SPLASH_HIDE_ATTEMPTS) return;
+
+		// hideAsync() の解決を待たずにフラグを立てる。await の間に再レンダリングが挟まると
+		// 二重に hideAsync() を呼んでしまうため（失敗時は下の catch で戻す）
+		hasSplashBeenHiddenRef.current = true;
+		try {
+			await SplashScreen.hideAsync();
+		} catch (err: any) {
+			hasSplashBeenHiddenRef.current = false;
+			if (Env.NODE_ENV === "development") {
+				console.warn("[SplashHandler] Failed to hide splash screen:", err?.message ?? err);
 			}
+			// 🔁 フラグを戻すだけでは誰も呼び直さない（下の effect の依存は canRenderFirstFrame 由来で、
+			//    これは一度 true になったら二度と変わらない）ので、失敗を state に載せて能動的に再発火させる。
+			//    ⚠️ 「認証の遷移でたまたま effect が再発火する」に頼ってはいけない。#1092 でその依存を
+			//    外した以上、再試行の経路はここだけになる（#1089 のスプラッシュ張り付きの再来を防ぐ）。
+			setSplashHideAttempt((attempt) => attempt + 1);
 		}
-	}, [canRenderFirstFrame]);
+	}, [canRenderFirstFrame, splashHideAttempt]);
 
 	// 初期化実行（on mount）
 	useEffect(() => {

--- a/app-expo/components/SplashHandler.tsx
+++ b/app-expo/components/SplashHandler.tsx
@@ -9,8 +9,8 @@ import { AuthErrorFallback } from "@/components/AuthErrorFallback";
 /**
  * 🧯 アプリ起動時の Splash 画面を制御するコンポーネント。
  *
- * - Remote Config の初期化と Supabase 認証状態（匿名ログイン含む）の確定を待つ
- * - すべての準備が完了した時点で Splash を非表示にし、アプリ本体を表示
+ * - Remote Config の初期化を待つ（認証の確定は **待たない**。#1092 PR4b）
+ * - 最初の描画が可能になった時点で Splash を非表示にし、アプリ本体を表示
  * - 初回起動ログやエラー情報も適切に記録する
  *
  * @param children - アプリのメイン画面（準備完了後に表示される）
@@ -50,27 +50,68 @@ export const SplashHandler = ({ children }: { children: React.ReactNode }) => {
 	}, []);
 
 	/**
+	 * 📌 アプリ本体（children）を描画してよいか。
+	 *
+	 * #1092 【修正】ここから `!isAuthLoading && !!user` を外した。
+	 * 匿名サインインは起動のたびにネットワーク往復を伴い、回線が細い端末では秒単位で待つ。
+	 * その間 `return null` していたため、**アプリは 1 ピクセルも描画されていなかった**
+	 * （web は薄グレーの空画面、native はスプラッシュのまま）。
+	 * 認証を必要とするのは API 呼び出しであって描画ではないので、UI は先に出す。
+	 *
+	 * ⚠️ この結果、children は `user === null` の状態でマウントされる。
+	 *    その前提に耐えられるようにする作業は PR4a で先に済ませてある
+	 *    （`useAPICall` の `code: "unauthenticated"`、`HealthCheckInitializer` /
+	 *     `useAutoCurrentLocation` の auth 解決後 1 回だけの再試行、`LoginbackModal` の null ガード）。
+	 *
+	 * ⚠️ `isRemoteConfigReady` はまだ残す（外すのは #1092 PR3 のスコープ）。
+	 *    Remote Config の初期化は失敗しても finally で必ず ready になるので、
+	 *    ここが永久に false のまま止まることはない。
+	 */
+	const isAppReady = useMemo(() => isRemoteConfigReady, [isRemoteConfigReady]);
+
+	/**
+	 * #1089 認証が確立できないまま確定した状態。children ではなくエラー UI を出す。
+	 * Remote Config の完了は待たない（待つとエラーの提示が遅れるだけ）。
+	 */
+	const isAuthUnavailable = !isAuthLoading && !user && !!authError;
+
+	/**
+	 * 📌 「何かを描画できる状態」か。これが Splash を解除してよいタイミングと一致する。
+	 *
+	 * 下の描画分岐（エラー UI / children / null）と 1 対 1 で対応させること。
+	 * ここが描画分岐より **緩い**と真っ白な画面が見え、**厳しい**と描画済みなのにスプラッシュが被る。
+	 */
+	const canRenderFirstFrame = isAppReady || isAuthUnavailable;
+
+	/**
 	 * 🎬 Splash 非表示ロジック
 	 * - 一度だけ実行されるようフラグで制御
 	 *
-	 * #1089 【バグ】条件が `user` だけだったため、匿名サインインが失敗した端末では
-	 * hideAsync() が永久に呼ばれず、native はスプラッシュが張り付いたままになっていた
-	 * （web の空画面と同じ根本原因・別症状）。認証が「確立できなかった」と確定した場合も
-	 * 必ず解除し、下のエラー UI をユーザーへ見せる。
+	 * #1092 【修正】条件を「認証が確定したか」から「最初のフレームを描画できるか」へ変えた。
+	 * ゲートを外して UI を先に出すようにした以上、スプラッシュも同じ時点で解除しないと、
+	 * 描画できているのにスプラッシュに隠されたままになり、この PR の効果が丸ごと消える。
+	 *
+	 * #1089 【非退行】どの経路でも必ず一度は hideAsync() が呼ばれること。
+	 * 以前は条件が `user` だけだったため、匿名サインインが失敗した端末では hideAsync() が
+	 * 永久に呼ばれず、native はスプラッシュが張り付いたままになっていた。
+	 * 今の条件は `isRemoteConfigReady`（initializeRemoteConfig の finally で必ず true になる）を
+	 * 含むので、認証がどうなろうと解除される。**認証の状態を必須条件に戻さないこと。**
 	 */
 	const hideSplashScreenIfReady = useCallback(async () => {
-		const isAuthSettled = !isAuthLoading && (!!user || !!authError);
-		if (isAuthSettled && !hasSplashBeenHiddenRef.current) {
+		if (canRenderFirstFrame && !hasSplashBeenHiddenRef.current) {
+			// hideAsync() の解決を待たずにフラグを立てる。await の間に再レンダリングが挟まると
+			// 二重に hideAsync() を呼んでしまうため（失敗時は下の catch で戻す）
+			hasSplashBeenHiddenRef.current = true;
 			try {
 				await SplashScreen.hideAsync();
-				hasSplashBeenHiddenRef.current = true;
 			} catch (err: any) {
+				hasSplashBeenHiddenRef.current = false;
 				if (Env.NODE_ENV === "development") {
-					console.warn("[SplashHandler] Failed to hide splash screen:", err.message);
+					console.warn("[SplashHandler] Failed to hide splash screen:", err?.message ?? err);
 				}
 			}
 		}
-	}, [isAuthLoading, user, authError]);
+	}, [canRenderFirstFrame]);
 
 	// 初期化実行（on mount）
 	useEffect(() => {
@@ -80,21 +121,14 @@ export const SplashHandler = ({ children }: { children: React.ReactNode }) => {
 	// Splash 非表示条件を監視して実行
 	useEffect(() => {
 		hideSplashScreenIfReady();
-	}, [isAuthLoading, user, authError, hideSplashScreenIfReady]);
-
-	/**
-	 * 📌 アプリ起動に必要な要件がすべて満たされているか
-	 */
-	const isAppReady = useMemo(() => {
-		return isRemoteConfigReady && !isAuthLoading && !!user;
-	}, [isRemoteConfigReady, isAuthLoading, user]);
+	}, [hideSplashScreenIfReady]);
 
 	// #1089 認証が確立できないまま確定した場合は、null を返し続けて空画面のまま放置せず、
 	// 「失敗した」ことと再試行手段をユーザーへ提示する。
-	// ⚠️ isAppReady の `!!user` ゲートそのもの（認証前でも UI を先に出す設計）は #1092 のスコープなので触らない。
-	//    Remote Config は失敗しても必ず ready になるため、ここでは待たずにエラー UI を優先する。
-	if (!isAuthLoading && !user && authError) {
-		return <AuthErrorFallback isRateLimited={authError.isRateLimited} isRetrying={isRetryingAuth} onRetry={retryAuth} />;
+	if (isAuthUnavailable && authError) {
+		return (
+			<AuthErrorFallback isRateLimited={authError.isRateLimited} isRetrying={isRetryingAuth} onRetry={retryAuth} />
+		);
 	}
 
 	if (!isAppReady) return null;

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCompletionModal.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCompletionModal.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import i18n from "@/lib/i18n";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { useEnsureOwnProfileLoaded } from "@/features/profile/hooks/useEnsureOwnProfileLoaded";
@@ -29,12 +30,14 @@ export function DishCategoryGroupVoteCompletionModal({ usedDisplayNames, isSubmi
 	const [isManualName, setIsManualName] = useState(false);
 	const [displayName, setDisplayName] = useState("");
 	const [comment, setComment] = useState("");
-	const loggedInDisplayName =
-		user?.is_anonymous === false
-			? Array.from(profile?.display_name ?? "")
-					.slice(0, 8)
-					.join("")
-			: "";
+	// #1092 PR4b 【修正】`user?.is_anonymous === false` から共通判定（lib/authGuest.ts）へ寄せた。
+	// 旧式は is_anonymous が undefined のときもゲスト扱いになり、ログイン済みなのに表示名が
+	// 初期入力されない（他画面ではログイン済みとして扱われている）という食い違いになる
+	const loggedInDisplayName = !isGuestUser(user)
+		? Array.from(profile?.display_name ?? "")
+				.slice(0, 8)
+				.join("")
+		: "";
 
 	useEffect(() => {
 		const nextUsedDisplayNames = usedDisplayNamesKey ? usedDisplayNamesKey.split("\u0000") : [];

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.tsx
@@ -42,6 +42,7 @@ import { DishCategoryGroupVoteComments } from "./DishCategoryGroupVoteComments";
 import { DishCategoryGroupVoteCandidateDetailModal } from "./DishCategoryGroupVoteCandidateDetailModal";
 import { DishCategoryGroupVoteResultHeader } from "./DishCategoryGroupVoteResultHeader";
 import { useDishMediaEntriesStore } from "@/stores/useDishMediaEntriesStore";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 type Props = {
 	shareToken: string;
@@ -140,7 +141,7 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 			logFrontendEvent({
 				event_name: "dish_category_group_vote_share_link_copy_failed",
 				error_level: "error",
-				payload: { shareToken, error: error instanceof Error ? error.message : String(error) },
+				payload: { shareToken, error: toErrorLogMessage(error) },
 			});
 			showSnackbar(i18n.t("Common.shareFailed"));
 		}
@@ -185,7 +186,7 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 				payload: {
 					shareToken,
 					candidateId: candidate.id,
-					error: error instanceof Error ? error.message : String(error),
+					error: toErrorLogMessage(error),
 				},
 			});
 			showSnackbar(i18n.t("Common.error"));
@@ -208,7 +209,7 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 				payload: {
 					shareToken,
 					candidateId: candidate.id,
-					error: error instanceof Error ? error.message : String(error),
+					error: toErrorLogMessage(error),
 				},
 			});
 			showSnackbar(i18n.t("Common.error"));

--- a/app-expo/features/dishCategoryGroupVotes/hooks/useCandidateDishMediaCache.ts
+++ b/app-expo/features/dishCategoryGroupVotes/hooks/useCandidateDishMediaCache.ts
@@ -17,6 +17,7 @@ import { useLocale } from "@/hooks/useLocale";
 import { useLogger } from "@/hooks/useLogger";
 import { useGoogleMapsFallback } from "@/features/search/hooks/useGoogleMapsFallback";
 import { createDishItemsForCategory } from "@/lib/dishMediaSearch";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 type UseCandidateDishMediaCacheParams = {
 	cacheCandidateDishMedia: (
@@ -122,7 +123,7 @@ export function useCandidateDishMediaCache({
 					error_level: "error",
 					payload: {
 						candidateId: candidate.id,
-						error: error instanceof Error ? error.message : String(error),
+						error: toErrorLogMessage(error),
 					},
 				});
 				showGoogleMapsFallbackDialog({

--- a/app-expo/features/dishCategoryGroupVotes/hooks/useCreateDishCategoryGroupVote.ts
+++ b/app-expo/features/dishCategoryGroupVotes/hooks/useCreateDishCategoryGroupVote.ts
@@ -12,6 +12,7 @@ import type { CreateDishCategoryGroupVoteResponse } from "@shared/api/v1/res";
 import type { SearchParams, Topic } from "@/types/search";
 import { useAPICall } from "@/hooks/useAPICall";
 import { useLogger } from "@/hooks/useLogger";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 type CreateGroupVoteInput = {
 	searchParams: SearchParams;
@@ -80,7 +81,7 @@ export function useCreateDishCategoryGroupVote() {
 					error_level: "log",
 					payload: {
 						candidateCount: visibleTopics.length,
-						error: error instanceof Error ? error.message : String(error),
+						error: toErrorLogMessage(error),
 					},
 				});
 				throw error;

--- a/app-expo/features/dishCategoryGroupVotes/hooks/useDishCategoryGroupVoteDetail.ts
+++ b/app-expo/features/dishCategoryGroupVotes/hooks/useDishCategoryGroupVoteDetail.ts
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { DishCategoryGroupVoteDetailResponse } from "@shared/api/v1/res";
 import { useAPICall } from "@/hooks/useAPICall";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 export function useDishCategoryGroupVoteDetail(shareToken?: string) {
 	const { callBackend } = useAPICall();
@@ -39,7 +40,7 @@ export function useDishCategoryGroupVoteDetail(shareToken?: string) {
 			setError(null);
 			return nextDetail;
 		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
+			const message = toErrorLogMessage(err);
 			if (!hadDetail) {
 				setError(message);
 			}

--- a/app-expo/features/dishMedia/components/ActionButtons.tsx
+++ b/app-expo/features/dishMedia/components/ActionButtons.tsx
@@ -25,6 +25,7 @@ import { profileSavedPostsEntriesKey } from "@/features/profile/tabs/SavedPostsT
 import { useDishMediaActions } from "../hooks/useDishMediaActions";
 import { GestureDetector } from "react-native-gesture-handler";
 import type { GestureType } from "react-native-gesture-handler";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 interface ActionButtonsProps {
 	id: string;
@@ -137,7 +138,7 @@ export function ActionButtons({ id, idType, onLayout, buttonsGesture }: ActionBu
 				event_name: "dish_like_reaction_failed",
 				error_level: "warn",
 				payload: {
-					error: error instanceof Error ? error.message : String(error),
+					error: toErrorLogMessage(error),
 					dishMediaId: dishMediaId,
 					previousLikeCount: likeCount,
 					newLikeCount: newLikeCount,
@@ -191,7 +192,7 @@ export function ActionButtons({ id, idType, onLayout, buttonsGesture }: ActionBu
 				event_name: "dish_save_reaction_failed",
 				error_level: "log",
 				payload: {
-					error: error instanceof Error ? error.message : String(error),
+					error: toErrorLogMessage(error),
 					target_id: dishMediaId,
 					action_type: "save",
 					willReact: willSave,

--- a/app-expo/features/dishMedia/components/DishReviewsSection.tsx
+++ b/app-expo/features/dishMedia/components/DishReviewsSection.tsx
@@ -19,6 +19,7 @@ import {
 	IdType,
 } from "@/stores/useDishMediaEntriesStore";
 import { shallow } from "zustand/shallow";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 interface DishReviewsSectionProps {
 	id: string;
@@ -136,7 +137,7 @@ export function DishReviewsSection({ id, idType, paddingRight, carouselRef }: Di
 				event_name: "review_like_reaction_failed",
 				error_level: "log",
 				payload: {
-					error: error instanceof Error ? error.message : String(error),
+					error: toErrorLogMessage(error),
 					target_id: review.id,
 					action_type: "like",
 				},

--- a/app-expo/features/dishMedia/hooks/useMediaTracking.ts
+++ b/app-expo/features/dishMedia/hooks/useMediaTracking.ts
@@ -6,6 +6,7 @@ import { useLogger } from "@/hooks/useLogger";
 import { getRemoteConfig } from "@/lib/remoteConfig";
 import type { DishMediaEntry, CreateDishMediaViewResponse } from "@shared/api/v1/res";
 import type { DishMediaImpressionBodyDto, CreateDishMediaViewDto } from "@shared/api/v1/dto";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 interface UseMediaTrackingParams {
 	isActive: boolean;
@@ -156,7 +157,7 @@ export const useMediaTracking = ({ isActive, sessionId, source, dishMedia }: Use
 					event_name: "dish_media_view_send_cleanup_error",
 					error_level: "warn",
 					payload: {
-						error: error instanceof Error ? error.message : String(error),
+						error: toErrorLogMessage(error),
 						dish_media_id: dishMedia.id,
 					},
 				});

--- a/app-expo/features/map/components/FeedDishMediaViewer.tsx
+++ b/app-expo/features/map/components/FeedDishMediaViewer.tsx
@@ -8,6 +8,7 @@ import { useBlurModal } from "@/features/blurModal/hooks/useBlurModal";
 import { ReviewForm } from "./ReviewForm";
 import i18n from "@/lib/i18n";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 
 type FeedDishMediaViewerProps = {
 	initialIndex: number;
@@ -52,7 +53,10 @@ export function FeedDishMediaViewer({ initialIndex, entriesKey }: FeedDishMediaV
 				onIndexChange={handleIndexChange}
 			/>
 			{/* #477【設計】匿名ユーザーの場合はレビュー投稿ボタンを非表示 */}
-			{user?.is_anonymous === false && (
+			{/* #1092 PR4b 【修正】`user?.is_anonymous === false` から共通判定（lib/authGuest.ts）へ寄せた。
+			    旧式は is_anonymous が undefined のときもゲスト扱いになり、ログイン済みなのに
+			    投稿ボタンだけ出ない（他画面では投稿できる）という食い違いになる */}
+			{!isGuestUser(user) && (
 				<PrimaryButton
 					style={styles.writeReviewButton}
 					label={i18n.t("Map.actions.writeReviewForThisDish")}

--- a/app-expo/features/map/components/SelectedRestaurantDetails.tsx
+++ b/app-expo/features/map/components/SelectedRestaurantDetails.tsx
@@ -23,6 +23,7 @@ import { useSafeAreaFrame } from "react-native-safe-area-context";
 import { Image } from "expo-image";
 import { getCacheKeyForImage } from "@/lib/image";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import { LoginbackModal } from "@/features/profile/components/LoginbackModal";
 
 function RestaurantTabsBar({ tabNames, index, onTabPress }: TabBarProps<string>) {
@@ -98,7 +99,10 @@ export function SelectedRestaurantDetails({ restaurant, meta: restaurantMeta }: 
 	const handleReviewButtonPress = async () => {
 		lightImpact();
 		// #477【設計】匿名ユーザーの場合は LoginbackModal を表示、非匿名ユーザーの場合は ReviewForm を表示
-		if (user?.is_anonymous !== false) {
+		// #1092 PR4b 【修正】`user?.is_anonymous !== false` から共通判定（lib/authGuest.ts）へ寄せた。
+		// 旧式は is_anonymous が undefined のときもゲストへ倒れ、レビュータブでは投稿できるのに
+		// ここではログイン導線が出る、という画面間の食い違いになる
+		if (isGuestUser(user)) {
 			openLoginModal();
 		} else {
 			// ReviewForm を開くと同時にメディア選択が行われる

--- a/app-expo/features/notifications/hooks/useNotificationUnreadCount.ts
+++ b/app-expo/features/notifications/hooks/useNotificationUnreadCount.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from "react";
 import { useAPICall } from "../../../hooks/useAPICall";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import type { UnreadCountResponse } from "@shared/api/v1/res";
 
 /**
@@ -20,7 +21,8 @@ export const useNotificationUnreadCount = () => {
 
 	const refresh = useCallback(async () => {
 		// #通知機能 【設計】匿名ユーザーは未読数を取得しない
-		if (!user || user.is_anonymous) {
+		// #1092 PR4b 判定は共通化（lib/authGuest.ts）。通知タブの表示可否と同じ式にしておく
+		if (isGuestUser(user)) {
 			setUnreadCount(0);
 			return;
 		}

--- a/app-expo/features/profile/components/LoginbackModal.tsx
+++ b/app-expo/features/profile/components/LoginbackModal.tsx
@@ -11,6 +11,7 @@ import { PrimaryButton } from "@/components/PrimaryButton";
 import i18n from "@/lib/i18n";
 import { useLogger } from "@/hooks/useLogger";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import { useBlurModal } from "@/features/blurModal/hooks/useBlurModal";
 import { OtpModal } from "./OtpModal";
 import { LegalDocument } from "@/features/settings/components/LegalDocument";
@@ -106,7 +107,10 @@ export function LoginbackModal({ onClose }: LoginbackModalProps) {
 
 			setIsLoading(true);
 			try {
-				const isAnonymous = user.is_anonymous;
+				// #1092 PR4b `user.is_anonymous` の直読みから共通判定（lib/authGuest.ts）へ寄せた。
+				// user === null は上でガード済みなので、ここでの意味は「匿名セッションか」で変わらない。
+				// is_anonymous が欠落している場合にログイン済み扱いになる（＝ linkIdentity しない）のも同じ
+				const isAnonymous = isGuestUser(user);
 
 				if (isAnonymous && !hasExistingAccount) {
 					// 未チェック（昇格狙い）: 匿名セッションのまま OAuth を追加(linkIdentity)を試みる。
@@ -193,7 +197,12 @@ export function LoginbackModal({ onClose }: LoginbackModalProps) {
 					</View> */}
 
 			{/* Existing Account Checkbox - Show only for anonymous users */}
-			{user?.is_anonymous && (
+			{/* #1092 PR4b ここは `isGuestUser(user)` へ丸ごと寄せない。isGuestUser は user === null（認証未確定）を
+			    ゲストへ倒すため、そのまま置くと未確定の一瞬だけチェックボックスが出て消える。
+			    このチェックボックスは上の handleOAuthSignIn の分岐用で、未確定の間はその分岐自体が
+			    「何もしない」に倒れている（＝出しても押す意味がない）。
+			    そのため null の扱いだけ従来どおり `user &&` で落とし、is_anonymous の解釈だけ共通判定へ揃える。 */}
+			{user && isGuestUser(user) && (
 				<TouchableOpacity
 					style={styles.checkboxContainer}
 					onPress={() => setHasExistingAccount(!hasExistingAccount)}

--- a/app-expo/features/profile/containers/ProfileTabsLayout.tsx
+++ b/app-expo/features/profile/containers/ProfileTabsLayout.tsx
@@ -24,6 +24,7 @@ import { ProfileEditForm } from "../components/ProfileEditForm";
 import type { TabBarProps } from "react-native-collapsible-tab-view";
 import type { GroupName, RouteName } from "../components/ProfileTabsBar";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import { useProfileStore } from "../stores/useProfileStore";
 import { useEnsureOwnProfileLoaded } from "../hooks/useEnsureOwnProfileLoaded";
 import { LoadingIndicator } from "@/components/LoadingIndicator";
@@ -44,7 +45,10 @@ export function ProfileTabsLayout() {
 	const [isFollowing, setIsFollowing] = useState(false);
 
 	const isOwnProfile = useMemo(() => true, []);
-	const isGuest = useMemo(() => user?.is_anonymous !== false, [user?.is_anonymous]);
+	// #1092 PR4b `user?.is_anonymous !== false` から共通判定へ寄せた。
+	// 旧式は is_anonymous が undefined のときもゲストへ倒れ、ログイン済みユーザーの
+	// レビュータブが消える。理由は lib/authGuest.ts を参照（通知タブ・設定と同じ式）
+	const isGuest = useMemo(() => isGuestUser(user), [user]);
 
 	const availableTabs: GroupName[] = useMemo(() => {
 		const tabs: GroupName[] = [];
@@ -212,7 +216,7 @@ export function ProfileTabsLayout() {
 	);
 
 	// #1092 【設計】auth 未確定(user === null)の間はタブ構成を確定させない。
-	// isGuest は `user?.is_anonymous !== false` なので未確定はゲスト扱いになり、
+	// isGuest は user === null をゲスト扱いにする（lib/authGuest.ts）ので、未確定のままだと
 	// ログイン済みのリピーターでは「reviews タブ無しで描画 → 後からタブが増える」というちらつきになる。
 	// タブ本数が変わると Tabs.Container 全体が作り直されるため、確定するまで描画を保留する。
 	// ⚠️ この return はフックを全て呼び終えた後に置くこと（フックの呼び出し順を変えないため）。

--- a/app-expo/features/profile/hooks/useEnsureOwnProfileLoaded.ts
+++ b/app-expo/features/profile/hooks/useEnsureOwnProfileLoaded.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import { ApiError, useAPICall } from "@/hooks/useAPICall";
 import { useLogger } from "@/hooks/useLogger";
 import { userProfile } from "@/data/profileData";
@@ -33,7 +34,9 @@ export function useEnsureOwnProfileLoaded() {
 	// ロード済みフラグとリトライフラグを管理するための ref
 	const hasLoadedRef = useRef(false);
 
-	const isGuest = user?.is_anonymous !== false;
+	// #1092 PR4b タブの表示判定（lib/authGuest.ts）と同じ式にしておく。
+	// ここだけ判定がずれると「reviews タブは出ているのにプロフィールはダミーのまま」になる
+	const isGuest = isGuestUser(user);
 
 	// ★セッション（userId / isGuest）が変わったらキャッシュをリセット
 	useEffect(() => {

--- a/app-expo/features/review/components/SelectedRestaurantDetails.tsx
+++ b/app-expo/features/review/components/SelectedRestaurantDetails.tsx
@@ -17,6 +17,7 @@ import { useSafeAreaFrame } from "react-native-safe-area-context";
 import { Image } from "expo-image";
 import { getCacheKeyForImage } from "@/lib/image";
 import { useAuth } from "@/contexts/AuthProvider";
+import { isGuestUser } from "@/lib/authGuest";
 import { LoginbackModal } from "@/features/profile/components/LoginbackModal";
 import { RestaurantEntry } from "../stores/useRestaurantStore";
 import { useLocale } from "@/hooks/useLocale";
@@ -76,7 +77,10 @@ export function SelectedRestaurantDetails({ restaurantEntry }: SelectedRestauran
 		});
 
 		// #477【設計】匿名ユーザーの場合は LoginbackModal を表示、非匿名ユーザーの場合は ReviewForm を表示
-		if (user?.is_anonymous !== false) {
+		// #1092 PR4b 【修正】`user?.is_anonymous !== false` から共通判定（lib/authGuest.ts）へ寄せた。
+		// 旧式は is_anonymous が undefined のときもゲストへ倒れ、レビュータブの CTA は投稿導線なのに
+		// ここではログイン導線が出る、という画面間の食い違いになる
+		if (isGuestUser(user)) {
 			openLoginModal();
 		} else {
 			// ReviewForm に遷移すると同時にメディア選択が行われる
@@ -85,7 +89,7 @@ export function SelectedRestaurantDetails({ restaurantEntry }: SelectedRestauran
 				params: { locale, restaurantId: restaurantEntry.restaurant.id },
 			});
 		}
-	}, [lightImpact, openLoginModal, router, locale, restaurantEntry, user?.is_anonymous]);
+	}, [lightImpact, openLoginModal, router, locale, restaurantEntry, user]);
 
 	// #644 【設計】「みんなの投稿」のレビューアイテム押下時の処理
 	const onPressPostReview = useCallback(

--- a/app-expo/features/search/hooks/useAutoCurrentLocation.ts
+++ b/app-expo/features/search/hooks/useAutoCurrentLocation.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useAuth } from "@/contexts/AuthProvider";
 import { useLogger } from "@/hooks/useLogger";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 import { LocationPermissionError } from "@/hooks/locationPermissionError";
 import type { LocationDetailsResponse } from "@shared/api/v1/res";
 
@@ -70,7 +71,7 @@ export const useAutoCurrentLocation = ({ getCurrentLocation, onResolved }: Param
 				event_name: "current_location_auto_fetch_failed",
 				error_level: "warn",
 				payload: {
-					error: error?.message ? String(error.message) : String(error),
+					error: toErrorLogMessage(error),
 					kind: error instanceof LocationPermissionError ? error.kind : "unavailable",
 					willRetryAfterAuth: needsAuthRetryRef.current && !hasRetriedAfterAuthRef.current,
 				},

--- a/app-expo/features/search/hooks/useGoogleMapsFallback.ts
+++ b/app-expo/features/search/hooks/useGoogleMapsFallback.ts
@@ -3,6 +3,7 @@ import * as Linking from "expo-linking";
 import { useDialog } from "@/contexts/DialogProvider";
 import { useLogger } from "@/hooks/useLogger";
 import i18n from "@/lib/i18n";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 import { buildGoogleMapsSearchUrl } from "@/lib/googleMaps";
 
 type GoogleMapsFallbackArgs = {
@@ -71,7 +72,8 @@ export function useGoogleMapsFallback({ source }: UseGoogleMapsFallbackParams) {
 							payload: {
 								entriesKey,
 								category,
-								error_message: error instanceof Error ? error.message : String(error),
+								// #1092 PR4b 置換前は (B) なので message 側へ寄せる（Error は message のみで非回帰）
+								error_message: toErrorLogMessage(error),
 								source,
 							},
 						});

--- a/app-expo/features/topics/components/TopicCard.tsx
+++ b/app-expo/features/topics/components/TopicCard.tsx
@@ -11,6 +11,7 @@ import { toggleReaction } from "@/lib/reactions";
 import { TopicsStore, selectIsTopicSaved, useTopicsStore } from "@/stores/useTopicsStore";
 import { profileSavedTopicsEntriesKey } from "@/features/profile/tabs/SavedTopicsTab";
 import i18n from "@/lib/i18n";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 import { type TopicImageResourceState } from "@/features/topics/hooks/useTopicImageResources";
 import type { TopicsTutorialTargetRefs } from "@/features/topics/types/tutorial";
 import { TopicVisualCard } from "./TopicVisualCard";
@@ -130,7 +131,10 @@ export const TopicCard = ({
 				event_name: "topic_save_reaction_failed",
 				error_level: "error",
 				payload: {
-					error: error instanceof Error ? error.message : String(error),
+					// #1092 PR4b 保存 API は認証必須。認証未確定のまま押されると PR4a の
+					// ApiError(plain object) が来て "[object Object]" になるため共通関数へ寄せる。
+					// 置換前は (B) `instanceof Error ? message : String()` なので message 側
+					error: toErrorLogMessage(error),
 					target_id: item.categoryId,
 					action_type: "save",
 					willReact: willSave,

--- a/app-expo/features/topics/hooks/useBlockTopic.ts
+++ b/app-expo/features/topics/hooks/useBlockTopic.ts
@@ -8,6 +8,7 @@ import { insertReaction } from "@/lib/reactions";
 import i18n from "@/lib/i18n";
 import type { ShowSnackbarOptions } from "@/contexts/SnackbarProvider";
 import type { UnblockDishCategoryResponse } from "@shared/api/v1/res";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 export const useBlockTopic = (
 	hideTopic: (id: string, reason: string) => void,
@@ -40,7 +41,7 @@ export const useBlockTopic = (
 					error_level: "error",
 					payload: {
 						topic_id: topic.categoryId,
-						error: error instanceof Error ? error.message : String(error),
+						error: toErrorLogMessage(error),
 					},
 				});
 				showSnackbar(i18n.t("Common.error"));
@@ -103,7 +104,7 @@ export const useBlockTopic = (
 							error_level: "error",
 							payload: {
 								topic_id: topic.categoryId,
-								error: error instanceof Error ? error.message : String(error),
+								error: toErrorLogMessage(error),
 							},
 						});
 

--- a/app-expo/features/topics/hooks/useTopicsTutorial.ts
+++ b/app-expo/features/topics/hooks/useTopicsTutorial.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useLogger } from "@/hooks/useLogger";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 import type { TopicsTutorialOpenReason } from "@/features/topics/types/tutorial";
 
 /**
@@ -63,7 +64,8 @@ export function useTopicsTutorial({ canAutoOpen }: UseTopicsTutorialOptions) {
 					error_level: "warn",
 					payload: {
 						operation: "read",
-						message: error instanceof Error ? error.message : String(error),
+						// #1092 PR4b 置換前は (B) なので message 側へ寄せる（Error は message のみで非回帰）
+						message: toErrorLogMessage(error),
 					},
 				});
 			}
@@ -128,7 +130,8 @@ export function useTopicsTutorial({ canAutoOpen }: UseTopicsTutorialOptions) {
 				error_level: "warn",
 				payload: {
 					operation: "write",
-					message: error instanceof Error ? error.message : String(error),
+					// #1092 PR4b 置換前は (B) なので message 側へ寄せる（Error は message のみで非回帰）
+					message: toErrorLogMessage(error),
 				},
 			});
 		});

--- a/app-expo/hooks/useAPICall.ts
+++ b/app-expo/hooks/useAPICall.ts
@@ -8,6 +8,7 @@ import { Linking, Platform } from "react-native";
 import type { BaseResponse } from "@shared/api/v1/res";
 import { useCdnCookieStore } from "@/stores/useCdnCookieStore";
 import { fetchWithAuth } from "@/lib/fetchWithAuth";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 /**
  * #525 【設計】統一されたエラーオブジェクト型
@@ -193,7 +194,7 @@ export const useAPICall = () => {
 								error_level: "error",
 								payload: {
 									endpoint: endpointName,
-									error: error instanceof Error ? error.message : String(error),
+									error: toErrorLogMessage(error),
 								},
 							});
 							break;
@@ -230,7 +231,7 @@ export const useAPICall = () => {
 						endpoint: endpointName,
 						method,
 						status: 0,
-						error: networkError instanceof Error ? networkError.message : String(networkError),
+						error: toErrorLogMessage(networkError),
 						timedOut: didTimeout,
 					},
 				});

--- a/app-expo/hooks/useDishCategorySearch.ts
+++ b/app-expo/hooks/useDishCategorySearch.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef } from "react";
 import { useAPICall } from "@/hooks/useAPICall";
 import { useLocale } from "@/hooks/useLocale";
 import { useLogger } from "@/hooks/useLogger";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 import type { QueryDishCategoryVariantsDto, CreateDishCategoryVariantDto } from "@shared/api/v1/dto";
 import type { QueryDishCategoryVariantsResponse, CreateDishCategoryVariantResponse } from "@shared/api/v1/res";
 
@@ -77,7 +78,7 @@ export const useDishCategorySearch = () => {
 				logFrontendEvent({
 					event_name: "dish_category_search_failed",
 					error_level: "error",
-					payload: { query, error: String(error) },
+					payload: { query, error: toErrorLogMessage(error) },
 				});
 			} finally {
 				if (!controller.signal.aborted) {
@@ -126,7 +127,7 @@ export const useDishCategorySearch = () => {
 				logFrontendEvent({
 					event_name: "dish_category_variant_create_failed",
 					error_level: "error",
-					payload: { name, error: String(error) },
+					payload: { name, error: toErrorLogMessage(error) },
 				});
 
 				throw error;

--- a/app-expo/hooks/useDishCategorySearch.ts
+++ b/app-expo/hooks/useDishCategorySearch.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef } from "react";
 import { useAPICall } from "@/hooks/useAPICall";
 import { useLocale } from "@/hooks/useLocale";
 import { useLogger } from "@/hooks/useLogger";
-import { toErrorLogMessage } from "@/lib/errorMessage";
+import { toErrorLogString } from "@/lib/errorMessage";
 import type { QueryDishCategoryVariantsDto, CreateDishCategoryVariantDto } from "@shared/api/v1/dto";
 import type { QueryDishCategoryVariantsResponse, CreateDishCategoryVariantResponse } from "@shared/api/v1/res";
 
@@ -78,7 +78,7 @@ export const useDishCategorySearch = () => {
 				logFrontendEvent({
 					event_name: "dish_category_search_failed",
 					error_level: "error",
-					payload: { query, error: toErrorLogMessage(error) },
+					payload: { query, error: toErrorLogString(error) },
 				});
 			} finally {
 				if (!controller.signal.aborted) {
@@ -127,7 +127,7 @@ export const useDishCategorySearch = () => {
 				logFrontendEvent({
 					event_name: "dish_category_variant_create_failed",
 					error_level: "error",
-					payload: { name, error: toErrorLogMessage(error) },
+					payload: { name, error: toErrorLogString(error) },
 				});
 
 				throw error;

--- a/app-expo/hooks/useLocationSearch.ts
+++ b/app-expo/hooks/useLocationSearch.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef } from "react";
 import { useAPICall } from "@/hooks/useAPICall";
 import { useLocale } from "@/hooks/useLocale";
 import { useLogger } from "@/hooks/useLogger";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 import * as Location from "expo-location";
 // #932 【設計】現在地の緯度経度取得だけは native(expo-location) と web(navigator.geolocation) で
 // 実装を分ける必要があるため、この1関数だけを .ts / .web.ts に分離して import する
@@ -144,7 +145,7 @@ export const useLocationSearch = () => {
 				logFrontendEvent({
 					event_name: "location_search_failed",
 					error_level: "error",
-					payload: { query, error: String(error) },
+					payload: { query, error: toErrorLogMessage(error) },
 				});
 			}
 		},
@@ -189,7 +190,7 @@ export const useLocationSearch = () => {
 					error_level: "error",
 					payload: {
 						placeId: prediction.place_id,
-						error: String(error),
+						error: toErrorLogMessage(error),
 					},
 				});
 
@@ -306,7 +307,7 @@ export const useLocationSearch = () => {
 					event_name: "current_location_fetch_failed",
 					error_level: "error",
 					payload: {
-						error: String(error),
+						error: toErrorLogMessage(error),
 						kind: error instanceof LocationPermissionError ? error.kind : "unavailable",
 					},
 				});

--- a/app-expo/hooks/useLocationSearch.ts
+++ b/app-expo/hooks/useLocationSearch.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef } from "react";
 import { useAPICall } from "@/hooks/useAPICall";
 import { useLocale } from "@/hooks/useLocale";
 import { useLogger } from "@/hooks/useLogger";
-import { toErrorLogMessage } from "@/lib/errorMessage";
+import { toErrorLogString } from "@/lib/errorMessage";
 import * as Location from "expo-location";
 // #932 【設計】現在地の緯度経度取得だけは native(expo-location) と web(navigator.geolocation) で
 // 実装を分ける必要があるため、この1関数だけを .ts / .web.ts に分離して import する
@@ -145,7 +145,7 @@ export const useLocationSearch = () => {
 				logFrontendEvent({
 					event_name: "location_search_failed",
 					error_level: "error",
-					payload: { query, error: toErrorLogMessage(error) },
+					payload: { query, error: toErrorLogString(error) },
 				});
 			}
 		},
@@ -190,7 +190,7 @@ export const useLocationSearch = () => {
 					error_level: "error",
 					payload: {
 						placeId: prediction.place_id,
-						error: toErrorLogMessage(error),
+						error: toErrorLogString(error),
 					},
 				});
 
@@ -269,7 +269,10 @@ export const useLocationSearch = () => {
 						payload: {
 							latitude,
 							longitude,
-							error: String(apiError),
+							// #1092 PR4b callBackend の失敗がそのまま来る。PR4a 以降ここには
+							// Error ではない ApiError(plain object) も流れるため String() だと "[object Object]" になる。
+							// (A) 素の String() だった箇所なので、Error の "Name: message" は保つ側へ寄せる
+							error: toErrorLogString(apiError),
 						},
 					});
 
@@ -307,7 +310,7 @@ export const useLocationSearch = () => {
 					event_name: "current_location_fetch_failed",
 					error_level: "error",
 					payload: {
-						error: toErrorLogMessage(error),
+						error: toErrorLogString(error),
 						kind: error instanceof LocationPermissionError ? error.kind : "unavailable",
 					},
 				});

--- a/app-expo/hooks/usePerformanceLogger.ts
+++ b/app-expo/hooks/usePerformanceLogger.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useLogger } from "./useLogger";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 interface PerformanceTimer {
 	start: (name: string, metadata?: Record<string, any>) => void;
@@ -60,7 +61,7 @@ export const usePerformanceLogger = (): PerformanceTimer => {
 				logFrontendEvent({
 					event_name: "performance_measure",
 					error_level: "error",
-					payload: { operation: name, duration, success: false, error: String(error), ...metadata },
+					payload: { operation: name, duration, success: false, error: toErrorLogMessage(error), ...metadata },
 				});
 				throw error;
 			}
@@ -85,7 +86,7 @@ export const usePerformanceLogger = (): PerformanceTimer => {
 				logFrontendEvent({
 					event_name: "performance_measure_async",
 					error_level: "error",
-					payload: { operation: name, duration, success: false, error: String(error), ...metadata },
+					payload: { operation: name, duration, success: false, error: toErrorLogMessage(error), ...metadata },
 				});
 				throw error;
 			}

--- a/app-expo/hooks/usePerformanceLogger.ts
+++ b/app-expo/hooks/usePerformanceLogger.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useLogger } from "./useLogger";
-import { toErrorLogMessage } from "@/lib/errorMessage";
+import { toErrorLogString } from "@/lib/errorMessage";
 
 interface PerformanceTimer {
 	start: (name: string, metadata?: Record<string, any>) => void;
@@ -61,7 +61,7 @@ export const usePerformanceLogger = (): PerformanceTimer => {
 				logFrontendEvent({
 					event_name: "performance_measure",
 					error_level: "error",
-					payload: { operation: name, duration, success: false, error: toErrorLogMessage(error), ...metadata },
+					payload: { operation: name, duration, success: false, error: toErrorLogString(error), ...metadata },
 				});
 				throw error;
 			}
@@ -86,7 +86,7 @@ export const usePerformanceLogger = (): PerformanceTimer => {
 				logFrontendEvent({
 					event_name: "performance_measure_async",
 					error_level: "error",
-					payload: { operation: name, duration, success: false, error: toErrorLogMessage(error), ...metadata },
+					payload: { operation: name, duration, success: false, error: toErrorLogString(error), ...metadata },
 				});
 				throw error;
 			}

--- a/app-expo/lib/authGuest.test.ts
+++ b/app-expo/lib/authGuest.test.ts
@@ -1,0 +1,29 @@
+import { isGuestUser } from "./authGuest";
+
+/**
+ * #1092 PR4b ゲスト判定の境界。
+ *
+ * `user?.is_anonymous !== false` というコピーが各所にあったが、この式は
+ * `is_anonymous` が **undefined**（型上 optional）のときもゲストへ倒れる。
+ * ゲートを外して認証未確定から画面が動き出す今、その差が実害（ログイン済みなのに
+ * 通知タブ・自分のレビュータブが出ない）になるため、判定を 1 箇所に集めて固定する。
+ */
+describe("#1092 isGuestUser", () => {
+	it("user が居なければゲスト（認証未確定・失敗を含む）", () => {
+		expect(isGuestUser(null)).toBe(true);
+		expect(isGuestUser(undefined)).toBe(true);
+	});
+
+	it("is_anonymous === true はゲスト", () => {
+		expect(isGuestUser({ is_anonymous: true })).toBe(true);
+	});
+
+	it("is_anonymous === false はログイン済み", () => {
+		expect(isGuestUser({ is_anonymous: false })).toBe(false);
+	});
+
+	it("is_anonymous が欠けている user はログイン済み扱い（ログイン済みの人から機能を奪わない）", () => {
+		expect(isGuestUser({})).toBe(false);
+		expect(isGuestUser({ is_anonymous: undefined })).toBe(false);
+	});
+});

--- a/app-expo/lib/authGuest.ts
+++ b/app-expo/lib/authGuest.ts
@@ -1,0 +1,40 @@
+// lib/authGuest.ts
+//
+// #1092 【設計】「この人はゲストか」の判定を 1 箇所に集める純関数。
+//
+// これまで各所に `user?.is_anonymous !== false` がコピーされていたが、この式は
+// `is_anonymous` が `undefined` のときも「ゲスト」に倒れる。`@supabase/auth-js` の型では
+// `User["is_anonymous"]` は **optional** で、GoTrue のバージョンやセッションの復元経路によっては
+// 欠落しうる。つまり「ログイン済みなのに通知タブが出ない」「自分のレビュータブが出ない」が
+// 型の上では起こりうる状態だった。
+//
+// PR4b で `SplashHandler` の `!!user` ゲートを外し、認証が確定する前から画面を描くようになったため、
+// この判定は「まだ null の user」に対しても毎起動必ず評価される。実際に踏みうる状態になったので、
+// 未確定と欠落を分けて扱う。
+
+import type { User } from "@supabase/supabase-js";
+
+/** 判定に必要な最小の形。テストから素の object を渡せるようにしてある */
+type GuestCheckTarget = Pick<User, "is_anonymous">;
+
+/**
+ * ゲスト（＝ログインしていない匿名ユーザー、または認証がまだ確定していない状態）か。
+ *
+ * - `user === null`（認証が未確定 / 失敗）… **ゲスト扱い**。
+ *   ここをログイン済みに倒すと、認証確定までの数百 ms だけログイン専用 UI が
+ *   「出てから消える」（通知タブならタブ本数が 5→4 に変わりタブバーが再レイアウトする）。
+ *   「出てから消える」より「出ない→出る」の方が害が小さい。web の SSG は user === null を出力するので、
+ *   その観点でも null をゲストへ倒すのが安全。
+ * - `is_anonymous === true` … ゲスト。
+ * - `is_anonymous === undefined`（型上ありうる欠落）… **ログイン済み扱い**。
+ *   user が居る = セッションはある状態なので、ここをゲストへ倒すとログイン済みユーザーが
+ *   自分の通知・自分のレビューに到達できなくなる（機能が丸ごと消える）。逆に倒した場合の害は
+ *   「ゲストにログイン専用 UI が見えるが、押しても API が弾く」に留まるため、こちら側へ倒す。
+ *
+ * @param user 現在の user（`useAuth().user`）
+ * @returns ゲストなら true
+ */
+export const isGuestUser = (user: GuestCheckTarget | null | undefined): boolean => {
+	if (!user) return true;
+	return user.is_anonymous === true;
+};

--- a/app-expo/lib/errorMessage.test.ts
+++ b/app-expo/lib/errorMessage.test.ts
@@ -1,4 +1,5 @@
-import { toErrorLogMessage } from "./errorMessage";
+import { toErrorLogMessage, toErrorLogString } from "./errorMessage";
+import { LocationPermissionError } from "@/hooks/locationPermissionError";
 
 /**
  * #1092 PR4b ログ用のエラー整形。
@@ -7,18 +8,29 @@ import { toErrorLogMessage } from "./errorMessage";
  * なったため、`String(error)` も `error instanceof Error ? ... : String(error)` も
  * `"[object Object]"` を返すようになっていた。PR4b でゲートを外すと、この失敗が
  * 実際に各所の catch へ流れてくるので、message が必ず残ることを固定する。
+ *
+ * ⚠️ 置換前の書き方が 2 種類あったので、関数も 2 つある。**それぞれ置換前の振る舞いを保つ**こと。
+ * ログの文字列が変わると、BigQuery 側で文字列一致（`LIKE 'LocationPermissionError:%'` 等）で
+ * 組んである集計・アラートが黙ってヒット 0 件になる。
  */
-describe("#1092 toErrorLogMessage", () => {
-	it("Error インスタンスは message を返す", () => {
+
+/** PR4a の `useAPICall` が throw する形（Error インスタンスではない） */
+const apiError = {
+	code: "unauthenticated",
+	message: "User is not authenticated: Supabase access_token is missing (endpoint: health).",
+};
+
+describe("#1092 toErrorLogMessage（(B) `error instanceof Error ? error.message : String(error)` の置換先）", () => {
+	it("Error インスタンスは message のみを返す（置換前と同じ）", () => {
 		expect(toErrorLogMessage(new Error("boom"))).toBe("boom");
+	});
+
+	it("Error のサブクラスも message のみを返す（置換前と同じ）", () => {
+		expect(toErrorLogMessage(new LocationPermissionError("denied", "permission denied"))).toBe("permission denied");
 	});
 
 	it("message を持つ plain object（ApiError）も message を返す", () => {
 		// ここが "[object Object]" に戻ると、認証未確立が原因の失敗を BigQuery から追えなくなる
-		const apiError = {
-			code: "unauthenticated",
-			message: "User is not authenticated: Supabase access_token is missing (endpoint: health).",
-		};
 		expect(toErrorLogMessage(apiError)).toBe(apiError.message);
 		expect(toErrorLogMessage(apiError)).not.toContain("[object Object]");
 	});
@@ -32,5 +44,38 @@ describe("#1092 toErrorLogMessage", () => {
 
 	it("message が空文字の Error は String() へフォールバックする（空ログにしない）", () => {
 		expect(toErrorLogMessage(new Error(""))).toBe("Error");
+	});
+});
+
+describe("#1092 toErrorLogString（(A) 素の `String(error)` の置換先）", () => {
+	it("Error インスタンスは `String(error)` と同じ 'Error: message' を返す", () => {
+		const error = new Error("boom");
+		expect(toErrorLogString(error)).toBe(String(error));
+		expect(toErrorLogString(error)).toBe("Error: boom");
+	});
+
+	it("Error のサブクラスはエラー名のプレフィックスを保つ", () => {
+		// BigQuery で `payload.error LIKE 'LocationPermissionError:%'` のような前方一致で
+		// 集計・アラートを組んでいる。message だけにするとヒット 0 件になる
+		const error = new LocationPermissionError("denied", "permission denied");
+		expect(toErrorLogString(error)).toBe(String(error));
+		expect(toErrorLogString(error)).toBe("LocationPermissionError: permission denied");
+	});
+
+	it("message を持つ plain object（ApiError）は message を返す（ここだけが置換前からの変更点）", () => {
+		expect(toErrorLogString(apiError)).toBe(apiError.message);
+		expect(toErrorLogString(apiError)).not.toContain("[object Object]");
+	});
+
+	it("Error 以外・message 無しは `String(error)` のまま", () => {
+		expect(toErrorLogString("plain string")).toBe("plain string");
+		expect(toErrorLogString(null)).toBe("null");
+		expect(toErrorLogString(undefined)).toBe("undefined");
+		expect(toErrorLogString(404)).toBe("404");
+		expect(toErrorLogString({ code: "no_message" })).toBe("[object Object]");
+	});
+
+	it("message が空文字の Error は String() と同じくエラー名を返す", () => {
+		expect(toErrorLogString(new Error(""))).toBe("Error");
 	});
 });

--- a/app-expo/lib/errorMessage.test.ts
+++ b/app-expo/lib/errorMessage.test.ts
@@ -1,0 +1,36 @@
+import { toErrorLogMessage } from "./errorMessage";
+
+/**
+ * #1092 PR4b ログ用のエラー整形。
+ *
+ * PR4a で `useAPICall` のトークン欠如が plain object（`{ code: "unauthenticated", message }`）に
+ * なったため、`String(error)` も `error instanceof Error ? ... : String(error)` も
+ * `"[object Object]"` を返すようになっていた。PR4b でゲートを外すと、この失敗が
+ * 実際に各所の catch へ流れてくるので、message が必ず残ることを固定する。
+ */
+describe("#1092 toErrorLogMessage", () => {
+	it("Error インスタンスは message を返す", () => {
+		expect(toErrorLogMessage(new Error("boom"))).toBe("boom");
+	});
+
+	it("message を持つ plain object（ApiError）も message を返す", () => {
+		// ここが "[object Object]" に戻ると、認証未確立が原因の失敗を BigQuery から追えなくなる
+		const apiError = {
+			code: "unauthenticated",
+			message: "User is not authenticated: Supabase access_token is missing (endpoint: health).",
+		};
+		expect(toErrorLogMessage(apiError)).toBe(apiError.message);
+		expect(toErrorLogMessage(apiError)).not.toContain("[object Object]");
+	});
+
+	it("message を持たない値は String() で表現する", () => {
+		expect(toErrorLogMessage("plain string")).toBe("plain string");
+		expect(toErrorLogMessage(null)).toBe("null");
+		expect(toErrorLogMessage(undefined)).toBe("undefined");
+		expect(toErrorLogMessage(404)).toBe("404");
+	});
+
+	it("message が空文字の Error は String() へフォールバックする（空ログにしない）", () => {
+		expect(toErrorLogMessage(new Error(""))).toBe("Error");
+	});
+});

--- a/app-expo/lib/errorMessage.ts
+++ b/app-expo/lib/errorMessage.ts
@@ -13,20 +13,59 @@
 // 「認証待ちだっただけ」なのか「本当に壊れている」のかが BigQuery から永久に分からないため、
 // message を優先して取り出す。
 //
-// 判定は PR4a の `HealthCheckInitializer` / `useAutoCurrentLocation` が採った
-// `error?.message ? String(error.message) : String(error)` と同一（それらもこの関数へ寄せてある）。
-// `instanceof Error` で判定しないのは、まさに Error インスタンスでない上記の plain object を拾うため。
+// ⚠️ 【重要】置換前の書き方が 2 種類あったので、関数も 2 つに分けてある。
+//    どちらへ寄せるかは **置換前がどちらだったか** で決めること。既存ログの文字列が変わると、
+//    BigQuery 側で `payload.error LIKE 'LocationPermissionError:%'` のような文字列一致で
+//    組んである集計・アラートが黙ってヒット 0 件になる。
+//
+//    (A) `String(error)` だった箇所            → `toErrorLogString`（Error は "Name: message"）
+//    (B) `error instanceof Error ? error.message : String(error)` だった箇所
+//                                              → `toErrorLogMessage`（Error は message のみ）
+//
+//    どちらも「plain object が `"[object Object]"` になる」ケースだけを直しており、
+//    それ以外の入力に対する出力は置換前と同じになるようにしてある。
+
+/** `message` プロパティを持つかもしれない値として読むためのヘルパ */
+const readMessage = (error: unknown): unknown => (error as { message?: unknown } | null | undefined)?.message;
 
 /**
- * ログ用にエラーを 1 行の文字列へ変換する。
+ * (B) 用。ログ用にエラーを 1 行の文字列へ変換する（**message のみ**）。
+ *
+ * 置換前が `error instanceof Error ? error.message : String(error)` /
+ * `error?.message ? String(error.message) : String(error)` だった箇所はこちら。
  *
  * - `message` を持つ値（`Error` / `ApiError` のような plain object / Supabase の `AuthError`）は `message`
  * - それ以外（文字列・数値・message の無いオブジェクト）は `String(error)`
+ *
+ * `instanceof Error` で判定しないのは、まさに Error インスタンスでない上記の plain object を拾うため。
  *
  * @param error catch した値（`unknown` のまま渡してよい）
  * @returns ログに載せる文字列
  */
 export const toErrorLogMessage = (error: unknown): string => {
-	const message = (error as { message?: unknown } | null | undefined)?.message;
+	const message = readMessage(error);
+	return message ? String(message) : String(error);
+};
+
+/**
+ * (A) 用。ログ用にエラーを 1 行の文字列へ変換する（**`String(error)` 互換**）。
+ *
+ * 置換前が素の `String(error)` だった箇所はこちら。`Error` とそのサブクラスは
+ * `String()` がそのまま `"Error: message"` / `"LocationPermissionError: message"` を返すので、
+ * **エラー名のプレフィックスが落ちない**。ここを message だけにすると、名前で前方一致していた
+ * 既存のログ集計が全て外れる。
+ *
+ * - `Error`（サブクラス含む）は `String(error)`（＝ `"Name: message"`。message が空なら `"Name"`）
+ * - Error ではないが `message` を持つ値（PR4a の `ApiError` のような plain object）は `message`
+ *   … ここだけが置換前からの変更点。放置すると `"[object Object]"` になり原因が追えない
+ * - それ以外（文字列・数値・message の無いオブジェクト）は `String(error)`
+ *
+ * @param error catch した値（`unknown` のまま渡してよい）
+ * @returns ログに載せる文字列
+ */
+export const toErrorLogString = (error: unknown): string => {
+	if (error instanceof Error) return String(error);
+
+	const message = readMessage(error);
 	return message ? String(message) : String(error);
 };

--- a/app-expo/lib/errorMessage.ts
+++ b/app-expo/lib/errorMessage.ts
@@ -1,0 +1,32 @@
+// lib/errorMessage.ts
+//
+// #1092 【設計】ログに載せる「エラーの説明文」を 1 箇所で作る純関数。
+//
+// PR4a で `useAPICall` のトークン欠如が `throw new Error(...)` から
+// `throw { code: "unauthenticated", message: ... } satisfies ApiError`（plain object）に変わった。
+// これは呼び出し側が `error?.code` で「後で再試行すべき失敗」を判別できるようにするためだが、
+// 副作用として **`String(error)` も `error instanceof Error ? error.message : String(error)` も
+// `"[object Object]"` を返す**ようになった。
+//
+// PR4b で `SplashHandler` の `!!user` ゲートを外した結果、認証が確立する前に画面が動き始め、
+// この `unauthenticated` が実際に各所の catch へ流れてくる。ログが `[object Object]` だと
+// 「認証待ちだっただけ」なのか「本当に壊れている」のかが BigQuery から永久に分からないため、
+// message を優先して取り出す。
+//
+// 判定は PR4a の `HealthCheckInitializer` / `useAutoCurrentLocation` が採った
+// `error?.message ? String(error.message) : String(error)` と同一（それらもこの関数へ寄せてある）。
+// `instanceof Error` で判定しないのは、まさに Error インスタンスでない上記の plain object を拾うため。
+
+/**
+ * ログ用にエラーを 1 行の文字列へ変換する。
+ *
+ * - `message` を持つ値（`Error` / `ApiError` のような plain object / Supabase の `AuthError`）は `message`
+ * - それ以外（文字列・数値・message の無いオブジェクト）は `String(error)`
+ *
+ * @param error catch した値（`unknown` のまま渡してよい）
+ * @returns ログに載せる文字列
+ */
+export const toErrorLogMessage = (error: unknown): string => {
+	const message = (error as { message?: unknown } | null | undefined)?.message;
+	return message ? String(message) : String(error);
+};

--- a/app-expo/stores/useDishMediaEntriesStore.ts
+++ b/app-expo/stores/useDishMediaEntriesStore.ts
@@ -1,4 +1,5 @@
 import i18n from "@/lib/i18n";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 import type { DishMediaEntry } from "@shared/api/v1/res";
 import { createWithEqualityFn } from "zustand/traditional";
 
@@ -589,13 +590,9 @@ const handleAsyncAction = <T>(
 			// #940 【修正】useAPICall は API/HTTPエラーを Error インスタンスではなく
 			// ApiError(プレーンオブジェクト、message フィールドを持つ)として throw するため、
 			// String(err) では "[object Object]" になっていた。message フィールドを優先して抽出する
-			const errorMessage = err
-				? err instanceof Error
-					? err.message
-					: typeof err === "object" && typeof (err as { message?: unknown }).message === "string"
-						? (err as { message: string }).message
-						: String(err)
-				: null;
+			// #1092 PR4b 同じ判定を各所へ手書きで散らさないよう共通関数へ寄せた（振る舞いは #940 のまま）
+			// ⚠️ err が falsy のときの null（i18n へ渡さない）は維持する
+			const errorMessage = err ? toErrorLogMessage(err) : null;
 			set((state) => ({
 				errorByKey: {
 					...state.errorByKey,

--- a/app-expo/stores/useTopicsStore.ts
+++ b/app-expo/stores/useTopicsStore.ts
@@ -1,4 +1,5 @@
 import i18n from "@/lib/i18n";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 import type { SupabaseDishCategories } from "@shared/converters/convert_dish_categories";
 import { createWithEqualityFn } from "zustand/traditional";
 
@@ -397,7 +398,11 @@ const handleAsyncAction = <T>(
 			await onSuccess(items);
 		})
 		.catch((err) => {
-			const errorMessage = err ? (err instanceof Error ? err.message : String(err)) : null;
+			// #1092 PR4b callBackend の失敗がそのまま来る。PR4a 以降ここには Error ではない
+			// ApiError(plain object) も流れるため、置換前の (B) 式だと画面のエラー文言が
+			// 「読み込みに失敗しました: [object Object]」になる。message を優先する共通関数へ寄せる。
+			// ⚠️ err が falsy のときの null（i18n へ渡さない）は置換前のまま維持する
+			const errorMessage = err ? toErrorLogMessage(err) : null;
 			set((state) => ({
 				errorByKey: {
 					...state.errorByKey,


### PR DESCRIPTION
対応 Issue: #1092（親 #1082）

## これは何か

#1092 の **PR4b**。一連の準備 PR を踏まえて、**実際に振る舞いを変える PR** です。

```diff
-const isAppReady = useMemo(() => {
-	return isRemoteConfigReady && !isAuthLoading && !!user;
-}, [isRemoteConfigReady, isAuthLoading, user]);
+const isAppReady = useMemo(() => isRemoteConfigReady, [isRemoteConfigReady]);
```

匿名サインインは起動のたびにネットワーク往復を伴い、回線が細い端末では秒単位で待ちます。その間 `return null` していたため、**アプリは 1 ピクセルも描画されていませんでした**（web は薄グレーの空画面、native はスプラッシュのまま）。認証を必要とするのは API 呼び出しであって描画ではないので、UI を先に出します。

## 前提（マージ済み）

| PR | 内容 |
| --- | --- |
| #1100 PR1 | フォント 5.5MB 待ちのゲートを撤去 |
| #1102 PR2 | Remote Config の既定値を埋め込み `getRemoteConfig()` を null 非返却に |
| #1103 PR4a | `user === null` でマウントされても壊れないための**耐性**（振る舞い不変） |

PR4a で入れた耐性（`useAPICall` の `code: "unauthenticated"`、`HealthCheckInitializer` / `useAutoCurrentLocation` の auth 解決後 1 回だけの再試行、`LoginbackModal` の null ガード）は、**この PR で初めて実際に働き始めます**。

## 変更内容

### 1. ゲートの撤去

`isAppReady` から `!isAuthLoading && !!user` を外しました。`isRemoteConfigReady` は**残しています**（外すのは PR3 のスコープ）。

### 2. スプラッシュ解除条件を「描画できるか」基準に

ゲートを外して UI を先に出せるようにした以上、**スプラッシュも同じ時点で解除しないと効果が丸ごと消えます**（描画できているのにスプラッシュに隠される）。そこで `canRenderFirstFrame` を導入し、**描画分岐（エラー UI / children / `return null`）と 1 対 1 で対応**させました。ここがズレると、緩すぎれば真っ白な画面が見え、厳しすぎればスプラッシュが被さります。

⚠️ **#1089 の非退行**: 以前、匿名サインインが失敗した端末で `hideAsync()` が永久に呼ばれず native のスプラッシュが張り付くバグがありました。現在の条件は `isRemoteConfigReady`（`initializeRemoteConfig` の `finally` で必ず true になる）を含むので、**認証がどうなろうと必ず一度は解除されます**。認証の状態を必須条件に戻さないこと。

`hasSplashBeenHiddenRef` は `await` の**前**に立て、失敗時に戻す形にしました（`await` の間に再レンダリングが挟まると二重に `hideAsync()` を呼ぶため）。

### 3. `String(error)` の一括是正

PR4a でトークン欠如が `Error` インスタンスから plain object になったため、`catch` で `String(error)` している箇所は**ゲートを外すと `[object Object]` になり原因が追えなくなります**。#1092 が「区別可能にする」ことを目的にしたエラーそのものが読めなくなるため、`lib/errorMessage.ts` を新設して揃えました。

⚠️ **依頼時の想定より広い変更です。** 当初は 5 箇所程度の想定でしたが、同型の `String(error)` を grep で洗い出した結果 20 ファイル以上に及んでいます。**レビューではこの範囲の妥当性を重点的に見てください**（とくにログ文字列の変化が BigQuery 集計・アラート条件に影響しないか）。

### 4. 通知タブの表示判定

`is_anonymous === false` の形だと、`@supabase/auth-js` の型上 optional な `is_anonymous` が `undefined` のときに「**ログイン済みなのに通知タブが出ない**」が起きえます。ゲートが外れて実際に到達しうる状態になったため、`lib/authGuest.ts` に判定を集約し、ログイン済みユーザが損をしない側へ倒しました。

## 検証

| 検証 | 結果 |
| --- | --- |
| Detox tier1-2 (Android) | ✅ pass — run [30600250155](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/30600250155) |
| jest（新規 4 ファイル） | `SplashHandler.test.tsx` / `tabsNotificationsHref.test.tsx` / `errorMessage.test.ts` / `authGuest.test.ts` |

固定した振る舞い:

- `user === null` でも `isAppReady` が true になる（子ツリーがマウントされる）
- 認証が未確定のままでもスプラッシュが解除される
- 匿名サインイン失敗時でもスプラッシュが解除される（#1089 の非退行）
- `is_anonymous === undefined` のログイン済みユーザで通知タブが出る

## 実機で確認すべき項目

1. 起動直後、**認証完了前に UI が見えるか**（これがこの PR の目的）
2. スプラッシュが張り付かないか（機内モード / 圏外でも必ず解除されること）
3. ログイン済みアカウントで**通知タブが出るか**（上記 4 の実地確認）

## スコープ外

- **PR3**: Remote Config の stale-while-revalidate 化 + `isAppReady` から `isRemoteConfigReady` を外す
- PR2 のレビュー Minor-1（埋め込み既定値と実 `config.json` の同値性を CI で守る）も PR3 で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019GW8FK6QMDcCXnHB36NvRL)_