### PR TITLE
#276 feat: API に robots.txt を追加して全クローラを拒否する

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { V2Module } from './v2/v2.module';
 import { InternalModule } from './internal/internal.module';
 import { ToolsModule } from './tools/tools.module';
 import { HealthModule } from './health/health.module';
+import { RobotsModule } from './robots/robots.module';
 import { ResponseWrapInterceptor } from './core/interceptors/response-wrap.interceptor';
 import { CoreModule } from './core/core.module';
 
@@ -26,6 +27,7 @@ import { CoreModule } from './core/core.module';
     InternalModule, // Internal endpoints for Cloud Tasks
     ToolsModule, // Tools endpoints for admin use
     HealthModule, // Add HealthModule
+    RobotsModule, // #276 robots.txt でクローラを全拒否
     CoreModule,
   ],
   controllers: [AppController],

--- a/api/src/robots/robots.controller.spec.ts
+++ b/api/src/robots/robots.controller.spec.ts
@@ -1,0 +1,75 @@
+import 'reflect-metadata';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, VersioningType } from '@nestjs/common';
+import request = require('supertest');
+import { RobotsController, ROBOTS_TXT_BODY } from './robots.controller';
+import { RobotsModule } from './robots.module';
+import { SKIP_WRAP_META_KEY } from '../core/interceptors/response-wrap.interceptor';
+
+describe('RobotsController', () => {
+  describe('unit', () => {
+    let controller: RobotsController;
+
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        controllers: [RobotsController],
+      }).compile();
+
+      controller = module.get<RobotsController>(RobotsController);
+    });
+
+    it('全クローラを拒否する本文を返す', () => {
+      expect(controller.getRobotsTxt()).toBe('User-agent: *\nDisallow: /\n');
+    });
+
+    it('ResponseWrapInterceptor の対象外に設定されている（プレーンテキストのまま返すため）', () => {
+      const skip = Reflect.getMetadata(
+        SKIP_WRAP_META_KEY,
+        controller.getRobotsTxt,
+      );
+      expect(skip).toBe(true);
+    });
+  });
+
+  // main.ts の app.enableVersioning() を再現した上で HTTP 経由の挙動を固定する。
+  // RobotsController は version を指定していないため、AppController(`/`) や
+  // HealthController(`/health`) と同様に /v1 等の prefix なしで登録される想定。
+  // この前提が崩れて /robots.txt が引けなくなった場合にここが赤くなる。
+  describe('HTTP', () => {
+    let app: INestApplication;
+
+    beforeEach(async () => {
+      const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [RobotsModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication();
+      app.enableVersioning({ type: VersioningType.URI });
+      await app.init();
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('GET /robots.txt が 200 で期待どおりの本文・ヘッダを返す', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/robots.txt')
+        .expect(200);
+
+      expect(res.text).toBe(ROBOTS_TXT_BODY);
+      expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
+      expect(res.headers['cache-control']).toBe(
+        'public, max-age=86400, immutable',
+      );
+    });
+
+    it('バージョン prefix 付きの /v1/robots.txt では引けない（無 prefix 登録であることの確認）', async () => {
+      await request(app.getHttpServer()).get('/v1/robots.txt').expect(404);
+    });
+
+    it('存在しないパスは従来どおり 404', async () => {
+      await request(app.getHttpServer()).get('/no-such-path').expect(404);
+    });
+  });
+});

--- a/api/src/robots/robots.controller.ts
+++ b/api/src/robots/robots.controller.ts
@@ -1,0 +1,21 @@
+// api/src/robots/robots.controller.ts
+import { Controller, Get, Header } from '@nestjs/common';
+import { SkipResponseWrap } from '../core/interceptors/response-wrap.interceptor';
+
+// #276 【設計】全クローラを拒否する robots.txt
+// - version を指定しない @Controller() のため main.ts の enableVersioning()
+//   による /v1, /v2 prefix が付かず、そのまま `/robots.txt` で公開される
+//   （AppController の `/`, HealthController の `/health` と同じ扱い）
+// - ResponseWrapInterceptor は素の text/plain を返すため @SkipResponseWrap() で除外
+export const ROBOTS_TXT_BODY = 'User-agent: *\nDisallow: /\n';
+
+@Controller()
+export class RobotsController {
+  @Get('robots.txt')
+  @SkipResponseWrap()
+  @Header('Content-Type', 'text/plain; charset=utf-8')
+  @Header('Cache-Control', 'public, max-age=86400, immutable')
+  getRobotsTxt(): string {
+    return ROBOTS_TXT_BODY;
+  }
+}

--- a/api/src/robots/robots.module.ts
+++ b/api/src/robots/robots.module.ts
@@ -1,0 +1,8 @@
+// api/src/robots/robots.module.ts
+import { Module } from '@nestjs/common';
+import { RobotsController } from './robots.controller';
+
+@Module({
+  controllers: [RobotsController],
+})
+export class RobotsModule {}


### PR DESCRIPTION
Issue #276 の実装です。API は REST 専用でインデックス不要なので、`GET /robots.txt` を 200 で返して全拒否します。

## 受入基準の充足

| 基準 | 実測 |
| --- | --- |
| `GET /robots.txt` が 200 | ✅ |
| 本文が `User-agent: *` / `Disallow: /` のみ | ✅ |
| `Content-Type: text/plain; charset=utf-8` | ✅ |
| `Cache-Control: public, max-age=86400, immutable` | ✅ |
| 既存エンドポイントへ影響なし | ✅ 追加のみ |
| 存在しないパスは 404 | ✅ テストで固定 |

## この Issue でいやらしかった点

単なる Controller 追加ではなく、既存のグローバル設定を 2 つ回避する必要がありました。

1. **バージョニング prefix**: `main.ts` の `enableVersioning()` により、通常の Controller は `/v1`, `/v2` 配下になります。`@Controller()` を version 指定なしで宣言することで、`AppController` の `/` や `HealthController` の `/health` と同じくルート直下に載ります
2. **`ResponseWrapInterceptor`**: 全レスポンスを `{data, success}` 形式へ包むグローバル interceptor があります。素の `text/plain` を返す必要があるため `@SkipResponseWrap()` で除外しています

## テスト

`src/robots/robots.controller.spec.ts` **5 passed / 5**、`tsc --noEmit` exit 0。

上の 2 点は壊れても本文だけ見ると気付きにくいので、構造を固定するテストを入れています。

| テスト | 守る内容 |
| --- | --- |
| `GET /robots.txt` が 200 で期待どおりの本文・ヘッダ | 受入基準そのもの |
| **`/v1/robots.txt` では引けない** | prefix なし登録が壊れたら赤くなる |
| `ResponseWrapInterceptor` の対象外 | 包まれるようになったら赤くなる |
| 存在しないパスは 404 | 既存ルーティングへの巻き添えが無いこと |

## 補足

グローバルガードは `MaintenanceGuard` のみで、認証ガードは各 Controller 側でした。したがって robots.txt が認証で弾かれることはありません。ただし**メンテナンスモード中は robots.txt も止まります** — 実害は無いと判断してそのままにしています。

ワーカーの run はターン切れで failure になりましたが、commit は完了しており、リーダー側で diff・テスト・typecheck を実測して確認しています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_