### PR TITLE
#1124 fix: iPhoneのログアウト後に設定画面でフリーズする不具合を修正

### DIFF
--- a/app-expo/contexts/AuthProvider.test.tsx
+++ b/app-expo/contexts/AuthProvider.test.tsx
@@ -234,19 +234,17 @@ describe("AuthProvider の 429 クールダウン（#1097）", () => {
 		// ★ コールバックはロック保持中に await されている。ここで叩いていたらデッドロックする
 		expect(auth.signInAnonymously).not.toHaveBeenCalled();
 
-		// ★ 再認証を開始する前に root へ遷移すると、AuthProvider の unmount cleanup が
-		// 再認証タイマーを取り消してしまう。遷移も callback の外へ予約する。
+		// iOS / Web は callback の外で再認証を開始してから遷移するとフリーズするため、
+		// callback 内でホームへ遷移する。匿名サインイン自体は callback の外で開始する。
 		const { useRouter } = jest.requireMock("expo-router") as { useRouter: () => { replace: jest.Mock } };
 		const { requestLogoutRedirect } = jest.requireMock("@/lib/logoutRedirect") as { requestLogoutRedirect: jest.Mock };
-		expect(requestLogoutRedirect).not.toHaveBeenCalled();
-		expect(useRouter().replace).not.toHaveBeenCalled();
+		expect(requestLogoutRedirect).toHaveBeenCalledWith("ja-JP");
+		expect(useRouter().replace).toHaveBeenCalledWith("/");
 
 		await act(async () => {
 			jest.advanceTimersByTime(0);
 		});
 
-		expect(requestLogoutRedirect).toHaveBeenCalledWith("ja-JP");
-		expect(useRouter().replace).toHaveBeenCalledWith("/");
 		expect(auth.signInAnonymously).toHaveBeenCalledTimes(1);
 	});
 

--- a/app-expo/contexts/AuthProvider.tsx
+++ b/app-expo/contexts/AuthProvider.tsx
@@ -413,9 +413,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 					router.replace("/");
 				};
 
-				// Web は callback の外で再認証を開始してから遷移するとフリーズするため、ここで同期的に
-				// 遷移する。AuthProvider の再マウント時に起動時の runAuthAttempt が匿名セッションを復元する。
-				if (Platform.OS === "web") {
+				// Web と iOS は callback の外で再認証を開始してから遷移するとフリーズするため、ここで
+				// 同期的に遷移する。AuthProvider の再マウント時に起動時の runAuthAttempt が匿名セッションを復元する。
+				// Android だけは root への replace が再認証タイマーを取り消し得るため、下で遅延させる。
+				if (Platform.OS !== "android") {
 					navigateHome();
 				} else {
 					// native の root への replace は AuthProvider を unmount し、上のタイマーを cleanup で


### PR DESCRIPTION
iOSとWebは即時遷移、Androidだけ再認証開始後に遷移するよう分離する