### PR TITLE
#1130 fix: お知らせ一覧とモーダル中身の SafeArea 食い込みを修正

### DIFF
--- a/app-expo/__tests__/notificationsSafeArea.test.tsx
+++ b/app-expo/__tests__/notificationsSafeArea.test.tsx
@@ -1,0 +1,146 @@
+// #1130 【設計】お知らせ一覧（app/[locale]/(tabs)/notifications/index.tsx）の SafeArea 不変条件テスト。
+//
+// 背景（Issue #1130）:
+// この画面は `react-native` の `SafeAreaView` を使っていた。これは **iOS 専用**の実装で、
+// Android では inset を一切足さない素の View と同じ振る舞いになる（RN 公式ドキュメント記載の制約）。
+// そのため Android だけヘッダーがステータスバーへ食い込んでいた。
+// 見本として指定されたブロック済み料理一覧（profile/blocked-topics.tsx）や、
+// 同じくタブ直下の検索・プロフィール画面は `react-native-safe-area-context` を使っており、
+// こちらは Android でも inset を適用する。
+//
+// 「実機で見た目を確認した」ではなく、
+//   1. 描画結果に react-native-safe-area-context の SafeAreaView が居て `edges={["top"]}` が渡ること
+//   2. ソース上で `react-native` からは SafeAreaView を import し直さないこと（＝バグの再発）
+// の 2 点を赤で守る。
+import * as fs from "fs";
+import * as path from "path";
+import React, { act } from "react";
+import TestRenderer, { type ReactTestInstance } from "react-test-renderer";
+
+// ---- 観測対象（SafeArea の扱い）以外はすべてスタブ化する ----
+jest.mock(
+	"lucide-react-native",
+	() =>
+		new Proxy(
+			{},
+			{
+				get: (_target, prop) =>
+					prop === "__esModule"
+						? true
+						: function MockIcon() {
+								return null;
+							},
+			},
+		),
+);
+
+// SafeAreaView に何が渡ったかをテストから観測できるよう、host View へそのまま素通しする
+jest.mock("react-native-safe-area-context", () => {
+	const ReactModule = require("react");
+	const { View } = require("react-native");
+	return {
+		__esModule: true,
+		SafeAreaView: ({ children, ...props }: { children?: React.ReactNode }) =>
+			ReactModule.createElement(View, { testID: "mock-safe-area-view", ...props }, children),
+		useSafeAreaInsets: () => ({ top: 24, bottom: 0, left: 0, right: 0 }),
+	};
+});
+
+jest.mock("expo-image", () => ({
+	Image: function MockExpoImage() {
+		return null;
+	},
+}));
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key, locale: "ja-JP" } }));
+jest.mock("@/components/LoadingIndicator", () => ({ LoadingIndicator: () => null }));
+jest.mock("expo-router", () => ({
+	useRouter: () => ({ push: jest.fn() }),
+	// フォーカス時の副作用（既読化 API 等）はこのテストの関心外なので発火させない
+	useFocusEffect: () => {},
+}));
+jest.mock("@/hooks/useHaptics", () => ({ useHaptics: () => ({ lightImpact: jest.fn() }) }));
+jest.mock("@/hooks/useLocale", () => ({ useLocale: () => ({ locale: "ja-JP", isJapanese: true }) }));
+jest.mock("@/hooks/useScreenTrace", () => ({ useScreenTrace: () => {} }));
+jest.mock("@/lib/image", () => ({ getCacheKeyForImage: () => "cache-key" }));
+jest.mock("@/lib/frontend-utils", () => ({ dateStringToTimestamp: () => "1分前" }));
+jest.mock("@/stores/useDishMediaEntriesStore", () => ({ useDishMediaEntriesStore: { getState: () => ({}) } }));
+jest.mock("@/features/notifications/hooks/useNotifications", () => ({
+	useNotifications: () => ({
+		items: [],
+		isLoadingInitial: false,
+		isLoadingMore: false,
+		refresh: jest.fn(),
+		loadMore: jest.fn(),
+	}),
+}));
+jest.mock("@/features/notifications/hooks/useMarkNotificationsRead", () => ({
+	useMarkNotificationsRead: () => ({ markAllAsRead: jest.fn() }),
+}));
+jest.mock("@/features/notifications/hooks/useNotificationUnreadCount", () => ({
+	useNotificationUnreadCount: () => ({ unreadCount: 0, refresh: jest.fn() }),
+}));
+
+// jest.mock のファクトリからは `mock` 始まりの変数だけ参照できる（babel-plugin-jest-hoist の制約）
+const mockLoggedInUser: { id: string; is_anonymous: boolean } = { id: "user-1", is_anonymous: false };
+let mockCurrentUser: typeof mockLoggedInUser | null = mockLoggedInUser;
+jest.mock("@/contexts/AuthProvider", () => ({ useAuth: () => ({ user: mockCurrentUser }) }));
+
+import NotificationsScreen from "../app/[locale]/(tabs)/notifications/index";
+
+/** 描画結果から SafeAreaView（モック）に対応する host 要素だけを取り出す */
+const findSafeAreaViews = (root: ReactTestInstance): ReactTestInstance[] =>
+	root.findAll((node) => typeof node.type === "string" && node.props?.testID === "mock-safe-area-view");
+
+const render = () => {
+	let renderer!: TestRenderer.ReactTestRenderer;
+	act(() => {
+		renderer = TestRenderer.create(<NotificationsScreen />);
+	});
+	return renderer;
+};
+
+describe("#1130 お知らせ一覧の SafeArea", () => {
+	afterEach(() => {
+		mockCurrentUser = mockLoggedInUser;
+	});
+
+	it("ログイン済みの一覧は SafeAreaView(react-native-safe-area-context) を edges={['top']} で使う", () => {
+		const renderer = render();
+		const safeAreaViews = findSafeAreaViews(renderer.root);
+
+		expect(safeAreaViews).toHaveLength(1);
+		expect(safeAreaViews[0].props.edges).toEqual(["top"]);
+	});
+
+	it("ゲスト向けの空画面も同じ edges 指定になっている", () => {
+		mockCurrentUser = null;
+		const renderer = render();
+		const safeAreaViews = findSafeAreaViews(renderer.root);
+
+		expect(safeAreaViews).toHaveLength(1);
+		expect(safeAreaViews[0].props.edges).toEqual(["top"]);
+	});
+
+	it("react-native の SafeAreaView（iOS 専用 = Android で無効）を import していない", () => {
+		const screenSource = fs.readFileSync(
+			path.join(__dirname, "..", "app", "[locale]", "(tabs)", "notifications", "index.tsx"),
+			"utf8",
+		);
+
+		// `import { ... SafeAreaView ... } from "react-native";` に当たったら失敗させる
+		const reactNativeImport = screenSource.match(/import\s*\{([^}]*)\}\s*from\s*"react-native"/);
+		expect(reactNativeImport).not.toBeNull();
+		expect(reactNativeImport?.[1]).not.toContain("SafeAreaView");
+		expect(screenSource).toContain('import { SafeAreaView } from "react-native-safe-area-context"');
+	});
+
+	it("見本のブロック済み料理一覧と同じ SafeArea の出所を使っている", () => {
+		const blockedTopicsSource = fs.readFileSync(
+			path.join(__dirname, "..", "app", "[locale]", "(tabs)", "profile", "blocked-topics.tsx"),
+			"utf8",
+		);
+
+		// 見本側が react-native-safe-area-context をやめたらこのテストの前提が崩れるので、そこも固定する
+		expect(blockedTopicsSource).toContain('import { SafeAreaView } from "react-native-safe-area-context"');
+	});
+});

--- a/app-expo/app/[locale]/(tabs)/notifications/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/notifications/index.tsx
@@ -1,6 +1,11 @@
 import React, { useCallback } from "react";
 import { LoadingIndicator } from "@/components/LoadingIndicator";
-import { View, Text, StyleSheet, FlatList, TouchableOpacity, SafeAreaView } from "react-native";
+import { View, Text, StyleSheet, FlatList, TouchableOpacity } from "react-native";
+// #1130 【修正】react-native の SafeAreaView は iOS 専用（Android では素の View に等しく inset を
+// 一切足さない）ため、Android だけヘッダーがステータスバーへ食い込んでいた。
+// ブロック済み料理一覧（profile/blocked-topics.tsx）や検索・プロフィールのタブ直下画面と同じく
+// react-native-safe-area-context の SafeAreaView を使う。
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Image } from "expo-image";
 import i18n from "@/lib/i18n";
 import { Heart, Bookmark } from "lucide-react-native";
@@ -203,7 +208,7 @@ export default function NotificationsScreen() {
 	// #1092 PR4b 判定は共通化（lib/authGuest.ts）。タブの表示可否と同じ式にしておく
 	if (isGuestUser(user)) {
 		return (
-			<SafeAreaView style={styles.container}>
+			<SafeAreaView style={styles.container} edges={["top"]}>
 				<View style={styles.header}>
 					<Text style={styles.headerTitle}>{i18n.t("Notifications.title")}</Text>
 				</View>
@@ -215,7 +220,9 @@ export default function NotificationsScreen() {
 	}
 
 	return (
-		<SafeAreaView style={styles.container}>
+		// #1130 edges は "top" のみ。下端はタブバー側（app/[locale]/(tabs)/_layout.tsx の
+		// `safeAreaInsets`）が面倒を見ているので、ここで bottom を足すと二重に余白が入る。
+		<SafeAreaView style={styles.container} edges={["top"]}>
 			{/* Header */}
 			<View style={styles.header}>
 				<Text style={styles.headerTitle}>{i18n.t("Notifications.title")}</Text>

--- a/app-expo/features/map/components/DishCategorySearchForm.test.tsx
+++ b/app-expo/features/map/components/DishCategorySearchForm.test.tsx
@@ -1,0 +1,84 @@
+// #1130 【設計】BlurModal の中身が SafeArea へ食い込む件の不変条件テスト。
+//
+// 背景（Issue #1130）:
+// レビュー投稿時の料理カテゴリ検索モーダル（BlurModal + DishCategorySearchForm）は、中身が
+// `marginHorizontal` だけの素の View だった。BlurModal は中身へ safe area inset を足さないため、
+// 上端は既定の `paddingVertical`（32）ぶんしか下がらず、Android のステータスバー領域へ重なっていた。
+//
+// Issue が見本に挙げた「保存料理カテゴリの地点検索」（features/profile/components/LocationSearchForm.tsx）は
+// Card（margin 16 + paddingVertical 20）に包まれているため、中身の上端が 32 + 16 + 20 = 68px まで下がり、
+// 結果として SafeArea を避けている。ここではその構造の一致を固定する。
+//
+// エミュレータが無いので inset の実際の見え方は測れない。代わりに
+//   1. 両フォームの最外殻が同じ Card であること
+//   2. Card が中身へ与えるオフセット（外側の margin と内側の paddingVertical）が両者で一致すること
+// を赤で守る。
+import React, { act } from "react";
+import TestRenderer, { type ReactTestInstance } from "react-test-renderer";
+
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key, locale: "ja-JP" } }));
+jest.mock("@/components/DishCategoryAutocomplete", () => ({ DishCategoryAutocomplete: () => null }));
+jest.mock("@/components/LocationAutocomplete", () => ({ LocationAutocomplete: () => null }));
+
+import { Card } from "@/components/Card";
+import { DishCategorySearchForm } from "./DishCategorySearchForm";
+import { LocationSearchForm } from "@/features/profile/components/LocationSearchForm";
+
+// React 19 では初期描画がスケジューラのタスクへ回されるため、act() で包む必要がある
+// （包まないと描画が「テスト終了後」に走り、モジュールが破棄済みで落ちる）。ReviewForm.test.tsx と同じ理由。
+const render = (element: React.ReactElement): TestRenderer.ReactTestRenderer => {
+	let renderer!: TestRenderer.ReactTestRenderer;
+	act(() => {
+		renderer = TestRenderer.create(element);
+	});
+	return renderer;
+};
+
+/** style（配列 / 入れ子）を素朴に 1 枚のオブジェクトへ潰す */
+const flattenStyle = (style: unknown): Record<string, unknown> => {
+	if (Array.isArray(style)) return Object.assign({}, ...style.map(flattenStyle));
+	if (style && typeof style === "object") return style as Record<string, unknown>;
+	return {};
+};
+
+/**
+ * Card が中身へ与えるオフセット。
+ * Card は「外側 View（margin と影）＋ 内側 surface View（padding）」の 2 枚構成なので、
+ * host 要素を上から 2 つ取れば外側・内側になる。
+ */
+const cardOffsetOf = (root: ReactTestInstance): { margin: unknown; paddingVertical: unknown } => {
+	const hosts = root.findByType(Card).findAll((node) => typeof node.type === "string");
+	return {
+		margin: flattenStyle(hosts[0].props.style).margin,
+		paddingVertical: flattenStyle(hosts[1].props.style).paddingVertical,
+	};
+};
+
+describe("#1130 料理カテゴリ検索モーダルの中身が SafeArea を避ける", () => {
+	it("最外殻が Card になっている（旧実装の素の View だと落ちる）", () => {
+		const renderer = render(<DishCategorySearchForm onSuggestionSelect={jest.fn()} />);
+
+		expect(renderer.root.findAllByType(Card)).toHaveLength(1);
+	});
+
+	it("見本（保存料理カテゴリの地点検索）と同じくタイトルを持つ", () => {
+		const renderer = render(<DishCategorySearchForm onSuggestionSelect={jest.fn()} />);
+
+		// i18n はキーをそのまま返すモックなので、タイトルに使うキーを直接確認できる
+		const titles = renderer.root.findAll(
+			(node) => typeof node.type === "string" && node.props?.children === "Map.actions.selectDishCategory",
+		);
+		expect(titles).not.toHaveLength(0);
+	});
+
+	it("Card が与えるオフセットが見本と一致する", () => {
+		const target = render(<DishCategorySearchForm onSuggestionSelect={jest.fn()} />);
+		const reference = render(<LocationSearchForm onSubmit={jest.fn()} onCancel={jest.fn()} />);
+
+		const targetOffset = cardOffsetOf(target.root);
+
+		expect(targetOffset).toEqual(cardOffsetOf(reference.root));
+		// 見本の実測値。Card 側の既定値が変わったらここも一緒に見直すこと
+		expect(targetOffset).toEqual({ margin: 16, paddingVertical: 20 });
+	});
+});

--- a/app-expo/features/map/components/DishCategorySearchForm.tsx
+++ b/app-expo/features/map/components/DishCategorySearchForm.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useEffect, useRef } from "react";
-import { View, StyleSheet } from "react-native";
+import { View, Text, StyleSheet } from "react-native";
 import i18n from "@/lib/i18n";
 import type { QueryDishCategoryVariantsResponse } from "@shared/api/v1/res";
+import { Card } from "@/components/Card";
 import { DishCategoryAutocomplete } from "@/components/DishCategoryAutocomplete";
 
 interface DishCategorySearchFormProps {
@@ -15,12 +16,22 @@ interface DishCategorySearchFormProps {
 	onUnmount?: (dishCategoryName: string) => void;
 	/** Placeholder text for the autocomplete input */
 	placeholder?: string;
+	/** Modal title */
+	title?: string;
 	/** Test ID for the autocomplete input */
 	testID?: string;
 }
 
 /**
  * Dish Category Search Form Component
+ *
+ * #1130 【修正】BlurModal の中身が SafeArea へ食い込んでいた。
+ * 旧実装は `marginHorizontal` だけの素の View だったため、中身の上端は BlurModal の
+ * `paddingVertical`（既定 32）ぶんしか下がらず、Android のステータスバー領域に重なっていた。
+ * 見本として指定された「保存料理カテゴリの地点検索」（features/profile/components/LocationSearchForm.tsx）と
+ * 同じく Card（margin 16 + paddingVertical 20）＋タイトルの構成に揃え、中身の上端を
+ * 32 + 16 + 20 = 68px まで下げる。× ボタンは BlurModal 側で `top: insets.top` に絶対配置されており
+ * SafeArea にかかったままで良い（Issue 本文の指定どおり）ので、共通実装には手を入れていない。
  */
 export function DishCategorySearchForm({
 	onSuggestionSelect,
@@ -28,6 +39,7 @@ export function DishCategorySearchForm({
 	onMount,
 	onUnmount,
 	placeholder = i18n.t("Map.placeholders.enterDishCategory"),
+	title = i18n.t("Map.actions.selectDishCategory"),
 	testID,
 }: DishCategorySearchFormProps) {
 	// Internal state - isolated from parent re-renders
@@ -65,23 +77,36 @@ export function DishCategorySearchForm({
 	}, [onClear]);
 
 	return (
-		<View style={styles.autocompleteContainer}>
-			<DishCategoryAutocomplete
-				value={dishCategoryName}
-				onChangeText={setDishCategoryName}
-				onSelectSuggestion={handleSuggestionSelect}
-				onClear={handleClear}
-				placeholder={i18n.t("Map.placeholders.enterDishCategory")}
-				autofocus={true}
-				testID={testID}
-			/>
-		</View>
+		<Card>
+			<Text style={styles.modalTitle}>{title}</Text>
+			<View style={styles.autocompleteContainer}>
+				<DishCategoryAutocomplete
+					value={dishCategoryName}
+					onChangeText={setDishCategoryName}
+					onSelectSuggestion={handleSuggestionSelect}
+					onClear={handleClear}
+					placeholder={placeholder}
+					autofocus={true}
+					testID={testID}
+				/>
+			</View>
+		</Card>
 	);
 }
 
 const styles = StyleSheet.create({
+	// LocationSearchForm.tsx の modalTitle と同じ指定（見本に揃えるため）
+	modalTitle: {
+		fontSize: 18,
+		fontWeight: "700",
+		color: "#1A1A1A",
+		marginBottom: 16,
+		textAlign: "center",
+		letterSpacing: -0.3,
+	},
 	autocompleteContainer: {
-		marginHorizontal: 16,
+		// 左右の余白は Card（margin 16 + paddingHorizontal 16）が持つため marginHorizontal は不要。
+		// 候補リストが出るまでモーダルの高さが跳ねないよう minHeight は維持する
 		minHeight: 300,
 	},
 });


### PR DESCRIPTION
## 対象 Issue

Closes #1130

## 変更（2 件を別コミットに分離）

**(1) お知らせ一覧の SafeArea**（`213cfff`）
- `app-expo/app/[locale]/(tabs)/notifications/index.tsx` — 見本として指定されたブロック済み料理一覧画面と同じ仕組みへ揃える
- `app-expo/__tests__/notificationsSafeArea.test.tsx`（新規）

**(2) BlurModal の中身が SafeArea へ食い込む**（`f5b2d2b`）
- `app-expo/features/map/components/DishCategorySearchForm.tsx` — ×ボタンは SafeArea にかかってよいが中身は避ける、という保存料理カテゴリの地点検索と同じレイアウトへ
- `app-expo/features/map/components/DishCategorySearchForm.test.tsx`（新規）

BlurModal の共通実装を直すか個別を直すかの判断理由は実装 run の報告を参照。

## 検証

- `pnpm --filter app-expo typecheck`
- `pnpm --filter app-expo test`

## 実機確認が必要

このランナーに Android エミュレータが無いため、**SafeArea inset の実際の見え方は検証できていません**。「見本画面と同じ構造になっていること」をコード差分で示す方針で実装しています。人間が Android 実機で確認すべきチェックリストは実装 run の報告を参照してください。

## base

統合ブランチ `claude/parallel-dev-orchestration-7he5dw` 宛。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_