### PR TITLE
#1135 fix: WebのOAuthコールバックと認証初期化の競合を解消

### DIFF
--- a/.codex/bigquery/event-catalog.md
+++ b/.codex/bigquery/event-catalog.md
@@ -195,7 +195,38 @@ rg -o 'event_name:\s*"[^"]+"' app-expo --glob '!**/node_modules/**'
 > `oauth_signin_success` はほぼ発火せず、`oauth_signin_browser_dismissed` は「キャンセル」を意味しない。
 > これらはブラウザセッションの結末の記録であって、認証の成否ではない。
 
+> **⚠️ #1135 認証初期化の「巻き戻し防止」イベント（`*Superseded` / `anonymousSignInDiscarded`）の解釈**
+>
+> 認証初期化（`AuthProvider.runAuthAttempt`）は、その最中に別経路（Web の OAuth code 交換など）が
+> 新しいセッションを載せた場合、自分が読んだ古い結果を書き戻さずにスキップする。
+> スキップしたことを記録するのが次の 3 イベントで、いずれも `error_level: "log"`（異常終了ではない）。
+>
+> | イベント | 発火位置 | 意味 |
+> |---|---|---|
+> | `sessionRestoreSuperseded` | `getSession()` がセッションを返した後 | 復元結果の書き戻しをスキップした |
+> | `anonymousSignInSuperseded` | `getSession()` が「セッション無し」を返した後 | 匿名サインインの**呼び出し自体**をスキップした |
+> | `anonymousSignInDiscarded` | 匿名サインイン**成功後**の書き戻し直前 | 匿名セッションを作ったが、その間に別セッションが載ったため書き戻しをスキップした |
+>
+> **⚠️ `sessionRestoreSuperseded` を「競合の検知シグナル」としてそのまま監視しないこと。**
+> コールドスタート時にアクセストークンが失効していると、`getSession()` がロック内でリフレッシュを行い
+> `TOKEN_REFRESHED` で世代が進むため、**正常起動でもこの分岐に入る**（アクセストークン寿命を超えて
+> 久しぶりに起動したセッションは全てこれになる。E2E のセッション注入経路も同様）。
+> 異常系（別ユーザーのセッションに追い越された）だけを見たい場合は
+> **`payload.stale_user_id` と `payload.current_user_id` の一致で区別する**こと。
+>
+> - `stale_user_id == current_user_id` … 正常。同一ユーザーのトークン更新に追い越されただけ（state は `TOKEN_REFRESHED` ハンドラが正しく設定済み）
+> - `stale_user_id != current_user_id` … 本来見たい競合。別経路が別ユーザーのセッションを確立した
+>
+> この性質上、`sessionRestored` の件数はこの修正以降減る（減った分が `sessionRestoreSuperseded` に移る）ため、
+> 過去分と件数を比較する際は両者の合計で見ること。
+> `anonymousSignInSuperseded` / `anonymousSignInDiscarded` は正常起動では発火しないので、そのまま競合の
+> 検知に使える（`anonymousSignInDiscarded` は「匿名サインインの枠を 1 消費したが使わなかった」を意味する。
+> Supabase の匿名サインインは 30 回/時/IP 制限があるため、多発する場合は経路を疑うこと）。
+
 - `sessionRestored`
+- `sessionRestoreSuperseded`
+- `anonymousSignInSuperseded`
+- `anonymousSignInDiscarded`
 - `signInAnonymously`
 - `authInitError`
 - `userChanged`

--- a/app-expo/__tests__/index.test.tsx
+++ b/app-expo/__tests__/index.test.tsx
@@ -21,8 +21,18 @@ jest.mock("expo-router", () => ({
 jest.mock("@/lib/logoutRedirect", () => ({ consumeLogoutRedirect: () => mockConsumeLogoutRedirect() }));
 jest.mock("expo-linking", () => ({
 	getInitialURL: () => mockGetInitialURL(),
-	// 実装と同じく path だけ取り出せれば足りる
-	parse: (url: string) => ({ path: url.replace(/^[a-zA-Z+.-]+:\/\/[^/]*/, "").replace(/^\//, "") || null }),
+	// 実装と同じく path だけ取り出せれば足りる。
+	// ⚠️ 本物の Linking.parse はクエリ／フラグメントを path に含めず queryParams 側へ分ける。
+	//    #1135 で問題になるのは «path だけ採用するとクエリ（= OAuth の code）が落ちる» ことなので、
+	//    ここを本物どおりにしておかないとテストが実機と違う世界を見てしまう。
+	parse: (url: string) => ({
+		path:
+			url
+				.replace(/^[a-zA-Z+.-]+:\/\/[^/]*/, "")
+				.replace(/^\//, "")
+				.split("#")[0]
+				.split("?")[0] || null,
+	}),
 }));
 jest.mock("expo-localization", () => ({ getLocales: () => [{ languageTag: "ja-JP" }] }));
 jest.mock("expo-splash-screen", () => ({ preventAutoHideAsync: jest.fn() }));
@@ -102,11 +112,62 @@ describe("app/index.tsx のディープリンク採用（#1124）", () => {
 		expect(mockReplace).toHaveBeenCalledWith("/ja-JP");
 	});
 
-	it("アプリ内ルートとして解釈できない起動時 URL は採用しない（OAuth コールバック等）", async () => {
+	it("アプリ内ルートとして解釈できない起動時 URL は採用しない（dev launcher の起動 URL）", async () => {
 		mockGetInitialURL.mockResolvedValue("nanitabeyo://expo-development-client/?url=http%3A%2F%2Flocalhost");
 
 		await renderIndex();
 
 		expect(mockReplace).toHaveBeenCalledWith("/ja-JP");
+	});
+
+	/**
+	 * #1135 Web の OAuth コールバック URL を「行き先」として採用してはいけない。
+	 *
+	 * Web では `Linking.parse("https://<host>/ja-JP/auth/callback?code=...").path` が
+	 * `ja-JP/auth/callback` になり、**先頭セグメント `ja-JP` は BCP 47 判定を通ってしまう**。
+	 * その結果 `router.replace("/ja-JP/auth/callback")` が呼ばれ、`code` を落とした行き先へ送られる。
+	 * 送られた先の callback 画面は交換すべき code を持たないので `oauth_callback_no_result` になる。
+	 *
+	 * ネイティブ（`nanitabeyo://ja-JP/auth/callback?...`）は `ja-JP` が hostname に入るため
+	 * 元から弾かれている。Web だけが穴だった。
+	 */
+	it("Web の OAuth コールバック URL は、code を落とした行き先として採用しない（#1135）", async () => {
+		mockGetInitialURL.mockResolvedValue(
+			"https://nanitabeyo.example/ja-JP/auth/callback?intent=link&provider=google&code=abcdef",
+		);
+
+		await renderIndex();
+
+		// ★ ここへ送ると code が落ちる
+		expect(mockReplace).not.toHaveBeenCalledWith("/ja-JP/auth/callback");
+		expect(mockReplace).toHaveBeenCalledWith("/ja-JP");
+	});
+
+	it("Web の OAuth エラー応答つきコールバック URL も採用しない（#1135）", async () => {
+		mockGetInitialURL.mockResolvedValue(
+			"https://nanitabeyo.example/ja-JP/auth/callback?error=server_error&error_code=identity_already_exists",
+		);
+
+		await renderIndex();
+
+		expect(mockReplace).not.toHaveBeenCalledWith("/ja-JP/auth/callback");
+		expect(mockReplace).toHaveBeenCalledWith("/ja-JP");
+	});
+
+	it("クエリを持たないコールバック URL も行き先にしない（#1135）", async () => {
+		mockGetInitialURL.mockResolvedValue("https://nanitabeyo.example/ja-JP/auth/callback");
+
+		await renderIndex();
+
+		expect(mockReplace).not.toHaveBeenCalledWith("/ja-JP/auth/callback");
+		expect(mockReplace).toHaveBeenCalledWith("/ja-JP");
+	});
+
+	it("ロケール配下の通常画面は、クエリ付きの Web URL でも従来どおり採用する（#1135 の非回帰）", async () => {
+		mockGetInitialURL.mockResolvedValue("https://nanitabeyo.example/ja-JP/profile?tab=reviews");
+
+		await renderIndex();
+
+		expect(mockReplace).toHaveBeenCalledWith("/ja-JP/profile");
 	});
 });

--- a/app-expo/app/index.tsx
+++ b/app-expo/app/index.tsx
@@ -7,6 +7,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { Env } from "@/constants/Env";
 import { getResolvedLocale } from "@/lib/i18n";
 import { consumeLogoutRedirect } from "@/lib/logoutRedirect";
+import { carriesOAuthResult } from "@/lib/oauthResultUrl";
 import * as WebBrowser from "expo-web-browser";
 WebBrowser.maybeCompleteAuthSession();
 
@@ -32,14 +33,26 @@ let hasConsumedInitialUrl = false;
  *（`ja-JP/profile` 等）だけを行き先として採用し、OAuth コールバックのような
  * ルーティング対象外の URL でリダイレクト先を上書きしてしまう事故を防ぐ。
  *
+ * #1135 【バグ】その「防ぐ」が Web では効いていなかった。
+ * Web のコールバック URL は `https://<host>/ja-JP/auth/callback?code=...` で、
+ * `Linking.parse().path` は `ja-JP/auth/callback`。**先頭セグメント `ja-JP` は BCP 47 判定を通る**ため
+ * そのまま採用され、`router.replace("/ja-JP/auth/callback")` で **`code` を落として** 遷移していた。
+ * 送られた先の callback 画面は交換すべき code を持たないので `oauth_callback_no_result` になる。
+ * （ネイティブの `nanitabeyo://ja-JP/auth/callback?...` は `ja-JP` が hostname 側に入るため元から弾かれる。）
+ *
+ * ここは «path だけ» を受け取る関数なので、クエリを見ずに済むよう「認証コールバックのルート自体を
+ * 行き先にしない」で表現する。クエリを持つ URL 側の判定は呼び出し元（`carriesOAuthResult`）で行う。
+ *
  * @param path `Linking.parse(url).path`（先頭スラッシュ無し / 無ければ null）
  * @returns 採用できる場合は "/ja-JP/profile" 形式 / それ以外は null
  */
 const toInAppPath = (path: string | null | undefined): string | null => {
 	const normalized = path?.replace(/^\/+/, "") ?? "";
 	if (!normalized) return null;
-	const [firstSegment] = normalized.split("/");
+	const [firstSegment, secondSegment] = normalized.split("/");
 	if (!firstSegment || !isValidBcp47Tag(firstSegment)) return null;
+	// #1135 `/[locale]/auth/*` は «クエリ込み» でしか意味を持たない route なので、行き先として採用しない
+	if (secondSegment === "auth") return null;
 	return `/${normalized}`;
 };
 
@@ -109,6 +122,13 @@ export default function App() {
 		Linking.getInitialURL()
 			.then((url) => {
 				if (cancelled) return;
+				// #1135 認証結果（code / error / access_token）を運んでいる URL は、行き先として採用しない。
+				// `Linking.parse().path` はクエリを落とすため、採用すると `code` ごと捨てて遷移することになる。
+				// 判定は lib/oauthResultUrl.ts の共有ロジック（callback 画面と同じもの）を使う。
+				if (carriesOAuthResult(url)) {
+					setInitialPath(null);
+					return;
+				}
 				setInitialPath(url ? (Linking.parse(url).path ?? null) : null);
 			})
 			.catch(() => {

--- a/app-expo/contexts/AuthProvider.test.tsx
+++ b/app-expo/contexts/AuthProvider.test.tsx
@@ -267,6 +267,100 @@ describe("AuthProvider の 429 クールダウン（#1097）", () => {
 		expect(authValue.user?.id).toBe("anon-1");
 	});
 
+	/**
+	 * #1135 「認証初期化は、その最中に確立された新しいセッションを上書きしない」という不変条件のテスト。
+	 *
+	 * Web の OAuth は全画面リダイレクトなので、コールバックのページロードでは
+	 * 認証初期化（runAuthAttempt）と `exchangeCodeForSession()` が同時に走る。
+	 * GoTrueClient._acquireLock はロック保持中に来た呼び出しを pendingInLock へ積み、
+	 * **外側の保持者はそれを drain し終わるまで解決しない**（@supabase/auth-js GoTrueClient.js:1123-1129）。
+	 * そのため `getSession()` は「交換前の匿名セッション」を読んだまま、**交換が終わった後に**解決する。
+	 * その戻り値を無条件に書き戻すと、確立済みの OAuth セッションを匿名ユーザーへ巻き戻す
+	 * （localStorage は OAuth なのに画面はゲストのまま = 「1 回目のログインで入れない」）。
+	 *
+	 * ここでは getSession() の解決を保留したまま SIGNED_IN を流すことで、その順序を直接再現する。
+	 */
+	it("復元中に OAuth の SIGNED_IN が入ったら、後から匿名セッションで上書きしない（#1135）", async () => {
+		// ロックの drain を再現する: getSession() は「交換前の匿名セッション」を読み終えているが、まだ解決しない
+		let resolveGetSession!: (result: unknown) => void;
+		auth.getSession.mockReturnValue(
+			new Promise((resolve) => {
+				resolveGetSession = resolve;
+			}),
+		);
+
+		await mountProvider();
+
+		// OAuth の code 交換が完了し、SIGNED_IN が届く（callback 画面の exchangeCodeForSession 由来）
+		await act(async () => {
+			await emitAuthStateChange("SIGNED_IN", fakeSession("oauth-1"));
+		});
+		expect(authValue.user?.id).toBe("oauth-1");
+
+		// ★ ここでようやく getSession() が「交換前の匿名セッション」で解決する
+		await act(async () => {
+			resolveGetSession({ data: { session: fakeSession("anon-1") }, error: null });
+		});
+
+		// 古い読み取り結果で巻き戻してはいけない
+		expect(authValue.user?.id).toBe("oauth-1");
+		expect(authValue.getSession()?.user.id).toBe("oauth-1");
+		// 復元経路を通っているので匿名サインインは走らない（OAuth セッションを潰す経路）
+		expect(auth.signInAnonymously).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * #1135 「セッションが無い」と読んだ後に OAuth セッションが載った場合、匿名サインインを叩かないこと。
+	 *
+	 * `signInAnonymously()` は `_saveSession` で storage を書き換えるため、ここで叩くと
+	 * 確立済みの OAuth セッションを **storage ごと** 潰す（React state だけの巻き戻しより重い破壊）。
+	 * 匿名セッションが残っていない状態で Web のコールバックに戻った場合に到達しうる経路。
+	 */
+	it("セッション無しと読んだ後に OAuth の SIGNED_IN が入ったら、匿名サインインを叩かない（#1135）", async () => {
+		let resolveGetSession!: (result: unknown) => void;
+		auth.getSession.mockReturnValue(
+			new Promise((resolve) => {
+				resolveGetSession = resolve;
+			}),
+		);
+		auth.signInAnonymously.mockResolvedValue({ data: { session: fakeSession("anon-1") }, error: null });
+
+		await mountProvider();
+
+		await act(async () => {
+			await emitAuthStateChange("SIGNED_IN", fakeSession("oauth-1"));
+		});
+
+		// getSession() は「交換前 = セッション無し」を読んだまま、交換完了後に解決する
+		await act(async () => {
+			resolveGetSession({ data: { session: null }, error: null });
+		});
+
+		expect(auth.signInAnonymously).not.toHaveBeenCalled();
+		expect(authValue.user?.id).toBe("oauth-1");
+		// #1089 の事後条件（どの経路でも loading は false / 認証確立時は authError は null）は維持される
+		expect(authValue.isAuthResolved).toBe(true);
+		expect(authValue.authError).toBeNull();
+	});
+
+	/**
+	 * #1135 復元経路で `setSession()` を呼ばないこと。
+	 *
+	 * `getSession()` は storage からの復元（必要ならリフレッシュ）まで済ませており、その直後に
+	 * 同じトークンで `setSession()` するのは `GET /auth/v1/user` を 1 往復増やすだけ。
+	 * その往復時間がまるごと上のテストの競合ウィンドウになるため、呼ばないことを固定する。
+	 */
+	it("復元経路では setSession を呼ばない（#1135 競合ウィンドウを作らない）", async () => {
+		auth.getSession.mockResolvedValueOnce({ data: { session: fakeSession("user-1") }, error: null });
+
+		await mountProvider();
+
+		// 復元自体はこれまでどおり成立する（sessionRef / setUser は残す）
+		expect(authValue.user?.id).toBe("user-1");
+		expect(authValue.getSession()?.user.id).toBe("user-1");
+		expect(auth.setSession).not.toHaveBeenCalled();
+	});
+
 	it("SIGNED_OUT が連続しても匿名サインインは 1 回にまとまる（枠を無駄に消費しない）", async () => {
 		auth.getSession.mockResolvedValueOnce({ data: { session: fakeSession("user-1") }, error: null });
 		auth.signInAnonymously.mockResolvedValue({ data: { session: fakeSession("anon-1") }, error: null });

--- a/app-expo/contexts/AuthProvider.test.tsx
+++ b/app-expo/contexts/AuthProvider.test.tsx
@@ -344,6 +344,94 @@ describe("AuthProvider の 429 クールダウン（#1097）", () => {
 	});
 
 	/**
+	 * #1135 匿名サインインの **完了後** の書き戻しも、その間に載った別セッションを巻き戻さないこと。
+	 *
+	 * 上 2 つのテストは「`getSession()` の解決が code 交換より後になる」インターリーブを見ているが、
+	 * `getSession()` が «交換が始まる前» に「セッション無し」で解決した場合は分岐ガードを通り抜け、
+	 * `retry(signInAnonymously)` の await をまたいだ区間が無防備になる。この区間では
+	 *   1. 匿名サインインが `_saveSession` → SIGNED_IN(匿名) を流す
+	 *   2. pendingInLock に積まれていた `exchangeCodeForSession()` が完了し SIGNED_IN(OAuth) を流す
+	 *   3. その後で `signInAnonymously()` の Promise が解決する
+	 * という順序が起こりうる。3 で無条件に書き戻すと、確立済みの OAuth セッションを匿名へ巻き戻す
+	 * （storage は OAuth のまま = 本 Issue と同型の症状）。
+	 *
+	 * ⚠️ ここを世代カウンタで守ることはできない。1 の SIGNED_IN も世代を進めるため、
+	 *    「自分が作った匿名セッション」と「別経路の OAuth セッション」を区別できず、
+	 *    正常な匿名サインインまで書き戻しをスキップしてしまう。
+	 *    そのため `sessionRef` が保持しているセッションの同一性（access_token）で判定する。
+	 */
+	it("匿名サインインの完了前に OAuth の SIGNED_IN が入ったら、後から匿名セッションで巻き戻さない（#1135）", async () => {
+		// getSession() は「交換開始前」に解決する = 世代ガードを通り抜けて匿名サインイン経路へ進む
+		auth.getSession.mockResolvedValue({ data: { session: null }, error: null });
+		// 匿名サインインは、下で明示的に解決するまで pending のまま
+		let completeSignIn!: (result: unknown) => void;
+		auth.signInAnonymously.mockReturnValue(
+			new Promise((resolve) => {
+				completeSignIn = resolve;
+			}),
+		);
+
+		await mountProvider();
+		expect(auth.signInAnonymously).toHaveBeenCalledTimes(1);
+
+		// 1. 匿名サインイン自身の SIGNED_IN（auth-js は _saveSession の後に必ず流す）
+		await act(async () => {
+			await emitAuthStateChange("SIGNED_IN", fakeSession("anon-1"));
+		});
+		expect(authValue.user?.id).toBe("anon-1");
+
+		// 2. pendingInLock に積まれていた code 交換が完了し、OAuth の SIGNED_IN が届く
+		await act(async () => {
+			await emitAuthStateChange("SIGNED_IN", fakeSession("oauth-1"));
+		});
+		expect(authValue.user?.id).toBe("oauth-1");
+
+		// 3. ★ ここでようやく signInAnonymously() が解決する
+		await act(async () => {
+			completeSignIn({ data: { session: fakeSession("anon-1") }, error: null });
+		});
+
+		// 既に OAuth セッションが載っているので、匿名セッションで書き戻してはいけない
+		expect(authValue.user?.id).toBe("oauth-1");
+		expect(authValue.getSession()?.user.id).toBe("oauth-1");
+		// #1089 の事後条件（loading は false / 認証確立時は authError は null）は維持される
+		expect(authValue.isAuthResolved).toBe(true);
+		expect(authValue.authError).toBeNull();
+	});
+
+	/**
+	 * #1135 上の巻き戻しガードが、正常な匿名サインインまで止めてしまわないこと。
+	 *
+	 * 世代カウンタで守ろうとすると、匿名サインイン自身の SIGNED_IN で世代が進むため
+	 * この経路が丸ごとスキップされる（＝匿名ユーザーが載らない）。同一性で判定していることを固定する。
+	 */
+	it("自分が作った匿名セッションの SIGNED_IN では、書き戻しをスキップしない（#1135）", async () => {
+		auth.getSession.mockResolvedValue({ data: { session: null }, error: null });
+		let completeSignIn!: (result: unknown) => void;
+		auth.signInAnonymously.mockReturnValue(
+			new Promise((resolve) => {
+				completeSignIn = resolve;
+			}),
+		);
+
+		await mountProvider();
+
+		// 匿名サインイン自身の SIGNED_IN だけが流れる（別経路は無い）
+		await act(async () => {
+			await emitAuthStateChange("SIGNED_IN", fakeSession("anon-1"));
+		});
+
+		await act(async () => {
+			completeSignIn({ data: { session: fakeSession("anon-1") }, error: null });
+		});
+
+		expect(authValue.user?.id).toBe("anon-1");
+		expect(authValue.getSession()?.user.id).toBe("anon-1");
+		expect(authValue.isAuthResolved).toBe(true);
+		expect(authValue.authError).toBeNull();
+	});
+
+	/**
 	 * #1135 復元経路で `setSession()` を呼ばないこと。
 	 *
 	 * `getSession()` は storage からの復元（必要ならリフレッシュ）まで済ませており、その直後に

--- a/app-expo/contexts/AuthProvider.tsx
+++ b/app-expo/contexts/AuthProvider.tsx
@@ -131,6 +131,24 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 	/** SIGNED_OUT 後の root 遷移。匿名セッションの再確立を開始してから実行する。 */
 	const signedOutNavigationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	/**
+	 * #1135 「今アプリに載っているセッションの世代」。`onAuthStateChange` が新しいセッションを
+	 * 載せるたびに 1 つ進む。認証初期化（runAuthAttempt）は await をまたぐ前にこの値を控え、
+	 * 書き戻す直前に変わっていないことを確認する。
+	 *
+	 * なぜ必要か:
+	 * GoTrueClient._acquireLock はロック保持中に来た呼び出しを pendingInLock へ積み、
+	 * **外側の保持者はそれを drain し終わるまで解決しない**（@supabase/auth-js GoTrueClient.js:1123-1129）。
+	 * そのため Web の OAuth コールバックでは、`getSession()` が «交換前» の匿名セッションを読んだまま、
+	 * `exchangeCodeForSession()` が終わった «後» に解決する。その戻り値を無条件に書き戻すと、
+	 * 確立済みの OAuth セッションを匿名ユーザーへ巻き戻してしまう
+	 * （＝ localStorage は OAuth なのに画面はゲストのまま。「1 回目のログインで入れない」）。
+	 *
+	 * ⚠️ SIGNED_OUT では進めない。SIGNED_OUT 経路は「新しいセッションを載せる」のではなく
+	 *    «セッションを消して runAuthAttempt を予約し直す» 経路であり（#1124）、そこで世代を進めると
+	 *    予約された再認証が自分の書き戻しを取りこぼす方向へ効きうる。
+	 */
+	const sessionGenerationRef = useRef(0);
+	/**
 	 * 401 を受けたリクエストが、新しい access token で即時再試行できるようにする。
 	 * Supabase の自動更新は後続リクエストには効くが、既に失敗した通信は再送しないため、
 	 * 更新済み Session を呼び出し元へ返しつつ、同期参照する sessionRef も先に更新する。
@@ -143,6 +161,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 		if (refreshedSession) {
 			sessionRef.current = refreshedSession;
 			setUser(refreshedSession.user);
+			// #1135 sessionRef を直接書く経路なので、ここでも世代を進める。
+			// （refreshSession() は TOKEN_REFRESHED も発火させるため二重に進みうるが、
+			//   判定は「変化したか」だけなので問題にならない）
+			sessionGenerationRef.current += 1;
 		}
 
 		return refreshedSession;
@@ -188,6 +210,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
 			isAuthenticatingRef.current = true;
 
+			// #1135 これ以降の await をまたいで「その間に新しいセッションが載ったか」を判定するための基準。
+			// 必ず最初の await より前で控えること（injectTestSession / getSession の最中こそが競合ウィンドウ）。
+			const generation = sessionGenerationRef.current;
+			/** #1135 この試行を始めてから、別経路（OAuth の code 交換など）が新しいセッションを載せたか */
+			const hasNewerSession = () => sessionGenerationRef.current !== generation;
+
 			try {
 				// #1030 【設計】E2E(Detox) 実行時のみ、起動引数で渡されたセッションを注入して匿名サインインを回避する
 				//（Supabase の匿名サインインは 30 回/時/IP 制限があり、dev/prod で同一プロジェクトを共有しているため）。
@@ -203,19 +231,44 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 				const restoredSession = sessionData?.session;
 
 				if (restoredSession) {
-					await supabase.auth.setSession({
-						access_token: restoredSession.access_token,
-						refresh_token: restoredSession.refresh_token,
-					});
+					// #1135 【バグ】以前はここで `supabase.auth.setSession({ access_token, refresh_token })` を
+					// await していたが、これは冗長なうえに有害だった。
+					// - 冗長: `getSession()` が既に storage からの復元（必要ならリフレッシュ）まで済ませている。
+					// - 有害: `_setSession` は `GET /auth/v1/user` を 1 往復叩いてから `_saveSession` +
+					//   `_notifyAllSubscribers('SIGNED_IN')` する（GoTrueClient.js:1344-1390）。
+					//   その往復時間がまるごと競合ウィンドウになり、Web の OAuth コールバックでは
+					//   `exchangeCodeForSession()` がそこへ着地して、下の書き戻しが必ず後勝ちしていた。
+					//   さらに `_saveSession` により **storage 上の OAuth セッションまで匿名で上書き** されうる。
+					// `sessionRestored` ログ・`sessionRef` 更新・`setUser` は下にそのまま残している。
+					if (hasNewerSession()) {
+						// #1135 読み取りの最中に別経路が新しいセッションを載せた（Web の OAuth code 交換など）。
+						// 古い読み取り結果で巻き戻さない。state は onAuthStateChange 側で既に更新済みなので、
+						// 「認証が確立している」という事後条件はここで何もしなくても満たされる。
+						logFrontendEvent({
+							event_name: "sessionRestoreSuperseded",
+							error_level: "log",
+							payload: { stale_user_id: restoredSession.user.id, current_user_id: sessionRef.current?.user.id },
+						});
+					} else {
+						logFrontendEvent({
+							event_name: "sessionRestored",
+							error_level: "log",
+							payload: { user_id: restoredSession.user.id },
+						});
 
+						sessionRef.current = restoredSession;
+						setUser(restoredSession.user);
+					}
+				} else if (hasNewerSession()) {
+					// #1135 セッションが無いと «読んだ» 後に、別経路が新しいセッションを載せた場合。
+					// ここで匿名サインインを叩くと `_saveSession` が storage 上の OAuth セッションを
+					// 完全に潰す（React state だけの巻き戻しより重い破壊になる）ため、絶対に叩かない。
+					// 事後条件は onAuthStateChange 側の setUser で満たされている。
 					logFrontendEvent({
-						event_name: "sessionRestored",
+						event_name: "anonymousSignInSuperseded",
 						error_level: "log",
-						payload: { user_id: restoredSession.user.id },
+						payload: { current_user_id: sessionRef.current?.user.id },
 					});
-
-					sessionRef.current = restoredSession;
-					setUser(restoredSession.user);
 				} else {
 					// #1089 匿名サインインはオフラインや 5xx といった一時的な理由で簡単に落ちるため、有限回リトライする。
 					// ⚠️ 429（レート制限）はここではリトライしない（isRetryableAuthError が false を返す）。
@@ -246,6 +299,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 						payload: { user_id: anonSession.user.id },
 					});
 
+					// #1135 ここは世代ガードを掛けない。今作った匿名セッションは auth-js がロック保持中に
+					// `_saveSession` 済みで、構造上「最新の書き込み」そのものだから（＝古い読み取り結果ではない）。
 					sessionRef.current = anonSession;
 					setUser(anonSession.user);
 				}
@@ -368,6 +423,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 				}
 				setUser(session.user);
 				sessionRef.current = session;
+				// #1135 新しいセッションを載せた。実行中の認証初期化が、これより前に読んだ古いセッションで
+				// 巻き戻すのを防ぐ（runAuthAttempt の hasNewerSession() が見る）。
+				sessionGenerationRef.current += 1;
 				// router.replace('/');
 			} else if (event === "SIGNED_OUT") {
 				sessionRef.current = null;
@@ -433,6 +491,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 				if (!session) return;
 				setUser(session.user);
 				sessionRef.current = session;
+				// #1135 SIGNED_IN と同じ理由で世代を進める（リフレッシュ済みトークンを古い値で潰さない）
+				sessionGenerationRef.current += 1;
 			} else if (event === "USER_UPDATED") {
 				// setUser(session.user);
 				// setSession(session);

--- a/app-expo/contexts/AuthProvider.tsx
+++ b/app-expo/contexts/AuthProvider.tsx
@@ -299,10 +299,33 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 						payload: { user_id: anonSession.user.id },
 					});
 
-					// #1135 ここは世代ガードを掛けない。今作った匿名セッションは auth-js がロック保持中に
-					// `_saveSession` 済みで、構造上「最新の書き込み」そのものだから（＝古い読み取り結果ではない）。
-					sessionRef.current = anonSession;
-					setUser(anonSession.user);
+					// #1135 匿名サインインの await をまたぐ区間も、別経路が載せたセッションを巻き戻さない。
+					// `getSession()` が «code 交換が始まる前» に「セッション無し」で解決すると、上の
+					// hasNewerSession() 分岐は素通りする。その後この await の最中に
+					//   1. 匿名サインインが `_saveSession` → SIGNED_IN(匿名)
+					//   2. pendingInLock の `exchangeCodeForSession()` が完了 → SIGNED_IN(OAuth)
+					// の順で流れると、無条件の書き戻しは確立済みの OAuth セッションを匿名へ巻き戻す
+					// （storage は OAuth のまま = 本 Issue と同型の症状）。
+					//
+					// ⚠️ ここを世代カウンタ（hasNewerSession）で守ることはできない。1 の SIGNED_IN でも
+					//    世代は進むため、「自分が作った匿名セッション」と「別経路のセッション」を区別できず、
+					//    競合が無い正常な匿名サインインまで書き戻しをスキップして user=null で固着する。
+					//    そこで «今 sessionRef に載っているのが自分以外のセッションか» を同一性で判定する。
+					const currentSession = sessionRef.current;
+					if (currentSession && currentSession.access_token !== anonSession.access_token) {
+						// 別経路が先にセッションを確立していた。state は onAuthStateChange 側で更新済みなので、
+						// 「認証が確立している」という事後条件はここで何もしなくても満たされる。
+						// （作ってしまった匿名ユーザーは storage 上も既に上書きされている＝ auth-js の管理下。
+						//   ここで消しに行くと確立済みセッションを触ることになるため、記録だけに留める）
+						logFrontendEvent({
+							event_name: "anonymousSignInDiscarded",
+							error_level: "log",
+							payload: { stale_user_id: anonSession.user.id, current_user_id: currentSession.user.id },
+						});
+					} else {
+						sessionRef.current = anonSession;
+						setUser(anonSession.user);
+					}
 				}
 
 				nextAttemptAllowedAtRef.current = 0;


### PR DESCRIPTION
## 対象 Issue

Closes #1135

## 根因

[Issue #1135 の調査コメント](https://github.com/Ayato-kosaka/nanitabeyo/issues/1135#issuecomment-5152134354)（独立した調査担当が実物の `@supabase/auth-js` を使った再現ハーネスで検証）のとおり:

`AuthProvider.runAuthAttempt()` の `getSession() → setSession() → setUser()` が **read-modify-write の競合**になっている。`setSession()` は `GET /auth/v1/user` を伴うネットワーク往復で、その間に走った `exchangeCodeForSession()` の結果を、直後の `setUser(restoredSession.user)` が**古い匿名ユーザーで上書きする**。

結果、**localStorage には OAuth セッションが入るのに React の `user` state は匿名のまま**になる（＝画面はゲスト表示）。2 回目のログインでは書き戻す値自体が OAuth セッションになるため成功する。

Web だけで起きるのは、全画面リダイレクトでアプリが再起動し、認証初期化と code 交換が同一ページロードで同時に走るため。ネイティブは `WebBrowser.openAuthSessionAsync` でアプリが再起動しないので競合しない。

## 変更

- `app-expo/contexts/AuthProvider.tsx` — 復元経路の冗長な `setSession()` を削除し、`await` をまたいだ書き戻しに世代ガードを追加
- `app-expo/app/index.tsx` — `toInAppPath` がクエリを落としたコールバック URL を採用しないよう修正
- `app-expo/contexts/AuthProvider.test.tsx` — 競合の回帰テスト（修正前に赤くなることを実測）
- `app-expo/__tests__/index.test.tsx` — Web のコールバック URL ケース

## 検証

- `pnpm --filter app-expo typecheck`
- `pnpm --filter app-expo test`（全件）
- 回帰テストが修正前のコードで赤くなることを実測（Artifact の `red-run/`）

エビデンスは Actions run 30706979862 相当の Artifact に格納。

## 実機でしか確認できない範囲

実 Google IdP との往復は自動化していないため、**1 回目のログインで入れることの最終確認はブラウザ実機が必要**です。Issue のコメント §6 に devtools での切り分け手順（見るべき localStorage キー・Network の 3 リクエスト）を記載しています。

## base

統合ブランチ `claude/parallel-dev-orchestration-7he5dw` 宛。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_