### PR TITLE
#1122 fix: モーダルを閉じてから店舗画面へ遷移する

### DIFF
--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.test.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.test.tsx
@@ -1,0 +1,298 @@
+// #1122 【設計】候補詳細モーダルの「店を見る」が、"モーダルを閉じてから" 遷移することを固定するテスト。
+//
+// 背景（Issue #1122）:
+// 旧実装の handleOpenCandidateDishMedia は BlurModal を閉じずに router.push していた。
+// BlurModal の中身は react-native-paper の Portal 経由で Portal.Host 直下（= Stack より上のレイヤー）
+// へ描かれるため、遷移しても StyleSheet.absoluteFill のバックドロップが遷移先の上に残り続け、
+// Web / Android では遷移先（DishMediaMap）をタップできなかった。
+// iOS だけ無事だったのは、遷移先 /search/result が presentation:"transparentModal"
+// （= ネイティブ modal presentation）で Portal.Host より上に載るため。
+//
+// このテストは「router.push の時点で Portal が既にアンマウントされている」ことを
+// イベント列で固定する。close を消す / close と push の順序を入れ替えると赤になる。
+// setTimeout での先送りに戻した場合も、fake timer を進めずに push が来ないため赤になる。
+import React, { act } from "react";
+import TestRenderer, { type ReactTestInstance } from "react-test-renderer";
+
+import type { DishCategoryGroupVoteCandidate, DishCategoryGroupVoteDetailResponse } from "@shared/api/v1/res";
+
+// 観測用のイベント列。jest.mock のファクトリからは `mock` 始まりの変数だけ参照できる
+const mockEvents: string[] = [];
+const mockRouterPush = jest.fn((..._args: unknown[]) => {
+	mockEvents.push("router.push");
+});
+
+// ---- 観測対象（Portal のアンマウントと router.push の順序）以外はすべてスタブ化する ----
+// lucide のアイコンは名前ごとに export されるため Proxy で一括スタブ化する（searchScreenPreload.test.tsx と同じ）
+jest.mock(
+	"lucide-react-native",
+	() =>
+		new Proxy(
+			{},
+			{
+				get: (_target, prop) =>
+					prop === "__esModule"
+						? true
+						: function MockIcon() {
+								return null;
+							},
+			},
+		),
+);
+jest.mock("expo-image", () => ({
+	Image: function MockExpoImage() {
+		return null;
+	},
+}));
+jest.mock("expo-blur", () => ({
+	BlurView: function MockBlurView() {
+		return null;
+	},
+}));
+// Portal は「どのレイヤーに描かれるか」ではなく「マウント/アンマウントの瞬間」だけ観測できれば足りる
+jest.mock("react-native-paper", () => {
+	const ReactModule = require("react");
+	return {
+		Portal: function MockPortal({ children }: { children: React.ReactNode }) {
+			ReactModule.useEffect(() => {
+				mockEvents.push("portal-mounted");
+				return () => {
+					mockEvents.push("portal-unmounted");
+				};
+			}, []);
+			return children;
+		},
+	};
+});
+// ⚠️ ファクトリ内で `mockRouterPush` を即座に参照すると、babel が import を巻き上げる関係で
+// TDZ（宣言前アクセス）になり router.push が undefined になる。必ず呼び出し時に解決すること
+jest.mock("expo-router", () => ({
+	router: {
+		push: (...args: unknown[]) => mockRouterPush(...args),
+		replace: jest.fn(),
+		back: jest.fn(),
+	},
+}));
+jest.mock("expo-clipboard", () => ({ setStringAsync: jest.fn(() => Promise.resolve()) }));
+jest.mock("@react-navigation/native", () => ({ useIsFocused: () => true }));
+jest.mock("react-native-safe-area-context", () => {
+	const { View: RNView } = require("react-native");
+	return { SafeAreaView: RNView, useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }) };
+});
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+jest.mock("@/lib/share", () => ({ generateShareUrl: () => "https://example.test/share" }));
+jest.mock("@/hooks/useLocale", () => ({ useLocale: () => ({ locale: "ja-JP", isJapanese: true }) }));
+jest.mock("@/hooks/useLogger", () => ({ useLogger: () => ({ logFrontendEvent: jest.fn() }) }));
+jest.mock("@/hooks/useAPICall", () => ({
+	useAPICall: () => ({ callBackend: jest.fn(() => Promise.resolve({ items: [] })) }),
+}));
+jest.mock("@/contexts/DialogProvider", () => ({
+	useDialog: () => ({ confirm: jest.fn(() => Promise.resolve(false)) }),
+}));
+jest.mock("@/contexts/SnackbarProvider", () => ({ useSnackbar: () => ({ showSnackbar: jest.fn() }) }));
+jest.mock("@/components/ScreenHeader", () => ({
+	ScreenHeader: function MockScreenHeader() {
+		return null;
+	},
+}));
+jest.mock("@/components/LoadingIndicator", () => ({
+	LoadingIndicator: function MockLoadingIndicator() {
+		return null;
+	},
+}));
+// PrimaryButton は押下だけできれば足りる。label をそのまま testID にして詳細モーダル内の
+// 「店を見る」を特定する（本物は haptics などを引き込むため差し替える）
+jest.mock("@/components/PrimaryButton", () => {
+	const ReactModule = require("react");
+	const { Pressable } = require("react-native");
+	return {
+		PrimaryButton: function MockPrimaryButton({
+			label,
+			onPress,
+			disabled,
+		}: {
+			label: string;
+			onPress?: () => void;
+			disabled?: boolean;
+		}) {
+			return ReactModule.createElement(Pressable, {
+				testID: `primary-button:${label}`,
+				onPress: disabled ? undefined : onPress,
+			});
+		},
+	};
+});
+// 一覧は「候補を押して詳細モーダルを開く」「一覧から直接店を見る」の 2 導線だけ再現する
+jest.mock("./DishCategoryGroupVoteCandidateList", () => {
+	const ReactModule = require("react");
+	const { Pressable } = require("react-native");
+	return {
+		DishCategoryGroupVoteCandidateList: function MockList({
+			candidates,
+			onPressCandidate,
+			onPressDishMedia,
+		}: {
+			candidates: { id: string }[];
+			onPressCandidate: (candidate: unknown) => void;
+			onPressDishMedia: (candidate: unknown) => void;
+		}) {
+			return candidates.map((candidate) =>
+				ReactModule.createElement(
+					ReactModule.Fragment,
+					{ key: candidate.id },
+					ReactModule.createElement(Pressable, {
+						testID: `list-open-detail:${candidate.id}`,
+						onPress: () => onPressCandidate(candidate),
+					}),
+					ReactModule.createElement(Pressable, {
+						testID: `list-open-dish-media:${candidate.id}`,
+						onPress: () => onPressDishMedia(candidate),
+					}),
+				),
+			);
+		},
+	};
+});
+jest.mock("./DishCategoryGroupVoteResultHeader", () => ({
+	DishCategoryGroupVoteResultHeader: function MockHeader() {
+		return null;
+	},
+}));
+jest.mock("./DishCategoryGroupVoteComments", () => ({
+	DishCategoryGroupVoteComments: function MockComments() {
+		return null;
+	},
+}));
+jest.mock("../hooks/useDishCategoryGroupVotePolling", () => ({ useDishCategoryGroupVotePolling: jest.fn() }));
+jest.mock("../hooks/useDishCategoryGroupVoteActions", () => ({
+	useDishCategoryGroupVoteActions: () => ({
+		cacheCandidateDishMedia: jest.fn(),
+		deleteCandidate: jest.fn(),
+		restoreCandidate: jest.fn(),
+		submitVote: jest.fn(),
+	}),
+}));
+// dishMediaSearchStatus:"found" の候補だけを扱うので、検索 helper と fallback は呼ばれない
+jest.mock("@/features/search/hooks/useGoogleMapsFallback", () => ({
+	useGoogleMapsFallback: () => ({ showGoogleMapsFallbackDialog: jest.fn() }),
+}));
+jest.mock("@/lib/dishMediaSearch", () => ({ createDishItemsForCategory: jest.fn() }));
+// 遷移前の dish-media 先読みは非同期なので、store ごとスタブ化して本テストへ持ち込まない
+jest.mock("@/stores/useDishMediaEntriesStore", () => ({
+	useDishMediaEntriesStore: {
+		getState: () => ({
+			mediaIdsByKey: {},
+			isLoadingByKey: {},
+			upsertDishMediaEntries: jest.fn(),
+			updateMediaIdsByKeyAsync: jest.fn(),
+		}),
+	},
+}));
+
+const mockRefresh = jest.fn(() => Promise.resolve());
+const mockDetail: { current: DishCategoryGroupVoteDetailResponse | null } = { current: null };
+jest.mock("../hooks/useDishCategoryGroupVoteDetail", () => ({
+	useDishCategoryGroupVoteDetail: () => ({
+		detail: mockDetail.current,
+		isLoading: false,
+		error: null,
+		refresh: mockRefresh,
+	}),
+}));
+
+import { DishCategoryGroupVoteResultScreen } from "./DishCategoryGroupVoteResultScreen";
+
+const CANDIDATE: DishCategoryGroupVoteCandidate = {
+	id: "candidate-1",
+	dishCategoryId: "dish-category-1",
+	displayName: "ラーメン",
+	tagline: "こってり",
+	imageUrl: "https://example.test/ramen.jpg",
+	// #1122 「店を見る」が即座に遷移する（= 検索を挟まない）経路を再現する
+	dishMediaIds: ["dish-media-1"],
+	dishMediaSearchStatus: "found",
+	displayOrder: 0,
+	deletedAt: null,
+	likeCount: 1,
+	dislikeCount: 0,
+	rank: 1,
+	votes: [{ participantId: "participant-1", displayName: "ねこ", reaction: "like" }],
+};
+
+const DETAIL: DishCategoryGroupVoteDetailResponse = {
+	session: {
+		id: "session-1",
+		shareToken: "share-token-1",
+		hostUserId: "user-1",
+		searchContext: {
+			location: { latitude: 35.1, longitude: 139.1 },
+			radius: 1000,
+			priceLevels: [],
+			localLanguageCode: "ja",
+		},
+		isHost: true,
+		hasVoted: true,
+		participantCount: 1,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+	},
+	candidates: [CANDIDATE],
+	participants: [{ id: "participant-1", displayName: "ねこ", comment: null, createdAt: "2026-01-01T00:00:00.000Z" }],
+};
+
+const press = (root: ReactTestInstance, testID: string) => {
+	const target = root.findByProps({ testID });
+	act(() => {
+		target.props.onPress?.();
+	});
+};
+
+describe("DishCategoryGroupVoteResultScreen の「店を見る」", () => {
+	beforeEach(() => {
+		mockEvents.length = 0;
+		mockDetail.current = DETAIL;
+	});
+
+	it("詳細モーダルから押すと、遷移より先にモーダルが閉じる", () => {
+		let renderer!: TestRenderer.ReactTestRenderer;
+		act(() => {
+			renderer = TestRenderer.create(<DishCategoryGroupVoteResultScreen shareToken="share-token-1" />);
+		});
+		const root = renderer.root;
+
+		// 詳細モーダルを開く（= Portal がマウントされる）
+		press(root, `list-open-detail:${CANDIDATE.id}`);
+		expect(mockEvents).toEqual(["portal-mounted"]);
+
+		// 詳細モーダル内の「店を見る」
+		press(root, "primary-button:DishCategoryGroupVotes.viewRestaurants");
+
+		// 遷移は 1 回だけ、かつ Portal のアンマウント（= モーダルのクローズ完了）より後
+		expect(mockRouterPush).toHaveBeenCalledTimes(1);
+		expect(mockEvents).toEqual(["portal-mounted", "portal-unmounted", "router.push"]);
+		expect(mockRouterPush.mock.calls[0][0]).toMatchObject({
+			pathname: "/[locale]/(tabs)/search/result",
+			params: { entriesKey: `dish-category-group-votes:share-token-1:${CANDIDATE.id}`, category: "ラーメン" },
+		});
+
+		act(() => {
+			renderer.unmount();
+		});
+	});
+
+	it("一覧カードから押した場合は、待つモーダルが無いのでそのまま遷移する", () => {
+		let renderer!: TestRenderer.ReactTestRenderer;
+		act(() => {
+			renderer = TestRenderer.create(<DishCategoryGroupVoteResultScreen shareToken="share-token-1" />);
+		});
+
+		press(renderer.root, `list-open-dish-media:${CANDIDATE.id}`);
+
+		expect(mockRouterPush).toHaveBeenCalledTimes(1);
+		expect(mockEvents).toEqual(["router.push"]);
+
+		act(() => {
+			renderer.unmount();
+		});
+	});
+});

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.test.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.test.tsx
@@ -164,19 +164,24 @@ jest.mock("./DishCategoryGroupVoteComments", () => ({
 	},
 }));
 jest.mock("../hooks/useDishCategoryGroupVotePolling", () => ({ useDishCategoryGroupVotePolling: jest.fn() }));
+// dishMediaSearchStatus:"not_searched" の候補では検索 → cache を経てから遷移するため、
+// 「検索中」を任意の長さで保持できるよう cache/検索 helper はテストから制御する
+const mockCacheCandidateDishMedia = jest.fn();
 jest.mock("../hooks/useDishCategoryGroupVoteActions", () => ({
 	useDishCategoryGroupVoteActions: () => ({
-		cacheCandidateDishMedia: jest.fn(),
+		cacheCandidateDishMedia: mockCacheCandidateDishMedia,
 		deleteCandidate: jest.fn(),
 		restoreCandidate: jest.fn(),
 		submitVote: jest.fn(),
 	}),
 }));
-// dishMediaSearchStatus:"found" の候補だけを扱うので、検索 helper と fallback は呼ばれない
 jest.mock("@/features/search/hooks/useGoogleMapsFallback", () => ({
 	useGoogleMapsFallback: () => ({ showGoogleMapsFallbackDialog: jest.fn() }),
 }));
-jest.mock("@/lib/dishMediaSearch", () => ({ createDishItemsForCategory: jest.fn() }));
+const mockCreateDishItemsForCategory = jest.fn();
+jest.mock("@/lib/dishMediaSearch", () => ({
+	createDishItemsForCategory: (...args: unknown[]) => mockCreateDishItemsForCategory(...args),
+}));
 // 遷移前の dish-media 先読みは非同期なので、store ごとスタブ化して本テストへ持ち込まない
 jest.mock("@/stores/useDishMediaEntriesStore", () => ({
 	useDishMediaEntriesStore: {
@@ -219,6 +224,17 @@ const CANDIDATE: DishCategoryGroupVoteCandidate = {
 	votes: [{ participantId: "participant-1", displayName: "ねこ", reaction: "like" }],
 };
 
+// #1122 未検索候補。「店を見る」を押すと検索 → cache を await してから遷移要求が来る
+const NOT_SEARCHED_CANDIDATE: DishCategoryGroupVoteCandidate = {
+	...CANDIDATE,
+	id: "candidate-2",
+	dishCategoryId: "dish-category-2",
+	displayName: "カレー",
+	dishMediaIds: [],
+	dishMediaSearchStatus: "not_searched",
+	displayOrder: 1,
+};
+
 const DETAIL: DishCategoryGroupVoteDetailResponse = {
 	session: {
 		id: "session-1",
@@ -236,7 +252,7 @@ const DETAIL: DishCategoryGroupVoteDetailResponse = {
 		createdAt: "2026-01-01T00:00:00.000Z",
 		updatedAt: "2026-01-01T00:00:00.000Z",
 	},
-	candidates: [CANDIDATE],
+	candidates: [CANDIDATE, NOT_SEARCHED_CANDIDATE],
 	participants: [{ id: "participant-1", displayName: "ねこ", comment: null, createdAt: "2026-01-01T00:00:00.000Z" }],
 };
 
@@ -247,10 +263,41 @@ const press = (root: ReactTestInstance, testID: string) => {
 	});
 };
 
+// モーダル右上の X。BlurModal が実物のまま描画されるので accessibilityLabel で引く
+const pressModalCloseButton = (root: ReactTestInstance) => {
+	const target = root.findAllByProps({ accessibilityLabel: "Common.close" })[0];
+	act(() => {
+		target.props.onPress?.();
+	});
+};
+
+// 検索 helper の解決タイミングをテスト側に握らせる
+const deferSearch = () => {
+	let resolve!: (items: { dish_media: { id: string } }[]) => void;
+	const promise = new Promise<{ dish_media: { id: string } }[]>((res) => {
+		resolve = res;
+	});
+	mockCreateDishItemsForCategory.mockReturnValueOnce(promise);
+	return async (items: { dish_media: { id: string } }[]) => {
+		await act(async () => {
+			resolve(items);
+			// 検索 → cacheCandidateDishMedia の 2 段 await を消化させる
+			await promise;
+		});
+	};
+};
+
 describe("DishCategoryGroupVoteResultScreen の「店を見る」", () => {
 	beforeEach(() => {
 		mockEvents.length = 0;
 		mockDetail.current = DETAIL;
+		mockRouterPush.mockClear();
+		mockCreateDishItemsForCategory.mockReset();
+		mockCacheCandidateDishMedia.mockReset();
+		mockCacheCandidateDishMedia.mockResolvedValue({
+			dishMediaSearchStatus: "found",
+			dishMediaIds: ["dish-media-2"],
+		});
 	});
 
 	it("詳細モーダルから押すと、遷移より先にモーダルが閉じる", () => {
@@ -290,6 +337,72 @@ describe("DishCategoryGroupVoteResultScreen の「店を見る」", () => {
 
 		expect(mockRouterPush).toHaveBeenCalledTimes(1);
 		expect(mockEvents).toEqual(["router.push"]);
+
+		act(() => {
+			renderer.unmount();
+		});
+	});
+
+	// #1122 【回帰】未検索候補では検索の await を挟むため、その間にモーダルを閉じられる。
+	// 押下時点の stale closure（isCandidateDetailVisible === true）のまま遷移を ref へ積むと、
+	// 次に別候補のモーダルを開いて閉じただけで、その残留分が発火して全く関係ない店へ飛ぶ。
+	it("検索中にモーダルを閉じたら、その後に別候補のモーダルを開閉しても遷移が残留発火しない", async () => {
+		const resolveSearch = deferSearch();
+		let renderer!: TestRenderer.ReactTestRenderer;
+		act(() => {
+			renderer = TestRenderer.create(<DishCategoryGroupVoteResultScreen shareToken="share-token-1" />);
+		});
+		const root = renderer.root;
+
+		// 候補 A（未検索）の詳細モーダルを開いて「店を見る」を押す → 検索の完了待ちに入る
+		press(root, `list-open-detail:${NOT_SEARCHED_CANDIDATE.id}`);
+		press(root, "primary-button:DishCategoryGroupVotes.viewRestaurants");
+		expect(mockCreateDishItemsForCategory).toHaveBeenCalledTimes(1);
+		expect(mockRouterPush).not.toHaveBeenCalled();
+
+		// 検索完了前にユーザーが X でモーダルを閉じる
+		pressModalCloseButton(root);
+		expect(mockEvents).toEqual(["portal-mounted", "portal-unmounted"]);
+
+		// 検索が完了する。ユーザーが自分で閉じた以上、勝手に遷移してはならない
+		await resolveSearch([{ dish_media: { id: "dish-media-2" } }]);
+		expect(mockRouterPush).not.toHaveBeenCalled();
+
+		// 候補 B の詳細モーダルを開いて閉じるだけ。ここで A への遷移が発火したら不具合
+		press(root, `list-open-detail:${CANDIDATE.id}`);
+		pressModalCloseButton(root);
+
+		expect(mockRouterPush).not.toHaveBeenCalled();
+		expect(mockEvents).toEqual(["portal-mounted", "portal-unmounted", "portal-mounted", "portal-unmounted"]);
+
+		act(() => {
+			renderer.unmount();
+		});
+	});
+
+	// #1122 【回帰】上のキャンセルを効かせすぎて、正常系（閉じずに待った場合）まで
+	// 遷移が消えてしまわないことを固定する
+	it("未検索候補でも、モーダルを開いたまま検索が終われば閉じてから遷移する", async () => {
+		const resolveSearch = deferSearch();
+		let renderer!: TestRenderer.ReactTestRenderer;
+		act(() => {
+			renderer = TestRenderer.create(<DishCategoryGroupVoteResultScreen shareToken="share-token-1" />);
+		});
+		const root = renderer.root;
+
+		press(root, `list-open-detail:${NOT_SEARCHED_CANDIDATE.id}`);
+		press(root, "primary-button:DishCategoryGroupVotes.viewRestaurants");
+		await resolveSearch([{ dish_media: { id: "dish-media-2" } }]);
+
+		expect(mockRouterPush).toHaveBeenCalledTimes(1);
+		expect(mockEvents).toEqual(["portal-mounted", "portal-unmounted", "router.push"]);
+		expect(mockRouterPush.mock.calls[0][0]).toMatchObject({
+			pathname: "/[locale]/(tabs)/search/result",
+			params: {
+				entriesKey: `dish-category-group-votes:share-token-1:${NOT_SEARCHED_CANDIDATE.id}`,
+				category: "カレー",
+			},
+		});
 
 		act(() => {
 			renderer.unmount();

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.tsx
@@ -70,7 +70,29 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 	// クローズ後に実行したい処理を ref へ積み、BlurModal 自身の onClose
 	// (visible=false のコミット後に発火 = Portal がアンマウント済み)で取り出して実行する。
 	const pendingAfterCandidateDetailCloseRef = useRef<(() => void) | null>(null);
+	// #1122 【追補】未検索(not_searched)の候補では openCandidateDishMedia が非同期検索を await して
+	// から遷移を要求してくる。その待ち時間にユーザーが X / バックドロップでモーダルを閉じられるため、
+	// 「押した時点の状態」で判断すると (a) 遷移が黙って消える (b) pending に積んだ navigate が残留し、
+	// 次に別候補のモーダルを開いて閉じただけで発火する、という 2 つの事故が起きる。
+	//
+	// そこで表示セッションの世代番号(開閉のたびに +1)を持ち、押下時の世代を控えておく。
+	// 完了時に世代が変わっていたら「ユーザーが自分でモーダルを閉じた/別候補へ移った」なので
+	// 遷移はキャンセルする。意図して閉じたのに勝手に画面が変わる方がユーザーには有害なため、
+	// (a) は「遷移を復活させる」ではなく「キャンセルを正とする」を選ぶ。
+	const candidateDetailSessionRef = useRef(0);
+	const isCandidateDetailVisibleRef = useRef(false);
+	// 「店を見る」押下時に詳細モーダルが開いていたならその世代、一覧カード導線なら null。
+	// 候補ごとに保持することで、別候補への操作が割り込んでも取り違えない。
+	const dishMediaRequestSessionRef = useRef(new Map<string, number | null>());
+	const handleCandidateDetailOpened = useCallback(() => {
+		isCandidateDetailVisibleRef.current = true;
+		candidateDetailSessionRef.current += 1;
+		// 前のセッションの積み残しはここで確実に捨てる(残っていると無関係な店へ飛ぶ)
+		pendingAfterCandidateDetailCloseRef.current = null;
+	}, []);
 	const handleCandidateDetailClosed = useCallback(() => {
+		isCandidateDetailVisibleRef.current = false;
+		candidateDetailSessionRef.current += 1;
 		const pending = pendingAfterCandidateDetailCloseRef.current;
 		pendingAfterCandidateDetailCloseRef.current = null;
 		pending?.();
@@ -79,25 +101,36 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 		BlurModal: CandidateDetailBlurModal,
 		open: openCandidateDetail,
 		close: closeCandidateDetail,
-		visible: isCandidateDetailVisible,
 	} = useBlurModal({
 		closeOnBackdropPress: true,
-		// onClose は useBlurModal 内の useEffect の依存に入るため、必ず安定参照を渡すこと
+		// onOpen / onClose は useBlurModal 内の useEffect の依存に入るため、必ず安定参照を渡すこと
+		onOpen: handleCandidateDetailOpened,
 		onClose: handleCandidateDetailClosed,
 	});
 
 	// #1122 モーダルが開いていれば閉じ、閉じ終わってから navigate を実行する。
 	// 既に閉じている(一覧カードからの導線)ときは待つものが無いのでそのまま実行する。
 	const navigateAfterCandidateDetailClosed = useCallback(
-		(navigate: () => void) => {
-			if (!isCandidateDetailVisible) {
+		(candidateId: string, navigate: () => void) => {
+			const requestedSession = dishMediaRequestSessionRef.current.get(candidateId) ?? null;
+			if (requestedSession === null) {
+				// 一覧カードからの導線。待つモーダルが無いのでそのまま遷移する
 				navigate();
+				return;
+			}
+			if (!isCandidateDetailVisibleRef.current || requestedSession !== candidateDetailSessionRef.current) {
+				// 検索中にユーザーがモーダルを閉じた(または別候補を開いた)。ユーザーの操作を優先して遷移しない
+				logFrontendEvent({
+					event_name: "dish_category_group_vote_candidate_dish_media_navigation_cancelled",
+					error_level: "log",
+					payload: { shareToken, candidateId },
+				});
 				return;
 			}
 			pendingAfterCandidateDetailCloseRef.current = navigate;
 			closeCandidateDetail();
 		},
-		[closeCandidateDetail, isCandidateDetailVisible],
+		[closeCandidateDetail, logFrontendEvent, shareToken],
 	);
 	const { detail, isLoading, error, refresh } = useDishCategoryGroupVoteDetail(shareToken);
 	// /store はネイティブ内ではホームへ戻るため、共有リンクを開いた Web 参加者だけに出す。
@@ -147,7 +180,7 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 			}
 
 			// #1122 モーダルのクローズ完了を待ってから遷移する(上の設計コメント参照)
-			navigateAfterCandidateDetailClosed(() => {
+			navigateAfterCandidateDetailClosed(candidate.id, () => {
 				router.push({
 					pathname: "/[locale]/(tabs)/search/result",
 					params: {
@@ -254,7 +287,17 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 	};
 
 	const handleOpenCandidateDishMedia = async (candidate: DishCategoryGroupVoteCandidate) => {
-		await openCandidateDishMedia(candidate);
+		// #1122 押下時点で詳細モーダルが開いていたか(=どの表示セッションから来た要求か)を控える。
+		// 検索を挟む経路では完了までに数秒空くため、判断材料は押下時に固定しておく必要がある。
+		dishMediaRequestSessionRef.current.set(
+			candidate.id,
+			isCandidateDetailVisibleRef.current ? candidateDetailSessionRef.current : null,
+		);
+		try {
+			await openCandidateDishMedia(candidate);
+		} finally {
+			dishMediaRequestSessionRef.current.delete(candidate.id);
+		}
 	};
 
 	if (isLoading && !detail) {

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.tsx
@@ -6,7 +6,7 @@
  */
 import * as Clipboard from "expo-clipboard";
 import { router } from "expo-router";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	AppState,
 	type AppStateStatus,
@@ -58,13 +58,47 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 	const { height: windowHeight } = useWindowDimensions();
 	const [appState, setAppState] = useState<AppStateStatus>(AppState.currentState);
 	const [selectedCandidate, setSelectedCandidate] = useState<DishCategoryGroupVoteCandidate | null>(null);
+	// #1122 【修正】候補詳細モーダルは react-native-paper の Portal 経由で Portal.Host 直下
+	// (= Stack より後ろ・上のレイヤー)へ描かれる。開いたまま遷移すると、遷移先の画面の上に
+	// バックドロップ(StyleSheet.absoluteFill の Pressable)が残り続けるため、
+	// 遷移先の DishMediaMap をタップできない。
+	// iOS だけ無事だったのは、遷移先 /search/result が presentation:"transparentModal"
+	// (= ネイティブの modal presentation)で、Portal.Host より上に載るから。
+	// Web / Android では screens が同じ View 階層内に積まれるので Portal 側が勝つ。
+	//
+	// そこで「閉じてから遷移する」を setTimeout ではなく因果で書く:
+	// クローズ後に実行したい処理を ref へ積み、BlurModal 自身の onClose
+	// (visible=false のコミット後に発火 = Portal がアンマウント済み)で取り出して実行する。
+	const pendingAfterCandidateDetailCloseRef = useRef<(() => void) | null>(null);
+	const handleCandidateDetailClosed = useCallback(() => {
+		const pending = pendingAfterCandidateDetailCloseRef.current;
+		pendingAfterCandidateDetailCloseRef.current = null;
+		pending?.();
+	}, []);
 	const {
 		BlurModal: CandidateDetailBlurModal,
 		open: openCandidateDetail,
 		close: closeCandidateDetail,
+		visible: isCandidateDetailVisible,
 	} = useBlurModal({
 		closeOnBackdropPress: true,
+		// onClose は useBlurModal 内の useEffect の依存に入るため、必ず安定参照を渡すこと
+		onClose: handleCandidateDetailClosed,
 	});
+
+	// #1122 モーダルが開いていれば閉じ、閉じ終わってから navigate を実行する。
+	// 既に閉じている(一覧カードからの導線)ときは待つものが無いのでそのまま実行する。
+	const navigateAfterCandidateDetailClosed = useCallback(
+		(navigate: () => void) => {
+			if (!isCandidateDetailVisible) {
+				navigate();
+				return;
+			}
+			pendingAfterCandidateDetailCloseRef.current = navigate;
+			closeCandidateDetail();
+		},
+		[closeCandidateDetail, isCandidateDetailVisible],
+	);
 	const { detail, isLoading, error, refresh } = useDishCategoryGroupVoteDetail(shareToken);
 	// /store はネイティブ内ではホームへ戻るため、共有リンクを開いた Web 参加者だけに出す。
 	const shouldShowStoreCta = detail?.session.hasVoted === true && Platform.OS === "web";
@@ -112,14 +146,17 @@ export function DishCategoryGroupVoteResultScreen({ shareToken }: Props) {
 				updateMediaIdsByKeyAsync(entriesKey, fetchIds(), (_, fetchedIds) => fetchedIds);
 			}
 
-			router.push({
-				pathname: "/[locale]/(tabs)/search/result",
-				params: {
-					locale,
-					entriesKey,
-					location: detail ? JSON.stringify(detail.session.searchContext.location) : undefined,
-					category: candidate.displayName,
-				},
+			// #1122 モーダルのクローズ完了を待ってから遷移する(上の設計コメント参照)
+			navigateAfterCandidateDetailClosed(() => {
+				router.push({
+					pathname: "/[locale]/(tabs)/search/result",
+					params: {
+						locale,
+						entriesKey,
+						location: detail ? JSON.stringify(detail.session.searchContext.location) : undefined,
+						category: candidate.displayName,
+					},
+				});
 			});
 		},
 	});


### PR DESCRIPTION
## 対象 Issue

Closes #1122

## 背景

`ja-JP/search/dish-category-group-votes/` でモーダルを開いてから「店を見る」を押すと、モーダルが閉じないまま DishMediaMap が開かれ、すぐ操作できない（web / Android で再現、iOS は無事）。

## 変更

- `app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.tsx` — モーダルのクローズ完了を待ってから遷移する順序へ
- `app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.test.tsx`（新規） — 「遷移よりクローズが先」という順序をテストで固定

## 検証

- `pnpm --filter app-expo typecheck`
- `pnpm --filter app-expo test`

## 実機確認が必要

このランナーではブラウザ・実機の目視確認をしていません。**iOS で回帰していないこと**を含め、実機での確認をおすすめします（チェックリストは実装 run の報告を参照）。

## 関連

#1120（同じ友達投票機能のゲスト UI ちらつき）は PR #1157 で別途対応。同じ機能領域ですが変更ファイルは重複していません。

## base

統合ブランチ `claude/parallel-dev-orchestration-7he5dw` 宛。