### PR TITLE
#1133 feat: 保存料理の地点検索で現在地と最近使った場所を使えるようにする

### DIFF
--- a/app-expo/features/profile/components/LocationSearchForm.test.tsx
+++ b/app-expo/features/profile/components/LocationSearchForm.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * #1133 保存料理タブの地点検索モーダルが、ホーム（検索タブ）と同じ入口を出していることを守るテスト。
+ *
+ * 現在地ボタンも「最近使った場所」も `LocationAutocomplete` の機能ではなく、
+ * **呼び出し元が props を渡して初めて出る**（`renderInputRight` / `recentLocations`）。
+ * つまり props を 1 つ落とすだけで機能が静かに消え、型でも他のテストでも気付けない。
+ * ここではその配線が生きていることだけを、実物の `LocationAutocomplete` ごと描画して確かめる。
+ */
+import React, { act } from "react";
+import TestRenderer from "react-test-renderer";
+import type { RecentLocation } from "@/components/LocationAutocomplete";
+
+// lucide のアイコンは名前ごとに export されるため Proxy で一括スタブ化する
+jest.mock(
+	"lucide-react-native",
+	() =>
+		new Proxy(
+			{},
+			{
+				get: (_target, prop) =>
+					prop === "__esModule"
+						? true
+						: function MockIcon() {
+								return null;
+							},
+			},
+		),
+);
+// LoadingIndicator はアニメーション実装を持ち込むため差し替える（検証対象ではない）
+jest.mock("@/components/LoadingIndicator", () => ({ LoadingIndicator: () => null }));
+// 翻訳の中身ではなくキーを見たいので、t はキーをそのまま返す
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+jest.mock("@/hooks/useHaptics", () => ({ useHaptics: () => ({ lightImpact: jest.fn() }) }));
+jest.mock("@/hooks/useLogger", () => ({ useLogger: () => ({ logFrontendEvent: jest.fn() }) }));
+jest.mock("@/contexts/SnackbarProvider", () => ({ useSnackbar: () => ({ showSnackbar: jest.fn() }) }));
+
+const mockGetCurrentLocation = jest.fn();
+jest.mock("@/hooks/useLocationSearch", () => ({
+	useLocationSearch: () => ({
+		getCurrentLocation: mockGetCurrentLocation,
+		suggestions: [],
+		status: "idle",
+		searchLocations: jest.fn(),
+		clearSuggestions: jest.fn(),
+	}),
+}));
+
+let mockRecentLocations: RecentLocation[] = [];
+const mockClearRecentLocations = jest.fn();
+jest.mock("@/features/search/hooks/useRecentLocations", () => ({
+	useRecentLocations: () => ({
+		recentLocations: mockRecentLocations,
+		isLoading: false,
+		addRecentLocation: jest.fn(),
+		clearRecentLocations: mockClearRecentLocations,
+	}),
+}));
+
+import { LocationSearchForm } from "./LocationSearchForm";
+
+const shibuya: RecentLocation = {
+	location: { latitude: 35.658, longitude: 139.701 },
+	address: "country:JP, locality:Tokyo",
+	localLanguageCode: "ja",
+	locationQuery: "渋谷駅",
+};
+
+const TEST_ID = "saved-topic-location-search";
+
+describe("#1133 LocationSearchForm", () => {
+	let renderer: TestRenderer.ReactTestRenderer;
+
+	beforeEach(() => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		mockRecentLocations = [];
+		mockGetCurrentLocation.mockResolvedValue({
+			location: { latitude: 35.68, longitude: 139.76 },
+			address: "country:JP, locality:Tokyo",
+			localLanguageCode: "ja",
+		});
+	});
+
+	const mount = async (onSubmit = jest.fn()) => {
+		await act(async () => {
+			renderer = TestRenderer.create(<LocationSearchForm onSubmit={onSubmit} testID={TEST_ID} />);
+		});
+		return onSubmit;
+	};
+
+	afterEach(async () => {
+		await act(async () => {
+			renderer?.unmount();
+		});
+	});
+
+	it("入力欄の右に現在地ボタンを出し、押すと現在地を確定して表示を『現在地』にする", async () => {
+		const onSubmit = await mount();
+
+		const button = renderer.root.findByProps({ testID: "saved-topic-current-location-button" });
+		expect(button.props.accessibilityLabel).toBe("Search.accessibility.useCurrentLocation");
+
+		await act(async () => {
+			await button.props.onPress();
+		});
+
+		// place_id を持たない経路なので resolved。呼び出し元は details を取り直さずに済む
+		expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ kind: "resolved" }));
+		expect(renderer.root.findByProps({ testID: `${TEST_ID}-input` }).props.value).toBe("Search.currentLocation");
+	});
+
+	it("未入力でフォーカスしたら、ホームと同じリストの「最近使った場所」を出す", async () => {
+		mockRecentLocations = [shibuya];
+		const onSubmit = await mount();
+
+		// autofocus は実 TextInput の focus() を呼ぶだけで onFocus は発火しないため、明示的に起こす
+		await act(async () => {
+			renderer.root.findByProps({ testID: `${TEST_ID}-input` }).props.onFocus();
+		});
+
+		const row = renderer.root.findByProps({ testID: `${TEST_ID}-recent-location-0` });
+		expect(renderer.root.findByProps({ testID: `${TEST_ID}-recent-locations` })).toBeTruthy();
+
+		await act(async () => {
+			row.props.onPress();
+		});
+
+		// 保存済みの緯度経度をそのまま復元する(#953)。ここで API を叩くと課金と待ち時間が増える
+		expect(mockGetCurrentLocation).not.toHaveBeenCalled();
+		expect(onSubmit).toHaveBeenCalledWith({ kind: "resolved", location: shibuya, locationQuery: "渋谷駅" });
+	});
+
+	it("最近使った場所が空なら消去ボタンは出さない（押せる対象が無いため）", async () => {
+		await mount();
+
+		await act(async () => {
+			renderer.root.findByProps({ testID: `${TEST_ID}-input` }).props.onFocus();
+		});
+
+		expect(renderer.root.findAllByProps({ testID: `${TEST_ID}-recent-locations-clear` })).toHaveLength(0);
+	});
+});

--- a/app-expo/features/profile/components/LocationSearchForm.tsx
+++ b/app-expo/features/profile/components/LocationSearchForm.tsx
@@ -1,17 +1,26 @@
-import React, { useState, useCallback } from "react";
-import { View, Text, StyleSheet } from "react-native";
+import React, { useEffect, useRef } from "react";
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+import { Navigation } from "lucide-react-native";
 import { Card } from "@/components/Card";
 import { LocationAutocomplete } from "@/components/LocationAutocomplete";
 import i18n from "@/lib/i18n";
-import type { AutocompleteLocation } from "@shared/api/v1/res";
+import { useLocationField, type SelectedLocation } from "@/features/search/hooks/useLocationField";
 
 interface LocationSearchFormProps {
 	/** Initial location text value */
 	initialLocationText?: string;
-	/** Called when user selects a location */
-	onSubmit: (location: AutocompleteLocation) => void;
-	/** Called when user cancels */
-	onCancel: () => void;
+	/**
+	 * #1133 【設計】確定した地点を親へ渡す。
+	 * 現在地・最近使った場所は `place_id` を持たず緯度経度が確定済み、サジェストはその逆なので、
+	 * 判別可能 union で渡して親に分岐を強制する。`AutocompleteLocation` のままだと前者が乗らない。
+	 */
+	onSubmit: (selected: SelectedLocation) => void;
+	/**
+	 * Called when user cancels.
+	 * ⚠️ 現状この JSX にキャンセル操作の要素が無く、呼ばれることはない（`BlurModal` 側の
+	 * 背景タップで閉じる）。導入時からの未参照 props で、削除の可否は判断待ちのため optional に留める。
+	 */
+	onCancel?: () => void;
 	/** Placeholder text for the location input */
 	placeholder?: string;
 	/** Modal title */
@@ -23,38 +32,66 @@ interface LocationSearchFormProps {
 /**
  * Location search form component that manages its own internal state to prevent
  * Japanese IME composition issues. Only communicates final values back to parent.
+ *
+ * #1133 【設計】入力欄の振る舞い（現在地取得・最近使った場所・クリア）は `useLocationField` が持つ。
+ * ホーム（検索タブ）と同じ体験にするため、`LocationAutocomplete` へ渡す props も
+ * `app/[locale]/(tabs)/search/index.tsx` と同じ形に揃えてある。差分があれば片方だけの不具合になる。
  */
 export function LocationSearchForm({
 	initialLocationText = "",
 	onSubmit,
-	onCancel,
 	placeholder = i18n.t("Search.placeholders.enterLocation"),
 	title = i18n.t("Search.locationModal.title"),
 	testID,
 }: LocationSearchFormProps) {
-	// Internal state - isolated from parent re-renders
-	const [locationText, setLocationText] = useState(initialLocationText);
+	const {
+		locationQuery,
+		setLocationQuery,
+		inputRef,
+		recentLocations,
+		clearRecentLocations,
+		handleSelectSuggestion,
+		handleSelectRecentLocation,
+		handleUseCurrentLocation,
+		handleClear,
+	} = useLocationField({ screen: "profile_saved_topics", onSelected: onSubmit });
 
-	const handleLocationSelect = useCallback(
-		(location: AutocompleteLocation) => {
-			onSubmit(location);
-		},
-		[onSubmit],
-	);
-
-	const handleCancel = useCallback(() => {
-		onCancel();
-	}, [onCancel]);
+	// 初期値の反映はマウント時の 1 回だけ。以降は利用者の入力が正なので上書きしない
+	// （`initialLocationText` が変わるたび入力を奪うと IME 入力中に文字が消える）
+	const didSeedInitialText = useRef(false);
+	useEffect(() => {
+		if (didSeedInitialText.current) return;
+		didSeedInitialText.current = true;
+		if (initialLocationText) setLocationQuery(initialLocationText);
+	}, [initialLocationText, setLocationQuery]);
 
 	return (
 		<Card>
 			<Text style={styles.modalTitle}>{title}</Text>
 			<View style={styles.locationSection}>
 				<LocationAutocomplete
-					value={locationText}
-					onChangeText={setLocationText}
-					onSelectSuggestion={handleLocationSelect}
+					ref={inputRef}
+					value={locationQuery}
+					onChangeText={setLocationQuery}
+					onSelectSuggestion={handleSelectSuggestion}
+					onClear={handleClear}
 					placeholder={placeholder}
+					// #1133 ホームと同じく、「現在地」表示のまま再フォーカスしたら手入力に切り替えられるようにする
+					autoClearOnFocus={locationQuery === i18n.t("Search.currentLocation")}
+					recentLocations={recentLocations}
+					onSelectRecentLocation={handleSelectRecentLocation}
+					onClearRecentLocations={recentLocations.length > 0 ? clearRecentLocations : undefined}
+					renderInputRight={
+						<TouchableOpacity
+							style={styles.currentLocationButton}
+							onPress={handleUseCurrentLocation}
+							hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+							accessibilityRole="button"
+							accessibilityLabel={i18n.t("Search.accessibility.useCurrentLocation")}
+							testID="saved-topic-current-location-button">
+							<Navigation size={20} color="#000000" />
+						</TouchableOpacity>
+					}
 					autofocus={true}
 					testID={testID}
 				/>
@@ -76,5 +113,11 @@ const styles = StyleSheet.create({
 		flexDirection: "row",
 		alignItems: "flex-start",
 		gap: 12,
+	},
+	// #1133 ホーム(`search/index.tsx` の currentLocationButton)と同一の見た目にする
+	currentLocationButton: {
+		padding: 16,
+		borderLeftWidth: 0.5,
+		borderLeftColor: "#C9C9C9",
 	},
 });

--- a/app-expo/features/profile/tabs/SavedTopicsTab.test.tsx
+++ b/app-expo/features/profile/tabs/SavedTopicsTab.test.tsx
@@ -252,17 +252,20 @@ describe("#1133 SavedTopicsTab の地点確定", () => {
 		await act(async () => {
 			captured.onItemPress!(topic, 0);
 		});
+		// details が未解決のうちに遷移していることを見たいので、ここでは完了を待たない
+		let pending: Promise<void> | void;
 		await act(async () => {
-			await captured.onSubmit!(predictionKyoto);
+			pending = captured.onSubmit!(predictionKyoto);
 		});
 
-		// details が未解決のまま遷移していること。await してしまうと、モーダル上に
-		// ローディングとエラー処理が無い今は「押しても何も起きない」時間ができる
+		// details を await してから遷移すると、モーダル上にローディングもエラー処理も無い今は
+		// 「押しても何も起きない」時間ができる
 		expect(mockRouterPush).toHaveBeenCalledTimes(1);
 		expect(mockAddRecentLocation).not.toHaveBeenCalled();
 
 		await act(async () => {
 			resolveDetails(kyotoDetails);
+			await pending;
 			await Promise.all(mockUpdateMediaIdsByKeyAsync.mock.results.map((r) => r.value));
 		});
 		expect(mockAddRecentLocation).toHaveBeenCalledTimes(1);

--- a/app-expo/features/profile/tabs/SavedTopicsTab.test.tsx
+++ b/app-expo/features/profile/tabs/SavedTopicsTab.test.tsx
@@ -1,0 +1,270 @@
+/**
+ * #1133 保存料理タブの「地点が確定してから検索結果へ飛ぶまで」を守るテスト。
+ *
+ * ここが本番で実際に走る経路。`useLocationField` 側にも似た形の検証はあるが、
+ * viewport の除去・「最近使った場所」への登録・details を取りに行くかどうかの分岐は
+ * このファイルの `handleLocationSelect` が自前で持っており（details が解決する頃には
+ * モーダル内の `LocationSearchForm` が閉じているため、フック側の関数を呼べない）、
+ * フックのテストは**この経路を一切通らない**。
+ *
+ * 落ちても型では気付けない差分を押さえる:
+ * - 確定済みの地点（現在地・最近使った場所）で details API を叩き直さないこと
+ * - サジェスト経由で保存するとき viewport を落とすこと（スプレッドに戻すと実行時に残る）
+ * - サジェストの details 取得が画面遷移を待たせないこと
+ * - entriesKey の location が経路ごとに `pid:` / `ll:` で作り分けられること
+ */
+import React, { act } from "react";
+import TestRenderer from "react-test-renderer";
+import type { LocationDetailsResponse } from "@shared/api/v1/res";
+import type { SelectedLocation } from "@/features/search/hooks/useLocationField";
+import type { DishCategory } from "@/stores/useTopicsStore";
+
+// 検証対象は handleLocationSelect の中身なので、UI とストアは境界でスタブ化する。
+// SaveTopicTab / LocationSearchForm は props を捕まえるだけの入れ物に差し替え、
+// 「トピックを選ぶ → 地点を確定する」という本番と同じ順序でハンドラを起動する。
+const captured: {
+	onItemPress?: (item: DishCategory, index: number) => void;
+	onSubmit?: (selected: SelectedLocation) => Promise<void> | void;
+} = {};
+
+jest.mock("./save/SaveTopicTab", () => ({
+	SaveTopicTab: (props: { onItemPress?: (item: DishCategory, index: number) => void }) => {
+		captured.onItemPress = props.onItemPress;
+		return null;
+	},
+}));
+
+jest.mock("../components/LocationSearchForm", () => ({
+	LocationSearchForm: (props: { onSubmit: (selected: SelectedLocation) => Promise<void> | void }) => {
+		captured.onSubmit = props.onSubmit;
+		return null;
+	},
+}));
+
+const mockRouterPush = jest.fn();
+jest.mock("expo-router", () => ({
+	router: { push: (...args: unknown[]) => mockRouterPush(...args) },
+	useLocalSearchParams: () => ({ userId: "user-1" }),
+}));
+
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+jest.mock("@/hooks/useLocale", () => ({ useLocale: () => ({ locale: "ja-JP", isJapanese: true }) }));
+jest.mock("@/hooks/useHaptics", () => ({ useHaptics: () => ({ lightImpact: jest.fn() }) }));
+jest.mock("@/hooks/useAPICall", () => ({ useAPICall: () => ({ callBackend: jest.fn() }) }));
+
+const mockLogFrontendEvent = jest.fn();
+jest.mock("@/hooks/useLogger", () => ({ useLogger: () => ({ logFrontendEvent: mockLogFrontendEvent }) }));
+
+const mockGetLocationDetails = jest.fn<Promise<LocationDetailsResponse>, [unknown]>();
+jest.mock("@/hooks/useLocationSearch", () => ({
+	useLocationSearch: () => ({ getLocationDetails: (...args: [unknown]) => mockGetLocationDetails(...args) }),
+}));
+
+const mockCreateDishItemsPromise = jest.fn();
+jest.mock("@/features/topics/hooks/useTopicSearch", () => ({
+	useTopicSearch: () => ({ createDishItemsPromise: mockCreateDishItemsPromise }),
+}));
+
+const mockAddRecentLocation = jest.fn();
+jest.mock("@/features/search/hooks/useRecentLocations", () => ({
+	useRecentLocations: () => ({
+		recentLocations: [],
+		isLoading: false,
+		addRecentLocation: mockAddRecentLocation,
+		clearRecentLocations: jest.fn(),
+	}),
+}));
+
+const mockCloseLocationModal = jest.fn();
+jest.mock("@/features/blurModal/hooks/useBlurModal", () => {
+	// モーダルの開閉状態は検証対象ではないので、常に中身を描画して onSubmit を取れるようにする
+	const BlurModal = ({ children }: { children: React.ReactNode | ((p: { close: () => void }) => React.ReactNode) }) =>
+		typeof children === "function" ? children({ close: mockCloseLocationModal }) : children;
+	return { useBlurModal: () => ({ BlurModal, open: jest.fn(), close: mockCloseLocationModal }) };
+});
+
+const mockUpdateMediaIdsByKeyAsync = jest.fn((_key: string, promise: Promise<string[]>) => promise);
+const mockUpsertDishMediaEntries = jest.fn();
+jest.mock("@/stores/useDishMediaEntriesStore", () => ({
+	useDishMediaEntriesStore: {
+		getState: () => ({
+			// 未取得・未ロードの状態にして getIds() を必ず走らせる
+			mediaIdsByKey: {},
+			isLoadingByKey: {},
+			upsertDishMediaEntries: mockUpsertDishMediaEntries,
+			updateMediaIdsByKeyAsync: mockUpdateMediaIdsByKeyAsync,
+		}),
+	},
+}));
+
+jest.mock("@/stores/useTopicsStore", () => {
+	const useTopicsStore = () => ({
+		ids: [],
+		isLoading: false,
+		error: null,
+		hasNextPage: false,
+		isLoadingMore: false,
+	});
+	// 初回マウントの取得は検証対象外なので、取得済みにして走らせない
+	useTopicsStore.getState = () => ({
+		fetchInitialByKey: jest.fn(),
+		hasFetchedInitialByKey: { profileSavedTopics: true },
+	});
+	return { useTopicsStore, selectTopicIdsByKey: () => () => undefined };
+});
+
+import { SavedTopicsTab } from "./SavedTopicsTab";
+
+const topic: DishCategory = {
+	id: "cat-1",
+	image_url: "https://example.com/ramen.png",
+	labels: { "ja-JP": "ラーメン" },
+	label_en: "ramen",
+} as DishCategory;
+
+/** 「最近使った場所」/ 現在地から来る、緯度経度が確定済みの地点 */
+const resolvedShibuya: SelectedLocation = {
+	kind: "resolved",
+	location: {
+		location: { latitude: 35.658, longitude: 139.701 },
+		address: "country:JP, locality:Tokyo",
+		localLanguageCode: "ja",
+	},
+	locationQuery: "渋谷駅",
+};
+
+/** サジェストから来る、place_id しか判っていない地点 */
+const predictionKyoto: SelectedLocation = {
+	kind: "prediction",
+	prediction: {
+		place_id: "place-kyoto",
+		text: "京都駅",
+		mainText: "京都駅",
+		secondaryText: "京都府京都市",
+		types: ["train_station"],
+	},
+	locationQuery: "京都駅",
+};
+
+const kyotoDetails: LocationDetailsResponse = {
+	location: { latitude: 34.985, longitude: 135.758 },
+	viewport: {
+		low: { latitude: 34.98, longitude: 135.75 },
+		high: { latitude: 34.99, longitude: 135.76 },
+	},
+	address: "country:JP, locality:Kyoto",
+	localLanguageCode: "ja",
+};
+
+describe("#1133 SavedTopicsTab の地点確定", () => {
+	let renderer: TestRenderer.ReactTestRenderer;
+
+	beforeEach(() => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		captured.onItemPress = undefined;
+		captured.onSubmit = undefined;
+		mockCreateDishItemsPromise.mockResolvedValue([{ dish_media: { id: "media-1" } }]);
+		mockGetLocationDetails.mockResolvedValue(kyotoDetails);
+	});
+
+	afterEach(async () => {
+		await act(async () => {
+			renderer?.unmount();
+		});
+	});
+
+	/** トピックを選んでモーダルを開き、地点確定ハンドラを本番と同じ順序で起動する */
+	const selectLocation = async (selected: SelectedLocation) => {
+		await act(async () => {
+			renderer = TestRenderer.create(<SavedTopicsTab isOwnProfile={true} />);
+		});
+		await act(async () => {
+			captured.onItemPress!(topic, 0);
+		});
+		await act(async () => {
+			await captured.onSubmit!(selected);
+		});
+		// getIds() は updateMediaIdsByKeyAsync に渡された非同期処理。中身まで検証したいので解決を待つ
+		await act(async () => {
+			await Promise.all(mockUpdateMediaIdsByKeyAsync.mock.results.map((r) => r.value));
+		});
+	};
+
+	const pushedEntriesKey = () => mockRouterPush.mock.calls[0][0].params.entriesKey as string;
+
+	it("確定済みの地点（現在地・最近使った場所）では details API を叩き直さない", async () => {
+		await selectLocation(resolvedShibuya);
+
+		// 緯度経度は既に手元にある。ここで叩くと課金と待ち時間が増えるだけで得るものが無い
+		expect(mockGetLocationDetails).not.toHaveBeenCalled();
+		// 保存済みの緯度経度がそのまま検索へ渡ること（詰め替えの取りこぼしを防ぐ）
+		expect(mockCreateDishItemsPromise).toHaveBeenCalledWith("cat-1", "ramen", 35.658, 139.701, "ja");
+	});
+
+	it("確定済みの地点は「最近使った場所」へ登録し直さない（MRU の更新はフォーム側の責務）", async () => {
+		await selectLocation(resolvedShibuya);
+
+		// #1129 の MRU 先頭移動は useLocationField が担う。ここで二重に積むと責務が二重化する
+		expect(mockAddRecentLocation).not.toHaveBeenCalled();
+	});
+
+	it("確定済みの地点の entriesKey は緯度経度（ll:）で作る", async () => {
+		await selectLocation(resolvedShibuya);
+
+		expect(pushedEntriesKey()).toContain("|loc:ll:35.6580,139.7010|");
+	});
+
+	it("サジェスト経由は details を取得し、viewport を落として「最近使った場所」へ保存する", async () => {
+		await selectLocation(predictionKyoto);
+
+		expect(mockGetLocationDetails).toHaveBeenCalledWith(
+			expect.objectContaining({ place_id: "place-kyoto" }) as unknown as never,
+		);
+		expect(mockAddRecentLocation).toHaveBeenCalledWith({
+			location: kyotoDetails.location,
+			address: kyotoDetails.address,
+			localLanguageCode: kyotoDetails.localLanguageCode,
+			locationQuery: "京都駅",
+		});
+		// スプレッドだけだと型上 Omit していても実行時に viewport が残る。キーの不在を明示的に確かめる
+		expect(mockAddRecentLocation.mock.calls[0][0]).not.toHaveProperty("viewport");
+		// 保存した地点がそのまま検索にも使われること（viewport 除去で緯度経度を壊していない）
+		expect(mockCreateDishItemsPromise).toHaveBeenCalledWith("cat-1", "ramen", 34.985, 135.758, "ja");
+	});
+
+	it("サジェスト経由の entriesKey は place_id（pid:）で作る", async () => {
+		await selectLocation(predictionKyoto);
+
+		expect(pushedEntriesKey()).toContain("|loc:pid:place-kyoto|");
+	});
+
+	it("サジェスト経由でも details の解決を待たずに検索結果へ遷移する", async () => {
+		let resolveDetails: (details: LocationDetailsResponse) => void = () => {};
+		mockGetLocationDetails.mockReturnValue(
+			new Promise<LocationDetailsResponse>((resolve) => {
+				resolveDetails = resolve;
+			}),
+		);
+
+		await act(async () => {
+			renderer = TestRenderer.create(<SavedTopicsTab isOwnProfile={true} />);
+		});
+		await act(async () => {
+			captured.onItemPress!(topic, 0);
+		});
+		await act(async () => {
+			await captured.onSubmit!(predictionKyoto);
+		});
+
+		// details が未解決のまま遷移していること。await してしまうと、モーダル上に
+		// ローディングとエラー処理が無い今は「押しても何も起きない」時間ができる
+		expect(mockRouterPush).toHaveBeenCalledTimes(1);
+		expect(mockAddRecentLocation).not.toHaveBeenCalled();
+
+		await act(async () => {
+			resolveDetails(kyotoDetails);
+			await Promise.all(mockUpdateMediaIdsByKeyAsync.mock.results.map((r) => r.value));
+		});
+		expect(mockAddRecentLocation).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app-expo/features/profile/tabs/SavedTopicsTab.tsx
+++ b/app-expo/features/profile/tabs/SavedTopicsTab.tsx
@@ -37,8 +37,10 @@ export function SavedTopicsTab({ isOwnProfile }: SavedTopicsTabProps) {
 	const { getLocationDetails } = useLocationSearch();
 	// #1133 【設計】「最近使った場所」への登録はここで行う。登録できるのは details が解決した後
 	// (＝遷移後に走る getIds() の中)であり、その時点でモーダル内の LocationSearchForm は
-	// 閉じているため、フォーム側が持つ useLocationField の registerRecentLocation は使えない。
+	// 閉じているため、フォーム側(useLocationField)には置けない。
 	// ストレージはホームと共有する(#953 の recent_locations_v1)ので、キーは増やさない。
+	// ⚠️ この経路の検証は SavedTopicsTab.test.tsx にある。viewport の除去・details を叩くかの分岐は
+	// 型では守れないため、ここを触ったら必ずテストを一緒に見ること。
 	const { addRecentLocation } = useRecentLocations();
 
 	const {

--- a/app-expo/features/profile/tabs/SavedTopicsTab.tsx
+++ b/app-expo/features/profile/tabs/SavedTopicsTab.tsx
@@ -14,8 +14,9 @@ import { useLocale } from "@/hooks/useLocale";
 import { useDishMediaEntriesStore } from "@/stores/useDishMediaEntriesStore";
 import { useTopicsStore, selectTopicIdsByKey, DishCategory } from "@/stores/useTopicsStore";
 import type { QueryMeSavedDishCategoriesDto } from "@shared/api/v1/dto";
-import type { QueryMeSavedDishCategoriesResponse } from "@shared/api/v1/res";
-import type { AutocompleteLocation } from "@shared/api/v1/res";
+import type { LocationDetailsResponse, QueryMeSavedDishCategoriesResponse } from "@shared/api/v1/res";
+import type { SelectedLocation } from "@/features/search/hooks/useLocationField";
+import { useRecentLocations } from "@/features/search/hooks/useRecentLocations";
 import { shallow } from "zustand/shallow";
 import { makeDishMediaEntriesKey } from "@/features/dishMedia/utils/dishMediaEntriesKey";
 import { DEFAULT_PRICE_LEVELS, DEFAULT_SEARCH_RADIUS } from "@/features/topics/constants";
@@ -34,6 +35,11 @@ export function SavedTopicsTab({ isOwnProfile }: SavedTopicsTabProps) {
 	const { callBackend } = useAPICall();
 	const { createDishItemsPromise } = useTopicSearch();
 	const { getLocationDetails } = useLocationSearch();
+	// #1133 【設計】「最近使った場所」への登録はここで行う。登録できるのは details が解決した後
+	// (＝遷移後に走る getIds() の中)であり、その時点でモーダル内の LocationSearchForm は
+	// 閉じているため、フォーム側が持つ useLocationField の registerRecentLocation は使えない。
+	// ストレージはホームと共有する(#953 の recent_locations_v1)ので、キーは増やさない。
+	const { addRecentLocation } = useRecentLocations();
 
 	const {
 		ids: topicIds,
@@ -133,7 +139,7 @@ export function SavedTopicsTab({ isOwnProfile }: SavedTopicsTabProps) {
 
 	// Handle location selection from autocomplete
 	const handleLocationSelect = useCallback(
-		async (location: AutocompleteLocation) => {
+		async (selected: SelectedLocation) => {
 			if (!selectedTopic) return;
 
 			// Close modal first
@@ -143,7 +149,19 @@ export function SavedTopicsTab({ isOwnProfile }: SavedTopicsTabProps) {
 				useDishMediaEntriesStore.getState();
 			const entriesKey = makeDishMediaEntriesKey({
 				categoryId: selectedTopic.id,
-				location: { place_id: location.place_id },
+				// #1133 【設計】経路によって手元にある情報が違うため、location キーを作り分ける。
+				// サジェストは place_id しか持たず(緯度経度は details API を叩くまで不明)、
+				// 現在地・最近使った場所は緯度経度だけを持ち place_id を持たない。
+				// makeDishMediaEntriesKey(#633) は両形式を受けるので、ここで詰め替えは不要。
+				// ⚠️ 結果として同じ地点でも経路が違えば別キーになる(`pid:` と `ll:`)。これは
+				// ホーム(常に `ll:`)と保存料理(従来 `pid:`)の間に元からある非対称で、今回広げない。
+				location:
+					selected.kind === "prediction"
+						? { place_id: selected.prediction.place_id }
+						: {
+								latitude: selected.location.location.latitude,
+								longitude: selected.location.location.longitude,
+							},
 				radius: DEFAULT_SEARCH_RADIUS,
 				priceLevels: [...DEFAULT_PRICE_LEVELS],
 				// #817 端末言語でレビューの並びが変わるためキーに含める
@@ -152,8 +170,20 @@ export function SavedTopicsTab({ isOwnProfile }: SavedTopicsTabProps) {
 
 			if (mediaIdsByKey[entriesKey] === undefined && !isLoadingByKey[entriesKey]) {
 				const getIds = async () => {
-					// Get location details including coordinates and language code
-					const locationDetails = await getLocationDetails(location);
+					// #1133 サジェスト経由だけ details を取りに行く。現在地・最近使った場所は緯度経度が
+					// 確定済みなので、遷移前にも遷移後にも API 待ちを増やさない。
+					let locationDetails: Omit<LocationDetailsResponse, "viewport">;
+					if (selected.kind === "prediction") {
+						const details = await getLocationDetails(selected.prediction);
+						// #1133 【仕様】details が取れて初めて緯度経度が判るので、ここで初めて登録できる。
+						// viewport はスプレッドすると型上は Omit していても実行時に残るため明示的に除く。
+						// 最近使った場所経由は既にリストにあり、MRU の先頭移動(#1129)は useLocationField 側が担う。
+						const { viewport: _viewport, ...locationWithoutViewport } = details;
+						addRecentLocation({ ...locationWithoutViewport, locationQuery: selected.locationQuery });
+						locationDetails = locationWithoutViewport;
+					} else {
+						locationDetails = selected.location;
+					}
 
 					const dishItems = await createDishItemsPromise(
 						selectedTopic.id,
@@ -167,6 +197,11 @@ export function SavedTopicsTab({ isOwnProfile }: SavedTopicsTabProps) {
 				};
 				updateMediaIdsByKeyAsync(entriesKey, getIds(), (_, ids) => ids);
 			}
+
+			// #1133 【既知の制約】getIds() は entriesKey が未取得のときしか走らないため、
+			// 同じカテゴリ×同じ地点で 2 回目に検索したときは「最近使った場所」への登録が起きない。
+			// 解消には遷移前に getLocationDetails を await する必要があり、モーダル上に
+			// ローディングとエラー処理を新設することになるため今回は採らない(別 Issue)。
 
 			// Navigate to result screen (referenced from topics.tsx handleViewDetails)
 			// Stay within profile tab as required
@@ -183,12 +218,22 @@ export function SavedTopicsTab({ isOwnProfile }: SavedTopicsTabProps) {
 				error_level: "log",
 				payload: {
 					topicId: selectedTopic.id,
-					location: location.text,
+					location: selected.locationQuery,
 					categoryId: selectedTopic.id,
+					// #1133 どの経路で地点が決まったかを出所として残す(サジェスト / 現在地・最近使った場所)
+					source: selected.kind,
 				},
 			});
 		},
-		[selectedTopic, closeLocationModal, createDishItemsPromise, locale, logFrontendEvent, getLocationDetails],
+		[
+			selectedTopic,
+			closeLocationModal,
+			createDishItemsPromise,
+			locale,
+			logFrontendEvent,
+			getLocationDetails,
+			addRecentLocation,
+		],
 	);
 
 	const handleLocationCancel = useCallback(() => {

--- a/app-expo/features/search/currentLocationErrorMessage.test.ts
+++ b/app-expo/features/search/currentLocationErrorMessage.test.ts
@@ -1,0 +1,42 @@
+import type { LocationPermissionErrorKind } from "@/hooks/locationPermissionError";
+import { getCurrentLocationErrorMessage, shouldFallbackToManualInput } from "./currentLocationErrorMessage";
+
+// 翻訳の中身ではなく「どのキーを引いたか」を固定したいので、t はキーをそのまま返す
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+
+/**
+ * #1133 現在地取得の失敗表示は、ホーム（検索タブ）と保存料理タブで**同一**でなければならない。
+ *
+ * 同じ「権限拒否」でも画面ごとに文言や導線が違うと、ユーザーは「別の不具合」だと受け取る。
+ * ここで kind → 翻訳キーの対応と、手入力へ誘導すべき kind を固定しておくことで、
+ * 片方の画面だけ書き換わる事故を防ぐ。
+ */
+describe("#1133 現在地取得の失敗文言は kind ごとに出し分ける", () => {
+	it.each<[LocationPermissionErrorKind, string]>([
+		["denied", "Search.errors.getCurrentLocationDenied"],
+		["unsupported", "Search.errors.getCurrentLocationUnsupported"],
+		["timeout", "Search.errors.getCurrentLocationTimeout"],
+		["unavailable", "Search.errors.getCurrentLocation"],
+	])("kind=%s のとき %s を引く", (kind, expectedKey) => {
+		expect(getCurrentLocationErrorMessage(kind)).toBe(expectedKey);
+	});
+
+	it("未知の kind は汎用の文言へ落とす（分類が増えても無言で失敗しない）", () => {
+		expect(getCurrentLocationErrorMessage("something_new" as LocationPermissionErrorKind)).toBe(
+			"Search.errors.getCurrentLocation",
+		);
+	});
+});
+
+describe("#1133 手入力へ誘導すべき失敗の判定", () => {
+	it.each<[LocationPermissionErrorKind, boolean]>([
+		// 再試行しても解決しない → 手入力へ誘導する
+		["denied", true],
+		["unsupported", true],
+		// 再試行で解決しうる → フォーカスを奪わず、もう一度現在地ボタンを押せるままにする
+		["timeout", false],
+		["unavailable", false],
+	])("kind=%s のとき %s", (kind, expected) => {
+		expect(shouldFallbackToManualInput(kind)).toBe(expected);
+	});
+});

--- a/app-expo/features/search/currentLocationErrorMessage.ts
+++ b/app-expo/features/search/currentLocationErrorMessage.ts
@@ -1,0 +1,39 @@
+import type { LocationPermissionErrorKind } from "@/hooks/locationPermissionError";
+import i18n from "@/lib/i18n";
+
+/**
+ * #1133 【設計】現在地取得の失敗時の出し分けを、画面から独立した純関数として持つ。
+ *
+ * 元は `app/[locale]/(tabs)/search/index.tsx` にローカル関数として書かれていた #932 の出し分けを
+ * そのまま切り出したもの。保存料理タブ（`features/profile/`）でも同じ現在地取得を提供するにあたり、
+ * 「同じ失敗理由に画面ごとに違う文言が出る」ことを構造的に防ぐために共有する。
+ *
+ * ⚠️ ホーム（検索タブ）側は**まだ差し替えていない**。ホームの移行は別 Issue で行う。
+ * その際に `search/index.tsx` のローカル関数を削除し、こちらへ寄せること。
+ * それまでは 2 箇所に同じ分岐が存在するので、文言を変えるときは**両方**直すこと。
+ */
+export function getCurrentLocationErrorMessage(kind: LocationPermissionErrorKind): string {
+	switch (kind) {
+		case "denied":
+			return i18n.t("Search.errors.getCurrentLocationDenied");
+		case "unsupported":
+			return i18n.t("Search.errors.getCurrentLocationUnsupported");
+		case "timeout":
+			return i18n.t("Search.errors.getCurrentLocationTimeout");
+		case "unavailable":
+		default:
+			return i18n.t("Search.errors.getCurrentLocation");
+	}
+}
+
+/**
+ * #932 【設計】手入力へフォーカス誘導すべき失敗か。
+ *
+ * 権限拒否（denied）と実行環境の非対応（unsupported）は、同じ操作を繰り返しても解決しない。
+ * この 2 つのときだけ地点入力欄へフォーカスを移し、ユーザーを手入力へ誘導する。
+ * timeout / unavailable は再試行で解決しうるので、フォーカスは奪わない
+ * （現在地ボタンをもう一度押せる状態のままにする）。
+ */
+export function shouldFallbackToManualInput(kind: LocationPermissionErrorKind): boolean {
+	return kind === "denied" || kind === "unsupported";
+}

--- a/app-expo/features/search/hooks/useLocationField.test.tsx
+++ b/app-expo/features/search/hooks/useLocationField.test.tsx
@@ -10,8 +10,12 @@ import { useLocationField, type SelectedLocation } from "./useLocationField";
  *
  * ここで固定したいのは、保存料理タブに機能を足す過程で**ホームの既存挙動が変質しないこと**と、
  * ホームにしか無かった細かい仕様（失敗時の手入力誘導・最近使った場所は API を叩き直さない・
- * 保存時に viewport を落とす・再選択で MRU 先頭へ）が、共通化の過程で落ちないこと。
+ * 再選択で MRU 先頭へ）が、共通化の過程で落ちないこと。
  * これらは落ちても型では気付けず、画面を触って初めて判る種類の差分なので、テストで押さえる。
+ *
+ * ⚠️ 「最近使った場所」への登録（viewport を落として保存する）はこのフックの責務ではない。
+ * details が解決する頃にはフォームが閉じており、登録は呼び出し元が行うため、
+ * その検証は `features/profile/tabs/SavedTopicsTab.test.tsx` にある。
  */
 
 const mockGetCurrentLocation = jest.fn<Promise<Omit<LocationDetailsResponse, "viewport">>, []>();
@@ -52,16 +56,6 @@ const shibuya: RecentLocation = {
 const currentPosition: Omit<LocationDetailsResponse, "viewport"> = {
 	location: { latitude: 35.68, longitude: 139.76 },
 	address: "country:JP, locality:Tokyo",
-	localLanguageCode: "ja",
-};
-
-const detailsWithViewport: LocationDetailsResponse = {
-	location: { latitude: 34.985, longitude: 135.758 },
-	viewport: {
-		low: { latitude: 34.98, longitude: 135.75 },
-		high: { latitude: 34.99, longitude: 135.76 },
-	},
-	address: "country:JP, locality:Kyoto",
 	localLanguageCode: "ja",
 };
 
@@ -182,23 +176,6 @@ describe("#1133 useLocationField", () => {
 		// #1129 はホームの画面側に実装されていてフック内に無いため、ここで呼ばないと
 		// 「ホームでは先頭に来るが保存料理では来ない」不整合になる
 		expect(mockAddRecentLocation).toHaveBeenCalledWith(shibuya);
-	});
-
-	it("最近使った場所へ登録するとき、viewport を落として保存する", async () => {
-		await mount();
-
-		await act(async () => {
-			field.registerRecentLocation(detailsWithViewport, "京都駅");
-		});
-
-		expect(mockAddRecentLocation).toHaveBeenCalledWith({
-			location: detailsWithViewport.location,
-			address: detailsWithViewport.address,
-			localLanguageCode: detailsWithViewport.localLanguageCode,
-			locationQuery: "京都駅",
-		});
-		// スプレッドだけだと実行時に viewport が残るため、キーの不在を明示的に確かめる
-		expect(mockAddRecentLocation.mock.calls[0][0]).not.toHaveProperty("viewport");
 	});
 
 	it("サジェスト選択は details を取りに行かず、未解決のまま呼び出し元へ委ねる", async () => {

--- a/app-expo/features/search/hooks/useLocationField.test.tsx
+++ b/app-expo/features/search/hooks/useLocationField.test.tsx
@@ -1,0 +1,251 @@
+import { act } from "react";
+import TestRenderer from "react-test-renderer";
+import type { LocationDetailsResponse } from "@shared/api/v1/res";
+import type { LocationAutocompleteHandle, RecentLocation } from "@/components/LocationAutocomplete";
+import { LocationPermissionError } from "@/hooks/locationPermissionError";
+import { useLocationField, type SelectedLocation } from "./useLocationField";
+
+/**
+ * #1133 「どのあたりで探す」の振る舞いをホーム（検索タブ）と保存料理タブで共有するためのフック。
+ *
+ * ここで固定したいのは、保存料理タブに機能を足す過程で**ホームの既存挙動が変質しないこと**と、
+ * ホームにしか無かった細かい仕様（失敗時の手入力誘導・最近使った場所は API を叩き直さない・
+ * 保存時に viewport を落とす・再選択で MRU 先頭へ）が、共通化の過程で落ちないこと。
+ * これらは落ちても型では気付けず、画面を触って初めて判る種類の差分なので、テストで押さえる。
+ */
+
+const mockGetCurrentLocation = jest.fn<Promise<Omit<LocationDetailsResponse, "viewport">>, []>();
+jest.mock("@/hooks/useLocationSearch", () => ({
+	useLocationSearch: () => ({ getCurrentLocation: () => mockGetCurrentLocation() }),
+}));
+
+const mockShowSnackbar = jest.fn();
+jest.mock("@/contexts/SnackbarProvider", () => ({ useSnackbar: () => ({ showSnackbar: mockShowSnackbar }) }));
+
+const mockLogFrontendEvent = jest.fn();
+jest.mock("@/hooks/useLogger", () => ({ useLogger: () => ({ logFrontendEvent: mockLogFrontendEvent }) }));
+
+jest.mock("@/hooks/useHaptics", () => ({ useHaptics: () => ({ lightImpact: jest.fn() }) }));
+
+// 翻訳の中身ではなくキーを見たいので、t はキーをそのまま返す
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+
+const mockAddRecentLocation = jest.fn();
+const mockClearRecentLocations = jest.fn();
+let mockRecentLocations: RecentLocation[] = [];
+jest.mock("@/features/search/hooks/useRecentLocations", () => ({
+	useRecentLocations: () => ({
+		recentLocations: mockRecentLocations,
+		isLoading: false,
+		addRecentLocation: mockAddRecentLocation,
+		clearRecentLocations: mockClearRecentLocations,
+	}),
+}));
+
+const shibuya: RecentLocation = {
+	location: { latitude: 35.658, longitude: 139.701 },
+	address: "country:JP, locality:Tokyo",
+	localLanguageCode: "ja",
+	locationQuery: "渋谷駅",
+};
+
+const currentPosition: Omit<LocationDetailsResponse, "viewport"> = {
+	location: { latitude: 35.68, longitude: 139.76 },
+	address: "country:JP, locality:Tokyo",
+	localLanguageCode: "ja",
+};
+
+const detailsWithViewport: LocationDetailsResponse = {
+	location: { latitude: 34.985, longitude: 135.758 },
+	viewport: {
+		low: { latitude: 34.98, longitude: 135.75 },
+		high: { latitude: 34.99, longitude: 135.76 },
+	},
+	address: "country:JP, locality:Kyoto",
+	localLanguageCode: "ja",
+};
+
+describe("#1133 useLocationField", () => {
+	const onSelected = jest.fn<void, [SelectedLocation]>();
+	const focus = jest.fn();
+
+	let field: ReturnType<typeof useLocationField>;
+	let renderer: TestRenderer.ReactTestRenderer;
+
+	const Probe = () => {
+		field = useLocationField({ screen: "profile_saved_topics", onSelected });
+		// 実際には LocationAutocomplete が ref に流し込む handle を模す
+		field.inputRef.current = { focus } as LocationAutocompleteHandle;
+		return null;
+	};
+
+	const mount = async () => {
+		await act(async () => {
+			renderer = TestRenderer.create(<Probe />);
+		});
+	};
+
+	beforeEach(() => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		mockRecentLocations = [];
+	});
+
+	afterEach(async () => {
+		await act(async () => {
+			renderer?.unmount();
+		});
+	});
+
+	it("現在地の取得に成功したら、確定済みの地点として通知し表示を『現在地』にする", async () => {
+		mockGetCurrentLocation.mockResolvedValue(currentPosition);
+		await mount();
+
+		await act(async () => {
+			await field.handleUseCurrentLocation();
+		});
+
+		// place_id を持たない経路なので、呼び出し元が details を取り直さないよう resolved で渡す
+		expect(onSelected).toHaveBeenCalledWith({
+			kind: "resolved",
+			location: currentPosition,
+			locationQuery: "Search.currentLocation",
+		});
+		expect(field.locationQuery).toBe("Search.currentLocation");
+		expect(mockShowSnackbar).not.toHaveBeenCalled();
+		// イベント名はホームと同一のまま、出所だけ payload で区別する
+		expect(mockLogFrontendEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event_name: "current_location_success",
+				payload: expect.objectContaining({ screen: "profile_saved_topics" }),
+			}),
+		);
+	});
+
+	it("権限拒否で失敗したら、理由に応じた文言を出して手入力へフォーカスを誘導する", async () => {
+		mockGetCurrentLocation.mockRejectedValue(new LocationPermissionError("denied", "location permission denied"));
+		await mount();
+
+		await act(async () => {
+			await field.handleUseCurrentLocation();
+		});
+
+		expect(onSelected).not.toHaveBeenCalled();
+		expect(mockShowSnackbar).toHaveBeenCalledWith("Search.errors.getCurrentLocationDenied");
+		// 再試行しても直らない失敗なので、ここで入力欄へ誘導しないとユーザーは詰まる
+		expect(focus).toHaveBeenCalled();
+		expect(mockLogFrontendEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event_name: "current_location_failed",
+				payload: expect.objectContaining({ kind: "denied", screen: "profile_saved_topics" }),
+			}),
+		);
+	});
+
+	it("タイムアウトで失敗したら文言は出すが、フォーカスは奪わない（もう一度押せる状態を保つ）", async () => {
+		mockGetCurrentLocation.mockRejectedValue(new LocationPermissionError("timeout", "timed out"));
+		await mount();
+
+		await act(async () => {
+			await field.handleUseCurrentLocation();
+		});
+
+		expect(mockShowSnackbar).toHaveBeenCalledWith("Search.errors.getCurrentLocationTimeout");
+		expect(focus).not.toHaveBeenCalled();
+	});
+
+	it("最近使った場所を選んだら、位置情報 API を一切呼ばずに確定済みの地点として通知する", async () => {
+		mockRecentLocations = [shibuya];
+		await mount();
+
+		await act(async () => {
+			field.handleSelectRecentLocation(shibuya);
+		});
+
+		// 保存済みの緯度経度をそのまま復元するのが #953 の要点。ここで API を叩くと課金と待ち時間が増える
+		expect(mockGetCurrentLocation).not.toHaveBeenCalled();
+		expect(onSelected).toHaveBeenCalledWith({
+			kind: "resolved",
+			location: shibuya,
+			locationQuery: "渋谷駅",
+		});
+		expect(field.locationQuery).toBe("渋谷駅");
+	});
+
+	it("#1129 最近使った場所を再選択したら MRU の先頭へ引き上げる（ホームと同じ挙動にする）", async () => {
+		mockRecentLocations = [shibuya];
+		await mount();
+
+		await act(async () => {
+			field.handleSelectRecentLocation(shibuya);
+		});
+
+		// #1129 はホームの画面側に実装されていてフック内に無いため、ここで呼ばないと
+		// 「ホームでは先頭に来るが保存料理では来ない」不整合になる
+		expect(mockAddRecentLocation).toHaveBeenCalledWith(shibuya);
+	});
+
+	it("最近使った場所へ登録するとき、viewport を落として保存する", async () => {
+		await mount();
+
+		await act(async () => {
+			field.registerRecentLocation(detailsWithViewport, "京都駅");
+		});
+
+		expect(mockAddRecentLocation).toHaveBeenCalledWith({
+			location: detailsWithViewport.location,
+			address: detailsWithViewport.address,
+			localLanguageCode: detailsWithViewport.localLanguageCode,
+			locationQuery: "京都駅",
+		});
+		// スプレッドだけだと実行時に viewport が残るため、キーの不在を明示的に確かめる
+		expect(mockAddRecentLocation.mock.calls[0][0]).not.toHaveProperty("viewport");
+	});
+
+	it("サジェスト選択は details を取りに行かず、未解決のまま呼び出し元へ委ねる", async () => {
+		await mount();
+		const prediction = {
+			place_id: "place-1",
+			text: "京都駅",
+			mainText: "京都駅",
+			secondaryText: "京都府京都市",
+			types: ["train_station"],
+		};
+
+		await act(async () => {
+			field.handleSelectSuggestion(prediction);
+		});
+
+		expect(onSelected).toHaveBeenCalledWith({ kind: "prediction", prediction, locationQuery: "京都駅" });
+		expect(field.locationQuery).toBe("京都駅");
+		// details をここで取ると、遷移前に待たされる。取得の要否とタイミングは呼び出し元の判断に残す
+		expect(mockAddRecentLocation).not.toHaveBeenCalled();
+	});
+
+	it("クリアは入力を空に戻すだけで、地点の確定は通知しない", async () => {
+		await mount();
+
+		await act(async () => {
+			field.handleSelectSuggestion({
+				place_id: "place-1",
+				text: "京都駅",
+				mainText: "京都駅",
+				secondaryText: "京都府京都市",
+				types: [],
+			});
+		});
+		onSelected.mockClear();
+
+		await act(async () => {
+			field.handleClear();
+		});
+
+		expect(field.locationQuery).toBe("");
+		expect(onSelected).not.toHaveBeenCalled();
+		expect(mockLogFrontendEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event_name: "location_cleared",
+				payload: expect.objectContaining({ screen: "profile_saved_topics" }),
+			}),
+		);
+	});
+});

--- a/app-expo/features/search/hooks/useLocationField.ts
+++ b/app-expo/features/search/hooks/useLocationField.ts
@@ -73,19 +73,11 @@ export function useLocationField({ screen, onSelected }: Params) {
 	const onSelectedRef = useRef(onSelected);
 	onSelectedRef.current = onSelected;
 
-	/**
-	 * #953 details 取得に成功した地点だけを「最近使った場所」に保存する。
-	 * サジェスト経由は詳細が取れて初めて緯度経度が判るため、呼び出し元が取得後に呼ぶ。
-	 */
-	const registerRecentLocation = useCallback(
-		(details: LocationDetailsResponse, query: string) => {
-			// viewport はスプレッドすると型上は Omit していても実行時には残ってしまうため、明示的に除く。
-			// 残すと AsyncStorage に不要な入れ子が積まれ、同一地点の重複判定にも関係しない値が保存され続ける。
-			const { viewport: _viewport, ...locationWithoutViewport } = details;
-			addRecentLocation({ ...locationWithoutViewport, locationQuery: query });
-		},
-		[addRecentLocation],
-	);
+	// #1133 【設計】「最近使った場所」への登録関数はここには置かない。
+	// サジェスト経由の登録は details が解決してから（＝呼び出し元が遷移したあと）でないとできず、
+	// その時点でこのフックを持つフォームは閉じている。ここに置くと**本番から呼ばれない関数**が
+	// テストだけ緑になり、実際に走る呼び出し元側の実装（viewport の除去など）は無防備になる。
+	// 登録は呼び出し元が行い、そこでテストする（`features/profile/tabs/SavedTopicsTab.test.tsx`）。
 
 	/** サジェスト選択。ここでは details を取りに行かず、取得の要否は呼び出し元に委ねる */
 	const handleSelectSuggestion = useCallback(
@@ -178,6 +170,5 @@ export function useLocationField({ screen, onSelected }: Params) {
 		handleSelectRecentLocation,
 		handleUseCurrentLocation,
 		handleClear,
-		registerRecentLocation,
 	};
 }

--- a/app-expo/features/search/hooks/useLocationField.ts
+++ b/app-expo/features/search/hooks/useLocationField.ts
@@ -1,0 +1,183 @@
+import { useCallback, useRef, useState } from "react";
+import type { AutocompleteLocation, LocationDetailsResponse } from "@shared/api/v1/res";
+import type { LocationAutocompleteHandle, RecentLocation } from "@/components/LocationAutocomplete";
+import { useSnackbar } from "@/contexts/SnackbarProvider";
+import { LocationPermissionError, type LocationPermissionErrorKind } from "@/hooks/locationPermissionError";
+import { useHaptics } from "@/hooks/useHaptics";
+import { useLocationSearch } from "@/hooks/useLocationSearch";
+import { useLogger } from "@/hooks/useLogger";
+import { toErrorLogString } from "@/lib/errorMessage";
+import i18n from "@/lib/i18n";
+import {
+	getCurrentLocationErrorMessage,
+	shouldFallbackToManualInput,
+} from "@/features/search/currentLocationErrorMessage";
+import { useRecentLocations } from "@/features/search/hooks/useRecentLocations";
+
+/** 緯度経度が確定済みの地点（details API のレスポンスから viewport を除いた形） */
+type ResolvedLocation = Omit<LocationDetailsResponse, "viewport">;
+
+/**
+ * #1133 【設計】確定した地点は「まだ緯度経度を知らない経路」と「もう知っている経路」の 2 種類しかない。
+ *
+ * オートコンプリートの候補は `place_id` しか持たず、緯度経度は details API を叩くまで判らない。
+ * 一方で現在地と「最近使った場所」は緯度経度が確定済みで、`place_id` を持たない。
+ * 呼び出し元はこの 2 つで後続処理（details の遅延取得の要否、検索キーの作り方）を変える必要があるため、
+ * 判別可能 union で返して分岐を強制する。どちらか一方だけを扱う実装は型で落ちる。
+ */
+export type SelectedLocation =
+	/** サジェスト選択。詳細(緯度経度)は未取得なので、必要なら呼び出し元が遅延取得する */
+	| { kind: "prediction"; prediction: AutocompleteLocation; locationQuery: string }
+	/** 現在地 or 最近使った場所。緯度経度が確定済みで place_id は無い */
+	| { kind: "resolved"; location: ResolvedLocation; locationQuery: string };
+
+type Params = {
+	/**
+	 * ログの payload に載せる画面名。
+	 * ⚠️ **イベント名は画面によらず同一**にし、出所は payload の `screen` で区別する。
+	 * 既存の分析基盤がイベント名で集計している可能性があり、名前を分けると過去との連続性が切れるため。
+	 */
+	screen: string;
+	/** 地点が確定したときに呼ばれる */
+	onSelected: (selected: SelectedLocation) => void;
+};
+
+/**
+ * #1133 「どのあたりで探す」の入力欄の振る舞い（現在地取得・最近使った場所・クリア）をまとめたフック。
+ *
+ * ホーム（検索タブ）では同じ振る舞いが `app/[locale]/(tabs)/search/index.tsx` に直接書かれている。
+ * 保存料理タブでも同じ体験を出すにあたり、コピーすると片方だけ直る事故が確実に起きるため共通化した。
+ *
+ * ⚠️ 現時点で**ホーム側はまだこのフックを使っていない**（移行は別 Issue）。
+ * それまではホームとこのフックに同じ振る舞いが 2 つ存在する。挙動を変えるときは両方直すこと。
+ * ここの実装はすべて「ホームの現在の挙動」に一致させてあり、意図的な差分は無い。
+ *
+ * UI（`LocationAutocomplete`）は状態を持たない表示専任なので、このフックは UI を持たず
+ * 「表示用の文字列・ref・ハンドラ」だけを返す。
+ */
+export function useLocationField({ screen, onSelected }: Params) {
+	const [locationQuery, setLocationQuery] = useState("");
+
+	const { getCurrentLocation } = useLocationSearch();
+	const { showSnackbar } = useSnackbar();
+	const { logFrontendEvent } = useLogger();
+	const { lightImpact } = useHaptics();
+	// #953 直近5件の地点。ホームと同じリストを共有する（ストレージキーは増やさない）
+	const { recentLocations, addRecentLocation, clearRecentLocations } = useRecentLocations();
+
+	// #932 【設計】現在地取得の恒久的な失敗(権限拒否・未対応)時に手入力へ誘導するため
+	const inputRef = useRef<LocationAutocompleteHandle>(null);
+
+	// onSelected は呼び出し元でインライン定義されがちなので ref 経由で最新を読む。
+	// 依存配列に入れると、返すハンドラの同一性が毎レンダリング壊れて子の再描画を誘発する。
+	const onSelectedRef = useRef(onSelected);
+	onSelectedRef.current = onSelected;
+
+	/**
+	 * #953 details 取得に成功した地点だけを「最近使った場所」に保存する。
+	 * サジェスト経由は詳細が取れて初めて緯度経度が判るため、呼び出し元が取得後に呼ぶ。
+	 */
+	const registerRecentLocation = useCallback(
+		(details: LocationDetailsResponse, query: string) => {
+			// viewport はスプレッドすると型上は Omit していても実行時には残ってしまうため、明示的に除く。
+			// 残すと AsyncStorage に不要な入れ子が積まれ、同一地点の重複判定にも関係しない値が保存され続ける。
+			const { viewport: _viewport, ...locationWithoutViewport } = details;
+			addRecentLocation({ ...locationWithoutViewport, locationQuery: query });
+		},
+		[addRecentLocation],
+	);
+
+	/** サジェスト選択。ここでは details を取りに行かず、取得の要否は呼び出し元に委ねる */
+	const handleSelectSuggestion = useCallback(
+		(prediction: AutocompleteLocation) => {
+			logFrontendEvent({
+				event_name: "location_selected",
+				error_level: "log",
+				payload: { placeId: prediction.place_id, mainText: prediction.mainText, screen },
+			});
+			setLocationQuery(prediction.mainText);
+			onSelectedRef.current({ kind: "prediction", prediction, locationQuery: prediction.mainText });
+		},
+		[logFrontendEvent, screen],
+	);
+
+	/** #953 最近使った場所は details API を呼び直さず、保存済みの location をそのまま復元する */
+	const handleSelectRecentLocation = useCallback(
+		(recent: RecentLocation) => {
+			logFrontendEvent({
+				event_name: "recent_location_selected",
+				error_level: "log",
+				payload: { locationQuery: recent.locationQuery, screen },
+			});
+			setLocationQuery(recent.locationQuery);
+			onSelectedRef.current({ kind: "resolved", location: recent, locationQuery: recent.locationQuery });
+			// #1129 【仕様】再選択した地点を MRU(Most Recently Used)順で先頭へ引き上げる。
+			// addRecentLocation は同一地点を除去してから先頭へ積むため、件数は増えない。
+			// ⚠️ #1129 はホームの画面側(`search/index.tsx`)に実装されており `useRecentLocations` の中には無い。
+			// そのためこの 1 行が要る。落とすと「ホームでは先頭に来るが保存料理では来ない」不整合になる。
+			addRecentLocation(recent);
+		},
+		[logFrontendEvent, addRecentLocation, screen],
+	);
+
+	const handleUseCurrentLocation = useCallback(async () => {
+		lightImpact();
+		logFrontendEvent({
+			event_name: "current_location_requested",
+			error_level: "log",
+			payload: { screen },
+		});
+		try {
+			const currentLocation = await getCurrentLocation();
+			const query = i18n.t("Search.currentLocation");
+			setLocationQuery(query);
+			onSelectedRef.current({ kind: "resolved", location: currentLocation, locationQuery: query });
+			logFrontendEvent({
+				event_name: "current_location_success",
+				error_level: "log",
+				payload: { hasLocation: !!currentLocation, screen },
+			});
+		} catch (error) {
+			const kind: LocationPermissionErrorKind = error instanceof LocationPermissionError ? error.kind : "unavailable";
+			logFrontendEvent({
+				event_name: "current_location_failed",
+				error_level: "error",
+				payload: { error: toErrorLogString(error), kind, screen },
+			});
+			showSnackbar(getCurrentLocationErrorMessage(kind));
+
+			// #932 【設計】権限拒否・未対応は再試行しても解決しないため、手入力へ誘導する
+			if (shouldFallbackToManualInput(kind)) {
+				inputRef.current?.focus();
+			}
+		}
+	}, [lightImpact, logFrontendEvent, getCurrentLocation, showSnackbar, screen]);
+
+	/**
+	 * 入力欄のクリア。
+	 * ⚠️ ここでは `onSelected` を呼ばない。`SelectedLocation` は「確定した地点」を表す型であり、
+	 * クリアは確定ではないため。呼び出し元が選択解除を知る必要が出たら、そのとき union を増やすこと。
+	 */
+	const handleClear = useCallback(() => {
+		lightImpact();
+		setLocationQuery("");
+		logFrontendEvent({
+			event_name: "location_cleared",
+			error_level: "log",
+			payload: { screen },
+		});
+	}, [lightImpact, logFrontendEvent, screen]);
+
+	return {
+		locationQuery,
+		setLocationQuery,
+		inputRef,
+		recentLocations,
+		clearRecentLocations,
+		handleSelectSuggestion,
+		handleSelectRecentLocation,
+		handleUseCurrentLocation,
+		handleClear,
+		registerRecentLocation,
+	};
+}


### PR DESCRIPTION
## 対象 Issue

Closes #1133

## 採用設計

[Issue #1133 の設計コメント](https://github.com/Ayato-kosaka/nanitabeyo/issues/1133#issuecomment-5152095421)で比較した 3 案のうち、**案 3（振る舞いを共通フックへ抽出し、今回は保存料理側だけが使う）**を採用しています。

案 1（コンポーネント抽出）を採らなかった理由は、ホームの地点選択がチュートリアル（`handleTutorialRequestLocation`）と `useAutoCurrentLocation` という**画面レベルの外部要求**に接続されており、コンポーネント化すると ref API か制御 props でそれを貫通させる必要があり、#642 / #1092 の導線を回帰範囲へ引き込むためです。フックなら戻り値を各画面が使うだけで済みます。

**この PR ではホームの挙動が 1 行も変わりません。**

## 変更（4 段階に分けて実装）

| Step | 内容 |
|---|---|
| 1 | `features/search/currentLocationErrorMessage.ts`（新規・純関数）+ テスト |
| 2 | `features/search/hooks/useLocationField.ts`（新規・共通フック）+ テスト |
| 3 | `features/profile/components/LocationSearchForm.tsx` をフックへ差し替え + テスト |
| 4 | `features/profile/tabs/SavedTopicsTab.tsx` を新しい選択結果の型へ対応 |

選択結果は判別可能な union（`kind: "prediction"` / `kind: "resolved"`）にし、`entriesKey` を `pid:` / `ll:` で作り分けています。現在地・最近使った場所は緯度経度が確定済みなので、**遷移前に追加の API 待ちが発生しません**。オートコンプリート経路の遅延取得は従来どおりです。

**翻訳キーの追加はありません**（設計時に 8 言語すべてで既存キーの実在を確認済み）。ログのイベント名も変えていません（payload へ `screen` / `source` を追加）。

## #1129 との関係

設計は MRU 更新を `useRecentLocations` フック内へ閉じることを推奨していましたが、#1129 は**画面側**で実装され先にマージされました。そのため本 PR では `useLocationField.handleSelectRecentLocation` にも同等の MRU 更新を入れ、「ホームでは先頭に来るが保存料理では来ない」不整合が起きないようにしています。PR #1150 のレビューが Major として挙げた条件はこれで満たされます。

## 検証

- `pnpm --filter app-expo typecheck`
- `pnpm --filter app-expo test`

**ブラウザ・実機での目視確認はしていません。**

## 実機で確認が必要な未確認事項

設計時点で未確認として挙がっていた 2 点は、そのまま残っています。

- **iOS の位置情報許可ダイアログが `BlurModal`（Portal）の上に正しく出るか** — OS ダイアログなので理屈上は問題ないが、プロフィールタブから初回許可が発火する経路は今回が初
- **モーダル内で「最近使った場所」5 件 + キーボード表示時にレイアウトが収まるか** — `Card` が `overflow: hidden` で、最近使った場所パネルは Card の高さを伸ばすため、画面外へはみ出す可能性がある

## 残した既知の制約

同じ `entriesKey` で 2 回目に検索したときは `getIds()` が走らないため、「最近使った場所」への登録（および #1129 の先頭移動）が起きません。解消には遷移前に `getLocationDetails` を await する設計が要り、モーダル上にローディングとエラー処理を新設することになるため今回は採っていません。コードコメントにも明記しています。

## base

統合ブランチ `claude/parallel-dev-orchestration-7he5dw` 宛。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_