### PR TITLE
#1121 fix: 外部リンクをWebで別タブ起動する

### DIFF
--- a/app-expo/app/[locale]/(tabs)/profile/settings.tsx
+++ b/app-expo/app/[locale]/(tabs)/profile/settings.tsx
@@ -27,6 +27,7 @@ import { useSnackbar } from "@/contexts/SnackbarProvider";
 import { useRouter } from "expo-router";
 import { useLocale } from "@/hooks/useLocale";
 import { ScreenHeader } from "@/components/ScreenHeader";
+import { openExternalUrl } from "@/lib/openExternalUrl";
 
 interface SettingsMenuItemProps {
 	label: string;
@@ -189,7 +190,9 @@ export default function SettingsScreen() {
 			const canOpenPrimary = await Linking.canOpenURL(primaryUrl);
 			const urlToOpen = canOpenPrimary ? primaryUrl : fallbackUrl;
 
-			await Linking.openURL(urlToOpen);
+			// #1121 外部遷移は openExternalUrl へ統一する。
+			// ここは上で web を早期 return しているので実行されるのはネイティブのみ
+			await openExternalUrl(urlToOpen);
 
 			logFrontendEvent({
 				event_name: "settings_leave_review_open_store_success",

--- a/app-expo/components/deepLinking/OpenInAppBanner.tsx
+++ b/app-expo/components/deepLinking/OpenInAppBanner.tsx
@@ -6,6 +6,7 @@ import i18n from "@/lib/i18n";
 import { resolvePublicLocale, SITE_NAME_BY_PUBLIC_LOCALE } from "@/constants/seoLocales";
 import { Env } from "@/constants/Env";
 import { useLocale } from "@/hooks/useLocale";
+import { openExternalUrl } from "@/lib/openExternalUrl";
 
 export interface OpenInAppBannerProps {
 	/** 現在のパス（例: "posts"） */
@@ -275,9 +276,10 @@ const OpenInAppBannerComponent: React.FC<OpenInAppBannerProps> = ({
 					{!!storeUrl && (
 						<Pressable
 							style={styles.storeButton}
-							// target="_blank" 相当：RNW の Pressable では a タグじゃないので window.open する
+							// target="_blank" 相当：RNW の Pressable では a タグじゃないので別タブで開く
 							// ただし “クリック同期” なのでブロックされにくい
-							onPress={() => window.open(storeUrl, "_blank", "noopener,noreferrer")}>
+							// #1121 window.open 直書きをやめ、外部遷移の共通ヘルパーへ寄せた（Web 専用コンポーネントなので挙動は同じ）
+							onPress={() => void openExternalUrl(storeUrl)}>
 							<Text style={styles.storeButtonText}>{i18n.t("DeepLinking.getApp")}</Text>
 						</Pressable>
 					)}

--- a/app-expo/features/dishMedia/hooks/useDishMediaActions.ts
+++ b/app-expo/features/dishMedia/hooks/useDishMediaActions.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { Platform } from "react-native";
-import * as Linking from "expo-linking";
 import { getGoogleMapsLink } from "@/lib/googlePlaces";
+import { openExternalUrl } from "@/lib/openExternalUrl";
 import { generateShareUrl, handleShare } from "@/lib/share";
 import { useLocale } from "@/hooks/useLocale";
 import { useLogger } from "@/hooks/useLogger";
@@ -45,15 +45,13 @@ export function useDishMediaActions({ source }: UseDishMediaActionsProps) {
 
 			try {
 				const { mapUrl, canOpen } = await getGoogleMapsLink(restaurant);
-				if (Platform.OS === "web") {
-					window.open(mapUrl, "_blank", "noopener,noreferrer");
+				// #1121 Web の別タブ起動は openExternalUrl へ寄せた。
+				// canOpen（Linking.canOpenURL）はネイティブのハンドラ有無の判定なので Web では見ない
+				if (Platform.OS !== "web" && !canOpen) {
+					showSnackbar(i18n.t("DishMediaContent.errors.mapOpenFailed"));
 					return;
 				}
-				if (canOpen) {
-					await Linking.openURL(mapUrl);
-				} else {
-					showSnackbar(i18n.t("DishMediaContent.errors.mapOpenFailed"));
-				}
+				await openExternalUrl(mapUrl);
 			} catch (error) {
 				showSnackbar(i18n.t("DishMediaContent.errors.mapOpenFailed"));
 				logFrontendEvent({

--- a/app-expo/features/map/components/SelectedRestaurantDetails.tsx
+++ b/app-expo/features/map/components/SelectedRestaurantDetails.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback } from "react";
 import { View, Text, StyleSheet, TouchableOpacity, LayoutChangeEvent, Platform } from "react-native";
 import { Camera, DollarSign, ExternalLink } from "lucide-react-native";
-import * as Linking from "expo-linking";
 import { Card } from "@/components/Card";
 import Stars from "@/components/Stars";
 import { PrimaryButton } from "@/components/PrimaryButton";
@@ -18,6 +17,7 @@ import { useSharedValueState } from "@/hooks/useSharedValueState";
 import type { QueryRestaurantsResponse } from "@shared/api/v1/res";
 import { useLogger } from "@/hooks/useLogger";
 import { getGoogleMapsLink } from "@/lib/googlePlaces";
+import { openExternalUrl } from "@/lib/openExternalUrl";
 import { useSnackbar } from "@/contexts/SnackbarProvider";
 import { useSafeAreaFrame } from "react-native-safe-area-context";
 import { Image } from "expo-image";
@@ -125,15 +125,13 @@ export function SelectedRestaurantDetails({ restaurant, meta: restaurantMeta }: 
 
 		try {
 			const { mapUrl, canOpen } = await getGoogleMapsLink(restaurant);
-			if (Platform.OS === "web") {
-				window.open(mapUrl, "_blank", "noopener,noreferrer");
+			// #1121 Web の別タブ起動は openExternalUrl へ寄せた。
+			// canOpen（Linking.canOpenURL）はネイティブのハンドラ有無の判定なので Web では見ない
+			if (Platform.OS !== "web" && !canOpen) {
+				showSnackbar(i18n.t("DishMediaContent.errors.mapOpenFailed"));
 				return;
 			}
-			if (canOpen) {
-				await Linking.openURL(mapUrl);
-			} else {
-				showSnackbar(i18n.t("DishMediaContent.errors.mapOpenFailed"));
-			}
+			await openExternalUrl(mapUrl);
 		} catch (error) {
 			showSnackbar(i18n.t("DishMediaContent.errors.mapOpenFailed"));
 			logFrontendEvent({

--- a/app-expo/features/search/hooks/useGoogleMapsFallback.ts
+++ b/app-expo/features/search/hooks/useGoogleMapsFallback.ts
@@ -1,10 +1,10 @@
 import { useCallback } from "react";
-import * as Linking from "expo-linking";
 import { useDialog } from "@/contexts/DialogProvider";
 import { useLogger } from "@/hooks/useLogger";
 import i18n from "@/lib/i18n";
 import { toErrorLogMessage } from "@/lib/errorMessage";
 import { buildGoogleMapsSearchUrl } from "@/lib/googleMaps";
+import { openExternalUrl } from "@/lib/openExternalUrl";
 
 type GoogleMapsFallbackArgs = {
 	entriesKey?: string;
@@ -53,7 +53,8 @@ export function useGoogleMapsFallback({ source }: UseGoogleMapsFallbackParams) {
 				cancelLabel: i18n.t("Search.googleMapsFallback.cancel"),
 				onConfirm: async () => {
 					try {
-						await Linking.openURL(url);
+						// #1121 Web は別タブで開く。同一タブ遷移だと SPA を離脱し、戻ったときに画面が壊れる
+						await openExternalUrl(url);
 						logFrontendEvent({
 							event_name: "google_maps_fallback_opened",
 							error_level: "log",

--- a/app-expo/hooks/useAPICall.ts
+++ b/app-expo/hooks/useAPICall.ts
@@ -4,11 +4,12 @@ import { useLogger } from "./useLogger";
 import { useAuth } from "@/contexts/AuthProvider";
 import i18n from "@/lib/i18n";
 import { useDialog } from "@/contexts/DialogProvider";
-import { Linking, Platform } from "react-native";
+import { Platform } from "react-native";
 import type { BaseResponse } from "@shared/api/v1/res";
 import { useCdnCookieStore } from "@/stores/useCdnCookieStore";
 import { fetchWithAuth } from "@/lib/fetchWithAuth";
 import { toErrorLogMessage } from "@/lib/errorMessage";
+import { openExternalUrl } from "@/lib/openExternalUrl";
 
 /**
  * #525 【設計】統一されたエラーオブジェクト型
@@ -311,7 +312,9 @@ export const useAPICall = () => {
 						okLabel: i18n.t("Common.goStore"),
 						onConfirm: () => {
 							if (storeUrl) {
-								Linking.openURL(storeUrl);
+								// #1121 外部遷移は openExternalUrl へ統一する。
+								// storeUrl は Platform.select の ios/android のみなので Web では undefined
+								void openExternalUrl(storeUrl);
 							}
 						},
 					});

--- a/app-expo/lib/openExternalUrl.test.ts
+++ b/app-expo/lib/openExternalUrl.test.ts
@@ -1,0 +1,72 @@
+/**
+ * #1121 `openExternalUrl` の分岐テスト。
+ *
+ * Web で `Linking.openURL()` が呼ばれると同一タブ遷移になり、`/ja-JP/search/topics` の
+ * Google Maps fallback が「戻るとエラー」になる。ここが退行すると画面側では気付けないので、
+ * Web / ネイティブそれぞれで **どちらの API を呼ぶか** を固定する。
+ *
+ * `Platform.OS` は jest-expo 側で固定されているため、モジュールごと差し替えて読み直す。
+ */
+
+type OpenExternalUrl = (url: string) => Promise<void>;
+
+const URL_TO_OPEN = "https://www.google.com/maps/search/?api=1&query=%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%B3";
+
+const loadOpenExternalUrl = (os: string, linkingOpenURL: jest.Mock): OpenExternalUrl => {
+	jest.resetModules();
+	// jest.doMock はホイストされないので、テストごとに OS を変えて読み直せる
+	jest.doMock("react-native", () => ({ Platform: { OS: os } }));
+	jest.doMock("expo-linking", () => ({ openURL: linkingOpenURL }));
+	return require("./openExternalUrl").openExternalUrl;
+};
+
+describe("#1121 openExternalUrl", () => {
+	describe("Web", () => {
+		it("別タブで開き、Linking.openURL（同一タブ遷移）は呼ばない", async () => {
+			const linkingOpenURL = jest.fn();
+			const windowOpen = jest.fn().mockReturnValue({});
+			(globalThis as any).window = { open: windowOpen };
+
+			const openExternalUrl = loadOpenExternalUrl("web", linkingOpenURL);
+			await openExternalUrl(URL_TO_OPEN);
+
+			expect(windowOpen).toHaveBeenCalledWith(URL_TO_OPEN, "_blank", "noopener,noreferrer");
+			expect(linkingOpenURL).not.toHaveBeenCalled();
+		});
+
+		it("ポップアップブロックで null が返っても throw せず、同一タブへ fallback しない", async () => {
+			const linkingOpenURL = jest.fn();
+			// ブロックされたブラウザは null を返す
+			const windowOpen = jest.fn().mockReturnValue(null);
+			(globalThis as any).window = { open: windowOpen };
+
+			const openExternalUrl = loadOpenExternalUrl("web", linkingOpenURL);
+
+			await expect(openExternalUrl(URL_TO_OPEN)).resolves.toBeUndefined();
+			expect(linkingOpenURL).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("ネイティブ", () => {
+		it.each(["ios", "android"])("%s では Linking.openURL へ委ねる", async (os) => {
+			const linkingOpenURL = jest.fn().mockResolvedValue(true);
+			const windowOpen = jest.fn();
+			(globalThis as any).window = { open: windowOpen };
+
+			const openExternalUrl = loadOpenExternalUrl(os, linkingOpenURL);
+			await openExternalUrl(URL_TO_OPEN);
+
+			expect(linkingOpenURL).toHaveBeenCalledWith(URL_TO_OPEN);
+			expect(windowOpen).not.toHaveBeenCalled();
+		});
+
+		it("Linking.openURL の失敗（対応アプリ無しなど）はそのまま呼び出し側へ伝える", async () => {
+			// useGoogleMapsFallback の google_maps_fallback_open_failed ログはこの reject に依存している
+			const linkingOpenURL = jest.fn().mockRejectedValue(new Error("No Activity found to handle Intent"));
+
+			const openExternalUrl = loadOpenExternalUrl("ios", linkingOpenURL);
+
+			await expect(openExternalUrl(URL_TO_OPEN)).rejects.toThrow("No Activity found to handle Intent");
+		});
+	});
+});

--- a/app-expo/lib/openExternalUrl.ts
+++ b/app-expo/lib/openExternalUrl.ts
@@ -1,0 +1,32 @@
+import { Platform } from "react-native";
+import * as Linking from "expo-linking";
+
+/**
+ * #1121 アプリ外（ブラウザ / 外部アプリ）へ遷移する URL を開く。
+ *
+ * Web で `Linking.openURL()` を呼ぶと react-native-web は同一タブを遷移させるため、
+ * SPA を離脱してしまい、ブラウザバックで戻ってきたときに復元に失敗して壊れる
+ * （`/ja-JP/search/topics` の Google Maps fallback ダイアログで発生）。
+ * そのため Web では常に別タブで開き、元のページを離脱させない。
+ *
+ * プラットフォーム判定と `window.open` の引数は、先行して個別に分岐していた
+ * `SelectedRestaurantDetails` / `useDishMediaActions` の実装に合わせている。
+ *
+ * ⚠️ Web でポップアップブロックされた場合 `window.open` は null を返すが、
+ *    **throw も fallback もしない**。
+ *    - 同一タブへ fallback すると、この関数が直そうとしている離脱そのものになる
+ *    - throw すると呼び出し側の「開けた / 失敗した」ログが反転する
+ *      （例: google_maps_fallback_opened → google_maps_fallback_open_failed）
+ *    置換前の 2 実装も戻り値を見ていないので、その振る舞いを維持する。
+ *
+ * ⚠️ Web ではユーザー操作のコールスタックから同期的に呼ばれるほどブロックされにくい。
+ *    呼び出し側で `await` を挟んでから呼ぶ場合は、その前提が崩れることに注意。
+ */
+export async function openExternalUrl(url: string): Promise<void> {
+	if (Platform.OS === "web") {
+		window.open(url, "_blank", "noopener,noreferrer");
+		return;
+	}
+
+	await Linking.openURL(url);
+}


### PR DESCRIPTION
## 対象 Issue

Closes #1121

## 背景

Web の `/ja-JP/search/topics` で「条件に合うお店を Google Map 上で確認できます」から遷移すると同一タブで離脱し、戻るとエラーになる。`useGoogleMapsFallback` が Web 分岐を持たず `Linking.openURL` を直接呼んでいたため。

Issue では「その他横展開もしたい。基本アプリから離れる時は、別画面起動したい」とも要望されている。

## 変更

- `app-expo/lib/openExternalUrl.ts`（新規） — Web は `window.open(url, "_blank", "noopener,noreferrer")`、それ以外は `Linking.openURL` へ振り分ける共通ヘルパー
- `app-expo/lib/openExternalUrl.test.ts`（新規） — Web / ネイティブ両分岐の単体テスト
- `app-expo/features/search/hooks/useGoogleMapsFallback.ts` — 本 Issue の主題。ヘルパーへ差し替え
- 横展開: `settings.tsx` / `useAPICall.ts` / `useDishMediaActions.ts` / `SelectedRestaurantDetails.tsx` / `OpenInAppBanner.tsx` をヘルパー呼び出しへ統一（既に正しく分岐していた箇所も重複を解消）

## 検証

- `pnpm --filter app-expo typecheck`
- `pnpm --filter app-expo test`
- Playwright による Web 目視検証

エビデンスは Actions run 30705919851 の Artifact に格納。画像は evidence-collect で公開のうえ本 PR へ追記予定。

## base

統合ブランチ `claude/parallel-dev-orchestration-7he5dw` 宛。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_