### PR TITLE
#1123 fix: 同名の駅候補をオートコンプリートで重複除去する

### DIFF
--- a/api/src/v1/locations/locations.service.spec.ts
+++ b/api/src/v1/locations/locations.service.spec.ts
@@ -693,19 +693,29 @@ describe('LocationsService', () => {
       ]);
     });
 
-    it('should keep same-name bus stops that are not rail stations', async () => {
-      // #1123 【テスト】bus_station / bus_stop は同名でものりば違いの別地点が正当に
-      // 存在するため RAIL_STATION_TYPES に含めていない。畳まれないことを守る。
+    it('should keep same-name bus stops that also carry the generic transit_station type', async () => {
+      // #1123 【受入条件4】【テスト】PR #1149 レビュー指摘: Google Places の実データでは
+      // バス停・バスターミナルは汎用の transit_station を併せ持つのが通例
+      // (例: ["bus_station", "transit_station", "point_of_interest", "establishment"])。
+      // 同名でも進行方向・のりば違いで別地点として正当に併存するため、
+      // 両方が残らなければならない。
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
           buildSuggestion(
             'place-bus-1',
             '渋谷駅前',
             '日本、東京都渋谷区道玄坂',
-            ['bus_station', 'establishment'],
+            [
+              'bus_station',
+              'transit_station',
+              'point_of_interest',
+              'establishment',
+            ],
           ),
           buildSuggestion('place-bus-2', '渋谷駅前', '日本、東京都渋谷区渋谷', [
             'bus_stop',
+            'transit_station',
+            'point_of_interest',
             'establishment',
           ]),
         ],
@@ -716,6 +726,40 @@ describe('LocationsService', () => {
       expect(result.map((place) => place.place_id)).toEqual([
         'place-bus-1',
         'place-bus-2',
+      ]);
+    });
+
+    it('should keep same-name tram stops on opposite sides of the street', async () => {
+      // #1123 【テスト】PR #1149 レビュー指摘(Minor): 路面電車の停留場は運用上バス停に
+      // 近く、上り/下りが同名で道路を挟んだ別地点として登録される地域がある。
+      // light_rail_station も畳み対象にしないことを守る。
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion('place-tram-1', '広電西広島', '日本、広島県広島市', [
+            'light_rail_station',
+            'transit_station',
+            'point_of_interest',
+            'establishment',
+          ]),
+          buildSuggestion(
+            'place-tram-2',
+            '広電西広島',
+            '日本、広島県広島市西区己斐本町',
+            [
+              'light_rail_station',
+              'transit_station',
+              'point_of_interest',
+              'establishment',
+            ],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result.map((place) => place.place_id)).toEqual([
+        'place-tram-1',
+        'place-tram-2',
       ]);
     });
 

--- a/api/src/v1/locations/locations.service.spec.ts
+++ b/api/src/v1/locations/locations.service.spec.ts
@@ -578,6 +578,147 @@ describe('LocationsService', () => {
       expect(result).toHaveLength(2);
     });
 
+    it('should keep only the top-ranked candidate for same-name station establishments', async () => {
+      // #1123 【受入条件1】【テスト】渋谷駅が2件の establishment(どちらも駅・交通施設)
+      // として返るケース。実データの place_id / types を fixture に使用。
+      // 双方 establishment のため #952 のルールでは畳めなかったが、鉄道駅 type を持つ
+      // 同名候補なので Google の関連度順で先頭の1件だけが残ること。
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion(
+            'ChIJz8MVLFiLGGARXP0DqqhoDow',
+            '渋谷駅',
+            '日本、東京都渋谷区',
+            [
+              'train_station',
+              'subway_station',
+              'transit_station',
+              'point_of_interest',
+              'establishment',
+            ],
+          ),
+          buildSuggestion(
+            'ChIJnxAAO1aLGGARJqvi8d4oczM',
+            '渋谷駅',
+            '日本、東京都渋谷区渋谷２丁目２４',
+            [
+              'train_station',
+              'subway_station',
+              'transit_station',
+              'point_of_interest',
+              'establishment',
+            ],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result).toHaveLength(1);
+      // 関連度順の先頭が残る(並び替えはしない)
+      expect(result[0].place_id).toBe('ChIJz8MVLFiLGGARXP0DqqhoDow');
+    });
+
+    it('should keep the top-ranked station and preserve relevance order of other candidates', async () => {
+      // #1123 【受入条件1,3】【テスト】重複した駅候補を畳んでも、他候補の
+      // 関連度順(元の配列順)が維持されること。「渋谷駅前」は別名なので残る。
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion(
+            'ChIJz8MVLFiLGGARXP0DqqhoDow',
+            '渋谷駅',
+            '日本、東京都渋谷区',
+            ['train_station', 'transit_station', 'establishment'],
+          ),
+          buildSuggestion('place-square', '渋谷駅前', '日本、東京都渋谷区', [
+            'bus_station',
+            'transit_station',
+            'establishment',
+          ]),
+          buildSuggestion(
+            'ChIJnxAAO1aLGGARJqvi8d4oczM',
+            '渋谷駅',
+            '日本、東京都渋谷区渋谷２丁目２４',
+            [
+              'train_station',
+              'subway_station',
+              'transit_station',
+              'establishment',
+            ],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result.map((place) => place.place_id)).toEqual([
+        'ChIJz8MVLFiLGGARXP0DqqhoDow',
+        'place-square',
+      ]);
+    });
+
+    it('should still keep same-name chain branches after the station rule was added', async () => {
+      // #1123 【受入条件2】【テスト】「スターバックス」のような同名だが別の実店舗は
+      // 鉄道駅 type を持たないため新ルールの対象外で、引き続き複数返ること
+      // (#952 の意図を壊していないことの回帰テスト)。
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion(
+            'place-sbux-shibuya',
+            'スターバックスコーヒー',
+            '日本、東京都渋谷区道玄坂',
+            ['cafe', 'food', 'point_of_interest', 'establishment'],
+          ),
+          buildSuggestion(
+            'place-sbux-udagawa',
+            'スターバックスコーヒー',
+            '日本、東京都渋谷区宇田川町',
+            ['cafe', 'food', 'point_of_interest', 'establishment'],
+          ),
+          buildSuggestion(
+            'place-sbux-ebisu',
+            'スターバックスコーヒー',
+            '日本、東京都渋谷区恵比寿',
+            ['cafe', 'food', 'point_of_interest', 'establishment'],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result.map((place) => place.place_id)).toEqual([
+        'place-sbux-shibuya',
+        'place-sbux-udagawa',
+        'place-sbux-ebisu',
+      ]);
+    });
+
+    it('should keep same-name bus stops that are not rail stations', async () => {
+      // #1123 【テスト】bus_station / bus_stop は同名でものりば違いの別地点が正当に
+      // 存在するため RAIL_STATION_TYPES に含めていない。畳まれないことを守る。
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion(
+            'place-bus-1',
+            '渋谷駅前',
+            '日本、東京都渋谷区道玄坂',
+            ['bus_station', 'establishment'],
+          ),
+          buildSuggestion('place-bus-2', '渋谷駅前', '日本、東京都渋谷区渋谷', [
+            'bus_stop',
+            'establishment',
+          ]),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result.map((place) => place.place_id)).toEqual([
+        'place-bus-1',
+        'place-bus-2',
+      ]);
+    });
+
     it('should collapse exact duplicates (same mainText and secondaryText)', async () => {
       // #952 【テスト】表示が完全一致する候補は区別できないため1件に畳むこと
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({

--- a/api/src/v1/locations/locations.service.ts
+++ b/api/src/v1/locations/locations.service.ts
@@ -566,9 +566,38 @@ export class LocationsService {
   }
 
   /**
+   * #1123 【設計】「同名なら同一の駅」とみなしてよい鉄道系 type の集合。
+   *
+   * 含めた理由:
+   * - train_station / subway_station / transit_station:
+   *   Issue #1123 の渋谷駅重複が該当。Google は同じ駅を「駅施設」と「出入口/番地相当」の
+   *   別 place_id で返すことがあり、どちらも establishment を持つため #952 のルールでは
+   *   畳めない。鉄道駅は同一エリア内に同名の別駅が存在しないため、同名なら同一駅と
+   *   みなして安全に畳める。
+   * - light_rail_station:
+   *   新交通システム/路面電車の駅も鉄道駅と同じ命名慣習(同名の別駅が存在しない)で、
+   *   transit_station との併記による同種の重複が発生するため含める。
+   *
+   * 含めなかった理由(安全側に倒す):
+   * - bus_station / bus_stop / transit_depot:
+   *   「渋谷駅前」のように、同名でも進行方向・のりば・事業者ごとに別地点として
+   *   存在するのが正常。畳むとユーザーが選びたいのりばを選べなくなる。
+   * - airport / international_airport / ferry_terminal / heliport / taxi_stand /
+   *   park_and_ride:
+   *   同名でターミナル違い等の別地点が正当に併存しうるうえ、#1123 のような粒度違い
+   *   重複の実例が確認できていないため対象外とする。
+   */
+  private static readonly RAIL_STATION_TYPES: ReadonlySet<string> = new Set([
+    'train_station',
+    'subway_station',
+    'transit_station',
+    'light_rail_station',
+  ]);
+
+  /**
    * #952 【設計】Autocomplete 候補の「同一地点の粒度違い重複」を除去する。
    *
-   * ルール(PR #980 レビュー指摘を受けた改訂版):
+   * ルール(PR #980 レビュー指摘を受けた改訂版 / #1123 でルール3-bを追加):
    * 1. mainText を正規化(NFKC + 空白除去)したものを同名判定のキーにする。
    *    「渋谷駅」と「渋谷駅前」のような別名は別キーになり残る。
    * 2. 落とすのは「同名の establishment(実在施設)が存在する場合の非 establishment 候補」
@@ -576,8 +605,12 @@ export class LocationsService {
    *    同一地点の粒度違い重複に相当する。
    * 3. 同名でも establishment 同士(例: 同名チェーンの別店舗。place_id・secondaryText が
    *    異なる別の実在地点)は全て残す。表示名だけで別地点を消してはならない。
+   * 3-b. #1123 例外: 同名かつ鉄道駅 type(RAIL_STATION_TYPES)を持つ候補は、
+   *    establishment 同士であっても同一駅の重複表示とみなし、Google の関連度順で
+   *    先頭の1件だけを残す。バス停など「同名の別地点」が正当に存在する交通施設を
+   *    RAIL_STATION_TYPES に含めないことで、この例外の適用範囲を鉄道駅に限定する。
    * 4. 完全重複(mainText と secondaryText の両方が一致)だけは同名同士でも1件に畳む。
-   * 5. 返却順は Google の関連度順(元の配列順)を維持する。
+   * 5. 返却順は Google の関連度順(元の配列順)を維持する。並び替えは行わない。
    */
   private dedupeAutocompletePlaces(
     places: AutocompleteLocationsResponse,
@@ -588,6 +621,10 @@ export class LocationsService {
     const isEstablishment = (place: { types: string[] }): boolean =>
       place.types.includes('establishment');
 
+    // #1123 鉄道駅・軌道系の交通施設候補かどうか(判定 type は RAIL_STATION_TYPES 参照)
+    const isRailStation = (place: { types: string[] }): boolean =>
+      place.types.some((type) => LocationsService.RAIL_STATION_TYPES.has(type));
+
     // 同名の establishment が1件でも存在する mainText キーの集合
     const establishmentNameKeys = new Set(
       places
@@ -596,6 +633,8 @@ export class LocationsService {
     );
 
     const seenExactKeys = new Set<string>();
+    // #1123 既に採用済みの鉄道駅候補の mainText キー(関連度順で先頭の1件が入る)
+    const keptRailStationNameKeys = new Set<string>();
 
     return places.filter((place) => {
       const nameKey = normalizeKey(place.mainText);
@@ -611,6 +650,15 @@ export class LocationsService {
       // geocode / street_address / premise 等)は同一地点の粒度違いとみなして落とす
       if (!isEstablishment(place) && establishmentNameKeys.has(nameKey)) {
         return false;
+      }
+
+      // ルール3-b(#1123): 同名の鉄道駅候補は先頭(= Google の関連度順で最上位)のみ残す。
+      // 走査順が元の配列順のため、採用済みキーを持つ後続の駅候補だけが落ちる。
+      if (isRailStation(place)) {
+        if (keptRailStationNameKeys.has(nameKey)) {
+          return false;
+        }
+        keptRailStationNameKeys.add(nameKey);
       }
 
       return true;

--- a/api/src/v1/locations/locations.service.ts
+++ b/api/src/v1/locations/locations.service.ts
@@ -569,16 +569,25 @@ export class LocationsService {
    * #1123 【設計】「同名なら同一の駅」とみなしてよい鉄道系 type の集合。
    *
    * 含めた理由:
-   * - train_station / subway_station / transit_station:
+   * - train_station / subway_station:
    *   Issue #1123 の渋谷駅重複が該当。Google は同じ駅を「駅施設」と「出入口/番地相当」の
    *   別 place_id で返すことがあり、どちらも establishment を持つため #952 のルールでは
    *   畳めない。鉄道駅は同一エリア内に同名の別駅が存在しないため、同名なら同一駅と
    *   みなして安全に畳める。
-   * - light_rail_station:
-   *   新交通システム/路面電車の駅も鉄道駅と同じ命名慣習(同名の別駅が存在しない)で、
-   *   transit_station との併記による同種の重複が発生するため含める。
    *
-   * 含めなかった理由(安全側に倒す):
+   * 含めなかった理由(安全側 = 同名の別地点を消さない側に倒す):
+   * - transit_station:
+   *   PR #1149 レビュー指摘。これは鉄道駅に固有の type ではなく交通施設全般に付く
+   *   汎用 type で、実データではバス停も
+   *   ["bus_station", "transit_station", "point_of_interest", "establishment"]
+   *   のように併せ持つ。含めると同名の別バス停(進行方向・のりば違い)が畳まれてしまい、
+   *   下記「bus_station を含めない」という保護が実質無効になる。
+   *   #1123 の渋谷駅 2 候補はどちらも train_station / subway_station を持つため、
+   *   transit_station を外しても Issue は解決する。
+   * - light_rail_station:
+   *   PR #1149 レビュー指摘。#1123 に実例が無く、路面電車の停留場は運用上バス停に近い
+   *   命名(上り/下りが同名で道路を挟んだ別地点)になる地域があるため、実例が出るまでは
+   *   畳まない側に倒す。
    * - bus_station / bus_stop / transit_depot:
    *   「渋谷駅前」のように、同名でも進行方向・のりば・事業者ごとに別地点として
    *   存在するのが正常。畳むとユーザーが選びたいのりばを選べなくなる。
@@ -590,9 +599,19 @@ export class LocationsService {
   private static readonly RAIL_STATION_TYPES: ReadonlySet<string> = new Set([
     'train_station',
     'subway_station',
-    'transit_station',
-    'light_rail_station',
   ]);
+
+  /**
+   * #1123 【設計】同名でも別地点として正当に併存する交通施設の type 集合。
+   *
+   * PR #1149 レビュー指摘を受けた多重防御。RAIL_STATION_TYPES から汎用の
+   * transit_station を外しただけでは、将来 type を追加した際に再び同じ穴が開く。
+   * これらの type を1つでも持つ候補は、たとえ鉄道駅 type を併せ持っていても
+   * (例: 駅前ロータリーのバスターミナルが train_station を併記するケース)
+   * 同名畳み込みの対象外とし、常に残す。
+   */
+  private static readonly NEVER_COLLAPSE_TRANSIT_TYPES: ReadonlySet<string> =
+    new Set(['bus_station', 'bus_stop', 'transit_depot']);
 
   /**
    * #952 【設計】Autocomplete 候補の「同一地点の粒度違い重複」を除去する。
@@ -607,8 +626,9 @@ export class LocationsService {
    *    異なる別の実在地点)は全て残す。表示名だけで別地点を消してはならない。
    * 3-b. #1123 例外: 同名かつ鉄道駅 type(RAIL_STATION_TYPES)を持つ候補は、
    *    establishment 同士であっても同一駅の重複表示とみなし、Google の関連度順で
-   *    先頭の1件だけを残す。バス停など「同名の別地点」が正当に存在する交通施設を
-   *    RAIL_STATION_TYPES に含めないことで、この例外の適用範囲を鉄道駅に限定する。
+   *    先頭の1件だけを残す。適用範囲を鉄道駅に限定するため、(i) 交通施設全般に付く
+   *    汎用 type(transit_station)を RAIL_STATION_TYPES に含めず、(ii) バス停など
+   *    NEVER_COLLAPSE_TRANSIT_TYPES を持つ候補は明示的に除外する(PR #1149 指摘)。
    * 4. 完全重複(mainText と secondaryText の両方が一致)だけは同名同士でも1件に畳む。
    * 5. 返却順は Google の関連度順(元の配列順)を維持する。並び替えは行わない。
    */
@@ -621,9 +641,16 @@ export class LocationsService {
     const isEstablishment = (place: { types: string[] }): boolean =>
       place.types.includes('establishment');
 
-    // #1123 鉄道駅・軌道系の交通施設候補かどうか(判定 type は RAIL_STATION_TYPES 参照)
+    // #1123 鉄道駅候補かどうか(判定 type は RAIL_STATION_TYPES 参照)。
+    // PR #1149: 同名でも別地点が正当に併存するバス停系 type を持つ候補は、
+    // 鉄道駅 type を併せ持っていても畳み込み対象にしない(安全側に倒す)。
     const isRailStation = (place: { types: string[] }): boolean =>
-      place.types.some((type) => LocationsService.RAIL_STATION_TYPES.has(type));
+      place.types.some((type) =>
+        LocationsService.RAIL_STATION_TYPES.has(type),
+      ) &&
+      !place.types.some((type) =>
+        LocationsService.NEVER_COLLAPSE_TRANSIT_TYPES.has(type),
+      );
 
     // 同名の establishment が1件でも存在する mainText キーの集合
     const establishmentNameKeys = new Set(


### PR DESCRIPTION
## 対象 Issue

Closes #1123

## 背景

`渋谷駅` の地点オートコンプリートで、同じ `mainText` の候補が 2 件返る。両方が `establishment` を含むため、既存の「同名チェーンの別店舗を守る」例外に該当して重複除去されていなかった。

## 変更

- `api/src/v1/locations/locations.service.ts` — 同一正規化 `mainText` かつ駅・交通施設の候補は、Google の関連度順で先頭 1 件だけを残す
- `api/src/v1/locations/locations.service.spec.ts` — 受入条件をテストケース化

## 受入条件との対応

- `渋谷駅` の検索で同名の駅候補は 1 件
- `スターバックス` など同名の別実店舗は複数返る（既存挙動を維持）
- `渋谷駅前` のような別名候補は残る

## 検証

- `pnpm --filter api typecheck`
- `pnpm --filter api test`

エビデンスは Actions run 30705992042 の Artifact に格納。

## 未実施

実環境（api-development）でのデプロイ検証はこの PR では未実施。API 変更のためリーダーが `api-deploy.yml` で development へ一時デプロイし、検証後に main を再デプロイして復旧する運用を別途行う。production へはデプロイしない。

## base

統合ブランチ `claude/parallel-dev-orchestration-7he5dw` 宛。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_