### PR TITLE
#528 fix: モーダル内のタップ開始でキーボードを閉じるのをやめ、閉じる責務を子へ移す

### DIFF
--- a/app-expo/components/DishCategoryAutocomplete.test.tsx
+++ b/app-expo/components/DishCategoryAutocomplete.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * #528 候補タップ時にキーボードを閉じる責務が「子（オートコンプリート側）」にあることを守るテスト。
+ * 意図は components/LocationAutocomplete.test.tsx と同じ。料理カテゴリ側（レビュー投稿・地図の
+ * 検索モーダル）も同じ BlurModal に載るため、同じ不変条件を両方で固定する。
+ */
+import React, { act } from "react";
+import TestRenderer from "react-test-renderer";
+import { Keyboard } from "react-native";
+import type { QueryDishCategoryVariantsResponse } from "@shared/api/v1/res";
+
+// lucide のアイコンは名前ごとに export されるため Proxy で一括スタブ化する
+jest.mock(
+	"lucide-react-native",
+	() =>
+		new Proxy(
+			{},
+			{
+				get: (_target, prop) =>
+					prop === "__esModule"
+						? true
+						: function MockIcon() {
+								return null;
+							},
+			},
+		),
+);
+jest.mock("@/components/LoadingIndicator", () => ({ LoadingIndicator: () => null }));
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+jest.mock("@/hooks/useHaptics", () => ({ useHaptics: () => ({ lightImpact: jest.fn() }) }));
+
+let mockSuggestions: QueryDishCategoryVariantsResponse = [];
+jest.mock("@/hooks/useDishCategorySearch", () => ({
+	useDishCategorySearch: () => ({
+		suggestions: mockSuggestions,
+		isSearching: false,
+		searchDishCategories: jest.fn(),
+	}),
+}));
+
+import { DishCategoryAutocomplete } from "./DishCategoryAutocomplete";
+
+const TEST_ID = "dish-category-autocomplete";
+
+const ramen = { dishCategoryId: "cat-ramen", label: "ラーメン" } as QueryDishCategoryVariantsResponse[number];
+
+describe("#528 DishCategoryAutocomplete の候補タップ", () => {
+	let renderer: TestRenderer.ReactTestRenderer;
+	let dismissSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		mockSuggestions = [ramen];
+		dismissSpy = jest.spyOn(Keyboard, "dismiss").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		act(() => renderer?.unmount());
+		jest.restoreAllMocks();
+	});
+
+	/** 検索閾値（2 文字）を満たす値を入れて focus させ、候補パネルが出た状態にする */
+	const mountFocused = (props: Partial<React.ComponentProps<typeof DishCategoryAutocomplete>> = {}) => {
+		act(() => {
+			renderer = TestRenderer.create(
+				<DishCategoryAutocomplete
+					value="ラーメン"
+					onChangeText={jest.fn()}
+					onSelectSuggestion={jest.fn()}
+					testID={TEST_ID}
+					{...props}
+				/>,
+			);
+		});
+		act(() => renderer.root.findByProps({ testID: `${TEST_ID}-input` }).props.onFocus());
+		return renderer;
+	};
+
+	it("候補を押すと onSelectSuggestion が呼ばれ、キーボードは子が自分で閉じる", () => {
+		const onSelectSuggestion = jest.fn();
+		mountFocused({ onSelectSuggestion });
+
+		const row = renderer.root.findByProps({ testID: `${TEST_ID}-suggestion-0` });
+		act(() => row.props.onPress());
+
+		expect(onSelectSuggestion).toHaveBeenCalledWith(ramen);
+		expect(dismissSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("キーボードを閉じるのはタップ開始ではなく onPress（押下成立後）である", () => {
+		mountFocused();
+
+		const row = renderer.root.findByProps({ testID: `${TEST_ID}-suggestion-0` });
+		// タップ開始のレスポンダ交渉だけを起こす。ここで閉じると押下が潰れる（#528 の事故）
+		act(() => {
+			row.props.onStartShouldSetResponder?.({});
+		});
+		expect(dismissSpy).not.toHaveBeenCalled();
+
+		act(() => row.props.onPress());
+		expect(dismissSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app-expo/components/DishCategoryAutocomplete.tsx
+++ b/app-expo/components/DishCategoryAutocomplete.tsx
@@ -8,6 +8,7 @@ import {
 	ScrollView,
 	Platform,
 	AccessibilityInfo,
+	Keyboard,
 } from "react-native";
 import { useDishCategorySearch } from "@/hooks/useDishCategorySearch";
 import { useHaptics } from "@/hooks/useHaptics";
@@ -149,6 +150,11 @@ export function DishCategoryAutocomplete({
 	const handleSuggestionPress = useCallback(
 		(suggestion: QueryDishCategoryVariantsResponse[number]) => {
 			lightImpact();
+			// #528 【設計】キーボードを閉じる責務は子（＝候補を押されたこのコンポーネント）が持つ。
+			// 以前は親の BlurModal がタップ**開始**時に閉じており、レイアウト再計算で候補リストが
+			// unmount されて onPress が潰れていた。onPress まで来ていればタップは成立済み。
+			// 詳細は LocationAutocomplete.tsx の同じ箇所を参照。
+			Keyboard.dismiss();
 			onSelectSuggestion(suggestion);
 			setShowSuggestions(false);
 

--- a/app-expo/components/LocationAutocomplete.test.tsx
+++ b/app-expo/components/LocationAutocomplete.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * #528 候補タップ時にキーボードを閉じる責務が「子（オートコンプリート側）」にあることを守るテスト。
+ *
+ * 背景（Issue #528）:
+ * 以前は親（`BlurModal` の `KeyboardAvoidingView`）が「すべてのタップ**開始**で `Keyboard.dismiss()`」
+ * していたため、候補タップが押下成立前に潰れていた。親からその副作用を外した以上、
+ * キーボードを閉じるのは候補を押した子自身の仕事になる。
+ *
+ * ここで固定するのは
+ *   1. 候補押下で `onSelectSuggestion` が実際に呼ばれること（選択が成立すること）
+ *   2. そのとき `Keyboard.dismiss()` を子が自分で呼ぶこと
+ *   3. 呼ぶのはタップ「開始」ではなく `onPress`（＝押下が成立した後）であること
+ * 3 は、親の実装で起きていた事故を子側で繰り返さないための歯止め。
+ */
+import React, { act } from "react";
+import TestRenderer from "react-test-renderer";
+import { Keyboard } from "react-native";
+import type { AutocompleteLocation } from "@shared/api/v1/res";
+
+// lucide のアイコンは名前ごとに export されるため Proxy で一括スタブ化する
+jest.mock(
+	"lucide-react-native",
+	() =>
+		new Proxy(
+			{},
+			{
+				get: (_target, prop) =>
+					prop === "__esModule"
+						? true
+						: function MockIcon() {
+								return null;
+							},
+			},
+		),
+);
+jest.mock("@/components/LoadingIndicator", () => ({ LoadingIndicator: () => null }));
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+jest.mock("@/hooks/useHaptics", () => ({ useHaptics: () => ({ lightImpact: jest.fn() }) }));
+
+let mockSuggestions: AutocompleteLocation[] = [];
+jest.mock("@/hooks/useLocationSearch", () => ({
+	useLocationSearch: () => ({
+		suggestions: mockSuggestions,
+		status: "success",
+		searchLocations: jest.fn(),
+		clearSuggestions: jest.fn(),
+	}),
+}));
+
+import { LocationAutocomplete, type RecentLocation } from "./LocationAutocomplete";
+
+const TEST_ID = "location-autocomplete";
+
+const shibuya = {
+	place_id: "place-shibuya",
+	text: "渋谷駅",
+	mainText: "渋谷駅",
+	secondaryText: "東京都渋谷区",
+	types: ["train_station"],
+} as unknown as AutocompleteLocation;
+
+const recentShibuya: RecentLocation = {
+	location: { latitude: 35.658, longitude: 139.701 },
+	address: "country:JP, locality:Tokyo",
+	localLanguageCode: "ja",
+	locationQuery: "渋谷駅",
+};
+
+describe("#528 LocationAutocomplete の候補タップ", () => {
+	let renderer: TestRenderer.ReactTestRenderer;
+	let dismissSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		mockSuggestions = [];
+		dismissSpy = jest.spyOn(Keyboard, "dismiss").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		act(() => renderer?.unmount());
+		jest.restoreAllMocks();
+	});
+
+	/** 値を入れて focus させ、候補パネルが出た状態にする */
+	const mountFocused = (props: Partial<React.ComponentProps<typeof LocationAutocomplete>> = {}) => {
+		act(() => {
+			renderer = TestRenderer.create(
+				<LocationAutocomplete
+					value="渋谷"
+					onChangeText={jest.fn()}
+					onSelectSuggestion={jest.fn()}
+					testID={TEST_ID}
+					{...props}
+				/>,
+			);
+		});
+		// autofocus は実 TextInput の focus() を呼ぶだけで onFocus は発火しないため、明示的に起こす
+		act(() => renderer.root.findByProps({ testID: `${TEST_ID}-input` }).props.onFocus());
+		return renderer;
+	};
+
+	it("候補を押すと onSelectSuggestion が呼ばれ、キーボードは子が自分で閉じる", () => {
+		mockSuggestions = [shibuya];
+		const onSelectSuggestion = jest.fn();
+		mountFocused({ onSelectSuggestion });
+
+		const row = renderer.root.findByProps({ testID: `${TEST_ID}-suggestion-0` });
+		act(() => row.props.onPress());
+
+		expect(onSelectSuggestion).toHaveBeenCalledWith(shibuya);
+		expect(dismissSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("キーボードを閉じるのはタップ開始ではなく onPress（押下成立後）である", () => {
+		mockSuggestions = [shibuya];
+		mountFocused();
+
+		const row = renderer.root.findByProps({ testID: `${TEST_ID}-suggestion-0` });
+		// タップ開始のレスポンダ交渉だけを起こす。ここで閉じると押下が潰れる（#528 の事故）
+		act(() => {
+			row.props.onStartShouldSetResponder?.({});
+		});
+		expect(dismissSpy).not.toHaveBeenCalled();
+
+		act(() => row.props.onPress());
+		expect(dismissSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("「最近使った場所」を押したときも同じくキーボードを閉じて選択を通す", () => {
+		const onSelectRecentLocation = jest.fn();
+		mountFocused({ value: "", recentLocations: [recentShibuya], onSelectRecentLocation });
+
+		const row = renderer.root.findByProps({ testID: `${TEST_ID}-recent-location-0` });
+		act(() => row.props.onPress());
+
+		expect(onSelectRecentLocation).toHaveBeenCalledWith(recentShibuya);
+		expect(dismissSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app-expo/components/LocationAutocomplete.tsx
+++ b/app-expo/components/LocationAutocomplete.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef, forwardRef, useImperativeHandle } from "react";
-import { View, Text, TextInput, TouchableOpacity, StyleSheet, ScrollView } from "react-native";
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ScrollView, Keyboard } from "react-native";
 import { useLocationSearch, type LocationSearchStatus } from "@/hooks/useLocationSearch";
 import { useHaptics } from "@/hooks/useHaptics";
 import i18n from "@/lib/i18n";
@@ -213,10 +213,16 @@ export const LocationAutocomplete = forwardRef<LocationAutocompleteHandle, Locat
 		const handleSuggestionPress = useCallback(
 			(suggestion: AutocompleteLocation) => {
 				lightImpact();
+				// #528 【設計】キーボードを閉じる責務は子（＝候補を押されたこのコンポーネント）が持つ。
+				// 以前は親の BlurModal がタップ**開始**時に閉じており、レイアウト再計算で候補リストが
+				// unmount されて onPress が潰れていた。onPress まで来ていればタップは成立済みなので、
+				// ここで閉じても選択は失われない。
+				Keyboard.dismiss();
 				onSelectSuggestion(suggestion);
 				setShowSuggestions(false);
 
 				// Delay blur to allow parent state update to complete
+				// （web では Keyboard.dismiss が実質何もしないため、blur はこちらで担保する）
 				setTimeout(() => {
 					inputRef.current?.blur();
 				}, BLUR_AFTER_SELECT_DELAY_MS);
@@ -228,6 +234,8 @@ export const LocationAutocomplete = forwardRef<LocationAutocompleteHandle, Locat
 		const handleRecentLocationPress = useCallback(
 			(recent: RecentLocation) => {
 				lightImpact();
+				// #528 候補と同じく、閉じるのは押下成立後（onPress）にこの子が自分で行う
+				Keyboard.dismiss();
 				onSelectRecentLocation?.(recent);
 				setIsFocused(false);
 

--- a/app-expo/features/blurModal/hooks/useBlurModal.test.tsx
+++ b/app-expo/features/blurModal/hooks/useBlurModal.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * #528 BlurModal ＋ キーボード ＋ オートコンプリートのタップ競合を守るテスト。
+ *
+ * 背景（Issue #528）:
+ * `BlurModal` の `KeyboardAvoidingView` が `onStartShouldSetResponder` で
+ * 「**すべてのタップの開始時に** `Keyboard.dismiss()` する」振る舞いを持っていた。
+ * そのため候補タップは
+ *   タップ開始 → 親が Keyboard.dismiss() → キーボード高の変化でレイアウト再計算
+ *   → 候補リストが畳まれて unmount → 子の onPress がキャンセル
+ * となり、「キーボードだけ閉じて選択が反応しない」状態になっていた
+ * （初回起動でだけ再現するのはレイアウトタイミングの揺らぎによるもので、原因は同じ）。
+ *
+ * 実機のタッチ順序は jest では再現できないので、代わりに責務分離の構造を固定する:
+ *   1. モーダルの中身の **祖先** が子のタップに触るレスポンダを持たないこと
+ *   2. キーボードを閉じる責務は背景タップ（バックドロップ）だけが持つこと
+ * 1 は修正前の実装で赤くなる（KeyboardAvoidingView が onStartShouldSetResponder を持つため）。
+ */
+import React, { act } from "react";
+import TestRenderer, { type ReactTestInstance } from "react-test-renderer";
+import { Keyboard, Pressable, View } from "react-native";
+
+// lucide のアイコンは名前ごとに export されるため Proxy で一括スタブ化する
+jest.mock(
+	"lucide-react-native",
+	() =>
+		new Proxy(
+			{},
+			{
+				get: (_target, prop) =>
+					prop === "__esModule"
+						? true
+						: function MockIcon() {
+								return null;
+							},
+			},
+		),
+);
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+jest.mock("expo-blur", () => ({ BlurView: () => null }));
+// Portal は Provider が無いと描画されないため、その場に子を出すだけの実装へ差し替える
+jest.mock("react-native-paper", () => ({ Portal: ({ children }: { children: React.ReactNode }) => children }));
+jest.mock("react-native-safe-area-context", () => ({
+	useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+import { useBlurModal, type BlurModalOptions } from "./useBlurModal";
+
+const CHILD_TEST_ID = "blur-modal-child";
+
+/** キーボードの表示状態を任意に起こせるよう、addListener を差し替えて購読を捕まえる */
+const keyboardHandlers: Record<string, Array<() => void>> = {};
+const showKeyboard = () => act(() => keyboardHandlers.keyboardDidShow?.forEach((h) => h()));
+
+/** テスト用ホスト。BlurModal は hook 経由でしか手に入らないので、描画と同時に open しておく */
+const Host = ({ options, onChildPress }: { options?: BlurModalOptions; onChildPress?: () => void }) => {
+	const { BlurModal, open } = useBlurModal(options);
+	const opened = React.useRef(false);
+	if (!opened.current) {
+		opened.current = true;
+		open();
+	}
+	return (
+		<BlurModal>
+			<Pressable testID={CHILD_TEST_ID} onPress={onChildPress}>
+				<View />
+			</Pressable>
+		</BlurModal>
+	);
+};
+
+/** host 要素（type が文字列のもの）だけを testID で引く。composite と二重に当たるのを避ける */
+const findHostByTestID = (root: ReactTestInstance, testID: string): ReactTestInstance =>
+	root.find((node) => typeof node.type === "string" && node.props?.testID === testID);
+
+/**
+ * 子（testID を持つ要素）より **上** の祖先だけを根に向かって並べる。
+ * Pressable は自分の内側にも testID 付きの View を描画し、そこには Pressability が
+ * onStartShouldSetResponder を必ず載せる（＝子自身の正当な実装）。ここで見たいのは
+ * 「親が子のタップに割り込んでいないか」なので、子の内部は除外する。
+ */
+const ancestorsOf = (root: ReactTestInstance, testID: string): ReactTestInstance[] => {
+	const chain: ReactTestInstance[] = [];
+	let node: ReactTestInstance | null = findHostByTestID(root, testID);
+	while (node && node.props?.testID === testID) node = node.parent;
+	for (; node; node = node.parent) chain.push(node);
+	return chain;
+};
+
+/** Pressable の onPress は host 要素には出ないので、押下は composite 側から起こす */
+const findPressableByTestID = (root: ReactTestInstance, testID: string): ReactTestInstance =>
+	root.findAllByType(Pressable).find((node) => node.props?.testID === testID)!;
+
+describe("#528 BlurModal のタップ責務分離", () => {
+	let renderer: TestRenderer.ReactTestRenderer;
+	let dismissSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		for (const key of Object.keys(keyboardHandlers)) delete keyboardHandlers[key];
+		jest.spyOn(Keyboard, "addListener").mockImplementation(((event: string, handler: () => void) => {
+			(keyboardHandlers[event] ??= []).push(handler);
+			return { remove: () => {} };
+		}) as unknown as typeof Keyboard.addListener);
+		dismissSpy = jest.spyOn(Keyboard, "dismiss").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		act(() => renderer?.unmount());
+		jest.restoreAllMocks();
+	});
+
+	const mount = (props: React.ComponentProps<typeof Host> = {}) => {
+		act(() => {
+			renderer = TestRenderer.create(<Host {...props} />);
+		});
+		return renderer;
+	};
+
+	it("モーダルの中身の祖先が、子のタップを奪うレスポンダを持たない", () => {
+		mount();
+
+		// onStartShouldSetResponder はタップ「開始」時に呼ばれる。親がここで副作用
+		// （Keyboard.dismiss 等）を起こすと、子の onPress 成立前にレイアウトが動いて押下が潰れる
+		const offenders = ancestorsOf(renderer.root, CHILD_TEST_ID)
+			.filter((node) => node.props?.onStartShouldSetResponder !== undefined)
+			.map((node) => (typeof node.type === "string" ? node.type : (node.type as { name?: string }).name || "?"));
+
+		expect(offenders).toEqual([]);
+	});
+
+	it("中身のタップ開始では親が何もせず、続く onPress が成立する", () => {
+		const onChildPress = jest.fn();
+		mount({ onChildPress });
+
+		// RN はタッチ開始時、対象から祖先へ向かって onStartShouldSetResponder を順に呼ぶ。
+		// ここではその交渉だけを再現する（この時点ではまだ onPress は確定していない）
+		act(() => {
+			for (const node of ancestorsOf(renderer.root, CHILD_TEST_ID)) {
+				node.props?.onStartShouldSetResponder?.({});
+			}
+		});
+
+		// キーボードを閉じるかどうかは子（オートコンプリート側）の判断。親はタップ開始で何もしない
+		expect(dismissSpy).not.toHaveBeenCalled();
+		// 中身も畳まれていないので、指を離したときの onPress がそのまま届く
+		act(() => findPressableByTestID(renderer.root, CHILD_TEST_ID).props.onPress());
+		expect(onChildPress).toHaveBeenCalledTimes(1);
+	});
+
+	it("背景タップでは、キーボードが出ていればまずキーボードだけ閉じる", () => {
+		mount({ options: { closeOnBackdropPress: true } });
+		showKeyboard();
+
+		// バックドロップは最初の Pressable（× ボタンより手前に描画される）
+		act(() => renderer.root.findAllByType(Pressable)[0].props.onPress());
+
+		expect(dismissSpy).toHaveBeenCalledTimes(1);
+		// キーボードを閉じただけなので、中身はまだ生きている
+		expect(renderer.root.findAll((n) => n.props?.testID === CHILD_TEST_ID)).not.toHaveLength(0);
+	});
+
+	it("キーボードが出ていない背景タップでは、closeOnBackdropPress のときモーダルを閉じる", () => {
+		mount({ options: { closeOnBackdropPress: true } });
+
+		act(() => renderer.root.findAllByType(Pressable)[0].props.onPress());
+
+		expect(dismissSpy).not.toHaveBeenCalled();
+		expect(renderer.root.findAll((n) => n.props?.testID === CHILD_TEST_ID)).toHaveLength(0);
+	});
+});

--- a/app-expo/features/blurModal/hooks/useBlurModal.tsx
+++ b/app-expo/features/blurModal/hooks/useBlurModal.tsx
@@ -159,15 +159,22 @@ export function useBlurModal({
 								)}
 							</Pressable>
 
+							{/*
+							  #528 【修正】ここに `onStartShouldSetResponder` を付けてはいけない。
+							  以前は「レスポンダは奪わず（false を返す）副作用として Keyboard.dismiss() だけ行う」
+							  実装だったが、このコールバックはタップ**開始**時に呼ばれるため、
+							    候補タップ開始 → 親が Keyboard.dismiss() → キーボード高の変化でレイアウト再計算
+							    → 候補リストが畳まれて unmount → 子の onPress がキャンセル
+							  となり「キーボードだけ閉じて選択が反応しない」不具合になっていた
+							  （初回起動でだけ再現したのはレイアウトタイミングの揺らぎによるもので原因は同じ）。
+							  キーボードを閉じる責務は、背景タップの `handleBackdropPress` と
+							  子（オートコンプリート側の候補押下）だけが持つ。
+							*/}
 							<KeyboardAvoidingView
 								style={{ flex: 1 }}
 								behavior={Platform.OS === "ios" ? "padding" : "height"}
 								keyboardVerticalOffset={keyboardVerticalOffset}
-								pointerEvents="box-none"
-								onStartShouldSetResponder={() => {
-									Keyboard.dismiss();
-									return false; // ← 自分ではレスポンダを奪わない（子要素にタップを渡す）
-								}}>
+								pointerEvents="box-none">
 								{/* Content (non-blocking layout wrapper) */}
 								<View pointerEvents="box-none" style={[contenContinerWrapperStyle]}>
 									<View pointerEvents="auto" style={contentContainerStyle}>


### PR DESCRIPTION
Issue #528 の修正です。初回起動時にオートコンプリート候補をタップすると、キーボードだけ閉じて選択が反応しない問題です。

## 真犯人

`app-expo/features/blurModal/hooks/useBlurModal.tsx` の `KeyboardAvoidingView` に付いていたこれです。

```tsx
onStartShouldSetResponder={() => {
  Keyboard.dismiss();
  return false; // ← 自分ではレスポンダを奪わない（子要素にタップを渡す）
}}
```

コメントのとおり**レスポンダは奪っていません**。しかしこのコールバックはタップ**開始**時に呼ばれます。

```
候補タップ開始
  → 親が Keyboard.dismiss()
  → キーボード高の変化でレイアウト再計算
  → 候補リストが畳まれて unmount
  → 子の onPress がキャンセル
```

「レスポンダを渡しているから安全」に見えて、**副作用の側で子を巻き添えにしていた**という構造です。初回起動でだけ再現したのはレイアウトタイミングの揺らぎで、原因は同じです。

## 修正（Issue の方針どおり）

| | 修正前 | 修正後 |
| --- | --- | --- |
| 親（モーダル） | **すべてのタップ開始**でキーボードを閉じる | 背景タップ（`handleBackdropPress`）でのみ閉じる |
| 子（候補側） | 何もしない | `onPress` 成立後に自分で `Keyboard.dismiss()` してから `onSelect` |

`onPress` まで到達していればタップは成立済みなので、そこで閉じても選択は失われません。

対象は `LocationAutocomplete`（候補・最近使った場所の両方）と `DishCategoryAutocomplete` です。

## 検証

`pnpm --filter app-expo test` **35 suites / 243 tests 全 pass**、`typecheck` exit 0。

**テストが本当に効くことをミューテーションで実測しました。** 削除した `onStartShouldSetResponder` を元に戻すと:

```
Test Suites: 1 failed, 34 passed, 35 total
Tests:       2 failed, 241 passed, 243 total
```

緑になるだけのテストではなく、この修正が戻されたら赤くなります。

## ⚠️ 実機で確認してほしいこと（挙動が変わります）

**モーダル内の余白をタップしてもキーボードが閉じなくなります。** 修正前は「モーダル内のどこを触っても閉じる」でしたが、今は「背景タップ」と「候補押下」でのみ閉じます。

これは Issue の指示どおりですが、**`BlurModal` を使う全モーダルに効く挙動変更**なので体感の確認をお願いします。

- [ ] **初回起動で、オートコンプリート候補をタップして選択できる**（Issue の完了条件そのもの）
- [ ] 背景タップでキーボードが閉じる
- [ ] モーダル内の余白タップで閉じなくなったことが不自然でないか
- [ ] 料理カテゴリ検索でも候補が選べる
- [ ] 「最近使った場所」も選べる
- [ ] iOS / Android 両方

タッチの実機挙動は jest では原理的に再現できないため、ここだけは人間の確認が要ります。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_