### PR TITLE
#1138 Transcoder 完了通知 subscription の自動失効を防止

### DIFF
--- a/infra/transcoder/20251201T0000_setup_transcoder_infra_and_pubsub.sh
+++ b/infra/transcoder/20251201T0000_setup_transcoder_infra_and_pubsub.sh
@@ -180,7 +180,7 @@ run_pubsub_setup() {
   echo "  - TOPIC_NAME       : ${topic_name}"
   echo
 
-  ./setup_transcoder_pubsub.sh \
+  bash ./setup_transcoder_pubsub.sh \
     "${PROJECT_ID}" \
     "${cloud_run_url}" \
     "${PUSH_SA_EMAIL}" \

--- a/infra/transcoder/setup_transcoder_pubsub.sh
+++ b/infra/transcoder/setup_transcoder_pubsub.sh
@@ -106,6 +106,7 @@ if ! gcloud pubsub subscriptions describe "${SUBSCRIPTION_NAME}" --project="${PR
     --push-auth-service-account="${PUSH_SA}" \
     --push-auth-token-audience="${CLOUD_RUN_URL}" \
     --ack-deadline=60 \
+    --expiration-period=never \
     --quiet
   echo "✅ Subscription created."
 else
@@ -115,6 +116,7 @@ else
     --push-endpoint="${PUSH_ENDPOINT}" \
     --push-auth-service-account="${PUSH_SA}" \
     --push-auth-token-audience="${CLOUD_RUN_URL}" \
+    --expiration-period=never \
     --quiet
   echo "✅ Subscription updated."
 fi


### PR DESCRIPTION
## 変更内容

- Pub/Sub push subscription の作成時に `--expiration-period=never` を指定
- 既存 subscription の更新時にも `--expiration-period=never` を指定
- 復旧ラッパースクリプトを実行可能に変更し、内部スクリプトを `bash` 経由で呼び出すよう修正

## 原因

Transcoder 完了通知用 subscription に expiration policy が明示されておらず、長期間通知がない dev / prod 環境で subscription が自動失効していました。その結果、Transcoder Job が成功しても webhook が呼ばれず、動画レビューが `processing` のまま残っていました。

## 影響・復旧

- dev / prod の subscription を再作成済み
- 両 subscription の `expirationPolicy: {}`（無期限）、push endpoint、OIDC audience、ack deadline 60秒を確認済み
- dev の滞留2件を `completed` に復旧済み
- dev topic へ成功通知を再送し、webhook HTTP 204 と BigQuery の完了イベント3件を確認済み

## 確認

- `git diff --check`
- `bash -n infra/transcoder/20251201T0000_setup_transcoder_infra_and_pubsub.sh infra/transcoder/setup_transcoder_pubsub.sh`
- subscription の作成・更新両経路を GCP 上で確認
- `TranscoderWebhookReceived`
- `TranscoderJobSucceeded`
- `DishMediaProcessingStatusUpdated`

Closes #1138