### PR TITLE
#1129 fix: 最近使った場所を再選択時に先頭へ移動する

### DIFF
--- a/app-expo/app/[locale]/(tabs)/search/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/search/index.tsx
@@ -109,6 +109,11 @@ export default function SearchScreen() {
 	// #932 【設計】現在地取得の恒久的な失敗(権限拒否・未対応)時に手入力へ誘導するため
 	const locationInputRef = useRef<LocationAutocompleteHandle>(null);
 
+	// #953 【仕様】直近5件の地点をローカル保存し、地点未入力でのフォーカス時に再選択候補として出す
+	// #1129 【設計】handleSelectRecentLocation が addRecentLocation を依存配列で参照するため、
+	// 宣言はハンドラ定義より前に置く必要がある(useCallback の依存配列は定義時に評価されるため)
+	const { recentLocations, addRecentLocation, clearRecentLocations } = useRecentLocations();
+
 	// #958 【修正】中央カラム幅に追従する4列グリッドのアイテムサイズ
 	const contentWidth = useContentWidth();
 	const itemWidth = useMemo(
@@ -203,8 +208,12 @@ export default function SearchScreen() {
 			});
 			setLocation(recent);
 			setLocationQuery(recent.locationQuery);
+			// #1129 【仕様】再選択した地点を MRU(Most Recently Used)順で先頭へ引き上げる。
+			// addRecentLocation は同一地点を除去してから先頭へ積むため、件数は増えない。
+			// 保存タイミングはオートコンプリート選択時(handleLocationSelect)と揃えて「選択した瞬間」とする。
+			addRecentLocation(recent);
 		},
-		[logFrontendEvent],
+		[logFrontendEvent, addRecentLocation],
 	);
 
 	const handleUseCurrentLocation = async () => {
@@ -336,9 +345,6 @@ export default function SearchScreen() {
 		lightImpact();
 		setShowAdvancedFilters(!showAdvancedFilters);
 	};
-
-	// #953 【仕様】直近5件の地点をローカル保存し、地点未入力でのフォーカス時に再選択候補として出す
-	const { recentLocations, addRecentLocation, clearRecentLocations } = useRecentLocations();
 
 	// #973【設計】検索ボタンをdisabledにすると handleSearch 内のバリデーションスナックバーが
 	// 発火しなくなるため、常にタップ可能にしたうえで見た目だけ「未充足」を伝える

--- a/app-expo/features/search/hooks/useRecentLocations.test.tsx
+++ b/app-expo/features/search/hooks/useRecentLocations.test.tsx
@@ -1,0 +1,134 @@
+import { act } from "react";
+import TestRenderer from "react-test-renderer";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useRecentLocations, type RecentLocation } from "./useRecentLocations";
+
+/**
+ * #1129 の感度テスト: **「最近使った場所」は MRU(Most Recently Used)順であること**。
+ *
+ * 「渋谷駅前おおしま皮膚科 / 渋谷駅」の順で並んでいるときに「渋谷駅」を選び直したら
+ * 「渋谷駅 / 渋谷駅前おおしま皮膚科」になってほしい、という Issue の要求を固定する。
+ * 先頭移動そのものは `addRecentLocation` が担っており、リストからの再選択でも
+ * このフックを通ることが前提になる（呼ばれなければ順序は永遠に変わらない）。
+ *
+ * 併せて #953 の不変条件（重複しない・最大5件・AsyncStorage へ永続化）も固定する。
+ */
+
+const STORAGE_KEY = "recent_locations_v1";
+
+/** 表示名と座標だけ変えた RecentLocation を作る。他フィールドは #953 の保存形式そのまま */
+const makeLocation = (locationQuery: string, latitude: number, longitude: number): RecentLocation => ({
+	location: { latitude, longitude },
+	address: "country:JP, locality:Tokyo",
+	localLanguageCode: "ja",
+	locationQuery,
+});
+
+const shibuyaStation = makeLocation("渋谷駅", 35.658, 139.7016);
+const oshimaClinic = makeLocation("渋谷駅前おおしま皮膚科", 35.6591, 139.7023);
+
+describe("#1129 最近使った場所は MRU 順に並ぶ", () => {
+	let renderer: TestRenderer.ReactTestRenderer;
+	let hookRef: ReturnType<typeof useRecentLocations>;
+
+	const Probe = () => {
+		hookRef = useRecentLocations();
+		return null;
+	};
+
+	/** マウントし、AsyncStorage からの初期ロード完了まで待つ */
+	const mount = async () => {
+		await act(async () => {
+			renderer = TestRenderer.create(<Probe />);
+		});
+	};
+
+	const add = async (location: RecentLocation) => {
+		await act(async () => {
+			await hookRef.addRecentLocation(location);
+		});
+	};
+
+	/** 実際に AsyncStorage へ書かれた内容を読み戻す（永続化の検証用） */
+	const readPersisted = async (): Promise<RecentLocation[]> => {
+		const raw = await AsyncStorage.getItem(STORAGE_KEY);
+		return raw ? (JSON.parse(raw) as RecentLocation[]) : [];
+	};
+
+	beforeEach(async () => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		// jest.setup.js のインメモリ実装は suite 内で状態を共有するため、毎回消す
+		await AsyncStorage.clear();
+	});
+
+	it("既存の地点を再選択すると先頭へ移動し、件数は変わらない", async () => {
+		await mount();
+		// Issue の再現状況: 上から「渋谷駅前おおしま皮膚科」「渋谷駅」
+		await add(shibuyaStation);
+		await add(oshimaClinic);
+		expect(hookRef.recentLocations.map((entry) => entry.locationQuery)).toEqual(["渋谷駅前おおしま皮膚科", "渋谷駅"]);
+
+		// 「渋谷駅」を選び直す = リストに載っているものと同一の値が渡ってくる
+		await add(shibuyaStation);
+
+		expect(hookRef.recentLocations.map((entry) => entry.locationQuery)).toEqual(["渋谷駅", "渋谷駅前おおしま皮膚科"]);
+		// 件数が増えない = 座標一致の dedupe が効いている
+		expect(hookRef.recentLocations).toHaveLength(2);
+	});
+
+	it("再選択後の並び順も AsyncStorage へ永続化される", async () => {
+		await mount();
+		await add(shibuyaStation);
+		await add(oshimaClinic);
+		await add(shibuyaStation);
+
+		expect((await readPersisted()).map((entry) => entry.locationQuery)).toEqual(["渋谷駅", "渋谷駅前おおしま皮膚科"]);
+	});
+
+	it("新規地点は先頭へ入り、5件を超えた分は古い順に捨てられる", async () => {
+		await mount();
+		for (let i = 1; i <= 6; i++) {
+			await add(makeLocation(`地点${i}`, 35 + i * 0.01, 139 + i * 0.01));
+		}
+
+		// 直近5件が新しい順。最も古い「地点1」だけが落ちる
+		expect(hookRef.recentLocations.map((entry) => entry.locationQuery)).toEqual([
+			"地点6",
+			"地点5",
+			"地点4",
+			"地点3",
+			"地点2",
+		]);
+		expect(await readPersisted()).toHaveLength(5);
+	});
+
+	it("上限まで埋まった状態で最古の地点を再選択しても、押し出されず先頭へ来る", async () => {
+		await mount();
+		const oldest = makeLocation("最古の地点", 35.1, 139.1);
+		await add(oldest);
+		for (let i = 2; i <= 5; i++) {
+			await add(makeLocation(`地点${i}`, 35 + i * 0.01, 139 + i * 0.01));
+		}
+		expect(hookRef.recentLocations).toHaveLength(5);
+
+		await add(oldest);
+
+		expect(hookRef.recentLocations[0].locationQuery).toBe("最古の地点");
+		expect(hookRef.recentLocations).toHaveLength(5);
+	});
+
+	it("保存済みの並びをマウント時に復元する", async () => {
+		await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify([oshimaClinic, shibuyaStation]));
+
+		await mount();
+
+		expect(hookRef.isLoading).toBe(false);
+		expect(hookRef.recentLocations.map((entry) => entry.locationQuery)).toEqual(["渋谷駅前おおしま皮膚科", "渋谷駅"]);
+	});
+
+	afterEach(async () => {
+		await act(async () => {
+			renderer?.unmount();
+		});
+	});
+});

--- a/app-expo/features/search/recentLocationReselect.test.tsx
+++ b/app-expo/features/search/recentLocationReselect.test.tsx
@@ -1,0 +1,128 @@
+// #1129 【設計】「最近使った場所」から選び直したとき、その地点を先頭へ引き上げるテスト。
+//
+// 背景: useRecentLocations.addRecentLocation は元から「同一地点を除いて先頭へ積む」実装だった
+// (= MRU のロジック自体は存在した)。にもかかわらず Issue の現象が起きていたのは、
+// **検索画面の handleSelectRecentLocation がそれを呼んでいなかった**ため。
+// オートコンプリートからの新規選択(handleLocationSelect)でしか呼ばれておらず、
+// リストから選び直しても順序は永遠に固定されたままだった。
+//
+// この配線は useRecentLocations の単体テストでは絶対に捕まえられない(フック側は正しいので)。
+// ここで「再選択 → addRecentLocation が呼ばれる」ことを固定する。
+import React from "react";
+import TestRenderer from "react-test-renderer";
+import type { RecentLocation } from "@/features/search/hooks/useRecentLocations";
+
+// 周辺依存のスタブ方針は searchScreenPreload.test.tsx と同じ(検索画面は AuthProvider →
+// lib/supabase → constants/Env まで芋づるに読み込むため、断ち切らないと suite ごと落ちる)
+jest.mock("expo-image", () => ({ Image: function MockExpoImage() {} }));
+jest.mock(
+	"lucide-react-native",
+	() =>
+		new Proxy(
+			{},
+			{
+				get: (_target, prop) => (prop === "__esModule" ? true : function MockIcon() {}),
+			},
+		),
+);
+jest.mock("expo-router", () => ({ router: { push: jest.fn(), replace: jest.fn() } }));
+jest.mock("@react-navigation/native", () => ({ useIsFocused: () => true }));
+jest.mock("react-native-safe-area-context", () => {
+	const { View: RNView } = require("react-native");
+	return { SafeAreaView: RNView };
+});
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+jest.mock("@/hooks/useLocale", () => ({ useLocale: () => ({ locale: "ja-JP", isJapanese: true }) }));
+jest.mock("@/hooks/useHaptics", () => ({ useHaptics: () => ({ lightImpact: jest.fn(), mediumImpact: jest.fn() }) }));
+jest.mock("@/hooks/useLogger", () => ({ useLogger: () => ({ logFrontendEvent: jest.fn() }) }));
+jest.mock("@/hooks/useScreenTrace", () => ({ useScreenTrace: jest.fn() }));
+jest.mock("@/hooks/useContentWidth", () => ({ useContentWidth: () => 390 }));
+jest.mock("@/contexts/AuthProvider", () => ({ useAuth: () => ({ user: null }) }));
+jest.mock("@/hooks/useLocationSearch", () => ({
+	useLocationSearch: () => ({
+		getCurrentLocation: () => Promise.resolve(null),
+		getLocationDetails: () => Promise.resolve(null),
+	}),
+}));
+jest.mock("@/contexts/SnackbarProvider", () => ({ useSnackbar: () => ({ showSnackbar: jest.fn() }) }));
+jest.mock("@/features/search/hooks/useAutoCurrentLocation", () => ({
+	useAutoCurrentLocation: () => ({ requestAutoCurrentLocation: jest.fn() }),
+}));
+jest.mock("@/features/search/hooks/useSearchTutorial", () => ({
+	useSearchTutorial: () => ({ hasSeenTutorial: false, isLoading: false, markTutorialAsSeen: jest.fn() }),
+}));
+jest.mock("@/components/PrimaryButton", () => ({ PrimaryButton: () => null }));
+jest.mock("@/features/search/components/TutorialBottomSheet", () => ({ TutorialBottomSheet: () => null }));
+jest.mock("@/features/search/components/DistanceSlider", () => ({ DistanceSlider: () => null }));
+jest.mock("@/features/search/components/PriceLevelsMultiSelect", () => ({ PriceLevelsMultiSelect: () => null }));
+jest.mock("@/features/search/components/SelectableGridItem", () => ({ SelectableGridItem: () => null }));
+jest.mock("@/features/search/components/SelectableChip", () => ({ SelectableChip: () => null }));
+
+// jest.mock のファクトリはホイストされるため、外側の変数を参照できない
+// (`mock` プレフィックスの変数だけが例外)。フィクスチャはファクトリ内に直書きする。
+const mockAddRecentLocation = jest.fn();
+jest.mock("@/features/search/hooks/useRecentLocations", () => ({
+	useRecentLocations: () => ({
+		// Issue の再現状況: 上から「渋谷駅前おおしま皮膚科」「渋谷駅」
+		recentLocations: [
+			{
+				location: { latitude: 35.6591, longitude: 139.7023 },
+				address: "country:JP, locality:Tokyo",
+				localLanguageCode: "ja",
+				locationQuery: "渋谷駅前おおしま皮膚科",
+			},
+			{
+				location: { latitude: 35.658, longitude: 139.7016 },
+				address: "country:JP, locality:Tokyo",
+				localLanguageCode: "ja",
+				locationQuery: "渋谷駅",
+			},
+		],
+		isLoading: false,
+		addRecentLocation: mockAddRecentLocation,
+		clearRecentLocations: jest.fn(),
+	}),
+}));
+
+const shibuyaStation: RecentLocation = {
+	location: { latitude: 35.658, longitude: 139.7016 },
+	address: "country:JP, locality:Tokyo",
+	localLanguageCode: "ja",
+	locationQuery: "渋谷駅",
+};
+
+// 検索画面から LocationAutocomplete へ渡された onSelectRecentLocation を掴み、
+// 「リストの1件を押した」状況を直接再現する(コンポーネント内部の表示条件には依存させない)
+let onSelectRecentLocation: ((location: RecentLocation) => void) | undefined;
+jest.mock("@/components/LocationAutocomplete", () => ({
+	LocationAutocomplete: (props: { onSelectRecentLocation?: (location: RecentLocation) => void }) => {
+		onSelectRecentLocation = props.onSelectRecentLocation;
+		return null;
+	},
+}));
+
+import SearchScreen from "@/app/[locale]/(tabs)/search/index";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("#1129 「最近使った場所」からの再選択", () => {
+	it("選んだ地点を addRecentLocation へ渡し、MRU 順の先頭へ引き上げる", () => {
+		let tree: TestRenderer.ReactTestRenderer | undefined;
+		TestRenderer.act(() => {
+			tree = TestRenderer.create(<SearchScreen />);
+		});
+
+		expect(onSelectRecentLocation).toBeDefined();
+		TestRenderer.act(() => {
+			// 「渋谷駅前おおしま皮膚科 / 渋谷駅」のうち下段の「渋谷駅」を押す
+			onSelectRecentLocation!(shibuyaStation);
+		});
+
+		// ここが呼ばれないと順序は永遠に変わらない(= Issue #1129 の現象)
+		expect(mockAddRecentLocation).toHaveBeenCalledWith(shibuyaStation);
+
+		TestRenderer.act(() => {
+			tree!.unmount();
+		});
+	});
+});


### PR DESCRIPTION
## 対象 Issue

Closes #1129

## 背景

「最近使った場所」から項目を選んで検索しても、その地点がリスト先頭へ来ない。`addRecentLocation` は元々「同一地点を除去して先頭へ置く」実装だが、最近使った場所リストからの再選択時には呼ばれていなかった。

## 変更

- `app-expo/app/[locale]/(tabs)/search/index.tsx` — 最近使った場所の再選択時にも MRU 更新を行う
- `app-expo/features/search/hooks/useRecentLocations.test.tsx`（新規）
- `app-expo/features/search/recentLocationReselect.test.tsx`（新規）

## 検証

- `pnpm --filter app-expo typecheck`
- `pnpm --filter app-expo test`

エビデンスは Actions run 30706067776 の Artifact に格納。

## #1133 との関係

#1133 の設計（[コメント](https://github.com/Ayato-kosaka/nanitabeyo/issues/1133#issuecomment-5152095421)）は、MRU 更新が `useRecentLocations` フック内に閉じるか画面側に置かれるかで追従要否が変わると指摘している。本 PR は**画面側（`search/index.tsx`）** に実装しているため、#1133 の実装側で同等の処理を共通フックへ入れる必要がある。#1133 の実装ワーカーへ申し送り済み。

推奨マージ順: #1129 → #1133。

## base

統合ブランチ `claude/parallel-dev-orchestration-7he5dw` 宛。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_