### PR TITLE
fix(test): DishCategorySearchForm のテストで LocationSearchForm の依存をモックする

### DIFF
--- a/app-expo/features/map/components/DishCategorySearchForm.test.tsx
+++ b/app-expo/features/map/components/DishCategorySearchForm.test.tsx
@@ -20,6 +20,36 @@ jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) =
 jest.mock("@/components/DishCategoryAutocomplete", () => ({ DishCategoryAutocomplete: () => null }));
 jest.mock("@/components/LocationAutocomplete", () => ({ LocationAutocomplete: () => null }));
 
+// ⚠️ ここで差し替えるのは見本（LocationSearchForm）が「依存するフック」だけ。
+// LocationSearchForm 本体は実物のまま描画すること。モックするとこの suite の主眼である
+// 「両フォームの Card オフセットの突き合わせ」が何も検証しなくなる。
+//
+// #1133 で LocationSearchForm が useLocationField 経由になり、
+// useLocationSearch → useAPICall → useLogger → logQueue → lib/supabase が芋づるで読み込まれ、
+// `createClient` が env 無しでモジュール評価時に throw する（suite ごと起動不能になる）。
+// 同じ回避を features/profile/components/LocationSearchForm.test.tsx が既に行っている。
+jest.mock("@/hooks/useLogger", () => ({ useLogger: () => ({ logFrontendEvent: jest.fn() }) }));
+jest.mock("@/hooks/useLocationSearch", () => ({
+	useLocationSearch: () => ({
+		getCurrentLocation: jest.fn(),
+		suggestions: [],
+		status: "idle",
+		searchLocations: jest.fn(),
+		clearSuggestions: jest.fn(),
+	}),
+}));
+// useSnackbar は Provider 外だと throw するので、描画できるよう最小の実装を与える
+jest.mock("@/contexts/SnackbarProvider", () => ({ useSnackbar: () => ({ showSnackbar: jest.fn() }) }));
+jest.mock("@/hooks/useHaptics", () => ({ useHaptics: () => ({ lightImpact: jest.fn() }) }));
+jest.mock("@/features/search/hooks/useRecentLocations", () => ({
+	useRecentLocations: () => ({
+		recentLocations: [],
+		isLoading: false,
+		addRecentLocation: jest.fn(),
+		clearRecentLocations: jest.fn(),
+	}),
+}));
+
 import { Card } from "@/components/Card";
 import { DishCategorySearchForm } from "./DishCategorySearchForm";
 import { LocationSearchForm } from "@/features/profile/components/LocationSearchForm";


### PR DESCRIPTION
## 背景

統合ブランチで `features/map/components/DishCategorySearchForm.test.tsx` が**スイート起動に失敗**していました。

```
● Test suite failed to run
  supabaseUrl is required.
    at Object.<anonymous> (lib/supabase.ts:50:37)
    at Object.require (lib/logQueue.ts:4:1)
    at Object.require (hooks/useLogger.ts:7:1)
    at Object.require (hooks/useAPICall.ts:3:1)
    at Object.require (hooks/useLocationSearch.ts:2:1)
    at Object.require (features/search/hooks/useLocationField.ts:7:1)
    at Object.require (features/profile/components/LocationSearchForm.tsx:7:1)
    at Object.require (features/map/components/DishCategorySearchForm.test.tsx:25:1)
```

## 原因

**#1130（PR #1155）と #1133（PR #1168）の組み合わせ固有の破綻**で、どちらも単体では緑でした。

1. #1130 が追加したこのテストは、レイアウト比較のため `LocationSearchForm` を import している
2. #1133 が `LocationSearchForm` を `useLocationField` 経由へ変えたため、`useLocationSearch → useAPICall → useLogger → logQueue → lib/supabase` が芋づるで読み込まれ、**モジュール読み込み時点で** `createClient` が env 無しで例外を投げる

各 PR の独立レビューでは原理的に検出できない型で、マージ結果そのものを検証して初めて出ました。

## 変更

`DishCategorySearchForm.test.tsx` にモックを追加（テストファイルのみ、+30 行）。

**`LocationSearchForm` 本体はモックしていません。** モックすると「両フォームが同じ Card オフセットを持つ」という #1130 の回帰ガードが死ぬためで、モックしたのは `LocationSearchForm` が依存するフック・モジュール側だけです。

実装コード（`.tsx` 本体）は変更していません。これはテスト側のモック不足です。

## 検証

- `pnpm --filter app-expo typecheck` → exit 0
- `pnpm --filter app-expo test` → **32 suites / 234 tests 全 pass**（修正前は 1 suite が起動失敗）

**モックで検証が空洞化していないことも確認済み**です。`DishCategorySearchForm` 側の Card オフセットだけを変えると「Card が与えるオフセットが見本と一致する」が赤くなることを実測しました（確認後に復元、作業ツリー clean）。

## base

統合ブランチ `claude/parallel-dev-orchestration-7he5dw` 宛。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_