### PR TITLE
#1126 fix: 保存店リストの横スクロール中に縦ジェスチャを発火させない

### DIFF
--- a/app-expo/features/review/components/SavedRestaurantsSheet.tsx
+++ b/app-expo/features/review/components/SavedRestaurantsSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useCallback, useState, forwardRef, useImperativeHandle } from "react";
-import { View, StyleSheet, Text, TouchableOpacity, useWindowDimensions } from "react-native";
+import { View, StyleSheet, Text, TouchableOpacity, useWindowDimensions, Platform } from "react-native";
 import { DetentChangeEvent, TrueSheet } from "@lodev09/react-native-true-sheet";
 import Carousel, { ICarouselInstance } from "react-native-reanimated-carousel";
 import { PrimaryButton } from "@/components/PrimaryButton";
@@ -12,8 +12,28 @@ import { InteractionManager } from "react-native";
 import { ScrollView } from "react-native";
 import { useContentWidth } from "@/hooks/useContentWidth";
 import { CARD_HEIGHT, LARGE_DETENT, computeSmallDetent } from "./savedRestaurantsSheetDetents";
+import {
+	CAROUSEL_DRAG_RESET_TIMEOUT_MS,
+	configureCarouselPanGesture,
+	isSheetDraggable,
+} from "./savedRestaurantsSheetGesture";
 
 type SavedRestaurant = QueryMeSavedRestaurantsResponse["data"][number];
+
+/**
+ * #1126 横スワイプ中にシートのドラッグを止める必要があるのは Android だけ。
+ *
+ * Android の `BottomSheetBehavior`(`ViewDragHelper`) は `abs(dy) > touchSlop(8dp)` だけで
+ * ドラッグを開始し、横方向の移動量と比較しない（詳細は savedRestaurantsSheetGesture.ts）。
+ * iOS（UIKit のシート）と web（@gorhom/bottom-sheet）はこの判定を持たないため、
+ * 挙動と見た目を変えないよう Android に限定する。
+ *
+ * なお TrueSheet は `draggable` が変わるたびにネイティブのグラバーを作り直し、
+ * `draggable === false` の間はグラバーを消してしまう（横スワイプのたびに点滅する）。
+ * そのため Android ではネイティブのグラバーを無効化し、ヘッダー内に同じ見た目
+ * （32x4dp / 角丸 / 黒 40% / シート上端から 16dp）のグラバーを自前で描画する。
+ */
+const GATES_SHEET_DRAG = Platform.OS === "android";
 
 export type SavedRestaurantsSheetHandle = {
 	present: () => Promise<void>;
@@ -148,10 +168,54 @@ export const SavedRestaurantsSheet = forwardRef<SavedRestaurantsSheetHandle, Sav
 		}, []);
 
 		const [detentIndex, setDetentIndex] = useState(0);
+		// #1126 カルーセルの横スワイプが成立している間だけシートのドラッグを止めるためのフラグ。
+		// isDraggingRef（カード誤タップ抑止）と違い、TrueSheet へ props で渡すので state が必要。
+		const [isSwipingCarousel, setIsSwipingCarousel] = useState(false);
 
-		const handleDetentChange = useCallback((event: DetentChangeEvent) => {
-			setDetentIndex(event.nativeEvent.index);
+		const endCarouselSwipe = useCallback(() => {
+			isDraggingRef.current = false;
+			setIsSwipingCarousel(false);
+			if (draggingTimeoutRef.current) {
+				clearTimeout(draggingTimeoutRef.current);
+				draggingTimeoutRef.current = null;
+			}
 		}, []);
+
+		const beginCarouselSwipe = useCallback(() => {
+			isDraggingRef.current = true;
+			setIsSwipingCarousel(true);
+			// #644 【バグ】タイムアウトフォールバックを追加して isDraggingRef が true のまま固まるのを防ぐ
+			// #1126 シートのドラッグ抑止も同じタイマーで必ず解除する（解除漏れでシートが動かせなくなるのを防ぐ）
+			if (draggingTimeoutRef.current) {
+				clearTimeout(draggingTimeoutRef.current);
+			}
+			draggingTimeoutRef.current = setTimeout(endCarouselSwipe, CAROUSEL_DRAG_RESET_TIMEOUT_MS);
+		}, [endCarouselSwipe]);
+
+		const handleDetentChange = useCallback(
+			(event: DetentChangeEvent) => {
+				setDetentIndex(event.nativeEvent.index);
+				// #1126 detent が変わるとカルーセル自体がアンマウントされ onScrollEnd が来ないことがあるため、
+				// ここでも抑止を解除しておく
+				endCarouselSwipe();
+			},
+			[endCarouselSwipe],
+		);
+
+		/**
+		 * #1126 `onSnapToItem` の関数 ID は reanimated-carousel の内部で
+		 * `onScrollEnd` → `onGestureEnd` → Pan ジェスチャの useMemo の依存に伝播する。
+		 * インライン関数のままだと、横スワイプ中の再レンダー（isSwipingCarousel の更新）で
+		 * ジェスチャオブジェクトが作り直され、進行中のスワイプが切れてしまう。
+		 */
+		const handleSnapToItem = useCallback(
+			(index: number) => {
+				endCarouselSwipe();
+				const restaurant = savedRestaurants[index];
+				if (restaurant) onSnapToRestaurant?.(restaurant);
+			},
+			[endCarouselSwipe, savedRestaurants, onSnapToRestaurant],
+		);
 
 		const activeIndex = useMemo(() => {
 			return savedRestaurants.findIndex((r) => r.restaurant.id === activeRestaurantId);
@@ -186,7 +250,9 @@ export const SavedRestaurantsSheet = forwardRef<SavedRestaurantsSheetHandle, Sav
 			<TrueSheet
 				ref={sheetRef}
 				detents={sheetDetents}
-				grabber
+				grabber={!GATES_SHEET_DRAG}
+				// #1126 横スワイプ中はシートを掴ませない（縦へ引いた場合はカルーセルが fail するので true のまま）
+				draggable={isSheetDraggable(detentIndex, GATES_SHEET_DRAG && isSwipingCarousel)}
 				cornerRadius={24}
 				backgroundColor="#FFFFFF"
 				dismissible={false}
@@ -194,6 +260,8 @@ export const SavedRestaurantsSheet = forwardRef<SavedRestaurantsSheetHandle, Sav
 				scrollable={detentIndex === 1}
 				header={
 					<View style={styles.header}>
+						{/* #1126 ネイティブのグラバーは draggable の切り替えで点滅するため、Android では自前で描画する */}
+						{GATES_SHEET_DRAG ? <View style={styles.grabber} /> : null}
 						<Text style={styles.savedRestaurantsTitle}>{i18n.t("Review.selectRestaurant.savedRestaurantList")}</Text>
 					</View>
 				}
@@ -235,37 +303,16 @@ export const SavedRestaurantsSheet = forwardRef<SavedRestaurantsSheetHandle, Sav
 										snapEnabled
 										maxScrollDistancePerSwipe={widthMetrics.cardWidth + 40}
 										mode="parallax"
+										// #1126 横方向専用の Pan にして、縦ジェスチャ（シートの展開）と排他にする
+										onConfigurePanGesture={configureCarouselPanGesture}
 										modeConfig={{
 											parallaxScrollingScale: 1,
 											parallaxAdjacentItemScale: 1,
 											parallaxScrollingOffset: ((widthMetrics.contentWidth - widthMetrics.cardWidth) * 3) / 4,
 										}}
-										onScrollStart={() => {
-											isDraggingRef.current = true;
-											// #644 【バグ】タイムアウトフォールバックを追加して isDraggingRef が true のまま固まるのを防ぐ
-											if (draggingTimeoutRef.current) {
-												clearTimeout(draggingTimeoutRef.current);
-											}
-											draggingTimeoutRef.current = setTimeout(() => {
-												isDraggingRef.current = false;
-											}, 500);
-										}}
-										onScrollEnd={() => {
-											isDraggingRef.current = false;
-											if (draggingTimeoutRef.current) {
-												clearTimeout(draggingTimeoutRef.current);
-												draggingTimeoutRef.current = null;
-											}
-										}}
-										onSnapToItem={(index) => {
-											isDraggingRef.current = false;
-											if (draggingTimeoutRef.current) {
-												clearTimeout(draggingTimeoutRef.current);
-												draggingTimeoutRef.current = null;
-											}
-											const restaurant = savedRestaurants[index];
-											if (restaurant) onSnapToRestaurant?.(restaurant);
-										}}
+										onScrollStart={beginCarouselSwipe}
+										onScrollEnd={endCarouselSwipe}
+										onSnapToItem={handleSnapToItem}
 										scrollAnimationDuration={350}
 										renderItem={renderItem}
 									/>
@@ -363,6 +410,17 @@ const styles = StyleSheet.create({
 	header: {
 		paddingHorizontal: 16,
 		marginVertical: 8,
+	},
+	// #1126 TrueSheet のネイティブグラバー（32x4dp / 角丸 / 黒 40% / シート上端から 16dp）の写し。
+	// header の marginTop が 8 なので、top: 8 でシート上端から 16 になる。
+	grabber: {
+		position: "absolute",
+		top: 8,
+		alignSelf: "center",
+		width: 32,
+		height: 4,
+		borderRadius: 2,
+		backgroundColor: "rgba(0, 0, 0, 0.4)",
 	},
 	savedRestaurantsTitle: {
 		fontSize: 14,

--- a/app-expo/features/review/components/savedRestaurantsSheetGesture.test.ts
+++ b/app-expo/features/review/components/savedRestaurantsSheetGesture.test.ts
@@ -1,0 +1,85 @@
+import type { PanGesture } from "react-native-gesture-handler";
+import {
+	CAROUSEL_ACTIVE_OFFSET_X,
+	CAROUSEL_DRAG_RESET_TIMEOUT_MS,
+	CAROUSEL_FAIL_OFFSET_Y,
+	configureCarouselPanGesture,
+	isSheetDraggable,
+} from "./savedRestaurantsSheetGesture";
+
+/**
+ * Android の `ViewConfiguration.getScaledTouchSlop()`（＝ BottomSheetBehavior がシートを
+ * 掴み始める縦方向のしきい値）。実機では 8dp。テスト内の期待値の根拠としてのみ使う。
+ */
+const ANDROID_SHEET_TOUCH_SLOP_DP = 8;
+
+type Recorder = {
+	gesture: Pick<PanGesture, "activeOffsetX" | "failOffsetY">;
+	activeOffsetX: jest.Mock;
+	failOffsetY: jest.Mock;
+};
+
+function createGestureRecorder(): Recorder {
+	const activeOffsetX = jest.fn(() => gesture);
+	const failOffsetY = jest.fn(() => gesture);
+	const gesture = { activeOffsetX, failOffsetY } as unknown as Pick<PanGesture, "activeOffsetX" | "failOffsetY">;
+	return { gesture, activeOffsetX, failOffsetY };
+}
+
+describe("#1126 configureCarouselPanGesture", () => {
+	it("横方向のしきい値（activeOffsetX）を左右対称に設定する", () => {
+		const { gesture, activeOffsetX } = createGestureRecorder();
+		configureCarouselPanGesture(gesture);
+		expect(activeOffsetX).toHaveBeenCalledTimes(1);
+		expect(activeOffsetX).toHaveBeenCalledWith([-CAROUSEL_ACTIVE_OFFSET_X, CAROUSEL_ACTIVE_OFFSET_X]);
+	});
+
+	it("縦方向へ動いたら fail するよう failOffsetY を上下対称に設定する", () => {
+		const { gesture, failOffsetY } = createGestureRecorder();
+		configureCarouselPanGesture(gesture);
+		expect(failOffsetY).toHaveBeenCalledTimes(1);
+		expect(failOffsetY).toHaveBeenCalledWith([-CAROUSEL_FAIL_OFFSET_Y, CAROUSEL_FAIL_OFFSET_Y]);
+	});
+
+	it("activeOffsetX と failOffsetY の両方を設定する（片方だけでは方向の排他にならない）", () => {
+		const { gesture, activeOffsetX, failOffsetY } = createGestureRecorder();
+		configureCarouselPanGesture(gesture);
+		expect(activeOffsetX).toHaveBeenCalled();
+		expect(failOffsetY).toHaveBeenCalled();
+	});
+});
+
+describe("#1126 カルーセルのしきい値の関係", () => {
+	it("横（activeOffsetX）より縦（failOffsetY）を大きくして横スワイプを優先する", () => {
+		expect(CAROUSEL_FAIL_OFFSET_Y).toBeGreaterThan(CAROUSEL_ACTIVE_OFFSET_X);
+	});
+
+	it("failOffsetY は Android のシート touchSlop(8dp) より大きい（縦へ引けばシートが先に反応する）", () => {
+		// これが逆転すると、意図的な縦ドラッグでもカルーセルが先に fail するだけでシートが掴めず、
+		// 「展開できない」という機能欠落になる
+		expect(CAROUSEL_FAIL_OFFSET_Y).toBeGreaterThan(ANDROID_SHEET_TOUCH_SLOP_DP);
+	});
+
+	it("しきい値は正の有限値である", () => {
+		for (const value of [CAROUSEL_ACTIVE_OFFSET_X, CAROUSEL_FAIL_OFFSET_Y, CAROUSEL_DRAG_RESET_TIMEOUT_MS]) {
+			expect(Number.isFinite(value)).toBe(true);
+			expect(value).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("#1126 isSheetDraggable", () => {
+	it("カルーセル表示中に横スワイプしている間はシートを掴ませない", () => {
+		expect(isSheetDraggable(0, true)).toBe(false);
+	});
+
+	it("カルーセル表示中でも横スワイプしていなければ縦ドラッグで展開できる", () => {
+		// 「敏感すぎる」の修正であって縦ジェスチャの削除ではないので、ここは必ず true
+		expect(isSheetDraggable(0, false)).toBe(true);
+	});
+
+	it("展開後（縦並びリスト）は常に掴める", () => {
+		expect(isSheetDraggable(1, false)).toBe(true);
+		expect(isSheetDraggable(1, true)).toBe(true);
+	});
+});

--- a/app-expo/features/review/components/savedRestaurantsSheetGesture.ts
+++ b/app-expo/features/review/components/savedRestaurantsSheetGesture.ts
@@ -1,0 +1,70 @@
+import type { PanGesture } from "react-native-gesture-handler";
+
+/**
+ * #1126 保存店カルーセル（横スクロール）と TrueSheet の縦ドラッグ（引き上げて縦並びへ展開）の
+ * ジェスチャ競合を解消するための設定値と判定ロジック。
+ *
+ * ■ 競合の根因
+ * Android の TrueSheet は Material の `BottomSheetBehavior` + `ViewDragHelper` で実装されている。
+ * `ViewDragHelper.checkTouchSlop()` は BottomSheetBehavior が「縦にしかドラッグできない」ため
+ * `abs(dy) > touchSlop` だけを見る。つまり **横の移動量と比較しない**。
+ * touchSlop は `ViewConfiguration.getScaledTouchSlop()` ＝ 8dp しかないので、
+ * カルーセルを横スワイプしているだけでも指が 8dp 縦にぶれた瞬間に
+ * CoordinatorLayout がタッチを横取りし（子には ACTION_CANCEL が飛ぶ）、シートが展開してしまう。
+ *
+ * ■ 方針
+ * 1. カルーセル側の Pan を「横方向専用」にする（`activeOffsetX` / `failOffsetY`）。
+ *    しきい値を上げるのではなく、方向で排他にする。
+ * 2. 横スワイプが成立している間だけ TrueSheet の `draggable` を false にして、
+ *    Android のネイティブ側にシートを掴ませない。
+ *    縦へ引いた場合はカルーセルが fail するので `draggable` は true のままで、従来どおり展開できる。
+ */
+
+/**
+ * カルーセルの Pan が「横スワイプ」として活性化するのに必要な横方向の移動量（dp）。
+ *
+ * react-native-reanimated-carousel の既定は「向き無指定・半径 10dp」なので、
+ * 縦ドラッグでもカルーセルが活性化していた。閾値の大きさは 10dp のまま、
+ * 判定対象を横方向だけに絞ることで、タップの取りこぼしを増やさずに方向を排他化する。
+ */
+export const CAROUSEL_ACTIVE_OFFSET_X = 10;
+
+/**
+ * カルーセルの Pan を「縦ジェスチャなので降りる（fail）」と判断する縦方向の移動量（dp）。
+ *
+ * `CAROUSEL_ACTIVE_OFFSET_X` の 2 倍にして横方向を優先する。
+ * また Android のシートが掴む閾値（touchSlop = 8dp）より必ず大きくしておくことで、
+ * 意図的な縦ドラッグでは「シートが掴む → カルーセルが fail」の順になり、展開操作が壊れない。
+ */
+export const CAROUSEL_FAIL_OFFSET_Y = 20;
+
+/**
+ * #644 で導入した「`onScrollEnd` が来ずにドラッグ中フラグが立ちっぱなしになる」ことへの
+ * フォールバックのタイムアウト（ms）。#1126 のシートドラッグ抑止も同じタイマーで解除する。
+ */
+export const CAROUSEL_DRAG_RESET_TIMEOUT_MS = 500;
+
+/**
+ * カルーセルの Pan ジェスチャを横方向専用に設定する。
+ *
+ * - 横へ `CAROUSEL_ACTIVE_OFFSET_X` dp 動くまで活性化しない
+ * - 先に縦へ `CAROUSEL_FAIL_OFFSET_Y` dp 動いたら fail して縦ジェスチャへ譲る
+ */
+export function configureCarouselPanGesture(gesture: Pick<PanGesture, "activeOffsetX" | "failOffsetY">): void {
+	gesture
+		.activeOffsetX([-CAROUSEL_ACTIVE_OFFSET_X, CAROUSEL_ACTIVE_OFFSET_X])
+		.failOffsetY([-CAROUSEL_FAIL_OFFSET_Y, CAROUSEL_FAIL_OFFSET_Y]);
+}
+
+/**
+ * TrueSheet にドラッグを許可してよいかを判定する。
+ *
+ * @param detentIndex 現在の detent（0 = 横並びカルーセル / 1 = 縦並びリスト）
+ * @param isSwipingCarousel カルーセルの横スワイプが成立中か
+ * @returns 横スワイプ中のカルーセル表示時だけ false（＝シートを掴ませない）
+ */
+export function isSheetDraggable(detentIndex: number, isSwipingCarousel: boolean): boolean {
+	// 展開後（detentIndex !== 0）はカルーセルが存在しないので、常にドラッグ可能にしておく
+	if (detentIndex !== 0) return true;
+	return !isSwipingCarousel;
+}


### PR DESCRIPTION
## 対象 Issue

Closes #1126

## 背景

レビュータブ（ログイン後）の保存したお店リストで、横スクロールの縦反応が敏感すぎて、普通に横スクロールしているだけで縦並び UI へ切り替わってしまう（Android で発覚）。横スクロールと、横並び↔縦並びを切り替える縦ジェスチャの競合。

## 変更

- `app-expo/features/review/components/savedRestaurantsSheetGesture.ts`（新規） — 方向判定・しきい値のロジックを純関数へ分離
- `app-expo/features/review/components/savedRestaurantsSheetGesture.test.ts`（新規） — 判定の単体テスト
- `app-expo/features/review/components/SavedRestaurantsSheet.tsx` — 横に動いている間は縦ジェスチャを発火させない排他制御

縦ジェスチャ自体は残しており、意図的に縦へ引けば従来どおり展開できます。

## 検証

- `pnpm --filter app-expo typecheck`
- `pnpm --filter app-expo test`

## 実機確認が必要

このランナーに Android エミュレータが無いため、**実際のタッチジェスチャは検証できていません**。しきい値の具体的な数値と、人間が Android 実機で確認すべきチェックリストは実装 run の報告を参照してください。マージ前に実機での触り心地の確認をおすすめします。

## base

統合ブランチ `claude/parallel-dev-orchestration-7he5dw` 宛。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_