### PR TITLE
#1156 fix: release ビルドの lint が metaspace 不足で OOM になるのを防ぐ

### DIFF
--- a/app-expo/app.config.ts
+++ b/app-expo/app.config.ts
@@ -199,6 +199,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 		// #1156 【設計】use_frameworks! 環境で React Native Core の非モジュラーヘッダ include が
 		// -Werror になるのを抑止する（react-native-maps が SDK 54 で踏んだ）。詳細はプラグイン内のコメント参照。
 		"./plugins/withNonModularHeaders",
+		// #1156 【設計】release ビルドの lint が metaspace 不足で OOM になるのを防ぐ。
+		// EAS の development は debug ビルドなので踏まないが、Detox E2E と preview/production は踏む。
+		"./plugins/withAndroidGradleMemory",
 		[
 			"expo-build-properties",
 			{

--- a/app-expo/plugins/withAndroidGradleMemory.js
+++ b/app-expo/plugins/withAndroidGradleMemory.js
@@ -1,0 +1,47 @@
+const { withGradleProperties } = require("expo/config-plugins");
+
+const KEY = "org.gradle.jvmargs";
+const VALUE = "-Xmx4096m -XX:MaxMetaspaceSize=2048m -Dfile.encoding=UTF-8";
+
+/**
+ * #1156 【設計】Gradle JVM の metaspace を広げ、release ビルドの lint が OOM で落ちるのを防ぐ。
+ *
+ * 背景:
+ *   Expo のテンプレートが生成する `android/gradle.properties` は
+ *   `org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m` を既定にしている。
+ *
+ *   Expo SDK 54 (React Native 0.81 / AGP 8.11) では autolink されるモジュール数と
+ *   各モジュールのクラス数が増え、AGP が release ビルドで走らせる `lintVitalAnalyzeRelease`
+ *   が 512m の metaspace を使い切って落ちるようになった。
+ *
+ *     Execution failed for task ':expo-modules-core:lintVitalAnalyzeRelease'.
+ *     > Unexpected failure during lint analysis
+ *         Message: Metaspace
+ *         Stack: `OutOfMemoryError: ...`
+ *
+ *   lint は「クラスをロードして解析する」ため、ヒープ(-Xmx)ではなく metaspace を食う。
+ *   ヒープだけ増やしても直らない。
+ *
+ * 影響範囲（重要）:
+ *   落ちるのは **release ビルドだけ**。EAS の `development` プロファイルは debug ビルドで
+ *   `lintVitalRelease` を通らないため、EAS Build Develop は成功していた。
+ *   一方、Detox E2E（`assembleRelease`）と EAS の `preview` / `production` プロファイルは
+ *   release ビルドなので、この対処が無いと同じ OOM を踏みうる。
+ *
+ * 他案を採らなかった理由:
+ *   `android { lint { checkReleaseBuilds false } }` で lint 自体を止める手もあるが、
+ *   release ビルド前の lint はマニフェスト不整合など出荷事故を防ぐ実質的な価値があるため
+ *   無効化しない。必要なメモリを与えるだけにする。
+ */
+const withAndroidGradleMemory = (config) =>
+	withGradleProperties(config, (cfg) => {
+		cfg.modResults = cfg.modResults.filter((item) => !(item.type === "property" && item.key === KEY));
+		cfg.modResults.push({
+			type: "comment",
+			value: `#1156 SDK 54 では lintVitalAnalyzeRelease が既定の MaxMetaspaceSize=512m を使い切って OOM になる`,
+		});
+		cfg.modResults.push({ type: "property", key: KEY, value: VALUE });
+		return cfg;
+	});
+
+module.exports = withAndroidGradleMemory;


### PR DESCRIPTION
対象 Issue: #1156 （#1164 の後続）

base は統合ブランチ `claude/eas-build-develop-xb2agu`。

## 発見の経緯

Expo SDK 54 化後の挙動差分を見るため、統合ブランチに対して E2E Detox（[run 30732848531](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/30732848531)）を回したところ、**Android の `detox build` が Gradle で失敗**した。テスト実行以前の問題であり、スクリーンショットが 1 枚も得られなかった。

```
Execution failed for task ':react-native-async-storage_async-storage:lintVitalAnalyzeRelease'.
Execution failed for task ':expo-modules-core:lintVitalAnalyzeRelease'.
> A failure occurred while executing com.android.build.gradle.internal.lint.AndroidLintWorkAction
   > Unexpected failure during lint analysis (this is a bug in lint or one of the libraries it depends on)
       Message: Metaspace
       Stack: `OutOfMemoryError:ClassLoader.defineClass1(...)`
```

## 原因

Expo のテンプレートが生成する `android/gradle.properties` の既定値は次のとおり。

```properties
# Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
```

Expo SDK 54（React Native 0.81 / AGP 8.11）では autolink されるモジュール数と各モジュールのクラス数が増え、AGP が release ビルドで走らせる `lintVitalAnalyzeRelease` が 512m の metaspace を使い切るようになった。

lint は「クラスをロードして解析する」処理なので、消費するのはヒープ（`-Xmx`）ではなく **metaspace** である。ヒープだけ増やしても直らない。

## ⚠️ 影響範囲 — Production 公開前に必要な修正

落ちるのは **release ビルドだけ**である。

| ビルド | configuration | `lintVitalRelease` | 状況 |
|---|---|---|---|
| EAS `development`（#1164 で検証済み） | debug | 走らない | ✅ 成功していた |
| Detox E2E（`assembleRelease`） | release | 走る | ❌ 本 Issue で失敗 |
| EAS `preview` / `production` | release | 走る | ⚠️ 同じ OOM を踏みうる |

EAS Build Develop が通っていたのは debug ビルドだったからであり、**`production` プロファイルでは同じ経路を通る**。#1156 の目的（Google Play への Production 公開）には本修正が要る。

## 対処

`app-expo/plugins/withAndroidGradleMemory.js` を追加し、`withGradleProperties` で `org.gradle.jvmargs` を `-Xmx4096m -XX:MaxMetaspaceSize=2048m -Dfile.encoding=UTF-8` へ引き上げる。

prebuild 後の `android/gradle.properties` に反映されることをローカルで確認済み。

```properties
# #1156 SDK 54 では lintVitalAnalyzeRelease が既定の MaxMetaspaceSize=512m を使い切って OOM になる
org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=2048m -Dfile.encoding=UTF-8
```

`android { lint { checkReleaseBuilds false } }` で lint 自体を止める案は採らなかった。release ビルド前の lint はマニフェスト不整合など出荷事故を防ぐ実質的な価値があるため、無効化せず必要なメモリを与えるだけにする。

## 検証

- ローカル: `expo prebuild --clean -p android` で `gradle.properties` への反映を確認
- `app-expo-check`（debug ビルド）はこの経路を通らないため、本修正の検証にはならない
- **実際の検証は E2E Detox（Android / `assembleRelease`）の再実行で行う**。マージ後に回す


---
_Generated by [Claude Code](https://claude.ai/code/session_01DHkFwY329RHjkc6J7ypiai)_