### PR TITLE
#1123 fix: 実 API の types に合わせて同名駅の畳み込み条件を修正する

### DIFF
--- a/api/src/v1/locations/locations.service.spec.ts
+++ b/api/src/v1/locations/locations.service.spec.ts
@@ -941,6 +941,86 @@ describe('LocationsService', () => {
       ]);
     });
 
+    it('should not treat a bus terminal as the evidence that a rail station exists', async () => {
+      // #1123 【テスト】ルール3-b(i) の「NEVER_COLLAPSE_TRANSIT_TYPES を持つ候補は
+      // 畳み込みの"根拠"としても数えない」を固定する。
+      //
+      // ここで並ぶ鉄道駅固有 type(train_station)は、バス停 type を併記した
+      // バスターミナル候補だけが持っている。根拠から除外しなければ、この1件を根拠に
+      // 同名の transit_station 候補が畳まれてしまう。
+      // (PR #1175 の独立レビュー M2: この除外を実装から削っても全テストが緑だった)
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion(
+            'place-bus-terminal',
+            '渋谷駅',
+            '日本、東京都渋谷区(バスターミナル)',
+            [
+              'train_station',
+              'bus_station',
+              'transit_station',
+              'point_of_interest',
+              'establishment',
+            ],
+          ),
+          buildSuggestion('place-transit-only-a', '渋谷駅', '日本、東京都渋谷区', [
+            'transit_station',
+            'point_of_interest',
+            'establishment',
+          ]),
+          buildSuggestion(
+            'place-transit-only-b',
+            '渋谷駅',
+            '日本、東京都渋谷区道玄坂',
+            ['transit_station', 'point_of_interest', 'establishment'],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      // 鉄道駅固有 type はバスターミナルしか持たないため根拠が成立せず、3件とも残る。
+      // 根拠から除外しないと、transit_station だけの2件が畳まれて2件に減る。
+      expect(result.map((place) => place.place_id)).toEqual([
+        'place-bus-terminal',
+        'place-transit-only-a',
+        'place-transit-only-b',
+      ]);
+    });
+
+    it('should keep a same-name candidate that has no transit type even when a rail station exists', async () => {
+      // #1123 【テスト】ルール3-b(ii) の「候補自身が COLLAPSIBLE_TRANSIT_TYPES を
+      // 持たなければ畳まない」を固定する。
+      //
+      // 受入条件5(八景島駅前 バス停)のケースは同名の鉄道駅が居ないため (i) の段階で
+      // 弾かれ、(ii) は一度も判定を左右していなかった。ここでは鉄道駅を同居させて
+      // (ii) だけが効く経路を通す。
+      // (PR #1175 の独立レビュー M3: (ii) を実装から削っても全テストが緑だった)
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion('place-rail-station', '八景島', '日本、神奈川県横浜市', [
+            'train_station',
+            'transit_station',
+            'point_of_interest',
+            'establishment',
+          ]),
+          buildSuggestion(
+            'place-no-transit-type',
+            '八景島',
+            '日本、神奈川県横浜市金沢区海の公園',
+            ['establishment', 'point_of_interest'],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result.map((place) => place.place_id)).toEqual([
+        'place-rail-station',
+        'place-no-transit-type',
+      ]);
+    });
+
     it('should keep same-name tram stops on opposite sides of the street', async () => {
       // #1123 【テスト】PR #1149 レビュー指摘(Minor): 路面電車の停留場は運用上バス停に
       // 近く、上り/下りが同名で道路を挟んだ別地点として登録される地域がある。

--- a/api/src/v1/locations/locations.service.spec.ts
+++ b/api/src/v1/locations/locations.service.spec.ts
@@ -580,9 +580,11 @@ describe('LocationsService', () => {
 
     it('should keep only the top-ranked candidate for same-name station establishments', async () => {
       // #1123 【受入条件1】【テスト】渋谷駅が2件の establishment(どちらも駅・交通施設)
-      // として返るケース。実データの place_id / types を fixture に使用。
-      // 双方 establishment のため #952 のルールでは畳めなかったが、鉄道駅 type を持つ
-      // 同名候補なので Google の関連度順で先頭の1件だけが残ること。
+      // として返るケース。types は development 実環境の Autocomplete レスポンス実測値
+      // (Issue #1123 の検証コメント)をそのまま使用する。
+      // 重要: 関連度順で先頭の候補は train_station / subway_station を持たず、
+      // 交通系 type は汎用の transit_station だけである。fixture をここから外すと
+      // 実装が壊れていてもテストが緑になる(PR #1149 で実際に起きた事故)。
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
           buildSuggestion(
@@ -590,11 +592,10 @@ describe('LocationsService', () => {
             '渋谷駅',
             '日本、東京都渋谷区',
             [
-              'train_station',
-              'subway_station',
-              'transit_station',
               'point_of_interest',
+              'transportation_service',
               'establishment',
+              'transit_station',
             ],
           ),
           buildSuggestion(
@@ -602,11 +603,12 @@ describe('LocationsService', () => {
             '渋谷駅',
             '日本、東京都渋谷区渋谷２丁目２４',
             [
-              'train_station',
-              'subway_station',
-              'transit_station',
+              'transportation_service',
               'point_of_interest',
+              'train_station',
+              'transit_station',
               'establishment',
+              'subway_station',
             ],
           ),
         ],

--- a/api/src/v1/locations/locations.service.spec.ts
+++ b/api/src/v1/locations/locations.service.spec.ts
@@ -621,31 +621,71 @@ describe('LocationsService', () => {
       expect(result[0].place_id).toBe('ChIJz8MVLFiLGGARXP0DqqhoDow');
     });
 
-    it('should keep the top-ranked station and preserve relevance order of other candidates', async () => {
-      // #1123 【受入条件1,3】【テスト】重複した駅候補を畳んでも、他候補の
-      // 関連度順(元の配列順)が維持されること。「渋谷駅前」は別名なので残る。
+    it('should reproduce the real development response for 渋谷駅', async () => {
+      // #1123 【受入条件1,3】【テスト】development 実環境の Autocomplete レスポンス
+      // 5件をそのまま fixture にしたケース(Issue #1123 の検証コメントの実測値)。
+      // - 同名の駅候補2件は先頭の1件だけが残る(受入条件1)
+      // - 「渋谷駅前」(premise, geocode)は別キーなので残る(受入条件3)。
+      //   同名の establishment が無いためルール2でも落ちない
+      // - 「渋谷駅 みどりの窓口」は正規化後も別キーなので残る
+      // - 返却順は Google の関連度順を維持する
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
           buildSuggestion(
             'ChIJz8MVLFiLGGARXP0DqqhoDow',
             '渋谷駅',
             '日本、東京都渋谷区',
-            ['train_station', 'transit_station', 'establishment'],
+            [
+              'point_of_interest',
+              'transportation_service',
+              'establishment',
+              'transit_station',
+            ],
           ),
-          buildSuggestion('place-square', '渋谷駅前', '日本、東京都渋谷区', [
-            'bus_station',
-            'transit_station',
-            'establishment',
-          ]),
           buildSuggestion(
             'ChIJnxAAO1aLGGARJqvi8d4oczM',
             '渋谷駅',
             '日本、東京都渋谷区渋谷２丁目２４',
             [
+              'transportation_service',
+              'point_of_interest',
               'train_station',
-              'subway_station',
               'transit_station',
               'establishment',
+              'subway_station',
+            ],
+          ),
+          buildSuggestion(
+            'ChIJN8-zcVeLGGARk4cjUnp9z-I',
+            '渋谷駅前おおしま皮膚科',
+            '日本、東京都渋谷区桜丘町２５−１８',
+            [
+              'point_of_interest',
+              'health',
+              'hair_care',
+              'establishment',
+              'doctor',
+              'service',
+              'beauty_salon',
+              'hospital',
+              'medical_clinic',
+            ],
+          ),
+          buildSuggestion(
+            'ChIJ97I--VeLGGARy5_VNv4n3iw',
+            '渋谷駅前',
+            '日本、東京都渋谷区',
+            ['premise', 'geocode'],
+          ),
+          buildSuggestion(
+            'ChIJ4cnQLFiLGGARSKxwdYkpEkI',
+            '渋谷駅 みどりの窓口',
+            '日本、東京都渋谷区道玄坂１丁目１',
+            [
+              'establishment',
+              'train_ticket_office',
+              'transportation_service',
+              'point_of_interest',
             ],
           ),
         ],
@@ -655,33 +695,123 @@ describe('LocationsService', () => {
 
       expect(result.map((place) => place.place_id)).toEqual([
         'ChIJz8MVLFiLGGARXP0DqqhoDow',
-        'place-square',
+        'ChIJN8-zcVeLGGARk4cjUnp9z-I',
+        'ChIJ97I--VeLGGARy5_VNv4n3iw',
+        'ChIJ4cnQLFiLGGARSKxwdYkpEkI',
       ]);
     });
 
+    it.each([
+      {
+        query: '新宿駅',
+        first: {
+          placeId: 'ChIJu9ljKNeMGGARcFUr-NmJhAk',
+          types: [
+            'transit_station',
+            'transportation_service',
+            'point_of_interest',
+            'establishment',
+          ],
+        },
+        second: {
+          placeId: 'ChIJH7qx1tCMGGAR1f2s7PGhMhw',
+          types: [
+            'train_station',
+            'subway_station',
+            'transit_station',
+            'transportation_service',
+            'point_of_interest',
+            'establishment',
+          ],
+        },
+      },
+      {
+        query: '東京駅',
+        first: {
+          placeId: 'ChIJu2cU7vuLGGART-M-fm6LD0E',
+          types: [
+            'transit_station',
+            'transportation_service',
+            'point_of_interest',
+            'establishment',
+          ],
+        },
+        second: {
+          placeId: 'ChIJC3Cf2PuLGGAROO00ukl8JwA',
+          types: [
+            'train_station',
+            'subway_station',
+            'transit_station',
+            'transportation_service',
+            'point_of_interest',
+            'establishment',
+          ],
+        },
+      },
+    ])(
+      'should keep only the top-ranked candidate for $query (same structure as 渋谷駅)',
+      async ({ query, first, second }) => {
+        // #1123 【受入条件1】【テスト】渋谷駅固有の問題ではないことの回帰テスト。
+        // 実環境検証(Issue #1123 の検証コメント)で、新宿駅・東京駅も
+        // 「関連度順の先頭は transit_station のみ / 2件目が train_station を持つ」
+        // という同一構造だと実測されている。
+        mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+          suggestions: [
+            buildSuggestion(first.placeId, query, '日本、東京都', first.types),
+            buildSuggestion(
+              second.placeId,
+              query,
+              '日本、東京都(番地レベル)',
+              second.types,
+            ),
+          ],
+        } as never);
+
+        const result = await service.autocompleteLocations({
+          ...mockQuery,
+          q: query,
+        });
+
+        expect(result.map((place) => place.place_id)).toEqual([first.placeId]);
+      },
+    );
+
     it('should still keep same-name chain branches after the station rule was added', async () => {
       // #1123 【受入条件2】【テスト】「スターバックス」のような同名だが別の実店舗は
-      // 鉄道駅 type を持たないため新ルールの対象外で、引き続き複数返ること
+      // 交通施設 type を持たないため新ルールの対象外で、引き続き複数返ること
       // (#952 の意図を壊していないことの回帰テスト)。
+      // types は実環境検証の「スターバックス」レスポンス実測値。実環境では 5 件の
+      // mainText が全て異なり同名衝突が起きなかったため、mainText / secondaryText を
+      // 揃えて同名衝突を意図的に作っている(実測値どおりだとルール3を通過しない)。
+      const realStarbucksTypes = [
+        'store',
+        'food_store',
+        'point_of_interest',
+        'bar',
+        'coffee_shop',
+        'establishment',
+        'food',
+        'cafe',
+      ];
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
           buildSuggestion(
-            'place-sbux-shibuya',
+            'ChIJq_fYt4iLGGARrOojmQ4IMyE',
             'スターバックスコーヒー',
-            '日本、東京都渋谷区道玄坂',
-            ['cafe', 'food', 'point_of_interest', 'establishment'],
+            '日本、東京都目黒区青葉台２丁目１９−２３',
+            realStarbucksTypes,
           ),
           buildSuggestion(
             'place-sbux-udagawa',
             'スターバックスコーヒー',
             '日本、東京都渋谷区宇田川町',
-            ['cafe', 'food', 'point_of_interest', 'establishment'],
+            realStarbucksTypes,
           ),
           buildSuggestion(
             'place-sbux-ebisu',
             'スターバックスコーヒー',
             '日本、東京都渋谷区恵比寿',
-            ['cafe', 'food', 'point_of_interest', 'establishment'],
+            realStarbucksTypes,
           ),
         ],
       } as never);
@@ -689,7 +819,7 @@ describe('LocationsService', () => {
       const result = await service.autocompleteLocations(mockQuery);
 
       expect(result.map((place) => place.place_id)).toEqual([
-        'place-sbux-shibuya',
+        'ChIJq_fYt4iLGGARrOojmQ4IMyE',
         'place-sbux-udagawa',
         'place-sbux-ebisu',
       ]);
@@ -701,6 +831,8 @@ describe('LocationsService', () => {
       // (例: ["bus_station", "transit_station", "point_of_interest", "establishment"])。
       // 同名でも進行方向・のりば違いで別地点として正当に併存するため、
       // 両方が残らなければならない。
+      // 二重の保護がかかる: (i) 同名に鉄道駅固有 type を持つ候補が無いので
+      // ルール3-b の根拠が成立しない、(ii) NEVER_COLLAPSE_TRANSIT_TYPES に該当する。
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
           buildSuggestion(
@@ -731,10 +863,89 @@ describe('LocationsService', () => {
       ]);
     });
 
+    it('should keep same-name bus stops even when a real rail station shares the name', async () => {
+      // #1123 【受入条件4】【テスト】鉄道駅と同名のバス停が並ぶケース。
+      // 駅候補があるためルール3-b の根拠は成立するが、バス停は
+      // NEVER_COLLAPSE_TRANSIT_TYPES による deny-list で常に残る。
+      // (transit_station を畳み込み対象へ戻してもバス停保護が壊れないことの回帰テスト)
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion(
+            'ChIJnxAAO1aLGGARJqvi8d4oczM',
+            '渋谷駅',
+            '日本、東京都渋谷区渋谷２丁目２４',
+            [
+              'train_station',
+              'subway_station',
+              'transit_station',
+              'point_of_interest',
+              'establishment',
+            ],
+          ),
+          buildSuggestion('place-bus-hachiko', '渋谷駅', '日本、東京都渋谷区', [
+            'bus_station',
+            'transit_station',
+            'point_of_interest',
+            'establishment',
+          ]),
+          buildSuggestion(
+            'place-bus-dogenzaka',
+            '渋谷駅',
+            '日本、東京都渋谷区道玄坂',
+            [
+              'bus_stop',
+              'transit_station',
+              'point_of_interest',
+              'establishment',
+            ],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result.map((place) => place.place_id)).toEqual([
+        'ChIJnxAAO1aLGGARJqvi8d4oczM',
+        'place-bus-hachiko',
+        'place-bus-dogenzaka',
+      ]);
+    });
+
+    it('should keep same-name candidates whose types are only establishment and point_of_interest', async () => {
+      // #1123 【受入条件5】【テスト】実環境検証で見つかった「types が
+      // establishment / point_of_interest だけのバス停」(例: 八景島駅前 バス停)。
+      // deny-list(bus_station 等)では守れないが、交通施設 type を持たないため
+      // ルール3-b の対象外となり両方残る。mainText は同じ(secondaryText だけ違う)。
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion(
+            'ChIJw3k2HQBBGGARN0m20RcqInE',
+            '八景島駅前 バス停',
+            '日本、神奈川県横浜市金沢区海の公園１０',
+            ['establishment', 'point_of_interest'],
+          ),
+          buildSuggestion(
+            'place-bus-stop-opposite',
+            '八景島駅前 バス停',
+            '日本、神奈川県横浜市金沢区海の公園４０',
+            ['establishment', 'point_of_interest'],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result.map((place) => place.place_id)).toEqual([
+        'ChIJw3k2HQBBGGARN0m20RcqInE',
+        'place-bus-stop-opposite',
+      ]);
+    });
+
     it('should keep same-name tram stops on opposite sides of the street', async () => {
       // #1123 【テスト】PR #1149 レビュー指摘(Minor): 路面電車の停留場は運用上バス停に
       // 近く、上り/下りが同名で道路を挟んだ別地点として登録される地域がある。
-      // light_rail_station も畳み対象にしないことを守る。
+      // light_rail_station は畳み込みの根拠(RAIL_STATION_TYPES)に含めないため、
+      // 停留場同士だけが並ぶこのケースは transit_station を併せ持っていても畳まれない。
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
           buildSuggestion('place-tram-1', '広電西広島', '日本、広島県広島市', [

--- a/api/src/v1/locations/locations.service.ts
+++ b/api/src/v1/locations/locations.service.ts
@@ -566,28 +566,25 @@ export class LocationsService {
   }
 
   /**
-   * #1123 【設計】「同名なら同一の駅」とみなしてよい鉄道系 type の集合。
+   * #1123 【設計】「この mainText には鉄道駅が実在する」と断定してよい、鉄道駅固有の
+   * type の集合(= 畳み込みの"根拠"となる type)。
    *
    * 含めた理由:
    * - train_station / subway_station:
-   *   Issue #1123 の渋谷駅重複が該当。Google は同じ駅を「駅施設」と「出入口/番地相当」の
-   *   別 place_id で返すことがあり、どちらも establishment を持つため #952 のルールでは
-   *   畳めない。鉄道駅は同一エリア内に同名の別駅が存在しないため、同名なら同一駅と
-   *   みなして安全に畳める。
+   *   鉄道駅にのみ付く type。鉄道駅は同一エリア内に同名の別駅が存在しないため、
+   *   同名なら同一駅とみなして安全に畳める。
    *
    * 含めなかった理由(安全側 = 同名の別地点を消さない側に倒す):
    * - transit_station:
-   *   PR #1149 レビュー指摘。これは鉄道駅に固有の type ではなく交通施設全般に付く
-   *   汎用 type で、実データではバス停も
+   *   交通施設全般に付く汎用 type で、実データではバス停も
    *   ["bus_station", "transit_station", "point_of_interest", "establishment"]
-   *   のように併せ持つ。含めると同名の別バス停(進行方向・のりば違い)が畳まれてしまい、
-   *   下記「bus_station を含めない」という保護が実質無効になる。
-   *   #1123 の渋谷駅 2 候補はどちらも train_station / subway_station を持つため、
-   *   transit_station を外しても Issue は解決する。
+   *   のように併せ持つ(PR #1149 レビュー指摘)。これ単独では駅と断定できないため
+   *   「根拠」には使わない。ただし後述のとおり「畳む対象」には含める
+   *   (COLLAPSIBLE_TRANSIT_TYPES 参照)。
    * - light_rail_station:
-   *   PR #1149 レビュー指摘。#1123 に実例が無く、路面電車の停留場は運用上バス停に近い
-   *   命名(上り/下りが同名で道路を挟んだ別地点)になる地域があるため、実例が出るまでは
-   *   畳まない側に倒す。
+   *   PR #1149 レビュー指摘。路面電車の停留場は運用上バス停に近い命名
+   *   (上り/下りが同名で道路を挟んだ別地点)になる地域があるため根拠にしない。
+   *   同名の停留場同士だけが並ぶケースでは鉄道駅固有 type が現れないので畳まれない。
    * - bus_station / bus_stop / transit_depot:
    *   「渋谷駅前」のように、同名でも進行方向・のりば・事業者ごとに別地点として
    *   存在するのが正常。畳むとユーザーが選びたいのりばを選べなくなる。
@@ -602,13 +599,35 @@ export class LocationsService {
   ]);
 
   /**
+   * #1123 【設計】「同名の鉄道駅が実在する」と分かっているときに、その駅の粒度違い
+   * 重複として畳んでよい交通施設 type の集合。
+   *
+   * development 実環境の実測(Issue #1123 の検証コメント)では、渋谷駅の関連度順
+   * 先頭候補(ChIJz8MVLFiLGGARXP0DqqhoDow)の types は
+   * ["point_of_interest", "transportation_service", "establishment", "transit_station"]
+   * で、鉄道駅固有 type を持たず交通系は汎用の transit_station だけだった
+   * (新宿駅・東京駅も同じ構造)。つまり「駅施設側」の候補は transit_station しか
+   * 持たないことがあるため、transit_station も畳み込み対象に含める必要がある。
+   *
+   * PR #1149 で懸念された「同名の別バス停が畳まれる」問題は、transit_station を
+   * ここに入れるだけでは起きない。畳み込みには別途
+   * 「同名に RAIL_STATION_TYPES を持つ候補が存在する」ことを要求するため、
+   * バス停同士(鉄道駅固有 type がどこにも現れない)は根拠が無く畳まれない。
+   * これは NEVER_COLLAPSE_TRANSIT_TYPES による type ベースの保護より堅い:
+   * 実環境には bus_station を持たない(types が establishment / point_of_interest
+   * だけの)バス停が存在し、deny-list だけでは守れないため。
+   */
+  private static readonly COLLAPSIBLE_TRANSIT_TYPES: ReadonlySet<string> =
+    new Set([...LocationsService.RAIL_STATION_TYPES, 'transit_station']);
+
+  /**
    * #1123 【設計】同名でも別地点として正当に併存する交通施設の type 集合。
    *
-   * PR #1149 レビュー指摘を受けた多重防御。RAIL_STATION_TYPES から汎用の
-   * transit_station を外しただけでは、将来 type を追加した際に再び同じ穴が開く。
-   * これらの type を1つでも持つ候補は、たとえ鉄道駅 type を併せ持っていても
-   * (例: 駅前ロータリーのバスターミナルが train_station を併記するケース)
-   * 同名畳み込みの対象外とし、常に残す。
+   * PR #1149 レビュー指摘を受けた多重防御。これらの type を1つでも持つ候補は、
+   * たとえ鉄道駅 type を併せ持っていても(例: 駅前ロータリーのバスターミナルが
+   * train_station を併記するケース)同名畳み込みの対象外とし、常に残す。
+   * 畳み込みの"根拠"としても数えない(バスターミナル1件を根拠に同名の駅候補を
+   * 畳んでしまわないため)。
    */
   private static readonly NEVER_COLLAPSE_TRANSIT_TYPES: ReadonlySet<string> =
     new Set(['bus_station', 'bus_stop', 'transit_depot']);
@@ -624,11 +643,18 @@ export class LocationsService {
    *    同一地点の粒度違い重複に相当する。
    * 3. 同名でも establishment 同士(例: 同名チェーンの別店舗。place_id・secondaryText が
    *    異なる別の実在地点)は全て残す。表示名だけで別地点を消してはならない。
-   * 3-b. #1123 例外: 同名かつ鉄道駅 type(RAIL_STATION_TYPES)を持つ候補は、
-   *    establishment 同士であっても同一駅の重複表示とみなし、Google の関連度順で
-   *    先頭の1件だけを残す。適用範囲を鉄道駅に限定するため、(i) 交通施設全般に付く
-   *    汎用 type(transit_station)を RAIL_STATION_TYPES に含めず、(ii) バス停など
-   *    NEVER_COLLAPSE_TRANSIT_TYPES を持つ候補は明示的に除外する(PR #1149 指摘)。
+   * 3-b. #1123 例外: 「同名の鉄道駅の粒度違い重複」は establishment 同士であっても
+   *    Google の関連度順で先頭の1件だけを残す。誤爆を防ぐため次の3条件を全て満たす
+   *    候補だけを対象にする:
+   *    (i)  同名(正規化後の mainText が一致)の候補の中に、鉄道駅固有 type
+   *         (RAIL_STATION_TYPES)を持つものが1件以上ある = 鉄道駅が実在する根拠
+   *    (ii) その候補自身が交通施設 type(COLLAPSIBLE_TRANSIT_TYPES)を持つ
+   *         = 駅施設側の粒度違い候補。実データでは transit_station しか持たない
+   *           ことがあるため汎用 type も含める(#1123 検証コメント)
+   *    (iii) バス停など NEVER_COLLAPSE_TRANSIT_TYPES を持たない(PR #1149 指摘)
+   *    (i) により、同名のバス停同士・停留場同士(鉄道駅固有 type がどこにも無い)は
+   *    そもそも対象にならない。交通系 type を持たない同名候補(チェーン店舗や、
+   *    types が establishment / point_of_interest だけのバス停)は (ii) で対象外。
    * 4. 完全重複(mainText と secondaryText の両方が一致)だけは同名同士でも1件に畳む。
    * 5. 返却順は Google の関連度順(元の配列順)を維持する。並び替えは行わない。
    */
@@ -641,16 +667,37 @@ export class LocationsService {
     const isEstablishment = (place: { types: string[] }): boolean =>
       place.types.includes('establishment');
 
-    // #1123 鉄道駅候補かどうか(判定 type は RAIL_STATION_TYPES 参照)。
-    // PR #1149: 同名でも別地点が正当に併存するバス停系 type を持つ候補は、
+    const hasAnyType = (
+      place: { types: string[] },
+      typeSet: ReadonlySet<string>,
+    ): boolean => place.types.some((type) => typeSet.has(type));
+
+    // #1123 PR #1149: 同名でも別地点が正当に併存するバス停系 type を持つ候補は、
     // 鉄道駅 type を併せ持っていても畳み込み対象にしない(安全側に倒す)。
-    const isRailStation = (place: { types: string[] }): boolean =>
-      place.types.some((type) =>
-        LocationsService.RAIL_STATION_TYPES.has(type),
-      ) &&
-      !place.types.some((type) =>
-        LocationsService.NEVER_COLLAPSE_TRANSIT_TYPES.has(type),
-      );
+    const isNeverCollapse = (place: { types: string[] }): boolean =>
+      hasAnyType(place, LocationsService.NEVER_COLLAPSE_TRANSIT_TYPES);
+
+    // #1123 ルール3-b(i): 鉄道駅固有 type を持つ候補が存在する mainText キーの集合。
+    // 「同名の鉄道駅が実在する」根拠。これが無い同名グループ(バス停同士など)は
+    // 畳み込みを一切行わない。
+    const railStationNameKeys = new Set(
+      places
+        .filter(
+          (place) =>
+            hasAnyType(place, LocationsService.RAIL_STATION_TYPES) &&
+            !isNeverCollapse(place),
+        )
+        .map((place) => normalizeKey(place.mainText)),
+    );
+
+    // #1123 ルール3-b: 同名の鉄道駅の粒度違い重複として畳んでよい候補かどうか
+    const isCollapsibleStation = (
+      place: { types: string[] },
+      nameKey: string,
+    ): boolean =>
+      railStationNameKeys.has(nameKey) &&
+      hasAnyType(place, LocationsService.COLLAPSIBLE_TRANSIT_TYPES) &&
+      !isNeverCollapse(place);
 
     // 同名の establishment が1件でも存在する mainText キーの集合
     const establishmentNameKeys = new Set(
@@ -681,7 +728,7 @@ export class LocationsService {
 
       // ルール3-b(#1123): 同名の鉄道駅候補は先頭(= Google の関連度順で最上位)のみ残す。
       // 走査順が元の配列順のため、採用済みキーを持つ後続の駅候補だけが落ちる。
-      if (isRailStation(place)) {
+      if (isCollapsibleStation(place, nameKey)) {
         if (keptRailStationNameKeys.has(nameKey)) {
           return false;
         }

--- a/api/src/v1/locations/locations.service.ts
+++ b/api/src/v1/locations/locations.service.ts
@@ -616,6 +616,13 @@ export class LocationsService {
    * これは NEVER_COLLAPSE_TRANSIT_TYPES による type ベースの保護より堅い:
    * 実環境には bus_station を持たない(types が establishment / point_of_interest
    * だけの)バス停が存在し、deny-list だけでは守れないため。
+   *
+   * 【受容済みリスク】(PR #1175 の独立レビュー 指摘3)
+   * 鉄道駅と同名で、かつ bus 系 type が欠落して transit_station だけを持つバス停は
+   * 畳まれる。上記のとおり Google の type 付与は欠落し得るため、deny-list による
+   * 保護は bus 系 type が付いている場合に限られる。
+   * この型シルエットは #1123 で畳みたい「駅施設側」候補と type だけでは区別できず、
+   * 畳まなければ #1123 が直らないため、畳む側を選んでいる。
    */
   private static readonly COLLAPSIBLE_TRANSIT_TYPES: ReadonlySet<string> =
     new Set([...LocationsService.RAIL_STATION_TYPES, 'transit_station']);


### PR DESCRIPTION
## 背景: development 実環境の検証で #1123 が直っていなかった

統合ブランチの #1123 実装（PR #1149 + そのレビュー修正）を development へデプロイして検証したところ、
**`渋谷駅` が依然として 2 件返り、Issue の受入条件を満たしていませんでした。**

原因は、ユニットテストの fixture が実 API と食い違っていたことです。

| | 関連度順の先頭候補 `ChIJz8MVLFiLGGARXP0DqqhoDow` の types |
| --- | --- |
| fixture（これまで） | `train_station`, `subway_station`, `transit_station`, `point_of_interest`, `establishment` |
| **実 API（実測）** | `point_of_interest`, `transportation_service`, `establishment`, **`transit_station`** |

**実データでは「駅施設側」の候補が鉄道駅固有 type を持たず、交通系は汎用の `transit_station` だけ**でした。
PR #1149 のレビューで「バス停も `transit_station` を持つから危険」として `RAIL_STATION_TYPES` から
`transit_station` を外した結果、この候補がどの判定にも掛からなくなり **#1123 そのものが再発**していました。
fixture が誤っていたためテストは緑のままで、この事故を検知できていませんでした（新宿駅・東京駅も同じ構造）。

## 修正方針: 「畳む根拠」と「畳む対象」を分離する

`transit_station` を `RAIL_STATION_TYPES` へ戻すだけでは、レビューが指摘したバス停の穴が再び開きます。
そこで判定を 2 段に分けました。

- `RAIL_STATION_TYPES`（`train_station` / `subway_station`）= **「同名の鉄道駅が実在する」根拠**
- `COLLAPSIBLE_TRANSIT_TYPES`（上記 + `transit_station`）= **根拠がある時に畳んでよい対象**

畳み込みは次の 3 条件を全て満たす候補だけに適用します。

1. 同名（正規化後の mainText 一致）の候補の中に鉄道駅固有 type を持つものが 1 件以上ある
2. その候補自身が `COLLAPSIBLE_TRANSIT_TYPES` を持つ
3. `NEVER_COLLAPSE_TRANSIT_TYPES`（`bus_station` / `bus_stop` / `transit_depot`）を持たない

条件 1 により、**同名のバス停同士・路面電車の停留場同士は鉄道駅固有 type がどこにも現れないため、そもそも畳み込みの対象になりません。**
これは deny-list による保護より堅いことが実環境の検証で確認できました。実際に
**types が `establishment` / `point_of_interest` だけのバス停**（例: 八景島駅前 バス停）が存在し、
deny-list だけでは守れません（受入条件 5 として回帰テスト化）。

## 実測結果

**fixture を実データへ直した時点で、修正前の実装が赤くなることを実測しました**（今回の事故の再発防止の要）。

```
● should keep only the top-ranked candidate for same-name station establishments
  Expected length: 1
  Received length: 2
```

修正後: `locations.service.spec.ts` **27 passed / 27**、`tsc --noEmit` exit 0。

## テストで固定した受入条件

| # | 内容 |
| --- | --- |
| 1 | 渋谷駅の同名駅候補が 1 件になる（**実 API の types をそのまま fixture 化**） |
| 1' | 新宿駅・東京駅も同じ構造で 1 件になる |
| 3 | development 実レスポンス 5 件を再現し、「渋谷駅前」「みどりの窓口」が残り関連度順が維持される |
| 4 | 鉄道駅と同名のバス停が消えない |
| 5 | types が `establishment` / `point_of_interest` だけの同名バス停が消えない |

また、`RAIL_STATION_TYPES` のコメントにあった **「#1123 の渋谷駅 2 候補はどちらも train_station / subway_station を持つ」という事実誤認**を修正しました。

## 残作業

このブランチのマージ後に development 再検証（+ 成否によらず main への復旧）を実施します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_