### PR TITLE
#1176 fix: 名前ベースの候補畳み込みをやめ、完全重複だけに限定する（#952 / #1123 の方針転換）

### DIFF
--- a/api/src/v1/locations/locations.service.spec.ts
+++ b/api/src/v1/locations/locations.service.spec.ts
@@ -419,14 +419,14 @@ describe('LocationsService', () => {
       },
     });
 
-    it('should dedupe same-name candidates keeping the establishment one', async () => {
-      // #952 【テスト】渋谷駅が「駅(establishment)」と「番地レベル(geocode)」で重複するケース。
-      // 関連度順では番地レベルが後だが、establishment が優先されて1件に畳まれること。
+    it('should keep same-name candidates that differ in secondaryText', async () => {
+      // #1176 【テスト】表示名が同じでも secondaryText が違えば別地点として区別できる。
+      // かつての #952 ルール2 は「同名の establishment がいれば非 establishment を落とす」
+      // だったが、地理的な絞り込みが無い以上その前提は成立しない。全件残すこと。
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
           buildSuggestion('place-station', '渋谷駅', '日本、東京都渋谷区', [
             'train_station',
-            'transit_station',
             'point_of_interest',
             'establishment',
           ]),
@@ -447,37 +447,97 @@ describe('LocationsService', () => {
 
       const result = await service.autocompleteLocations(mockQuery);
 
-      expect(result).toHaveLength(2);
-      expect(result[0].place_id).toBe('place-station');
-      expect(result[1].place_id).toBe('place-mark-city');
+      expect(result.map((place) => place.place_id)).toEqual([
+        'place-station',
+        'place-address',
+        'place-mark-city',
+      ]);
     });
 
-    it('should prefer the establishment even when the address-level candidate comes first', async () => {
-      // #952 【テスト】関連度順で番地レベルが先頭に来ても、駅(establishment)が残ること。
-      // 返却順は先勝ちの位置(先頭)を維持する。
+    it('should keep same-name stations in different prefectures', async () => {
+      // #1176 【テスト】これがこの変更の主目的。日本には同名の別駅が実在する。
+      // 名前ベースで畳むと、明石の大久保駅を選びたいユーザーが選択不能になる。
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
           buildSuggestion(
-            'place-address',
-            '渋谷駅',
-            '日本、東京都渋谷区２丁目２４',
-            ['geocode'],
+            'place-okubo-tokyo',
+            '大久保駅',
+            '日本、東京都新宿区百人町',
+            [
+              'train_station',
+              'transit_station',
+              'transportation_service',
+              'point_of_interest',
+              'establishment',
+            ],
           ),
-          buildSuggestion('place-station', '渋谷駅', '日本、東京都渋谷区', [
-            'train_station',
-            'establishment',
-          ]),
+          buildSuggestion(
+            'place-okubo-hyogo',
+            '大久保駅',
+            '日本、兵庫県明石市大久保町',
+            [
+              'train_station',
+              'transit_station',
+              'transportation_service',
+              'point_of_interest',
+              'establishment',
+            ],
+          ),
         ],
       } as never);
 
       const result = await service.autocompleteLocations(mockQuery);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].place_id).toBe('place-station');
+      expect(result.map((place) => place.place_id)).toEqual([
+        'place-okubo-tokyo',
+        'place-okubo-hyogo',
+      ]);
+    });
+
+    it('should keep the granularity duplicates of the same station', async () => {
+      // #1176 【テスト】#1123 で畳んでいた「同一駅の粒度違い重複」も、今後は残す。
+      // これは意図的な譲歩である: 重複表示のわずらわしさより、
+      // 別地点が選択不能になる方が損害が大きい(#1176)。
+      // types は development 実環境の実測値(Issue #1123 の検証コメント)。
+      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
+        suggestions: [
+          buildSuggestion(
+            'ChIJz8MVLFiLGGARXP0DqqhoDow',
+            '渋谷駅',
+            '日本、東京都渋谷区',
+            [
+              'point_of_interest',
+              'transportation_service',
+              'establishment',
+              'transit_station',
+            ],
+          ),
+          buildSuggestion(
+            'ChIJnxAAO1aLGGARJqvi8d4oczM',
+            '渋谷駅',
+            '日本、東京都渋谷区渋谷２丁目２４',
+            [
+              'transportation_service',
+              'point_of_interest',
+              'train_station',
+              'transit_station',
+              'establishment',
+              'subway_station',
+            ],
+          ),
+        ],
+      } as never);
+
+      const result = await service.autocompleteLocations(mockQuery);
+
+      expect(result.map((place) => place.place_id)).toEqual([
+        'ChIJz8MVLFiLGGARXP0DqqhoDow',
+        'ChIJnxAAO1aLGGARJqvi8d4oczM',
+      ]);
     });
 
     it('should keep distinct names untouched', async () => {
-      // #952 【テスト】「渋谷駅」と「渋谷駅前」は別地点なので dedup 対象外であること
+      // 「渋谷駅」と「渋谷駅前」は別地点なので当然残る。
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
           buildSuggestion('place-station', '渋谷駅', '日本、東京都渋谷区', [
@@ -496,34 +556,53 @@ describe('LocationsService', () => {
       expect(result).toHaveLength(2);
     });
 
-    it('should dedupe full-width/half-width and spacing variants of the same name', async () => {
-      // #952 【テスト】NFKC 正規化 + 空白除去により表記ゆれの同名も1件に畳まれること
+    it('should keep same-name bus stops', async () => {
+      // #1176 【テスト】同名の別バス停(進行方向・のりば違い)が残ること。
+      // 以前は deny-list(bus_station 等)で守っていたが、実環境には
+      // types が establishment / point_of_interest だけのバス停が存在し
+      // (八景島駅前 バス停)、type ベースの保護では守り切れなかった。
+      // 名前で畳まなくなったため、type に依存せず守られる。
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
+          buildSuggestion('place-bus-a', '市役所前', '日本、福岡県久留米市中央町', [
+            'bus_stop',
+            'transit_station',
+            'point_of_interest',
+            'establishment',
+          ]),
+          buildSuggestion('place-bus-b', '市役所前', '日本、福岡県柳川市本町', [
+            'bus_stop',
+            'transit_station',
+            'point_of_interest',
+            'establishment',
+          ]),
           buildSuggestion(
-            'place-1',
-            'ＡＢＣマート 渋谷',
-            '日本、東京都渋谷区',
-            ['establishment'],
+            'place-bus-no-type-a',
+            '八景島駅前 バス停',
+            '日本、神奈川県横浜市金沢区海の公園１０',
+            ['establishment', 'point_of_interest'],
           ),
           buildSuggestion(
-            'place-2',
-            'ABCマート渋谷',
-            '日本、東京都渋谷区２丁目',
-            ['geocode'],
+            'place-bus-no-type-b',
+            '八景島駅前 バス停',
+            '日本、神奈川県横浜市金沢区海の公園４０',
+            ['establishment', 'point_of_interest'],
           ),
         ],
       } as never);
 
       const result = await service.autocompleteLocations(mockQuery);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].place_id).toBe('place-1');
+      expect(result.map((place) => place.place_id)).toEqual([
+        'place-bus-a',
+        'place-bus-b',
+        'place-bus-no-type-a',
+        'place-bus-no-type-b',
+      ]);
     });
 
     it('should keep multiple same-name establishments (e.g. chain branches)', async () => {
-      // #952 【テスト】PR #980 レビュー指摘: 同名チェーンの別店舗(establishment 同士、
-      // place_id・secondaryText が異なる)は表示名が同じでも別地点なので全て残ること
+      // 同名チェーンの別店舗はもともと残す仕様。回帰させないこと。
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
           buildSuggestion(
@@ -538,38 +617,6 @@ describe('LocationsService', () => {
             '日本、東京都渋谷区宇田川町',
             ['cafe', 'establishment'],
           ),
-          buildSuggestion(
-            'place-sbux-addr',
-            'スターバックス',
-            '日本、東京都渋谷区２丁目',
-            ['geocode'],
-          ),
-        ],
-      } as never);
-
-      const result = await service.autocompleteLocations(mockQuery);
-
-      // establishment 2店舗は残り、同名の番地レベル geocode だけが落ちる
-      expect(result).toHaveLength(2);
-      expect(result.map((place) => place.place_id)).toEqual([
-        'place-sbux-1',
-        'place-sbux-2',
-      ]);
-    });
-
-    it('should keep non-establishment candidates when no same-name establishment exists', async () => {
-      // #952 【テスト】同名の establishment が無い場合、住所系候補はそのまま残ること
-      // (住所そのものを検索したいケースを壊さない)
-      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
-        suggestions: [
-          buildSuggestion('place-addr-1', '渋谷２丁目', '日本、東京都渋谷区', [
-            'geocode',
-          ]),
-          buildSuggestion('place-town', '渋谷区', '日本、東京都', [
-            'locality',
-            'political',
-            'geocode',
-          ]),
         ],
       } as never);
 
@@ -578,482 +625,27 @@ describe('LocationsService', () => {
       expect(result).toHaveLength(2);
     });
 
-    it('should keep only the top-ranked candidate for same-name station establishments', async () => {
-      // #1123 【受入条件1】【テスト】渋谷駅が2件の establishment(どちらも駅・交通施設)
-      // として返るケース。types は development 実環境の Autocomplete レスポンス実測値
-      // (Issue #1123 の検証コメント)をそのまま使用する。
-      // 重要: 関連度順で先頭の候補は train_station / subway_station を持たず、
-      // 交通系 type は汎用の transit_station だけである。fixture をここから外すと
-      // 実装が壊れていてもテストが緑になる(PR #1149 で実際に起きた事故)。
+    it('should collapse exact duplicates even with full-width/spacing variants', async () => {
+      // #1176 【テスト】残した唯一の畳み込み(ルール2)は NFKC 正規化 + 空白除去を経ること。
+      // mainText と secondaryText の両方が一致するので UI 上まったく区別が付かない。
       mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
         suggestions: [
           buildSuggestion(
-            'ChIJz8MVLFiLGGARXP0DqqhoDow',
-            '渋谷駅',
+            'place-1',
+            'ＡＢＣマート 渋谷',
             '日本、東京都渋谷区',
-            [
-              'point_of_interest',
-              'transportation_service',
-              'establishment',
-              'transit_station',
-            ],
+            ['establishment'],
           ),
-          buildSuggestion(
-            'ChIJnxAAO1aLGGARJqvi8d4oczM',
-            '渋谷駅',
-            '日本、東京都渋谷区渋谷２丁目２４',
-            [
-              'transportation_service',
-              'point_of_interest',
-              'train_station',
-              'transit_station',
-              'establishment',
-              'subway_station',
-            ],
-          ),
+          buildSuggestion('place-2', 'ABCマート渋谷', '日本、東京都渋谷区', [
+            'establishment',
+          ]),
         ],
       } as never);
 
       const result = await service.autocompleteLocations(mockQuery);
 
       expect(result).toHaveLength(1);
-      // 関連度順の先頭が残る(並び替えはしない)
-      expect(result[0].place_id).toBe('ChIJz8MVLFiLGGARXP0DqqhoDow');
-    });
-
-    it('should reproduce the real development response for 渋谷駅', async () => {
-      // #1123 【受入条件1,3】【テスト】development 実環境の Autocomplete レスポンス
-      // 5件をそのまま fixture にしたケース(Issue #1123 の検証コメントの実測値)。
-      // - 同名の駅候補2件は先頭の1件だけが残る(受入条件1)
-      // - 「渋谷駅前」(premise, geocode)は別キーなので残る(受入条件3)。
-      //   同名の establishment が無いためルール2でも落ちない
-      // - 「渋谷駅 みどりの窓口」は正規化後も別キーなので残る
-      // - 返却順は Google の関連度順を維持する
-      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
-        suggestions: [
-          buildSuggestion(
-            'ChIJz8MVLFiLGGARXP0DqqhoDow',
-            '渋谷駅',
-            '日本、東京都渋谷区',
-            [
-              'point_of_interest',
-              'transportation_service',
-              'establishment',
-              'transit_station',
-            ],
-          ),
-          buildSuggestion(
-            'ChIJnxAAO1aLGGARJqvi8d4oczM',
-            '渋谷駅',
-            '日本、東京都渋谷区渋谷２丁目２４',
-            [
-              'transportation_service',
-              'point_of_interest',
-              'train_station',
-              'transit_station',
-              'establishment',
-              'subway_station',
-            ],
-          ),
-          buildSuggestion(
-            'ChIJN8-zcVeLGGARk4cjUnp9z-I',
-            '渋谷駅前おおしま皮膚科',
-            '日本、東京都渋谷区桜丘町２５−１８',
-            [
-              'point_of_interest',
-              'health',
-              'hair_care',
-              'establishment',
-              'doctor',
-              'service',
-              'beauty_salon',
-              'hospital',
-              'medical_clinic',
-            ],
-          ),
-          buildSuggestion(
-            'ChIJ97I--VeLGGARy5_VNv4n3iw',
-            '渋谷駅前',
-            '日本、東京都渋谷区',
-            ['premise', 'geocode'],
-          ),
-          buildSuggestion(
-            'ChIJ4cnQLFiLGGARSKxwdYkpEkI',
-            '渋谷駅 みどりの窓口',
-            '日本、東京都渋谷区道玄坂１丁目１',
-            [
-              'establishment',
-              'train_ticket_office',
-              'transportation_service',
-              'point_of_interest',
-            ],
-          ),
-        ],
-      } as never);
-
-      const result = await service.autocompleteLocations(mockQuery);
-
-      expect(result.map((place) => place.place_id)).toEqual([
-        'ChIJz8MVLFiLGGARXP0DqqhoDow',
-        'ChIJN8-zcVeLGGARk4cjUnp9z-I',
-        'ChIJ97I--VeLGGARy5_VNv4n3iw',
-        'ChIJ4cnQLFiLGGARSKxwdYkpEkI',
-      ]);
-    });
-
-    it.each([
-      {
-        query: '新宿駅',
-        first: {
-          placeId: 'ChIJu9ljKNeMGGARcFUr-NmJhAk',
-          types: [
-            'transit_station',
-            'transportation_service',
-            'point_of_interest',
-            'establishment',
-          ],
-        },
-        second: {
-          placeId: 'ChIJH7qx1tCMGGAR1f2s7PGhMhw',
-          types: [
-            'train_station',
-            'subway_station',
-            'transit_station',
-            'transportation_service',
-            'point_of_interest',
-            'establishment',
-          ],
-        },
-      },
-      {
-        query: '東京駅',
-        first: {
-          placeId: 'ChIJu2cU7vuLGGART-M-fm6LD0E',
-          types: [
-            'transit_station',
-            'transportation_service',
-            'point_of_interest',
-            'establishment',
-          ],
-        },
-        second: {
-          placeId: 'ChIJC3Cf2PuLGGAROO00ukl8JwA',
-          types: [
-            'train_station',
-            'subway_station',
-            'transit_station',
-            'transportation_service',
-            'point_of_interest',
-            'establishment',
-          ],
-        },
-      },
-    ])(
-      'should keep only the top-ranked candidate for $query (same structure as 渋谷駅)',
-      async ({ query, first, second }) => {
-        // #1123 【受入条件1】【テスト】渋谷駅固有の問題ではないことの回帰テスト。
-        // 実環境検証(Issue #1123 の検証コメント)で、新宿駅・東京駅も
-        // 「関連度順の先頭は transit_station のみ / 2件目が train_station を持つ」
-        // という同一構造だと実測されている。
-        mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
-          suggestions: [
-            buildSuggestion(first.placeId, query, '日本、東京都', first.types),
-            buildSuggestion(
-              second.placeId,
-              query,
-              '日本、東京都(番地レベル)',
-              second.types,
-            ),
-          ],
-        } as never);
-
-        const result = await service.autocompleteLocations({
-          ...mockQuery,
-          q: query,
-        });
-
-        expect(result.map((place) => place.place_id)).toEqual([first.placeId]);
-      },
-    );
-
-    it('should still keep same-name chain branches after the station rule was added', async () => {
-      // #1123 【受入条件2】【テスト】「スターバックス」のような同名だが別の実店舗は
-      // 交通施設 type を持たないため新ルールの対象外で、引き続き複数返ること
-      // (#952 の意図を壊していないことの回帰テスト)。
-      // types は実環境検証の「スターバックス」レスポンス実測値。実環境では 5 件の
-      // mainText が全て異なり同名衝突が起きなかったため、mainText / secondaryText を
-      // 揃えて同名衝突を意図的に作っている(実測値どおりだとルール3を通過しない)。
-      const realStarbucksTypes = [
-        'store',
-        'food_store',
-        'point_of_interest',
-        'bar',
-        'coffee_shop',
-        'establishment',
-        'food',
-        'cafe',
-      ];
-      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
-        suggestions: [
-          buildSuggestion(
-            'ChIJq_fYt4iLGGARrOojmQ4IMyE',
-            'スターバックスコーヒー',
-            '日本、東京都目黒区青葉台２丁目１９−２３',
-            realStarbucksTypes,
-          ),
-          buildSuggestion(
-            'place-sbux-udagawa',
-            'スターバックスコーヒー',
-            '日本、東京都渋谷区宇田川町',
-            realStarbucksTypes,
-          ),
-          buildSuggestion(
-            'place-sbux-ebisu',
-            'スターバックスコーヒー',
-            '日本、東京都渋谷区恵比寿',
-            realStarbucksTypes,
-          ),
-        ],
-      } as never);
-
-      const result = await service.autocompleteLocations(mockQuery);
-
-      expect(result.map((place) => place.place_id)).toEqual([
-        'ChIJq_fYt4iLGGARrOojmQ4IMyE',
-        'place-sbux-udagawa',
-        'place-sbux-ebisu',
-      ]);
-    });
-
-    it('should keep same-name bus stops that also carry the generic transit_station type', async () => {
-      // #1123 【受入条件4】【テスト】PR #1149 レビュー指摘: Google Places の実データでは
-      // バス停・バスターミナルは汎用の transit_station を併せ持つのが通例
-      // (例: ["bus_station", "transit_station", "point_of_interest", "establishment"])。
-      // 同名でも進行方向・のりば違いで別地点として正当に併存するため、
-      // 両方が残らなければならない。
-      // 二重の保護がかかる: (i) 同名に鉄道駅固有 type を持つ候補が無いので
-      // ルール3-b の根拠が成立しない、(ii) NEVER_COLLAPSE_TRANSIT_TYPES に該当する。
-      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
-        suggestions: [
-          buildSuggestion(
-            'place-bus-1',
-            '渋谷駅前',
-            '日本、東京都渋谷区道玄坂',
-            [
-              'bus_station',
-              'transit_station',
-              'point_of_interest',
-              'establishment',
-            ],
-          ),
-          buildSuggestion('place-bus-2', '渋谷駅前', '日本、東京都渋谷区渋谷', [
-            'bus_stop',
-            'transit_station',
-            'point_of_interest',
-            'establishment',
-          ]),
-        ],
-      } as never);
-
-      const result = await service.autocompleteLocations(mockQuery);
-
-      expect(result.map((place) => place.place_id)).toEqual([
-        'place-bus-1',
-        'place-bus-2',
-      ]);
-    });
-
-    it('should keep same-name bus stops even when a real rail station shares the name', async () => {
-      // #1123 【受入条件4】【テスト】鉄道駅と同名のバス停が並ぶケース。
-      // 駅候補があるためルール3-b の根拠は成立するが、バス停は
-      // NEVER_COLLAPSE_TRANSIT_TYPES による deny-list で常に残る。
-      // (transit_station を畳み込み対象へ戻してもバス停保護が壊れないことの回帰テスト)
-      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
-        suggestions: [
-          buildSuggestion(
-            'ChIJnxAAO1aLGGARJqvi8d4oczM',
-            '渋谷駅',
-            '日本、東京都渋谷区渋谷２丁目２４',
-            [
-              'train_station',
-              'subway_station',
-              'transit_station',
-              'point_of_interest',
-              'establishment',
-            ],
-          ),
-          buildSuggestion('place-bus-hachiko', '渋谷駅', '日本、東京都渋谷区', [
-            'bus_station',
-            'transit_station',
-            'point_of_interest',
-            'establishment',
-          ]),
-          buildSuggestion(
-            'place-bus-dogenzaka',
-            '渋谷駅',
-            '日本、東京都渋谷区道玄坂',
-            [
-              'bus_stop',
-              'transit_station',
-              'point_of_interest',
-              'establishment',
-            ],
-          ),
-        ],
-      } as never);
-
-      const result = await service.autocompleteLocations(mockQuery);
-
-      expect(result.map((place) => place.place_id)).toEqual([
-        'ChIJnxAAO1aLGGARJqvi8d4oczM',
-        'place-bus-hachiko',
-        'place-bus-dogenzaka',
-      ]);
-    });
-
-    it('should keep same-name candidates whose types are only establishment and point_of_interest', async () => {
-      // #1123 【受入条件5】【テスト】実環境検証で見つかった「types が
-      // establishment / point_of_interest だけのバス停」(例: 八景島駅前 バス停)。
-      // deny-list(bus_station 等)では守れないが、交通施設 type を持たないため
-      // ルール3-b の対象外となり両方残る。mainText は同じ(secondaryText だけ違う)。
-      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
-        suggestions: [
-          buildSuggestion(
-            'ChIJw3k2HQBBGGARN0m20RcqInE',
-            '八景島駅前 バス停',
-            '日本、神奈川県横浜市金沢区海の公園１０',
-            ['establishment', 'point_of_interest'],
-          ),
-          buildSuggestion(
-            'place-bus-stop-opposite',
-            '八景島駅前 バス停',
-            '日本、神奈川県横浜市金沢区海の公園４０',
-            ['establishment', 'point_of_interest'],
-          ),
-        ],
-      } as never);
-
-      const result = await service.autocompleteLocations(mockQuery);
-
-      expect(result.map((place) => place.place_id)).toEqual([
-        'ChIJw3k2HQBBGGARN0m20RcqInE',
-        'place-bus-stop-opposite',
-      ]);
-    });
-
-    it('should not treat a bus terminal as the evidence that a rail station exists', async () => {
-      // #1123 【テスト】ルール3-b(i) の「NEVER_COLLAPSE_TRANSIT_TYPES を持つ候補は
-      // 畳み込みの"根拠"としても数えない」を固定する。
-      //
-      // ここで並ぶ鉄道駅固有 type(train_station)は、バス停 type を併記した
-      // バスターミナル候補だけが持っている。根拠から除外しなければ、この1件を根拠に
-      // 同名の transit_station 候補が畳まれてしまう。
-      // (PR #1175 の独立レビュー M2: この除外を実装から削っても全テストが緑だった)
-      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
-        suggestions: [
-          buildSuggestion(
-            'place-bus-terminal',
-            '渋谷駅',
-            '日本、東京都渋谷区(バスターミナル)',
-            [
-              'train_station',
-              'bus_station',
-              'transit_station',
-              'point_of_interest',
-              'establishment',
-            ],
-          ),
-          buildSuggestion('place-transit-only-a', '渋谷駅', '日本、東京都渋谷区', [
-            'transit_station',
-            'point_of_interest',
-            'establishment',
-          ]),
-          buildSuggestion(
-            'place-transit-only-b',
-            '渋谷駅',
-            '日本、東京都渋谷区道玄坂',
-            ['transit_station', 'point_of_interest', 'establishment'],
-          ),
-        ],
-      } as never);
-
-      const result = await service.autocompleteLocations(mockQuery);
-
-      // 鉄道駅固有 type はバスターミナルしか持たないため根拠が成立せず、3件とも残る。
-      // 根拠から除外しないと、transit_station だけの2件が畳まれて2件に減る。
-      expect(result.map((place) => place.place_id)).toEqual([
-        'place-bus-terminal',
-        'place-transit-only-a',
-        'place-transit-only-b',
-      ]);
-    });
-
-    it('should keep a same-name candidate that has no transit type even when a rail station exists', async () => {
-      // #1123 【テスト】ルール3-b(ii) の「候補自身が COLLAPSIBLE_TRANSIT_TYPES を
-      // 持たなければ畳まない」を固定する。
-      //
-      // 受入条件5(八景島駅前 バス停)のケースは同名の鉄道駅が居ないため (i) の段階で
-      // 弾かれ、(ii) は一度も判定を左右していなかった。ここでは鉄道駅を同居させて
-      // (ii) だけが効く経路を通す。
-      // (PR #1175 の独立レビュー M3: (ii) を実装から削っても全テストが緑だった)
-      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
-        suggestions: [
-          buildSuggestion('place-rail-station', '八景島', '日本、神奈川県横浜市', [
-            'train_station',
-            'transit_station',
-            'point_of_interest',
-            'establishment',
-          ]),
-          buildSuggestion(
-            'place-no-transit-type',
-            '八景島',
-            '日本、神奈川県横浜市金沢区海の公園',
-            ['establishment', 'point_of_interest'],
-          ),
-        ],
-      } as never);
-
-      const result = await service.autocompleteLocations(mockQuery);
-
-      expect(result.map((place) => place.place_id)).toEqual([
-        'place-rail-station',
-        'place-no-transit-type',
-      ]);
-    });
-
-    it('should keep same-name tram stops on opposite sides of the street', async () => {
-      // #1123 【テスト】PR #1149 レビュー指摘(Minor): 路面電車の停留場は運用上バス停に
-      // 近く、上り/下りが同名で道路を挟んだ別地点として登録される地域がある。
-      // light_rail_station は畳み込みの根拠(RAIL_STATION_TYPES)に含めないため、
-      // 停留場同士だけが並ぶこのケースは transit_station を併せ持っていても畳まれない。
-      mockExternalApiService.callPlacesAutocomplete.mockResolvedValue({
-        suggestions: [
-          buildSuggestion('place-tram-1', '広電西広島', '日本、広島県広島市', [
-            'light_rail_station',
-            'transit_station',
-            'point_of_interest',
-            'establishment',
-          ]),
-          buildSuggestion(
-            'place-tram-2',
-            '広電西広島',
-            '日本、広島県広島市西区己斐本町',
-            [
-              'light_rail_station',
-              'transit_station',
-              'point_of_interest',
-              'establishment',
-            ],
-          ),
-        ],
-      } as never);
-
-      const result = await service.autocompleteLocations(mockQuery);
-
-      expect(result.map((place) => place.place_id)).toEqual([
-        'place-tram-1',
-        'place-tram-2',
-      ]);
+      expect(result[0].place_id).toBe('place-1');
     });
 
     it('should collapse exact duplicates (same mainText and secondaryText)', async () => {

--- a/api/src/v1/locations/locations.service.ts
+++ b/api/src/v1/locations/locations.service.ts
@@ -566,104 +566,31 @@ export class LocationsService {
   }
 
   /**
-   * #1123 【設計】「この mainText には鉄道駅が実在する」と断定してよい、鉄道駅固有の
-   * type の集合(= 畳み込みの"根拠"となる type)。
+   * #1176 【設計】Autocomplete 候補の重複除去は「表示が完全に同一のもの」だけに限定する。
    *
-   * 含めた理由:
-   * - train_station / subway_station:
-   *   鉄道駅にのみ付く type。鉄道駅は同一エリア内に同名の別駅が存在しないため、
-   *   同名なら同一駅とみなして安全に畳める。
+   * かつては #952(同名の非 establishment を落とす)と #1123(同名の鉄道駅を1件に畳む)の
+   * ルールを持っていたが、いずれも **mainText(表示名)が同じなら同一地点とみなす**
+   * 前提に立っていた。この前提は成立しない。
    *
-   * 含めなかった理由(安全側 = 同名の別地点を消さない側に倒す):
-   * - transit_station:
-   *   交通施設全般に付く汎用 type で、実データではバス停も
-   *   ["bus_station", "transit_station", "point_of_interest", "establishment"]
-   *   のように併せ持つ(PR #1149 レビュー指摘)。これ単独では駅と断定できないため
-   *   「根拠」には使わない。ただし後述のとおり「畳む対象」には含める
-   *   (COLLAPSIBLE_TRANSIT_TYPES 参照)。
-   * - light_rail_station:
-   *   PR #1149 レビュー指摘。路面電車の停留場は運用上バス停に近い命名
-   *   (上り/下りが同名で道路を挟んだ別地点)になる地域があるため根拠にしない。
-   *   同名の停留場同士だけが並ぶケースでは鉄道駅固有 type が現れないので畳まれない。
-   * - bus_station / bus_stop / transit_depot:
-   *   「渋谷駅前」のように、同名でも進行方向・のりば・事業者ごとに別地点として
-   *   存在するのが正常。畳むとユーザーが選びたいのりばを選べなくなる。
-   * - airport / international_airport / ferry_terminal / heliport / taxi_stand /
-   *   park_and_ride:
-   *   同名でターミナル違い等の別地点が正当に併存しうるうえ、#1123 のような粒度違い
-   *   重複の実例が確認できていないため対象外とする。
-   */
-  private static readonly RAIL_STATION_TYPES: ReadonlySet<string> = new Set([
-    'train_station',
-    'subway_station',
-  ]);
-
-  /**
-   * #1123 【設計】「同名の鉄道駅が実在する」と分かっているときに、その駅の粒度違い
-   * 重複として畳んでよい交通施設 type の集合。
+   * `autocompleteLocations` のリクエストには locationBias / locationRestriction が無く、
+   * 全国の候補が同一レスポンスに並び得る。日本には同名の別駅・別施設が多数実在する
+   * (大久保駅 = 東京都新宿区 / 兵庫県明石市 / 京都府宇治市 / 秋田市 など)。
+   * 名前ベースで畳むと、ユーザーが選びたい地点が候補から消えて **選択不能** になる(#1176)。
    *
-   * development 実環境の実測(Issue #1123 の検証コメント)では、渋谷駅の関連度順
-   * 先頭候補(ChIJz8MVLFiLGGARXP0DqqhoDow)の types は
-   * ["point_of_interest", "transportation_service", "establishment", "transit_station"]
-   * で、鉄道駅固有 type を持たず交通系は汎用の transit_station だけだった
-   * (新宿駅・東京駅も同じ構造)。つまり「駅施設側」の候補は transit_station しか
-   * 持たないことがあるため、transit_station も畳み込み対象に含める必要がある。
+   * 重複表示は「わずらわしい」だけだが、選択不能は「目的を達成できない」であり、
+   * 損害の非対称性が大きい。したがって Google の返す候補は原則そのまま通す。
    *
-   * PR #1149 で懸念された「同名の別バス停が畳まれる」問題は、transit_station を
-   * ここに入れるだけでは起きない。畳み込みには別途
-   * 「同名に RAIL_STATION_TYPES を持つ候補が存在する」ことを要求するため、
-   * バス停同士(鉄道駅固有 type がどこにも現れない)は根拠が無く畳まれない。
-   * これは NEVER_COLLAPSE_TRANSIT_TYPES による type ベースの保護より堅い:
-   * 実環境には bus_station を持たない(types が establishment / point_of_interest
-   * だけの)バス停が存在し、deny-list だけでは守れないため。
+   * 残す唯一の例外がルール2(完全重複)である。mainText と secondaryText の**両方**が
+   * 一致する候補は、UI 上まったく区別が付かず、ユーザーはどちらを選んでも同じ体験になる。
+   * この場合だけは畳んでも選択肢を奪わない。
    *
-   * 【受容済みリスク】(PR #1175 の独立レビュー 指摘3)
-   * 鉄道駅と同名で、かつ bus 系 type が欠落して transit_station だけを持つバス停は
-   * 畳まれる。上記のとおり Google の type 付与は欠落し得るため、deny-list による
-   * 保護は bus 系 type が付いている場合に限られる。
-   * この型シルエットは #1123 で畳みたい「駅施設側」候補と type だけでは区別できず、
-   * 畳まなければ #1123 が直らないため、畳む側を選んでいる。
-   */
-  private static readonly COLLAPSIBLE_TRANSIT_TYPES: ReadonlySet<string> =
-    new Set([...LocationsService.RAIL_STATION_TYPES, 'transit_station']);
-
-  /**
-   * #1123 【設計】同名でも別地点として正当に併存する交通施設の type 集合。
+   * ルール:
+   * 1. mainText / secondaryText を正規化(NFKC + 空白除去)する。
+   * 2. mainText と secondaryText が**両方**一致する候補だけを1件に畳む。
+   * 3. 返却順は Google の関連度順(元の配列順)を維持する。並び替えは行わない。
    *
-   * PR #1149 レビュー指摘を受けた多重防御。これらの type を1つでも持つ候補は、
-   * たとえ鉄道駅 type を併せ持っていても(例: 駅前ロータリーのバスターミナルが
-   * train_station を併記するケース)同名畳み込みの対象外とし、常に残す。
-   * 畳み込みの"根拠"としても数えない(バスターミナル1件を根拠に同名の駅候補を
-   * 畳んでしまわないため)。
-   */
-  private static readonly NEVER_COLLAPSE_TRANSIT_TYPES: ReadonlySet<string> =
-    new Set(['bus_station', 'bus_stop', 'transit_depot']);
-
-  /**
-   * #952 【設計】Autocomplete 候補の「同一地点の粒度違い重複」を除去する。
-   *
-   * ルール(PR #980 レビュー指摘を受けた改訂版 / #1123 でルール3-bを追加):
-   * 1. mainText を正規化(NFKC + 空白除去)したものを同名判定のキーにする。
-   *    「渋谷駅」と「渋谷駅前」のような別名は別キーになり残る。
-   * 2. 落とすのは「同名の establishment(実在施設)が存在する場合の非 establishment 候補」
-   *    だけに限定する。これが「渋谷駅(駅)と 渋谷駅(番地レベル geocode)」のような
-   *    同一地点の粒度違い重複に相当する。
-   * 3. 同名でも establishment 同士(例: 同名チェーンの別店舗。place_id・secondaryText が
-   *    異なる別の実在地点)は全て残す。表示名だけで別地点を消してはならない。
-   * 3-b. #1123 例外: 「同名の鉄道駅の粒度違い重複」は establishment 同士であっても
-   *    Google の関連度順で先頭の1件だけを残す。誤爆を防ぐため次の3条件を全て満たす
-   *    候補だけを対象にする:
-   *    (i)  同名(正規化後の mainText が一致)の候補の中に、鉄道駅固有 type
-   *         (RAIL_STATION_TYPES)を持つものが1件以上ある = 鉄道駅が実在する根拠
-   *    (ii) その候補自身が交通施設 type(COLLAPSIBLE_TRANSIT_TYPES)を持つ
-   *         = 駅施設側の粒度違い候補。実データでは transit_station しか持たない
-   *           ことがあるため汎用 type も含める(#1123 検証コメント)
-   *    (iii) バス停など NEVER_COLLAPSE_TRANSIT_TYPES を持たない(PR #1149 指摘)
-   *    (i) により、同名のバス停同士・停留場同士(鉄道駅固有 type がどこにも無い)は
-   *    そもそも対象にならない。交通系 type を持たない同名候補(チェーン店舗や、
-   *    types が establishment / point_of_interest だけのバス停)は (ii) で対象外。
-   * 4. 完全重複(mainText と secondaryText の両方が一致)だけは同名同士でも1件に畳む。
-   * 5. 返却順は Google の関連度順(元の配列順)を維持する。並び替えは行わない。
+   * 将来 locationBias を入れて候補が地理的に絞られるようになれば、名前ベースの
+   * 畳み込みを再検討する余地はある。それまでは通す側に倒す。
    */
   private dedupeAutocompletePlaces(
     places: AutocompleteLocationsResponse,
@@ -671,76 +598,17 @@ export class LocationsService {
     const normalizeKey = (text: string): string =>
       text.normalize('NFKC').replace(/\s+/g, '');
 
-    const isEstablishment = (place: { types: string[] }): boolean =>
-      place.types.includes('establishment');
-
-    const hasAnyType = (
-      place: { types: string[] },
-      typeSet: ReadonlySet<string>,
-    ): boolean => place.types.some((type) => typeSet.has(type));
-
-    // #1123 PR #1149: 同名でも別地点が正当に併存するバス停系 type を持つ候補は、
-    // 鉄道駅 type を併せ持っていても畳み込み対象にしない(安全側に倒す)。
-    const isNeverCollapse = (place: { types: string[] }): boolean =>
-      hasAnyType(place, LocationsService.NEVER_COLLAPSE_TRANSIT_TYPES);
-
-    // #1123 ルール3-b(i): 鉄道駅固有 type を持つ候補が存在する mainText キーの集合。
-    // 「同名の鉄道駅が実在する」根拠。これが無い同名グループ(バス停同士など)は
-    // 畳み込みを一切行わない。
-    const railStationNameKeys = new Set(
-      places
-        .filter(
-          (place) =>
-            hasAnyType(place, LocationsService.RAIL_STATION_TYPES) &&
-            !isNeverCollapse(place),
-        )
-        .map((place) => normalizeKey(place.mainText)),
-    );
-
-    // #1123 ルール3-b: 同名の鉄道駅の粒度違い重複として畳んでよい候補かどうか
-    const isCollapsibleStation = (
-      place: { types: string[] },
-      nameKey: string,
-    ): boolean =>
-      railStationNameKeys.has(nameKey) &&
-      hasAnyType(place, LocationsService.COLLAPSIBLE_TRANSIT_TYPES) &&
-      !isNeverCollapse(place);
-
-    // 同名の establishment が1件でも存在する mainText キーの集合
-    const establishmentNameKeys = new Set(
-      places
-        .filter((place) => isEstablishment(place))
-        .map((place) => normalizeKey(place.mainText)),
-    );
-
     const seenExactKeys = new Set<string>();
-    // #1123 既に採用済みの鉄道駅候補の mainText キー(関連度順で先頭の1件が入る)
-    const keptRailStationNameKeys = new Set<string>();
 
     return places.filter((place) => {
-      const nameKey = normalizeKey(place.mainText);
-
-      // ルール4: mainText + secondaryText まで完全一致する候補は同一表示になるため1件に畳む
-      const exactKey = `${nameKey}\u0000${normalizeKey(place.secondaryText)}`;
+      // ルール2: mainText + secondaryText まで完全一致する候補は同一表示になるため1件に畳む
+      const exactKey = `${normalizeKey(place.mainText)}\u0000${normalizeKey(
+        place.secondaryText,
+      )}`;
       if (seenExactKeys.has(exactKey)) {
         return false;
       }
       seenExactKeys.add(exactKey);
-
-      // ルール2: 同名の establishment が存在するなら、非 establishment(番地レベルの
-      // geocode / street_address / premise 等)は同一地点の粒度違いとみなして落とす
-      if (!isEstablishment(place) && establishmentNameKeys.has(nameKey)) {
-        return false;
-      }
-
-      // ルール3-b(#1123): 同名の鉄道駅候補は先頭(= Google の関連度順で最上位)のみ残す。
-      // 走査順が元の配列順のため、採用済みキーを持つ後続の駅候補だけが落ちる。
-      if (isCollapsibleStation(place, nameKey)) {
-        if (keptRailStationNameKeys.has(nameKey)) {
-          return false;
-        }
-        keptRailStationNameKeys.add(nameKey);
-      }
 
       return true;
     });


### PR DESCRIPTION
## 結論: #952 と #1123 の「名前で畳む」方針を撤回します

#1176（別都道府県の同名駅が 1 件に畳まれて選べない）は、パッチで塞ぐ類のバグではなく、
**#952 / #1123 が置いていた前提そのものの誤り**でした。

両者とも「mainText（表示名）が同じなら同一地点とみなしてよい」という前提に立っています。
しかし `autocompleteLocations` のリクエストには `locationBias` / `locationRestriction` が無く、
**全国の候補が同一レスポンスに並び得ます。** 日本には同名の別駅・別施設が多数実在します
（大久保駅 = 東京都新宿区 / 兵庫県明石市 / 京都府宇治市 / 秋田市）。

### 損害が非対称です

| | 畳まない場合 | 畳む場合 |
| --- | --- | --- |
| 症状 | 同じ駅が 2 行出る | 明石の大久保駅が候補から**消える** |
| ユーザーへの影響 | わずらわしい | **目的を達成できない**（どちらを選んでも東京へ飛ぶ） |
| 気付けるか | 見れば分かる | **気付けない**（消えたものは見えない） |

重複表示は「不便」ですが、選択不能は「機能していない」です。**通す側に倒します。**

## 変更内容

残すルールを 2 つだけにしました。

1. mainText / secondaryText を正規化（NFKC + 空白除去）する
2. **mainText と secondaryText の両方が一致する候補だけ**を 1 件に畳む
3. 返却順は Google の関連度順を維持する

ルール 2 が唯一の畳み込みです。両方一致するなら UI 上まったく区別が付かず、ユーザーはどちらを選んでも同じ体験になるため、畳んでも選択肢を奪いません。**区別できるものは畳まない**、という一本の線に整理しました。

削除したもの:

- 旧ルール 2（同名の establishment がいれば非 establishment を落とす）= #952 の中核
- 旧ルール 3-b（同名の鉄道駅を関連度順の先頭 1 件に畳む）= #1123
- `RAIL_STATION_TYPES` / `COLLAPSIBLE_TRANSIT_TYPES` / `NEVER_COLLAPSE_TRANSIT_TYPES`

`NEVER_COLLAPSE_TRANSIT_TYPES` のような type ベースの deny-list が不要になったのは実質的な改善です。
実環境には **`bus_station` を持たないバス停**（八景島駅前 バス停は types が `establishment`, `point_of_interest` のみ）が存在し、
deny-list では守り切れませんでした。名前で畳まなくなったため、type に依存せず守られます。

## 副作用として受け入れること

- `渋谷駅` は再び 2 件表示になります（駅施設と番地レベルの粒度違い）。これは #1123 の意図的な差し戻しです
- `渋谷駅` の番地レベル geocode も残ります。これは #952 の意図的な差し戻しです

## 検証

`locations.service.spec.ts` **19 passed / 19**、`tsc --noEmit` exit 0。

回帰テストとして固定したもの:

| テスト | 守る内容 |
| --- | --- |
| `should keep same-name stations in different prefectures` | **#1176 の再現ケース**。東京と明石の大久保駅が両方残る |
| `should keep same-name candidates that differ in secondaryText` | secondaryText が違えば別地点として残る |
| `should keep the granularity duplicates of the same station` | #1123 で畳んでいた渋谷駅 2 件が残る（意図的な差し戻しの明示） |
| `should keep same-name bus stops` | 同名バス停が type に依存せず残る（`establishment`/`point_of_interest` のみのものを含む） |
| `should keep multiple same-name establishments` | 同名チェーン店舗が残る |
| `should collapse exact duplicates even with full-width/spacing variants` | 残した唯一の畳み込みが正規化を経ること |

## 将来

`locationBias` を入れて候補が地理的に絞られるようになれば、名前ベースの畳み込みを再検討する余地はあります。
それまでは通す側に倒します。この方針はコードの docstring にも書いてあります。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_