### PR TITLE
#1120 fix: ログイン状態確定前にゲスト用UIを描画しない

### DIFF
--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCompletionModal.test.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCompletionModal.test.tsx
@@ -1,0 +1,145 @@
+// #1120 【設計】投票完了モーダルが「ログイン判定が確定する前にゲスト向け UI を描かない」ことを固定するテスト。
+//
+// 背景（Issue #1120）:
+// このモーダルは BlurModal が open した瞬間に初めてマウントされるため、
+// `useEnsureOwnProfileLoaded()` のプロフィール取得もそこから始まる。旧実装は
+// `profile?.display_name ?? ""` だけを見て分岐していたので、ログイン済みユーザーでも
+//   1. profile === null の間 → ゲスト向けの絵文字候補が描かれる
+//   2. profile 到着 → nickname が初期入力され、候補が消える
+// という「一瞬だけ絵文字が出る」ちらつきになっていた。
+//
+// 固定する不変条件:
+//   ログイン状態（および nickname）が未確定の間は、ゲスト向けの絵文字候補を一度も描画しない。
+//
+// 遅延（setTimeout / opacity）で隠す実装に差し替えると、下の「未確定の間に一度も描かれない」
+// アサーションは通らない（未確定の時点で要素はツリーに存在してしまうため）。
+import React, { act } from "react";
+import { TextInput } from "react-native";
+import TestRenderer, { type ReactTestRenderer } from "react-test-renderer";
+
+// ---- 観測対象（ログイン状態の分岐）以外はすべてスタブ化する ----
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+jest.mock("@/components/LoadingIndicator", () => ({ LoadingIndicator: () => null }));
+jest.mock("@/components/PrimaryButton", () => ({ PrimaryButton: () => null }));
+
+/** useAuth() の戻り値。各テストが describe 内で書き換える */
+let mockAuthState: { user: { is_anonymous?: boolean } | null; isAuthResolved: boolean };
+jest.mock("@/contexts/AuthProvider", () => ({ useAuth: () => mockAuthState }));
+
+/** useEnsureOwnProfileLoaded() の戻り値（プロフィール取得が決着したか） */
+let mockIsProfileResolved: boolean;
+jest.mock("@/features/profile/hooks/useEnsureOwnProfileLoaded", () => ({
+	useEnsureOwnProfileLoaded: () => ({ isProfileResolved: mockIsProfileResolved }),
+}));
+
+/** ストアに載っているプロフィール（未ロード時は null） */
+let mockProfile: { display_name: string } | null;
+jest.mock("@/features/profile/stores/useProfileStore", () => ({
+	useProfileStore: (selector: (state: { profile: unknown }) => unknown) => selector({ profile: mockProfile }),
+}));
+
+import { DishCategoryGroupVoteCompletionModal } from "./DishCategoryGroupVoteCompletionModal";
+
+// React 19 では初期描画がスケジューラのタスクへ回されるため、act() で包む必要がある
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const SUGGESTIONS_TEST_ID = "dish-category-group-vote-name-suggestions";
+const LOADING_TEST_ID = "dish-category-group-vote-completion-loading";
+
+const renderModal = () => {
+	let renderer!: ReactTestRenderer;
+	act(() => {
+		renderer = TestRenderer.create(
+			<DishCategoryGroupVoteCompletionModal usedDisplayNames={["🐶"]} isSubmitting={false} onSubmit={jest.fn()} />,
+		);
+	});
+	return renderer;
+};
+
+/** 絵文字候補（ゲスト向け UI）が今ツリーに存在するか */
+const hasNameSuggestions = (renderer: ReactTestRenderer) =>
+	renderer.root.findAllByProps({ testID: SUGGESTIONS_TEST_ID }).length > 0;
+
+/** ログイン判定の確定待ちローディングが出ているか */
+const hasIdentityLoading = (renderer: ReactTestRenderer) =>
+	renderer.root.findAllByProps({ testID: LOADING_TEST_ID }).length > 0;
+
+/** 表示名入力欄の現在値 */
+const displayNameValue = (renderer: ReactTestRenderer) => renderer.root.findAllByType(TextInput)[0]?.props.value;
+
+beforeEach(() => {
+	mockAuthState = { user: null, isAuthResolved: false };
+	mockIsProfileResolved = false;
+	mockProfile = null;
+});
+
+describe("DishCategoryGroupVoteCompletionModal のログイン判定", () => {
+	it("認証がまだ確定していない間は、ゲスト向けの絵文字候補を描画しない", () => {
+		// user === null は isGuestUser() ではゲストへ倒れる。それでも「未確定」であることを優先する
+		mockAuthState = { user: null, isAuthResolved: false };
+
+		const renderer = renderModal();
+
+		expect(hasNameSuggestions(renderer)).toBe(false);
+		expect(hasIdentityLoading(renderer)).toBe(true);
+	});
+
+	it("ログイン済みでプロフィール取得が終わっていない間は、ゲスト向けの絵文字候補を描画しない", () => {
+		mockAuthState = { user: { is_anonymous: false }, isAuthResolved: true };
+		mockIsProfileResolved = false;
+		mockProfile = null;
+
+		const renderer = renderModal();
+
+		expect(hasNameSuggestions(renderer)).toBe(false);
+		expect(hasIdentityLoading(renderer)).toBe(true);
+	});
+
+	it("ログイン済みユーザーには、絵文字候補を一度も描かずに nickname だけを見せる（#1120 のちらつき）", () => {
+		// 実際の流れを再現する: マウント時は profile 未取得 → あとから display_name が届く
+		mockAuthState = { user: { is_anonymous: false }, isAuthResolved: true };
+		mockIsProfileResolved = false;
+		mockProfile = null;
+
+		const renderer = renderModal();
+		expect(hasNameSuggestions(renderer)).toBe(false);
+
+		act(() => {
+			mockIsProfileResolved = true;
+			mockProfile = { display_name: "ログイン太郎" };
+			renderer.update(
+				<DishCategoryGroupVoteCompletionModal usedDisplayNames={["🐶"]} isSubmitting={false} onSubmit={jest.fn()} />,
+			);
+		});
+
+		// 確定後もゲスト向け候補は出ず、nickname が初期入力されている
+		expect(hasNameSuggestions(renderer)).toBe(false);
+		expect(hasIdentityLoading(renderer)).toBe(false);
+		expect(displayNameValue(renderer)).toBe("ログイン太郎");
+	});
+
+	it("ゲスト確定なら、プロフィール取得を待たずに絵文字候補を出す", () => {
+		// ゲストは display_name を参照しないため、プロフィールの決着を待つ理由がない
+		mockAuthState = { user: { is_anonymous: true }, isAuthResolved: true };
+		mockIsProfileResolved = false;
+		mockProfile = null;
+
+		const renderer = renderModal();
+
+		expect(hasIdentityLoading(renderer)).toBe(false);
+		expect(hasNameSuggestions(renderer)).toBe(true);
+		expect(displayNameValue(renderer)).toBe("");
+	});
+
+	it("プロフィール取得が失敗して profile が null のままでも、ローディングで固まらない", () => {
+		// 決着済み（= これ以上待っても display_name は来ない）なら、匿名と同じ入力導線へフォールバックする
+		mockAuthState = { user: { is_anonymous: false }, isAuthResolved: true };
+		mockIsProfileResolved = true;
+		mockProfile = null;
+
+		const renderer = renderModal();
+
+		expect(hasIdentityLoading(renderer)).toBe(false);
+		expect(hasNameSuggestions(renderer)).toBe(true);
+	});
+});

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCompletionModal.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCompletionModal.tsx
@@ -10,6 +10,7 @@ import { StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-nativ
 import { useAuth } from "@/contexts/AuthProvider";
 import { isGuestUser } from "@/lib/authGuest";
 import i18n from "@/lib/i18n";
+import { LoadingIndicator } from "@/components/LoadingIndicator";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { useEnsureOwnProfileLoaded } from "@/features/profile/hooks/useEnsureOwnProfileLoaded";
 import { useProfileStore } from "@/features/profile/stores/useProfileStore";
@@ -22,8 +23,8 @@ type Props = {
 };
 
 export function DishCategoryGroupVoteCompletionModal({ usedDisplayNames, isSubmitting, onSubmit }: Props) {
-	const { user } = useAuth();
-	useEnsureOwnProfileLoaded();
+	const { user, isAuthResolved } = useAuth();
+	const { isProfileResolved } = useEnsureOwnProfileLoaded();
 	const profile = useProfileStore((state) => state.profile);
 	const usedDisplayNamesKey = useMemo(() => usedDisplayNames.join("\u0000"), [usedDisplayNames]);
 	const [suggestions, setSuggestions] = useState<string[]>([]);
@@ -33,13 +34,31 @@ export function DishCategoryGroupVoteCompletionModal({ usedDisplayNames, isSubmi
 	// #1092 PR4b 【修正】`user?.is_anonymous === false` から共通判定（lib/authGuest.ts）へ寄せた。
 	// 旧式は is_anonymous が undefined のときもゲスト扱いになり、ログイン済みなのに表示名が
 	// 初期入力されない（他画面ではログイン済みとして扱われている）という食い違いになる
-	const loggedInDisplayName = !isGuestUser(user)
+	const isGuest = isGuestUser(user);
+
+	// #1120 【設計】「ゲスト向けの絵文字候補」と「ログインユーザーの nickname 初期入力」の分岐に必要な
+	// 材料がそろったか。そろう前に描くと、ログイン済みユーザーに一瞬だけ絵文字候補が出てから
+	// nickname へ差し替わる（Issue #1120）。
+	//
+	// - `isAuthResolved === false` … ゲストかログイン済みかがまだ決まっていない。
+	//   `isGuestUser(null)` は「ゲスト」へ倒れる仕様（lib/authGuest.ts）なので、
+	//   ここを待たないと必ずゲスト向け UI を先に描いてしまう。
+	// - ログイン済みで `isProfileResolved === false` … display_name の取得が終わっていない。
+	//   このモーダルは BlurModal が open した瞬間に初めてマウントされる = プロフィール取得も
+	//   そこから始まるため、`profile === null` の窓を毎回必ず通る。
+	//
+	// ゲスト確定なら profile を参照しないので、プロフィール取得を待たずに描いてよい。
+	const isIdentityResolved = isAuthResolved && (isGuest || isProfileResolved);
+
+	const loggedInDisplayName = !isGuest
 		? Array.from(profile?.display_name ?? "")
 				.slice(0, 8)
 				.join("")
 		: "";
 
 	useEffect(() => {
+		// #1120 未確定のスナップショットで入力欄を初期化しない（確定してから一度だけ初期化する）
+		if (!isIdentityResolved) return;
 		const nextUsedDisplayNames = usedDisplayNamesKey ? usedDisplayNamesKey.split("\u0000") : [];
 		const nextSuggestions = buildDishCategoryGroupVoteNameSuggestions(nextUsedDisplayNames);
 		setSuggestions(nextSuggestions);
@@ -48,7 +67,7 @@ export function DishCategoryGroupVoteCompletionModal({ usedDisplayNames, isSubmi
 		setIsManualName(Boolean(loggedInDisplayName));
 		setDisplayName(defaultDisplayName);
 		setComment("");
-	}, [loggedInDisplayName, usedDisplayNamesKey]);
+	}, [isIdentityResolved, loggedInDisplayName, usedDisplayNamesKey]);
 
 	useEffect(() => {
 		if (displayName.trim().length === 0) {
@@ -65,6 +84,19 @@ export function DishCategoryGroupVoteCompletionModal({ usedDisplayNames, isSubmi
 
 	const canSubmit = displayName.trim().length > 0 && !isSubmitting;
 
+	// #1120 【設計】確定するまではどちらの分岐も描かない。
+	// 「ゲスト向けを出しておいて後から差し替える」も「遅延で隠す」もしない ＝ ちらつきの原因を消す。
+	if (!isIdentityResolved) {
+		return (
+			<View style={styles.modal}>
+				<Text style={styles.title}>{i18n.t("DishCategoryGroupVotes.completionTitle")}</Text>
+				<View testID="dish-category-group-vote-completion-loading" style={styles.identityLoading}>
+					<LoadingIndicator size="large" />
+				</View>
+			</View>
+		);
+	}
+
 	return (
 		<View style={styles.modal}>
 			<Text style={styles.title}>{i18n.t("DishCategoryGroupVotes.completionTitle")}</Text>
@@ -80,7 +112,7 @@ export function DishCategoryGroupVoteCompletionModal({ usedDisplayNames, isSubmi
 				maxLength={8}
 			/>
 			{suggestions.length > 0 && (!isManualName || displayName.trim().length === 0) ? (
-				<View style={styles.suggestions}>
+				<View testID="dish-category-group-vote-name-suggestions" style={styles.suggestions}>
 					<Text style={styles.suggestionLabel}>{i18n.t("DishCategoryGroupVotes.nameSuggestionLabel")}</Text>
 					<View style={styles.suggestionRow}>
 						{suggestions.map((suggestion) => (
@@ -134,6 +166,13 @@ const styles = StyleSheet.create({
 	suggestions: {
 		marginTop: 14,
 		gap: 8,
+	},
+	// #1120 ログイン判定の確定待ち。確定後のフォームとおおよそ同じ高さにして、
+	// 差し替わったときにモーダルが大きく伸縮しないようにする
+	identityLoading: {
+		minHeight: 220,
+		alignItems: "center",
+		justifyContent: "center",
 	},
 	suggestionLabel: {
 		fontSize: 12,

--- a/app-expo/features/profile/hooks/useEnsureOwnProfileLoaded.test.tsx
+++ b/app-expo/features/profile/hooks/useEnsureOwnProfileLoaded.test.tsx
@@ -1,0 +1,85 @@
+// #1120 【設計】useEnsureOwnProfileLoaded が返す「決着したか」の意味を固定するテスト。
+//
+// 呼び出し側（DishCategoryGroupVoteCompletionModal）は、この値が false の間はゲスト向け UI を
+// 描かずに待つ。つまりここが「取得前から true」になると #1120 のちらつきが再発し、
+// 逆に「取得後も false のまま」になると UI がローディングで固着する。両方向を赤で守る。
+import React, { act } from "react";
+import TestRenderer from "react-test-renderer";
+
+let mockUser: { id: string; is_anonymous?: boolean } | null = null;
+jest.mock("@/contexts/AuthProvider", () => ({ useAuth: () => ({ user: mockUser }) }));
+
+/** callBackend の解決タイミングをテストから握る */
+let mockResolveProfile: (value: unknown) => void;
+const mockCallBackend = jest.fn(
+	() =>
+		new Promise((resolve) => {
+			mockResolveProfile = resolve;
+		}),
+);
+jest.mock("@/hooks/useAPICall", () => ({ useAPICall: () => ({ callBackend: mockCallBackend }) }));
+jest.mock("@/hooks/useLogger", () => ({ useLogger: () => ({ logFrontendEvent: jest.fn() }) }));
+jest.mock("@/features/profile/hooks/useProfile", () => ({ useProfile: () => ({ createUserProfile: jest.fn() }) }));
+jest.mock("expo-image", () => ({ Image: { prefetch: jest.fn(() => Promise.resolve(true)) } }));
+jest.mock("@/data/profileData", () => ({ userProfile: { display_name: "guest" } }));
+
+import { useEnsureOwnProfileLoaded } from "./useEnsureOwnProfileLoaded";
+import { useProfileStore } from "../stores/useProfileStore";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/** フックの戻り値を毎レンダー記録するだけのハーネス */
+let latest: { isProfileResolved: boolean };
+function Harness() {
+	latest = useEnsureOwnProfileLoaded();
+	return null;
+}
+
+beforeEach(() => {
+	useProfileStore.getState().resetProfile();
+	mockCallBackend.mockClear();
+});
+
+describe("useEnsureOwnProfileLoaded の isProfileResolved", () => {
+	it("ログインユーザーでは、プロフィール取得が終わるまで false のまま", async () => {
+		mockUser = { id: "user-1", is_anonymous: false };
+
+		await act(async () => {
+			TestRenderer.create(<Harness />);
+		});
+
+		// API のレスポンス待ち = まだ display_name が分からない
+		expect(mockCallBackend).toHaveBeenCalled();
+		expect(latest.isProfileResolved).toBe(false);
+
+		await act(async () => {
+			mockResolveProfile({ display_name: "ログイン太郎", avatarUrls: undefined });
+		});
+
+		expect(latest.isProfileResolved).toBe(true);
+		expect(useProfileStore.getState().profile).toEqual({ display_name: "ログイン太郎", avatarUrls: undefined });
+	});
+
+	it("ゲストユーザーでは API を待たずに決着する", async () => {
+		mockUser = { id: "guest-1", is_anonymous: true };
+
+		await act(async () => {
+			TestRenderer.create(<Harness />);
+		});
+
+		expect(mockCallBackend).not.toHaveBeenCalled();
+		expect(latest.isProfileResolved).toBe(true);
+	});
+
+	it("プロフィール取得が失敗しても決着する（ローディングで固着させない）", async () => {
+		mockUser = { id: "user-2", is_anonymous: false };
+		mockCallBackend.mockImplementationOnce(() => Promise.reject({ status: 500, message: "boom" }) as never);
+
+		await act(async () => {
+			TestRenderer.create(<Harness />);
+		});
+
+		expect(latest.isProfileResolved).toBe(true);
+		expect(useProfileStore.getState().profile).toBeNull();
+	});
+});

--- a/app-expo/features/profile/hooks/useEnsureOwnProfileLoaded.ts
+++ b/app-expo/features/profile/hooks/useEnsureOwnProfileLoaded.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "@/contexts/AuthProvider";
 import { isGuestUser } from "@/lib/authGuest";
 import { ApiError, useAPICall } from "@/hooks/useAPICall";
@@ -25,14 +25,21 @@ import { useProfile } from "./useProfile";
  *   // profile が利用可能
  * }
  * ```
+ *
+ * #1120 【設計】戻り値の `isProfileResolved` は「ロードが決着したか（成功・失敗を問わず）」。
+ * `profile === null` は「まだ読んでいない」と「読んだが取れなかった」の両方を意味するため、
+ * これだけを見て UI を分岐すると、ログイン済みユーザーにも数百 ms だけゲスト向け UI が出て
+ * 消える（= ちらつき）。未決着の間は分岐そのものを保留する用途に使う。
  */
-export function useEnsureOwnProfileLoaded() {
+export function useEnsureOwnProfileLoaded(): { isProfileResolved: boolean } {
 	const { user } = useAuth();
 	const { callBackend } = useAPICall();
 	const { logFrontendEvent } = useLogger();
 	const { createUserProfile } = useProfile();
 	// ロード済みフラグとリトライフラグを管理するための ref
 	const hasLoadedRef = useRef(false);
+	// #1120 ref は再レンダーを起こさないため、呼び出し側へ返す決着状態は state で持つ
+	const [isProfileResolved, setIsProfileResolved] = useState(false);
 
 	// #1092 PR4b タブの表示判定（lib/authGuest.ts）と同じ式にしておく。
 	// ここだけ判定がずれると「reviews タブは出ているのにプロフィールはダミーのまま」になる
@@ -42,19 +49,28 @@ export function useEnsureOwnProfileLoaded() {
 	useEffect(() => {
 		useProfileStore.getState().resetProfile();
 		hasLoadedRef.current = false;
+		// #1120 セッションが変わればロードもやり直しになるので、決着状態も未決着へ戻す
+		setIsProfileResolved(false);
 	}, [user?.id, isGuest]);
 
 	useEffect(() => {
 		// #467 【設計】既にプロフィールがロード済みの場合は何もしない
-		if (hasLoadedRef.current) return;
+		if (hasLoadedRef.current) {
+			setIsProfileResolved(true);
+			return;
+		}
 		const { profile, setProfile } = useProfileStore.getState();
-		if (profile) return;
+		if (profile) {
+			setIsProfileResolved(true);
+			return;
+		}
 
 		const loadProfile = async () => {
 			// #467 【設計】ゲストユーザーの場合はダミープロフィールを設定
 			if (isGuest) {
 				setProfile(userProfile);
 				hasLoadedRef.current = true;
+				setIsProfileResolved(true);
 				return;
 			}
 
@@ -93,9 +109,14 @@ export function useEnsureOwnProfileLoaded() {
 				});
 			} finally {
 				hasLoadedRef.current = true;
+				// #1120 失敗しても「決着した（= これ以上待っても profile は増えない）」ことは確定する。
+				// ここを成功時だけにすると、プロフィール取得が落ちた人の UI が永久にローディングで固まる
+				setIsProfileResolved(true);
 			}
 		};
 
 		loadProfile();
 	}, [callBackend, isGuest, logFrontendEvent, user?.id, createUserProfile]);
+
+	return { isProfileResolved };
 }


### PR DESCRIPTION
## 対象 Issue

Closes #1120

## 背景

ログインユーザーが友達投票を行うと、一瞬ゲストユーザー用の絵文字選び UI が出てから nickname に切り替わる。ログイン状態（プロフィール）の確定を待たずにゲスト向け分岐を描画してしまっていた。

## 変更

- `app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCompletionModal.tsx` — 状態が未確定の間はゲスト用 UI を描画しない
- `app-expo/features/profile/hooks/useEnsureOwnProfileLoaded.ts` — 確定/未確定を呼び出し側が区別できるように
- 対応するテストを 2 ファイル追加

ちらつきを遅延で隠すのではなく、**状態が未確定の間は分岐を確定させない**方針で修正しています。テストで「未確定の間はゲスト用 UI を描画しない」という不変条件を固定しました。

## 検証

- `pnpm --filter app-expo typecheck`
- `pnpm --filter app-expo test`

## 実機確認が必要

このランナーではブラウザ・実機の目視確認をしていません。ちらつきが実際に消えたかは実機で確認してください（チェックリストは実装 run の報告を参照）。

## 関連

#1122（同じ友達投票機能のモーダル遷移バグ）は PR #1158 で別途対応。同じ機能領域ですが変更ファイルは重複していません。

## base

統合ブランチ `claude/parallel-dev-orchestration-7he5dw` 宛。