### PR TITLE
#1062 fix: OAuth コールバックが認証結果 code を取り落とし、匿名のまま「成功」する問題を修正

### DIFF
--- a/.codex/bigquery/event-catalog.md
+++ b/.codex/bigquery/event-catalog.md
@@ -174,12 +174,20 @@ rg -o 'event_name:\s*"[^"]+"' app-expo --glob '!**/node_modules/**'
 > 修正後は次の関係が成り立つ（発火条件を狭めただけで、旧系列は再構成できる）。
 >
 > ```
-> 旧 oauth_signin_success   ≡ 新 oauth_signin_success + oauth_signin_cancelled
+> 旧 oauth_signin_success   ≡ 新 oauth_signin_success + oauth_signin_browser_dismissed
 > 旧 oauth_callback_success ≡ 新 oauth_callback_success + oauth_callback_no_result + oauth_callback_error
 > ```
 >
 > ログインが成立したかを判定するには `oauth_callback_success`（`payload.via` / `payload.source` /
 > `payload.is_anonymous` を持つ）を使い、`onAuthStateChange:SIGNED_IN` の追随を確認すること。
+>
+> **⚠️ `oauth_signin_*` でログインの成否を判定しないこと。** Android の
+> `WebBrowser.openAuthSessionAsync` は「AppState が active に戻ったこと」と「deep link の url イベント」を
+> race させるため、**deep link でログインに成功した場合でも `dismiss` を返す**。実測でも、成功と同一試行で
+> `oauth_signin_browser_dismissed` が記録され、その 1 秒後に `oauth_callback_success` と
+> `userChanged`（`previous_user_id != new_user_id`）が出ている。したがって Android では
+> `oauth_signin_success` はほぼ発火せず、`oauth_signin_browser_dismissed` は「キャンセル」を意味しない。
+> これらはブラウザセッションの結末の記録であって、認証の成否ではない。
 
 - `sessionRestored`
 - `signInAnonymously`
@@ -199,7 +207,7 @@ rg -o 'event_name:\s*"[^"]+"' app-expo --glob '!**/node_modules/**'
 - `otp_verify_error`
 - `authentication_success`
 - `oauth_signin_success`
-- `oauth_signin_cancelled`
+- `oauth_signin_browser_dismissed`
 - `oauth_signin_error`
 - `profile_shared`
 - `profile_edit_started`

--- a/.codex/bigquery/event-catalog.md
+++ b/.codex/bigquery/event-catalog.md
@@ -163,11 +163,30 @@ rg -o 'event_name:\s*"[^"]+"' app-expo --glob '!**/node_modules/**'
 
 ### Profile, Auth, And Settings
 
+> **⚠️ #1062 以前の OAuth 系イベントの解釈について**
+>
+> #1062 の修正コミット以前、`oauth_callback_success` は「例外が投げられなかったこと」しか意味しておらず、
+> **セッションを確立できていない失敗が混入している**（特に Android の development build を QR /
+> `expo start` の `a` キーで起動したセッション。`Linking.getInitialURL()` が dev launcher の起動 URL を
+> 返し続け、`code` が取り落とされていた）。同様に `oauth_signin_success` にはブラウザのキャンセルが
+> 含まれている。過去分と比較する際はこの点に注意すること。
+>
+> 修正後は次の関係が成り立つ（発火条件を狭めただけで、旧系列は再構成できる）。
+>
+> ```
+> 旧 oauth_signin_success   ≡ 新 oauth_signin_success + oauth_signin_cancelled
+> 旧 oauth_callback_success ≡ 新 oauth_callback_success + oauth_callback_no_result + oauth_callback_error
+> ```
+>
+> ログインが成立したかを判定するには `oauth_callback_success`（`payload.via` / `payload.source` /
+> `payload.is_anonymous` を持つ）を使い、`onAuthStateChange:SIGNED_IN` の追随を確認すること。
+
 - `sessionRestored`
 - `signInAnonymously`
 - `authInitError`
 - `userChanged`
 - `oauth_callback_success`
+- `oauth_callback_no_result`
 - `oauth_link_conflict`
 - `oauth_callback_error`
 - `oauth_conflict_switch_existing`
@@ -180,6 +199,7 @@ rg -o 'event_name:\s*"[^"]+"' app-expo --glob '!**/node_modules/**'
 - `otp_verify_error`
 - `authentication_success`
 - `oauth_signin_success`
+- `oauth_signin_cancelled`
 - `oauth_signin_error`
 - `profile_shared`
 - `profile_edit_started`

--- a/.codex/bigquery/event-catalog.md
+++ b/.codex/bigquery/event-catalog.md
@@ -174,9 +174,15 @@ rg -o 'event_name:\s*"[^"]+"' app-expo --glob '!**/node_modules/**'
 > 修正後は次の関係が成り立つ（発火条件を狭めただけで、旧系列は再構成できる）。
 >
 > ```
-> 旧 oauth_signin_success   ≡ 新 oauth_signin_success + oauth_signin_browser_dismissed
-> 旧 oauth_callback_success ≡ 新 oauth_callback_success + oauth_callback_no_result + oauth_callback_error
+> 旧 oauth_signin_success                    ≡ 新 oauth_signin_success + oauth_signin_browser_dismissed
+> 旧 oauth_callback_success + 旧 oauth_callback_error
+>                                            ≡ 新 oauth_callback_success + oauth_callback_no_result + oauth_callback_error
 > ```
+>
+> callback 側を「旧 success ≡ 新 success + no_result + error」と書くのは誤り。旧コードでも
+> throw 経路（iOS / Web でのエラー応答・exchange 失敗）は旧 `oauth_callback_error` を出していた。
+> 新 `oauth_callback_error` には「旧 success に化けていた分（Android QR 起動で握り潰されていたエラー）」と
+> 「旧 error 相当分」が混在する。
 >
 > ログインが成立したかを判定するには `oauth_callback_success`（`payload.via` / `payload.source` /
 > `payload.is_anonymous` を持つ）を使い、`onAuthStateChange:SIGNED_IN` の追随を確認すること。

--- a/app-expo/app/[locale]/auth/callback.tsx
+++ b/app-expo/app/[locale]/auth/callback.tsx
@@ -175,18 +175,22 @@ export default function AuthCallbackScreen() {
 			// 既存アカウントに切り替え（prompt=none でサイレント認証）
 			const launch = await signInWithOAuth(conflictProvider);
 
-			// #1062 【設計】ブラウザを閉じた場合はスピナー画面に貼り付いたままになるため、プロフィールへ戻す
+			// #1062 【設計】結末は記録するだけで、ここでは画面遷移しない。
+			// Android の dismiss は「ユーザーが閉じた」を意味しない（deep link 成功時にも起こる）。
+			// ここでプロフィールへ戻すと、成功時に expo-router の callback 遷移と競合して
+			// code を処理できないまま離脱しうる。成否の判断と遷移は callback 画面へ一本化する。
+			// 本当にユーザーが閉じた場合にスピナーが残るのは修正前からの挙動で、本 PR では変えない。
 			if (launch.outcome === "cancelled") {
 				logFrontendEvent({
-					event_name: "oauth_signin_cancelled",
+					event_name: "oauth_signin_browser_dismissed",
 					error_level: "log",
 					payload: {
 						provider: conflictProvider,
+						outcome: launch.outcome,
 						browser_result_type: launch.browserResultType,
 						context: "conflict_switch",
 					},
 				});
-				router.replace({ pathname: "/[locale]/profile", params: { locale } });
 			}
 		} catch (error) {
 			logFrontendEvent({

--- a/app-expo/app/[locale]/auth/callback.tsx
+++ b/app-expo/app/[locale]/auth/callback.tsx
@@ -5,27 +5,37 @@
 - linkIdentity の衝突時に警告ダイアログを表示し、ユーザーの確認後に切替/キャンセルを選択可能にする。
 - 処理中はスピナーのみを表示し、ユーザー操作は不要（ダイアログ表示時を除く）。
 
-Web 専用フォールバックについて
-- Web 向けのフォールバック（リダイレクト受け口）として機能します。
-- ネイティブ（iOS/Android）では Linking のリスナーによって処理されますが、Web ではこのルートが認証プロバイダからの戻り先になります。
+認証結果 URL の選び方について（#1062）
+- ネイティブでは expo-router のパラメータ（signInWithOAuth の router.replace / OS のディープリンク）で、
+  Web では現在の URL として、認証結果が届きます。
+- どちらを使うかは「出所の優先順位」ではなく「認証結果を実際に含んでいるか」で決めます（lib/oauthResultUrl.ts）。
+  Android の development build を QR 起動すると Linking.getInitialURL() が dev launcher の起動 URL を
+  返し続けるため、出所で優先すると code を取り落とします（実機で QR 起動＝失敗 / アイコン起動＝成功 を確認）。
 
 補足
-- 初期 URL は Linking.getInitialURL()（expo-router からの遷移でも保持）で取得します。
-- 成功/失敗をフロントエンドログに記録し、いずれの場合も /(tabs)/profile に遷移します。
+- セッションを確立できなかった場合は oauth_callback_no_result を error レベルで記録し、
+  成功ログもプロフィール作成も行いません。いずれの場合も /[locale]/profile に遷移します。
 */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LoadingIndicator } from "@/components/LoadingIndicator";
-import { View, Text, StyleSheet, Linking, Modal, TouchableOpacity, Platform } from "react-native";
+import { View, Text, StyleSheet, Linking, TouchableOpacity } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthProvider";
 import { useLogger } from "@/hooks/useLogger";
 import i18n from "@/lib/i18n";
 import { Provider } from "@supabase/supabase-js";
-import * as AuthSession from "expo-auth-session";
 import { useProfile } from "@/features/profile/hooks/useProfile";
 import { useBlurModal } from "@/features/blurModal/hooks/useBlurModal";
 import { Card } from "@/components/Card";
+import { describeOAuthUrl, pickOAuthResultUrl, type OAuthUrlCandidate } from "@/lib/oauthResultUrl";
+
+/**
+ * router のパラメータを URL の形に載せるための器。
+ * #1062 【設計】クエリしか読まないため、ホスト部分に意味は無い。
+ * 以前はここで Platform 分岐と AuthSession.makeRedirectUri による再構築を行っていたが、
+ * 認証結果の判定に redirect URI の正確な復元は不要なので廃止した。
+ */
+const ROUTER_PARAM_URL_BASE = "nanitabeyo://oauth-result";
 
 /**
  * OAuth認証のコールバック画面
@@ -40,37 +50,84 @@ export default function AuthCallbackScreen() {
 	const { BlurModal: ConflictModal, open: openConflictModal, close: closeConflictModal } = useBlurModal();
 	const [conflictProvider, setConflictProvider] = useState<Provider | null>(null);
 
-	useEffect(() => {
-		const handleAuthCallback = async () => {
-			// 初回URL（フラグメント含む）を取得
-			const initialUrl = await Linking.getInitialURL();
-			const qs = new URLSearchParams(Object.entries(rest).map(([k, v]) => [k, String(v)])).toString();
-			const redirectBase =
-				Platform.OS === "web"
-					? `${window.location.origin}/${locale}/auth/callback`
-					: AuthSession.makeRedirectUri({ scheme: "nanitabeyo", path: `${locale}/auth/callback` });
-			const url = initialUrl || `${redirectBase}?${qs}`; // expo-routerで遷移してきた場合も getInitialURL が持っています
-			try {
-				await handleOAuthResultUrl(url);
+	// 同じ code を二度交換しないためのラッチ（effect が再実行されても処理は一度きり）
+	const hasHandledRef = useRef(false);
 
-				const {
-					data: { user },
-				} = await supabase.auth.getUser();
+	useEffect(() => {
+		if (hasHandledRef.current) return;
+		hasHandledRef.current = true;
+
+		const handleAuthCallback = async () => {
+			const qs = new URLSearchParams(Object.entries(rest).map(([k, v]) => [k, String(v)])).toString();
+			// 初回URL（フラグメント含む）。Web では現在の URL、ネイティブでは起動時の URL。
+			const initialUrl = await Linking.getInitialURL();
+
+			// #1062 【設計】出所の順序ではなく「認証結果を実際に含むか」で選ぶ。
+			// router_params を先に置くのは、これが最も新しい結果だから（順序は保険で、正しさは順序に依存しない）。
+			const candidates: OAuthUrlCandidate[] = [
+				{ source: "router_params", url: qs ? `${ROUTER_PARAM_URL_BASE}?${qs}` : null },
+				{ source: "initial_url", url: initialUrl },
+			];
+			const picked = pickOAuthResultUrl(candidates);
+
+			const goToProfile = () => router.replace({ pathname: "/[locale]/profile", params: { locale } });
+
+			if (!picked) {
+				// ここが従来の「無言の失敗」の出口。成功ログもプロフィール作成も行わない。
+				logFrontendEvent({
+					event_name: "oauth_callback_no_result",
+					error_level: "error",
+					payload: {
+						intent: rest.intent ?? null,
+						provider: rest.provider ?? null,
+						candidates: candidates.map((candidate) => ({
+							source: candidate.source,
+							...(describeOAuthUrl(candidate.url) ?? {}),
+						})),
+					},
+				});
+				goToProfile();
+				return;
+			}
+
+			try {
+				const result = await handleOAuthResultUrl(picked.url);
+
+				if (result.status !== "authenticated") {
+					logFrontendEvent({
+						event_name: "oauth_callback_no_result",
+						error_level: "error",
+						payload: {
+							intent: rest.intent ?? null,
+							provider: rest.provider ?? null,
+							source: picked.source,
+							url_shape: describeOAuthUrl(picked.url),
+						},
+					});
+					goToProfile();
+					return;
+				}
+
+				const { user, via } = result;
 
 				logFrontendEvent({
 					event_name: "oauth_callback_success",
 					error_level: "log",
-					payload: { user_id: user?.id, from: "setSession" },
+					payload: {
+						user_id: user.id,
+						is_anonymous: user.is_anonymous ?? null,
+						via,
+						source: picked.source,
+						intent: rest.intent ?? null,
+					},
 				});
 
-				// 必要ならプロフィール作成
-				if (user) {
-					await createUserProfile({
-						displayName: user.user_metadata?.name ?? user.identities?.[0]?.identity_data?.name,
-						avatar: user.user_metadata?.avatar_url ?? user.identities?.[0]?.identity_data?.avatar_url,
-					});
-				}
-				router.replace({ pathname: "/[locale]/profile", params: { locale } });
+				// 必要ならプロフィール作成（セッションを確立できた場合のみ）
+				await createUserProfile({
+					displayName: user.user_metadata?.name ?? user.identities?.[0]?.identity_data?.name,
+					avatar: user.user_metadata?.avatar_url ?? user.identities?.[0]?.identity_data?.avatar_url,
+				});
+				goToProfile();
 			} catch (error: unknown) {
 				// linkIdentity による identity_already_exists エラーの場合は警告ダイアログを表示
 				const err = error as any;
@@ -84,13 +141,18 @@ export default function AuthCallbackScreen() {
 					openConflictModal();
 					return;
 				} else {
-					router.replace({ pathname: "/[locale]/profile", params: { locale } });
+					goToProfile();
 				}
 
 				logFrontendEvent({
 					event_name: "oauth_callback_error",
 					error_level: "error",
-					payload: { error: error instanceof Error ? error.message : String(error), url },
+					payload: {
+						error: error instanceof Error ? error.message : String(error),
+						// #1062 【設計】生の URL は code / access_token を含むため記録しない
+						source: picked.source,
+						url_shape: describeOAuthUrl(picked.url),
+					},
 				});
 			}
 		};
@@ -111,14 +173,28 @@ export default function AuthCallbackScreen() {
 			});
 
 			// 既存アカウントに切り替え（prompt=none でサイレント認証）
-			await signInWithOAuth(conflictProvider);
+			const launch = await signInWithOAuth(conflictProvider);
+
+			// #1062 【設計】ブラウザを閉じた場合はスピナー画面に貼り付いたままになるため、プロフィールへ戻す
+			if (launch.outcome === "cancelled") {
+				logFrontendEvent({
+					event_name: "oauth_signin_cancelled",
+					error_level: "log",
+					payload: {
+						provider: conflictProvider,
+						browser_result_type: launch.browserResultType,
+						context: "conflict_switch",
+					},
+				});
+				router.replace({ pathname: "/[locale]/profile", params: { locale } });
+			}
 		} catch (error) {
 			logFrontendEvent({
 				event_name: "oauth_conflict_switch_error",
 				error_level: "error",
 				payload: { provider: conflictProvider, error: (error as Error).message },
 			});
-			router.replace("/(tabs)/profile");
+			router.replace({ pathname: "/[locale]/profile", params: { locale } });
 		}
 	};
 
@@ -130,7 +206,7 @@ export default function AuthCallbackScreen() {
 		});
 
 		closeConflictModal();
-		router.replace("/(tabs)/profile");
+		router.replace({ pathname: "/[locale]/profile", params: { locale } });
 	};
 
 	return (

--- a/app-expo/contexts/AuthProvider.tsx
+++ b/app-expo/contexts/AuthProvider.tsx
@@ -37,6 +37,28 @@ export type AuthFailure = {
 	message: string;
 };
 
+/**
+ * #1062 【設計】OAuth 用ブラウザセッションの結末。
+ * - `cancelled` はユーザーがブラウザを閉じた等で結果 URL を受け取れなかったことを表す。
+ *   セッションは一切変化していないため、呼び出し側は成功として扱ってはいけない。
+ */
+export type OAuthLaunchOutcome =
+	/** Web: この後ブラウザ側の全画面リダイレクトが起きる */
+	| { outcome: "redirecting" }
+	/** ネイティブ: ブラウザが結果 URL を返し、callback 画面へ引き継いだ */
+	| { outcome: "returned" }
+	/** ネイティブ: cancel / dismiss / locked。セッションは変化していない */
+	| { outcome: "cancelled"; browserResultType: string };
+
+/**
+ * #1062 【設計】コールバック URL の処理結果。
+ * 従来は「セッションが確立できなかった」ことを `null` で表していたため、
+ * 呼び出し側が戻り値を検査せず成功ログを出してしまっていた。判別可能ユニオンで明示する。
+ */
+export type OAuthCallbackResult =
+	| { status: "authenticated"; user: User; via: "pkce" | "implicit" }
+	| { status: "no_result" };
+
 type AuthContextType = {
 	user: User | null;
 	getSession: () => Session | null;
@@ -60,11 +82,17 @@ type AuthContextType = {
 	loginWithEmail: (email: string, password: string) => Promise<void>;
 	logout: (options?: SignOut) => Promise<void>;
 	signUpWithEmail: (email: string, password: string) => Promise<void>;
-	signInWithOAuth: (provider: Provider, options?: { queryParams?: { [key: string]: string } }) => Promise<void>;
+	signInWithOAuth: (
+		provider: Provider,
+		options?: { queryParams?: { [key: string]: string } },
+	) => Promise<OAuthLaunchOutcome>;
 	signInWithOtp: (phone: string) => Promise<void>;
 	verifyOtp: (phone: string, token: string) => Promise<void>;
-	linkIdentity: (provider: Provider, options?: { queryParams?: { [key: string]: string } }) => Promise<void>;
-	handleOAuthResultUrl: (url?: string | null) => Promise<User | null | undefined>;
+	linkIdentity: (
+		provider: Provider,
+		options?: { queryParams?: { [key: string]: string } },
+	) => Promise<OAuthLaunchOutcome>;
+	handleOAuthResultUrl: (url?: string | null) => Promise<OAuthCallbackResult>;
 };
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -389,7 +417,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 	 * 新規ユーザー作成 または 既存ユーザー へのログインを行う。
 	 * @param provider - 'google' などのOAuthプロバイダー名
 	 */
-	const signInWithOAuth = async (provider: Provider, options?: { queryParams?: { [key: string]: string } }) => {
+	const signInWithOAuth = async (
+		provider: Provider,
+		options?: { queryParams?: { [key: string]: string } },
+	): Promise<OAuthLaunchOutcome> => {
 		const { queryParams = {} } = options || {};
 
 		// Google のときはデフォルトで毎回アカウント選択を出す
@@ -417,18 +448,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 		});
 		if (error) throw error;
 		if (Platform.OS !== "web" && data?.url) {
-			const result = await WebBrowser.openAuthSessionAsync(data.url, redirectTo);
-			if (result.type === "success" && result.url) {
-				const parsed = Linking.parse(result.url);
-				const locale = (parsed.hostname ?? "ja-JP") as string;
-				const qp = Object.fromEntries(Object.entries(parsed.queryParams ?? {}).map(([k, v]) => [k, String(v)])); // queryParams は string | number | boolean | null などが来るので文字列化
-				const href: Href = {
-					pathname: "/[locale]/auth/callback",
-					params: { locale, ...qp },
-				};
-				router.replace(href);
-			}
+			return openOAuthBrowserSession(data.url, redirectTo);
 		}
+		// Web はこの後ブラウザ側でリダイレクトされる
+		return { outcome: "redirecting" };
 	};
 
 	/**
@@ -463,7 +486,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 	const linkIdentity = async (
 		provider: Provider,
 		options?: { queryParams?: { [key: string]: string } },
-	): Promise<void> => {
+	): Promise<OAuthLaunchOutcome> => {
 		const { queryParams = {} } = options || {};
 
 		// Google のときはデフォルトで毎回アカウント選択を出す
@@ -495,25 +518,43 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 		});
 		if (error) throw error;
 		if (Platform.OS !== "web" && data?.url) {
-			const result = await WebBrowser.openAuthSessionAsync(data.url, redirectTo);
-			if (result.type === "success" && result.url) {
-				const parsed = Linking.parse(result.url);
-				const locale = (parsed.hostname ?? "ja-JP") as string;
-				const qp = Object.fromEntries(Object.entries(parsed.queryParams ?? {}).map(([k, v]) => [k, String(v)])); // queryParams は string | number | boolean | null などが来るので文字列化
-				const href: Href = {
-					pathname: "/[locale]/auth/callback",
-					params: { locale, ...qp },
-				};
-				router.replace(href);
-			}
+			return openOAuthBrowserSession(data.url, redirectTo);
 		}
+		// Web はこの後ブラウザ側でリダイレクトされる
+		return { outcome: "redirecting" };
+	};
+
+	/**
+	 * ネイティブで OAuth 用のブラウザセッションを開き、戻ってきた URL を callback 画面へ引き渡す。
+	 *
+	 * #1062 【設計】`result.type` が success 以外（ユーザーがブラウザを閉じた等）のときは
+	 * セッションが一切変化していないため、`cancelled` として呼び出し側へ返す。
+	 * 従来は戻り値を返しておらず、キャンセルでも `oauth_signin_success` が記録されていた。
+	 */
+	const openOAuthBrowserSession = async (authUrl: string, redirectTo: string): Promise<OAuthLaunchOutcome> => {
+		const result = await WebBrowser.openAuthSessionAsync(authUrl, redirectTo);
+		if (result.type !== "success" || !result.url) {
+			return { outcome: "cancelled", browserResultType: result.type };
+		}
+
+		const parsed = Linking.parse(result.url);
+		const parsedLocale = (parsed.hostname ?? "ja-JP") as string;
+		const qp = Object.fromEntries(Object.entries(parsed.queryParams ?? {}).map(([k, v]) => [k, String(v)])); // queryParams は string | number | boolean | null などが来るので文字列化
+		const href: Href = {
+			pathname: "/[locale]/auth/callback",
+			params: { locale: parsedLocale, ...qp },
+		};
+		router.replace(href);
+		return { outcome: "returned" };
 	};
 
 	/** OAuthのリダイレクトURIから認証結果を処理する
 	 * - PKCE (codeフロー) と 旧インプリシット (#access_token) の両方に対応
+	 * - #1062 【設計】セッションを確立できなかった場合は `no_result` を返す。
+	 *   従来は黙って `null` を返しており、呼び出し側が失敗に気付けなかった。
 	 */
-	const handleOAuthResultUrl = async (url?: string | null) => {
-		if (!url) return;
+	const handleOAuthResultUrl = async (url?: string | null): Promise<OAuthCallbackResult> => {
+		if (!url) return { status: "no_result" };
 
 		const parsed = Linking.parse(url);
 		const code = parsed.queryParams?.code as string | undefined;
@@ -534,10 +575,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 		}
 
 		// 1) PKCE (codeフロー)
+		// #1062 【設計】交換結果の user をそのまま返す。以前は getUser() で現行セッションを
+		// 取り直していたため、交換が行われなかった場合に「匿名ユーザー」が成功として記録されていた。
 		if (code) {
 			const { data, error } = await supabase.auth.exchangeCodeForSession(code);
 			if (error) throw error;
-			return data.user;
+			if (!data.user) return { status: "no_result" };
+			return { status: "authenticated", user: data.user, via: "pkce" };
 		}
 
 		// 2) 旧: インプリシット（#access_token）
@@ -546,16 +590,14 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 			const params = new URLSearchParams(hash);
 			const access_token = params.get("access_token");
 			const refresh_token = params.get("refresh_token");
-			const expires_at = params.get("expires_at");
 			if (access_token && refresh_token) {
-				await supabase.auth.setSession({ access_token, refresh_token });
-				const {
-					data: { user },
-				} = await supabase.auth.getUser();
-				return user ?? null;
+				const { data, error } = await supabase.auth.setSession({ access_token, refresh_token });
+				if (error) throw error;
+				if (!data.user) return { status: "no_result" };
+				return { status: "authenticated", user: data.user, via: "implicit" };
 			}
 		}
-		return null;
+		return { status: "no_result" };
 	};
 
 	/**

--- a/app-expo/features/profile/components/LoginbackModal.tsx
+++ b/app-expo/features/profile/components/LoginbackModal.tsx
@@ -119,31 +119,27 @@ export function LoginbackModal({ onClose }: LoginbackModalProps) {
 					: // チェック済み（既存ログイン狙い）または既にログイン済みなら、通常の OAuth サインインを行う。
 						await signInWithOAuth(provider);
 
-				// #1062 【設計】ブラウザを閉じた等で認証結果 URL を受け取れなかった場合、
-				// セッションは一切変化していないため成功として記録しない。
-				// モーダルは閉じず、そのまま再試行できるようにする。
-				if (launch.outcome === "cancelled") {
-					logFrontendEvent({
-						event_name: "oauth_signin_cancelled",
-						error_level: "log",
-						payload: {
-							provider,
-							isUpgrade,
-							hasExistingAccount,
-							browser_result_type: launch.browserResultType,
-							context: "login_modal",
-						},
-					});
-					return;
-				}
-
+				// #1062 【設計】ブラウザセッションの結末を記録する。ただし **これで成否を判定してはいけない**。
+				// Android の openAuthSessionAsync は「AppState が active に戻ったこと」と
+				// 「deep link の url イベント」を race させるため、deep link でログインに成功した場合でも
+				// dismiss が勝つことがある（実測: 成功と同一試行で dismiss が記録される）。
+				// 成否は callback 画面の oauth_callback_success / oauth_callback_no_result を正とする。
 				logFrontendEvent({
-					event_name: "oauth_signin_success",
+					event_name:
+						launch.outcome === "cancelled" ? "oauth_signin_browser_dismissed" : "oauth_signin_success",
 					error_level: "log",
-					payload: { provider, isUpgrade, hasExistingAccount, outcome: launch.outcome },
+					payload: {
+						provider,
+						isUpgrade,
+						hasExistingAccount,
+						outcome: launch.outcome,
+						...(launch.outcome === "cancelled" ? { browser_result_type: launch.browserResultType } : {}),
+						context: "login_modal",
+					},
 				});
 
-				// OAuth 成功時に明示的にモーダルを閉じる（Android で戻ったときに残る問題を解消）
+				// ⚠️ 結末によらず必ず閉じる。dismiss でモーダルを開いたままにすると、
+				// Android では「ログインできたのにモーダルが残る」状態になる（上記 race のため）。
 				onClose();
 			} catch (error: unknown) {
 				logFrontendEvent({

--- a/app-expo/features/profile/components/LoginbackModal.tsx
+++ b/app-expo/features/profile/components/LoginbackModal.tsx
@@ -111,18 +111,36 @@ export function LoginbackModal({ onClose }: LoginbackModalProps) {
 				// user === null は上でガード済みなので、ここでの意味は「匿名セッションか」で変わらない。
 				// is_anonymous が欠落している場合にログイン済み扱いになる（＝ linkIdentity しない）のも同じ
 				const isAnonymous = isGuestUser(user);
+				const isUpgrade = isAnonymous && !hasExistingAccount;
 
-				if (isAnonymous && !hasExistingAccount) {
-					// 未チェック（昇格狙い）: 匿名セッションのまま OAuth を追加(linkIdentity)を試みる。
-					await linkIdentity(provider);
-				} else {
-					// チェック済み（既存ログイン狙い）または既にログイン済みなら、通常の OAuth サインインを行う。
-					await signInWithOAuth(provider);
+				const launch = isUpgrade
+					? // 未チェック（昇格狙い）: 匿名セッションのまま OAuth を追加(linkIdentity)を試みる。
+						await linkIdentity(provider)
+					: // チェック済み（既存ログイン狙い）または既にログイン済みなら、通常の OAuth サインインを行う。
+						await signInWithOAuth(provider);
+
+				// #1062 【設計】ブラウザを閉じた等で認証結果 URL を受け取れなかった場合、
+				// セッションは一切変化していないため成功として記録しない。
+				// モーダルは閉じず、そのまま再試行できるようにする。
+				if (launch.outcome === "cancelled") {
+					logFrontendEvent({
+						event_name: "oauth_signin_cancelled",
+						error_level: "log",
+						payload: {
+							provider,
+							isUpgrade,
+							hasExistingAccount,
+							browser_result_type: launch.browserResultType,
+							context: "login_modal",
+						},
+					});
+					return;
 				}
+
 				logFrontendEvent({
 					event_name: "oauth_signin_success",
 					error_level: "log",
-					payload: { provider, isUpgrade: isAnonymous && !hasExistingAccount, hasExistingAccount },
+					payload: { provider, isUpgrade, hasExistingAccount, outcome: launch.outcome },
 				});
 
 				// OAuth 成功時に明示的にモーダルを閉じる（Android で戻ったときに残る問題を解消）

--- a/app-expo/lib/oauthResultUrl.test.ts
+++ b/app-expo/lib/oauthResultUrl.test.ts
@@ -1,0 +1,128 @@
+import { carriesOAuthResult, describeOAuthUrl, pickOAuthResultUrl, type OAuthUrlCandidate } from "./oauthResultUrl";
+
+/** Android の development build を QR / `a` キーで起動したときに getInitialURL() が返す URL（#1062 の元凶） */
+const DEV_LAUNCHER_URL = "nanitabeyo://expo-development-client/?url=https%3A%2F%2Fabc.exp.direct";
+const PKCE_URL = "nanitabeyo://ja-JP/auth/callback?intent=signin&code=abc123";
+const IMPLICIT_URL = "nanitabeyo://ja-JP/auth/callback#access_token=tok123&refresh_token=ref456&expires_at=1";
+const ERROR_URL = "nanitabeyo://ja-JP/auth/callback?intent=link&error=server_error&error_code=identity_already_exists";
+const WEB_PKCE_URL = "https://app.nanitabeyo.net/ja-JP/auth/callback?intent=signin&code=abc123";
+
+describe("carriesOAuthResult", () => {
+	it("PKCE の code を持つ URL を認証結果とみなす", () => {
+		expect(carriesOAuthResult(PKCE_URL)).toBe(true);
+		expect(carriesOAuthResult(WEB_PKCE_URL)).toBe(true);
+	});
+
+	it("インプリシットの #access_token を持つ URL を認証結果とみなす", () => {
+		expect(carriesOAuthResult(IMPLICIT_URL)).toBe(true);
+	});
+
+	it("エラー応答を認証結果とみなす（握り潰さず callback 側で扱わせるため）", () => {
+		expect(carriesOAuthResult(ERROR_URL)).toBe(true);
+		expect(carriesOAuthResult("nanitabeyo://ja-JP/auth/callback?error_code=bad")).toBe(true);
+	});
+
+	it("dev launcher の起動 URL を認証結果とみなさない（#1062 の中核）", () => {
+		expect(carriesOAuthResult(DEV_LAUNCHER_URL)).toBe(false);
+	});
+
+	it("認証結果を持たない URL / null / 空文字を false にする", () => {
+		expect(carriesOAuthResult("nanitabeyo://ja-JP/auth/callback?intent=signin")).toBe(false);
+		expect(carriesOAuthResult("nanitabeyo://ja-JP/profile")).toBe(false);
+		expect(carriesOAuthResult(null)).toBe(false);
+		expect(carriesOAuthResult(undefined)).toBe(false);
+		expect(carriesOAuthResult("")).toBe(false);
+	});
+
+	// ?? チェーンで書くと get("code") が "" を返した時点で短絡し、後続を見ずに false になる
+	it("空値の ?code= があっても、後続の #access_token / error を見落とさない", () => {
+		expect(carriesOAuthResult("nanitabeyo://ja-JP/auth/callback?code=#access_token=tok")).toBe(true);
+		expect(carriesOAuthResult("nanitabeyo://ja-JP/auth/callback?code=&error=server_error")).toBe(true);
+	});
+});
+
+describe("pickOAuthResultUrl", () => {
+	// 修正前は initial_url が無条件に優先され、ここで code を取り落としていた
+	it("Android dev client(QR起動): initial_url が dev launcher URL でも router_params の code を選ぶ", () => {
+		const candidates: OAuthUrlCandidate[] = [
+			{ source: "router_params", url: PKCE_URL },
+			{ source: "initial_url", url: DEV_LAUNCHER_URL },
+		];
+		expect(pickOAuthResultUrl(candidates)).toEqual({ source: "router_params", url: PKCE_URL });
+	});
+
+	it("アイコン起動 / production: initial_url が null でも router_params から選べる", () => {
+		const candidates: OAuthUrlCandidate[] = [
+			{ source: "router_params", url: PKCE_URL },
+			{ source: "initial_url", url: null },
+		];
+		expect(pickOAuthResultUrl(candidates)?.source).toBe("router_params");
+	});
+
+	it("コールドスタート: router_params が空でも initial_url の code を拾う", () => {
+		const candidates: OAuthUrlCandidate[] = [
+			{ source: "router_params", url: null },
+			{ source: "initial_url", url: PKCE_URL },
+		];
+		expect(pickOAuthResultUrl(candidates)?.source).toBe("initial_url");
+	});
+
+	it("Web インプリシット: fragment は router params に載らないため initial_url が選ばれる", () => {
+		const candidates: OAuthUrlCandidate[] = [
+			{ source: "router_params", url: "nanitabeyo://oauth-result?intent=signin" },
+			{ source: "initial_url", url: IMPLICIT_URL },
+		];
+		expect(pickOAuthResultUrl(candidates)?.source).toBe("initial_url");
+	});
+
+	it("エラー応答も選択される（成功として素通りさせない）", () => {
+		const candidates: OAuthUrlCandidate[] = [
+			{ source: "router_params", url: ERROR_URL },
+			{ source: "initial_url", url: DEV_LAUNCHER_URL },
+		];
+		expect(pickOAuthResultUrl(candidates)?.source).toBe("router_params");
+	});
+
+	it("どの候補も認証結果を持たなければ null（= 失敗として扱わせる）", () => {
+		const candidates: OAuthUrlCandidate[] = [
+			{ source: "router_params", url: null },
+			{ source: "initial_url", url: DEV_LAUNCHER_URL },
+		];
+		expect(pickOAuthResultUrl(candidates)).toBeNull();
+	});
+
+	it("候補が空でも null を返す", () => {
+		expect(pickOAuthResultUrl([])).toBeNull();
+	});
+});
+
+describe("describeOAuthUrl", () => {
+	it("キー名と非機密なエラーだけを返す", () => {
+		expect(describeOAuthUrl(ERROR_URL)).toEqual({
+			scheme: "nanitabeyo",
+			query_keys: ["error", "error_code", "intent"],
+			fragment_keys: [],
+			error: "server_error",
+			error_code: "identity_already_exists",
+		});
+	});
+
+	it("fragment のキー名も拾う", () => {
+		expect(describeOAuthUrl(IMPLICIT_URL)?.fragment_keys).toEqual(["access_token", "expires_at", "refresh_token"]);
+	});
+
+	it("null / undefined は null を返す", () => {
+		expect(describeOAuthUrl(null)).toBeNull();
+		expect(describeOAuthUrl(undefined)).toBeNull();
+	});
+
+	// ログ基盤へ秘密値を流さないことの回帰テスト
+	it("code / access_token / refresh_token の値を一切含めない", () => {
+		for (const url of [PKCE_URL, IMPLICIT_URL, WEB_PKCE_URL]) {
+			const serialized = JSON.stringify(describeOAuthUrl(url));
+			expect(serialized).not.toContain("abc123");
+			expect(serialized).not.toContain("tok123");
+			expect(serialized).not.toContain("ref456");
+		}
+	});
+});

--- a/app-expo/lib/oauthResultUrl.ts
+++ b/app-expo/lib/oauthResultUrl.ts
@@ -1,0 +1,81 @@
+/*
+このファイルの責務
+- OAuth のリダイレクト結果を運んでいる URL を「中身」で判定・選択する純粋関数を提供する。
+- expo / supabase / react-native に依存しないため、単体テストで全分岐を検証できる。
+
+なぜ「中身」で選ぶのか（#1062）
+- 従来は `Linking.getInitialURL() || <router params から組み立てた URL>` と、
+  出所の優先順位で決めていた。
+- ところが Android の development build を QR / `expo start` の `a` キーで起動すると、
+  dev launcher の起動 intent（`nanitabeyo://expo-development-client/?url=...`）が
+  MainActivity に残り続け、`getInitialURL()` はそのセッション中ずっとその URL を返す。
+  `onNewIntent` では `getIntent()` が更新されないため、OAuth の戻りが届いても変わらない。
+- 結果、`code` を持つ router params 側が捨てられ、`exchangeCodeForSession` が呼ばれないまま
+  「成功」として扱われていた（実機で QR 起動＝失敗 / アイコン起動＝成功 を確認済み）。
+- そこで「どこから来たか」ではなく「認証結果を実際に持っているか」で選ぶ。
+  これにより起動経路・プラットフォーム・ビルド種別に依存しなくなる。
+*/
+
+/** 認証結果 URL の出所。ログの `source` としてそのまま記録する。 */
+export type OAuthUrlSource = "router_params" | "initial_url";
+
+export type OAuthUrlCandidate = {
+	source: OAuthUrlSource;
+	url: string | null;
+};
+
+/** URL のクエリ部とフラグメント部を取り出す。 */
+const splitUrl = (url: string): { query: URLSearchParams; fragment: URLSearchParams } => {
+	const [beforeHash, fragment = ""] = url.split("#");
+	const search = beforeHash.split("?").slice(1).join("?");
+	return { query: new URLSearchParams(search), fragment: new URLSearchParams(fragment) };
+};
+
+/**
+ * この URL が OAuth の結果（PKCE の code / エラー応答 / インプリシットの access_token）を
+ * 運んでいるかを、中身だけで判定する。
+ *
+ * ⚠️ `??` チェーンで書かないこと。`?code=`（値が空）のとき `get("code")` は "" を返すため、
+ * チェーンがそこで止まって後続の判定に到達せず、偽陰性になる。必ず `has()` と `||` で書く。
+ */
+export const carriesOAuthResult = (url: string | null | undefined): url is string => {
+	if (!url) return false;
+	const { query, fragment } = splitUrl(url);
+	return query.has("code") || query.has("error") || query.has("error_code") || fragment.has("access_token");
+};
+
+/**
+ * 候補のうち、認証結果を実際に持っている最初のものを返す。
+ * どれも持っていなければ null を返し、呼び出し側に「失敗」として扱わせる（黙って進ませない）。
+ */
+export const pickOAuthResultUrl = (candidates: OAuthUrlCandidate[]): OAuthUrlCandidate | null =>
+	candidates.find((candidate) => carriesOAuthResult(candidate.url)) ?? null;
+
+/** `describeOAuthUrl` の戻り値。値ではなく「形」だけを持つ。 */
+export type OAuthUrlShape = {
+	scheme: string | null;
+	query_keys: string[];
+	fragment_keys: string[];
+	error: string | null;
+	error_code: string | null;
+};
+
+/**
+ * ログ出力用に URL の «形» だけを取り出す。
+ *
+ * ⚠️ `code` / `access_token` / `refresh_token` の «値» は絶対に含めないこと。
+ * これらはログ基盤（Cloud Logging → BigQuery）へ流れるため、生の URL を記録してはいけない。
+ * 含めてよいのは、キー名と、非機密な `error` / `error_code` だけ。
+ */
+export const describeOAuthUrl = (url: string | null | undefined): OAuthUrlShape | null => {
+	if (!url) return null;
+	const { query, fragment } = splitUrl(url);
+	const scheme = url.includes(":") ? url.split(":")[0] : null;
+	return {
+		scheme,
+		query_keys: [...query.keys()].sort(),
+		fragment_keys: [...fragment.keys()].sort(),
+		error: query.get("error") ?? null,
+		error_code: query.get("error_code") ?? null,
+	};
+};


### PR DESCRIPTION
Closes #1062

## 事象

Android の development build を **QR / `expo start` の `a` キーで起動したセッション**で、Google/Apple ログインが匿名セッションのまま無言で失敗していた。UI にもログにもエラーが出ず、`oauth_signin_success` / `oauth_callback_success` が記録されるため、**成功として観測されていた**。

## 原因（実機で確定済み）

QR 起動は `ACTION_VIEW` + `nanitabeyo://expo-development-client/?url=...` の deep link 起動であり、expo-dev-launcher (`DevLauncherController.createAppIntent()`) がこの intent の `action` / `data` を MainActivity の起動 intent へコピーする。`IntentModule` は `onNewIntent` で `getIntent()` を更新しないため、`Linking.getInitialURL()` はそのセッション中ずっとこの **`code` を含まない URL** を返し続ける。

`callback.tsx` は `initialUrl || <router params から組み立てた URL>` と**出所の優先順位**で選んでいたため、expo-router 経由で届いている `code` を捨て、`exchangeCodeForSession` を一度も呼ばないまま `getUser()` が返す匿名ユーザーを「成功」として記録し、その匿名 uid に `users` レコードまで作っていた。

**切り分け（同一端末・同一アカウント・同一コード、起動方法だけを変えた）:**

| 条件 | 結果 |
|---|---|
| dev client / 強制停止 → アイコン起動 → URL 手入力・履歴 | ✅ 成功 |
| dev client / 強制停止 → QR スキャン | ❌ 失敗 |
| 本番アプリ | ✅ 成功 |

**回帰ではない**: 原因行 `const url = initialUrl || ...` は `798d8e4e`（2025-09-23）以降無変更。`pnpm-lock.yaml` の解決済みバージョン（`expo@53.0.24` / `expo-dev-client@5.2.4` / `expo-dev-launcher@5.1.16` / `expo-linking@7.1.7` / `expo-web-browser@14.2.0` / `expo-auth-session@6.2.1` / `expo-router@5.1.7` / `react-native@0.79.5`）も 2026-02-26 と現在で完全に同一。2025-09 から存在した潜在欠陥が、起動方法によって顕在化したもの。

## 変更内容

Issue #1062 の [統合レビュー](``https://github.com/Ayato-kosaka/nanitabeyo/issues/1062#issuecomment-5122180831)の確定設計をベースに、原因が1点に絞れたことを受けて**スコープを最小化した案A**（報告者が選択）。``

### 1. 認証結果 URL を「中身」で選ぶ — `app-expo/lib/oauthResultUrl.ts`（新規）

「どこから来たか」ではなく「**認証結果を実際に含んでいるか**」（`code` / `error` / `#access_token`）で選ぶ純粋関数。起動経路・プラットフォーム・ビルド種別に依存しなくなり、`callback.tsx` から `Platform.OS` 分岐と `AuthSession.makeRedirectUri` による再構築が消えた。

`carriesOAuthResult` は `??` チェーンではなく `has()` + `||` で実装している。`?code=`（値が空）のとき `get("code")` が `""` を返してチェーンが短絡し、後続の `#access_token` を見落とす偽陰性になるため（テストで固定）。

### 2. 失敗を失敗として観測できるようにした

- `handleOAuthResultUrl` の戻り値を判別可能ユニオン（`authenticated` / `no_result`）へ。従来は黙って `null` を返しており、呼び出し側が失敗に気付けなかった。
- 成功時は `exchangeCodeForSession` / `setSession` が返した user をそのまま使う（`getUser()` の取り直しをやめる）。**「匿名ユーザーの id が成功ログに載った」直接の原因はここ。**
- セッション未確立時は `oauth_callback_no_result`（error）を記録し、**成功ログもプロフィール作成も行わない**。匿名 uid への `users` レコード作成（データ汚染）が止まる。

### 3. ブラウザセッションの結末を記録する（ただし成否判定には使わない）

`signInWithOAuth` / `linkIdentity` が `OAuthLaunchOutcome`（`redirecting` / `returned` / `cancelled`）を返す。

⚠️ **Android の `openAuthSessionAsync` は「AppState が active に戻ったこと」と「deep link の url イベント」を race させるため、ログイン成功時でも `dismiss` を返す**（実機ログで確認）。したがって:

- イベント名は `oauth_signin_browser_dismissed`（「キャンセル」ではない）。
- **結末によらず必ずモーダルを閉じる。** 当初 `cancelled` で閉じない実装にしたところ「ログインできたのにモーダルが残る」回帰になったため修正済み（`c8095a2a`）。
- conflict 切替経路では `cancelled` 時に画面遷移しない。ここで遷移すると成功時に expo-router の callback 遷移と競合し、本 PR が直した不具合を再発させうる。

### 4. ログの衛生・整合

- `oauth_callback_error` の payload から生 URL を除去し `describeOAuthUrl`（キー名と非機密な `error` / `error_code` のみ）へ置換。`code` / `access_token` / `refresh_token` がログ基盤へ流れる経路を塞いだ（テストで固定）。
- `.codex/bigquery/event-catalog.md` に新イベント2件を追記。修正前の `oauth_callback_success` に失敗が混入している旨、旧系列の再構成式、および **`oauth_signin_*` で成否を判定してはならない**旨を注記。

### 5. その他

- conflict ダイアログの遷移先 `/(tabs)/profile` → `/[locale]/profile`（`[locale]` 抜けの不正 href）。
- 同じ code を二度交換しないための `hasHandledRef` ラッチ。

## 検証結果

### 実機（Android dev client / **QR 起動**）— 報告者が確認

| # | 項目 | 結果 |
|---|---|---|
| 1 | ログインが成功する | ✅ |
| 2 | ログイン後にモーダルが閉じる | ✅ |
| 3 | 自分でブラウザを閉じた場合も閉じる | ✅ |

dev ログの決定的な証拠:

```
18:52:12  oauth_callback_success
          {"user_id":"de582758…","is_anonymous":false,"via":"pkce",
           "source":"router_params","intent":"signin"}
18:52:12  userChanged
          {"previous_user_id":"e1fb9d81…","new_user_id":"de582758…"}
```

`source: "router_params"` = **修正前に捨てられていた候補**。`via: "pkce"` で `exchangeCodeForSession` が実際に走り、`userChanged` が実ユーザー切替になっている。dev の Android でこれが記録されたのは初めて。

### 自動テスト

| | スイート | テスト |
|---|---|---|
| origin/main（別 worktree で対照実行） | 1 failed / 13 passed / 14 | **111 passed** |
| 本ブランチ | 1 failed / 14 passed / 15 | **128 passed**（+17） |

- 失敗 1 件は `features/search/searchScreenPreload.test.tsx`（`constants/Env.ts:16` の `extra.eas.projectId` がテスト環境で解決できない）で、**main でも同一に失敗する既存問題**。
- `pnpm --filter app-expo typecheck` → **exit 0**
- main の `contexts/AuthProvider.test.tsx`（#1097 の 429 クールダウン不変条件）を含む既存スイートは全て green。

## スコープから外したもの

- **jest 基盤の追加** — 作業中に #1079 で jest-expo 基盤が main に入ったため取り下げ、main の基盤に相乗り。新規テストは main の `testMatch` にそのまま乗る。
- **`unit-test.yml`（`pull_request` トリガ新設）** — #1112 の対応コミットに「pull_request トリガーの workflow 新設は CI コストと運用の方針判断を伴うため意図的に対象外とし、#1112 に残す」とあり、方針判断を無関係な修正 PR で既成事実化すべきでないため取り下げ。**このリポジトリには現在 PR で走る CI が無く、本 PR にも check run は付いていない。**
- **`app.config.ts` の `autoVerify` intentFilter 是正** — 調査の結果、本件とは無関係と確定（カスタムスキーム経由で正常に復帰できている）。Android 11 以前で App Links を巻き添え無効化しうる別件。

## 既知の残課題（フォローアップ）

独立レビューの Low 指摘のうち、本 PR で対応しなかったもの:

- **L1**: `carriesOAuthResult` が fragment 側の `error` を見ない。`flowType: "pkce"` 固定でエラーは query 側に載るため実質デッドパスであり、旧コードは同ケースを「成功」にしていたので回帰でもない。閉じ際に動作中の認証コードへ手を入れるリスクを避けて見送った。
- **L3**: テストは述語のみを守り、`callback.tsx` の配線は無防備。将来 `initialUrl || ...` へ戻す回帰は検出できない。
- **L4**: 同一 code の二重交換の残余リスク（PLAUSIBLE 止まり、ログイン失敗経路ではない）。
- 既に作られてしまった匿名 uid の `users` レコードのクリーンアップ。本 PR は「これ以上増やさない」だけ。
- `oauth_callback_success.payload.from`（常に `"setSession"` の定数）を削除した。リポジトリ内に参照は無いが、外部の保存クエリ・ダッシュボードが参照していれば 0 件になる。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuEGiWBbi4vuYyJLG3mcmj