### PR TITLE
#528 #1129 test(e2e): 実機確認へ回していた項目を E2E へ移す（web / mobile 両方）

### DIFF
--- a/e2e-mobile/screens/SearchScreen.ts
+++ b/e2e-mobile/screens/SearchScreen.ts
@@ -364,16 +364,6 @@ export class SearchScreen {
 	}
 
 	/**
-	 * 場所サジェストのパネルが **いま見えているか** を待たずに判定する（#528）。
-	 *
-	 * ⚠️ 通常のアサーションには使わないこと（`visibleNow` と同じ理由で、false は
-	 * 「まだ描画されていない」だけの可能性がある）。分岐（開いていなければ開き直す）専用。
-	 */
-	async hasVisibleLocationSuggestions(timeout = 2_000): Promise<boolean> {
-		return visibleNow(this.locationSuggestions, timeout);
-	}
-
-	/**
 	 * 場所入力欄の現在値を読む（#528）。
 	 *
 	 * ⚠️ **アサーションの主観測点にはしないこと。** Detox の `toHaveValue` / `toHaveText` は

--- a/e2e-mobile/screens/SearchScreen.ts
+++ b/e2e-mobile/screens/SearchScreen.ts
@@ -352,6 +352,64 @@ export class SearchScreen {
 		await tapWhenVisible(this.locationSuggestion(index));
 	}
 
+	/**
+	 * 場所入力欄をタップしてフォーカスを与える（#528）。
+	 *
+	 * `typeLocation()` から入力操作だけを切り離したもの。`LocationAutocomplete` は
+	 * `showSuggestions = 入力あり && フォーカス中` で候補を出すため、**入力済みの文字列を消さずに
+	 * 候補パネルだけ開き直したい**ときに使う。
+	 */
+	async focusLocationInput(): Promise<void> {
+		await tapWhenVisible(this.locationInput);
+	}
+
+	/**
+	 * 場所サジェストのパネルが **いま見えているか** を待たずに判定する（#528）。
+	 *
+	 * ⚠️ 通常のアサーションには使わないこと（`visibleNow` と同じ理由で、false は
+	 * 「まだ描画されていない」だけの可能性がある）。分岐（開いていなければ開き直す）専用。
+	 */
+	async hasVisibleLocationSuggestions(timeout = 2_000): Promise<boolean> {
+		return visibleNow(this.locationSuggestions, timeout);
+	}
+
+	/**
+	 * 場所入力欄の現在値を読む（#528）。
+	 *
+	 * ⚠️ **アサーションの主観測点にはしないこと。** Detox の `toHaveValue` / `toHaveText` は
+	 * TextInput に対する挙動がプラットフォームで揺れる（location-autocomplete.test.ts の
+	 * ヘッダに既に書いてあるとおり、既存 spec は「クリアボタンの有無」へ置き換えている）。
+	 * ここで `getAttributes()` を使うのは **「入力欄に何かが入った」ことを補助的に見る**ためで、
+	 * 「選択が成立した」の判定は検索が通ること（`submit()` 後に画面が進むこと）で行う。
+	 *
+	 * 戻り値の型が iOS / Android で分かれるため `text` だけを拾う形に絞る
+	 * （`readPreloadProbeDetail()` / ResultScreen.ts の読み取りと同じ扱い）。
+	 *
+	 * @returns 入力欄のテキスト。読めなかった場合は空文字
+	 */
+	async readLocationInputText(): Promise<string> {
+		try {
+			const attributes = (await element(this.locationInput).getAttributes()) as { text?: string };
+			return attributes.text ?? "";
+		} catch {
+			// 「まだ描画されていない」「属性を読めない」はどちらも空扱いにする。
+			// 呼び出し側は「空でないこと」を見るため、読めなければ素直に失敗すればよい
+			return "";
+		}
+	}
+
+	/**
+	 * 場所入力欄のリターンキーを押してキーボードを閉じる（#528 / ベストエフォート）。
+	 *
+	 * `clearLocationIfPresent()` が内部で使っているものと同じ操作を spec から呼べるようにしたもの。
+	 * Detox にプラットフォーム共通の「キーボードを閉じる」API は無く、Android は IME 自体を
+	 * 無効化してある（scripts/setup-android-locale.sh）ためそもそもキーボードが出ない。
+	 * **失敗しても検証を止めない**（環境差で落ちても、その失敗は検証したい事実と無関係なため）。
+	 */
+	async dismissKeyboardIfOpen(): Promise<void> {
+		await this.dismissKeyboard();
+	}
+
 	/** 時間帯を選択する */
 	async selectTimeSlot(id: "morning" | "lunch" | "dinner" | "late_night"): Promise<void> {
 		await tapWhenVisible(this.timeSlot(id));

--- a/e2e-mobile/screens/SearchScreen.ts
+++ b/e2e-mobile/screens/SearchScreen.ts
@@ -98,6 +98,11 @@ export class SearchScreen {
 	readonly locationClearButton = by.id("search-location-autocomplete-clear");
 	/** 場所サジェストのリスト */
 	readonly locationSuggestions = by.id("search-location-autocomplete-suggestions");
+	/** 「最近使った場所」のリスト（#953。e2e-web の recentLocationsList に対応）。
+	 *  未入力でフォーカスしたときだけ描画される */
+	readonly recentLocationsList = by.id("search-location-autocomplete-recent-locations");
+	/** 「最近使った場所」を全件クリアするボタン（1件以上あるときだけ描画される） */
+	readonly recentLocationsClearButton = by.id("search-location-autocomplete-recent-locations-clear");
 	/** 入力欄右端の「現在地を使う」ボタン */
 	readonly currentLocationButton = by.id("search-current-location-button");
 
@@ -165,6 +170,11 @@ export class SearchScreen {
 	/** n 番目の場所サジェスト（0 始まり） */
 	locationSuggestion(index: number): Detox.NativeMatcher {
 		return by.id(`search-location-autocomplete-suggestion-${index}`);
+	}
+
+	/** n 番目の「最近使った場所」（0 始まり、先頭が最新） */
+	recentLocation(index: number): Detox.NativeMatcher {
+		return by.id(`search-location-autocomplete-recent-location-${index}`);
 	}
 
 	/** 時間帯グリッドの項目（id は app-expo/features/search/constants.ts の timeSlots の値） */
@@ -350,6 +360,31 @@ export class SearchScreen {
 	async selectLocationSuggestion(index: number): Promise<void> {
 		await waitUntilVisible(this.locationSuggestion(index));
 		await tapWhenVisible(this.locationSuggestion(index));
+	}
+
+	/**
+	 * 「最近使った場所」パネルを表示する（e2e-web の openRecentLocations に対応）。
+	 *
+	 * `LocationAutocomplete` は「入力が空 && フォーカス中」のときだけこのパネルを出す
+	 * （showRecentLocations の条件）。`clearLocationIfPresent` はクリア後にリターンキーで
+	 * キーボードを閉じてしまう（= blur してパネルが閉じる）ため、そのあとで
+	 * 明示的に入力欄をタップし直してフォーカスを確定させる。
+	 */
+	async openRecentLocations(): Promise<void> {
+		await this.clearLocationIfPresent();
+		await tapWhenVisible(this.locationInput);
+		await waitUntilVisible(this.recentLocationsList);
+	}
+
+	/**
+	 * n 番目の「最近使った場所」の accessibilityLabel（= `RecentLocation.locationQuery`）を読み取る。
+	 *
+	 * 実 API の検索結果は地名も件数も事前に確定できないため、e2e-web のように入力欄の値を
+	 * 直接アサートするのではなく、ResultScreen の likeLabel と同じ「ラベルを読んで比較する」
+	 * 方式に倣う（値そのものではなく、選び直し前後で一致/変化したことを検証する）。
+	 */
+	async recentLocationLabel(index: number): Promise<string> {
+		return readLabel(this.recentLocation(index), 0);
 	}
 
 	/** 時間帯を選択する */
@@ -555,4 +590,16 @@ export class SearchScreen {
 			.whileElement(this.scrollView)
 			.scroll(pixels, "down", 0.5, 0.5);
 	}
+}
+
+/**
+ * 指定要素の accessibilityLabel を取得する（ResultScreen.ts の readLabel と同じ仕組み）。
+ *
+ * `getAttributes()` の戻り値は iOS / Android・単一 / 複数一致で型が分かれるが、
+ * `atIndex()` で 1 件に絞っているため `label` を持つ形にしかならない。
+ * 型定義がその絞り込みを表現できないので、ここで局所的に吸収する。
+ */
+async function readLabel(matcher: Detox.NativeMatcher, index: number): Promise<string> {
+	const attributes = (await element(matcher).atIndex(index).getAttributes()) as { label?: string };
+	return attributes.label ?? "";
 }

--- a/e2e-mobile/tests/search/location-suggestion-tap.test.ts
+++ b/e2e-mobile/tests/search/location-suggestion-tap.test.ts
@@ -4,6 +4,7 @@ import {
 	element,
 	expect,
 	launchAppWithSession,
+	visibleNow,
 	waitUntilGone,
 	waitUntilNotVisible,
 	waitUntilVisible,
@@ -112,9 +113,16 @@ describe("場所オートコンプリートの候補タップ（実 API / #528�
 		// global-snackbar を出して遷移をガードするため、トピック画面へは進めない
 		await search.submit();
 
-		await expect(element(search.snackbar)).not.toBeVisible();
-		// トピック生成（AI）の完了は待たない。遷移したことだけをヘッダで確認する
+		// トピック生成（AI）の完了は待たない。遷移したことだけをヘッダで確認する。
+		// 地点が確定していなければここへ到達できず、25 秒待って落ちる
 		await topics.expectHeaderVisible();
+		// 遷移を確認したうえで、バリデーション通知が出ていないことも押さえる。
+		// 「遷移はしたがスナックバーも出ている」という中途半端な壊れ方を見逃さないため。
+		// ⚠️ Detox の `not.toBeVisible()` ではなく `visibleNow` で見る。スナックバーは非表示のとき
+		// **要素ごと描画されない**（react-native-paper の Snackbar）ため、「見えない」と
+		// 「存在しない」が混ざる。`visibleNow` はどちらも false に潰してくれる
+		const snackbarShown = await visibleNow(search.snackbar, 1_000);
+		assert.equal(snackbarShown, false, "地点を選択して検索したのにバリデーション通知が表示されている");
 	});
 
 	// ─ テストケース: 候補パネルを開いたままキーボードを閉じても、そのあと候補を選択できる ─
@@ -151,15 +159,18 @@ describe("場所オートコンプリートの候補タップ（実 API / #528�
 		// #528 の事故はこの「閉じる」に伴うレイアウト再計算で起きていた
 		await search.dismissKeyboardIfOpen();
 
-		// 入力欄が blur すると 150ms 後に候補パネルを畳む予約が入る（`BLUR_SUGGESTION_HIDE_DELAY_MS`）。
-		// 畳まれてしまった場合は入力欄をタップし直して開き直す。
-		// ⚠️ ここは「畳まれるのが正しい / 畳まれないのが正しい」を主張しない。閉じ方が
-		// プラットフォーム（IME の有無）に依存するためで、この spec が見たいのは
-		// **開き直したあとのタップが成立するか**である
-		if (!(await search.hasVisibleLocationSuggestions())) {
-			await search.focusLocationInput();
-			await waitUntilVisible(search.locationSuggestions);
-		}
+		// 入力欄をタップし直して候補パネルを開いた状態へ戻す。
+		//
+		// ⚠️ ここは「キーボードを閉じたら候補が畳まれる / 畳まれない」を主張しない。
+		// リターンキーで入力欄が blur すると 150ms 後にパネルを畳む予約が入る
+		//（`BLUR_SUGGESTION_HIDE_DELAY_MS`）が、IME を無効化した Android では
+		// そもそも blur が起きないため、閉じたかどうかはプラットフォーム依存になる。
+		// **条件分岐せず必ずタップし直す**ことで、どちらの経路でも同じ状態から次へ進める:
+		// - blur 済みなら再フォーカスで `handleFocus` が畳む予約をキャンセルしてパネルを開き直す
+		// - フォーカスが残っているなら onFocus は再発火せず、パネルもそのまま
+		// この spec が見たいのは閉じ方ではなく、**そのあとのタップが成立するか**である
+		await search.focusLocationInput();
+		await waitUntilVisible(search.locationSuggestions);
 		await waitUntilVisible(search.locationSuggestion(0));
 
 		await search.selectLocationSuggestion(0);

--- a/e2e-mobile/tests/search/location-suggestion-tap.test.ts
+++ b/e2e-mobile/tests/search/location-suggestion-tap.test.ts
@@ -1,0 +1,178 @@
+import { strict as assert } from "node:assert";
+
+import {
+	element,
+	expect,
+	launchAppWithSession,
+	waitUntilGone,
+	waitUntilNotVisible,
+	waitUntilVisible,
+} from "../../fixtures/e2e";
+import { SearchScreen } from "../../screens/SearchScreen";
+import { TopicsScreen } from "../../screens/TopicsScreen";
+
+/**
+ * 📍 場所オートコンプリートの「候補タップで地点が選択される」回帰テスト（実 API / Tier 2）
+ *
+ * 対応 Issue: #528「アプリ初回起動時、オートコンプリート候補をタップするとキーボードだけ閉じて
+ *             選択が反応しない」／ 修正 PR #1180
+ *
+ * ## この spec が守るもの
+ * #1180 以前は `useBlurModal` の `KeyboardAvoidingView` が
+ * `onStartShouldSetResponder={() => { Keyboard.dismiss(); return false; }}` を持っており、
+ *
+ *   候補タップ**開始** → 親が Keyboard.dismiss() → キーボード高の変化でレイアウト再計算
+ *   → 候補リストが unmount → 子の onPress がキャンセル
+ *
+ * となって「キーボードだけ閉じて選択が反応しない」状態になっていた。
+ * 修正はこの副作用を親から外し、キーボードを閉じる責務を **候補を押された子側**
+ *（`LocationAutocomplete` / `DishCategoryAutocomplete` の `handleSuggestionPress`）へ移したもの。
+ *
+ * ⚠️ アプリ側の単体テスト（app-expo の `useBlurModal.test.tsx` / `LocationAutocomplete.test.tsx`）は
+ * 「親がレスポンダを奪わない」「子が `Keyboard.dismiss()` を呼ぶ」という**実装の形**を固定している。
+ * ここで守るのはその 1 段上、**「ユーザーが候補を押したら地点が本当に確定する」**という結果である。
+ * 実装の形が変わっても（例えば別の方法でキーボードを閉じるようになっても）、
+ * 結果が壊れたときにだけ赤くなるのがこの spec の役割。
+ *
+ * ## 「選択が成立した」の観測点を “入力欄の値” にしていない理由
+ * `location-autocomplete.test.ts` のヘッダにあるとおり、Detox の `toHaveValue` / `toHaveText` は
+ * TextInput に対する挙動がプラットフォームで揺れるため、既存 spec は入力欄の**値**の
+ * アサーションを避けている。ここも同じ方針に従い、主観測点は
+ *
+ *   **「地点が確定したので検索が成立し、トピック画面へ進む」**
+ *
+ * とする。#528 が再発すると `handleLocationSelect` が呼ばれず検索の必須項目である `location` が
+ * null のままになるため、検索ボタンは `global-snackbar` を出して遷移をガードする
+ *（`search-form.test.ts` の「場所が未確定のまま検索するとバリデーション通知が出て遷移しない」が
+ * まさにその状態を検証している）。つまりこの spec と search-form.test.ts は表裏の関係にある。
+ *
+ * 入力欄の値は `getAttributes()` で**補助的に**だけ見る（「何も入っていない」＝ 明らかな失敗を、
+ * 検索まで進まずに素早く名指しで報告するため）。
+ *
+ * ## トピック生成（AI）の完了は待たない
+ * 観測点は `topics-header-title` の表示までに留め、`TopicsScreen.expectLoaded()`（カードの描画待ち＝
+ * AI 生成の完了待ちで実測数十秒）は呼ばない。この spec が見たいのは「地点が確定して遷移したか」であって
+ * トピック生成の成否ではなく、そこは `topics-flow.test.ts` が担当している。
+ *
+ * ## e2e-web との対応
+ * e2e-web は `tests/search/location-autocomplete.spec.ts` の
+ * 「mousedownを250ms保持するスロークリックでもサジェストを選択できる」(#991) が同じ
+ * 「候補を押したのに選択が成立しない」クラスの不具合を守っている。ただし原因は Web 固有
+ *（mousedown → blur の競合）で、#528 はネイティブ固有（キーボード高の変化によるレイアウト再計算）。
+ * **同じ症状に対する、プラットフォームごとの別々の回帰テスト**という関係になる。
+ */
+describe("場所オートコンプリートの候補タップ（実 API / #528）", () => {
+	const search = new SearchScreen();
+	const topics = new TopicsScreen();
+
+	// #1027 【バグ】beforeAll だと前のテストが残した状態（開いたキーボード・スクロール位置・遷移先の画面）を
+	// 次のテストが引き継ぐ。とくにこの spec は 1 本目で画面遷移するため、テストごとに起動し直して
+	// 独立性を担保する。セッション注入起動は匿名クォータを消費しない（fixtures/e2e.ts）
+	beforeEach(async () => {
+		// #1030 【設計】3-1: 匿名サインインのクォータを消費しないよう、確立済みセッションを注入して起動する
+		await launchAppWithSession({ as: "anon" });
+		await search.expectLoaded();
+	});
+
+	// ─ テストケース: 候補をタップすると、その地点が実際に選択される ─
+	// 手順:
+	//   1. 自動取得された現在地が入っている可能性があるため、明示的にクリアして「場所未確定」を作る
+	//   2. 場所入力欄をタップしてフォーカスし、「渋谷」を入力する（フォーカスが無いと候補パネルが開かない）
+	//   3. サジェストリストと先頭項目の表示を待つ
+	//   4. 先頭の候補をタップする ← #528 の再現操作
+	//   5. サジェストリストが閉じ、入力欄には候補の文言が入っている（＝ 空に戻っていない）ことを検証
+	//   6. 検索を実行し、バリデーション通知が出ずにトピック画面へ進むことを検証
+	//      （＝ 地点が「入力欄の見た目」だけでなく検索条件として確定している）
+	it("候補をタップするとその地点が選択され、検索がトピック画面へ進む", async () => {
+		await search.clearLocationIfPresent();
+
+		await search.typeLocation("渋谷");
+		await waitUntilVisible(search.locationSuggestions);
+		await waitUntilVisible(search.locationSuggestion(0));
+
+		await search.selectLocationSuggestion(0);
+
+		// 候補パネルは選択と同時に畳まれる（`handleSuggestionPress` の `setShowSuggestions(false)`）。
+		// #528 の再発時はそもそも onPress が走らないため、ここが最初に赤くなる
+		await waitUntilGone(search.locationSuggestions);
+
+		// クリアボタンは「入力が 1 文字以上ある」ときだけ描画される。
+		// 選択後も残っている ＝ 入力欄が空に戻っていない（既存 spec と同じ、値に依存しない観測点）
+		await expect(element(search.locationClearButton)).toExist();
+
+		// 補助的な確認。値そのものは比較せず「何も入っていない」だけを弾く（プラットフォーム差を踏まないため）
+		const inputText = await search.readLocationInputText();
+		assert.notEqual(
+			inputText,
+			"",
+			"候補をタップしたのに場所入力欄が空です（選択が成立していない可能性。#528 の再発を疑うこと）",
+		);
+
+		// ここからが主観測点。地点が確定していなければ handleSearch のバリデーションが
+		// global-snackbar を出して遷移をガードするため、トピック画面へは進めない
+		await search.submit();
+
+		await expect(element(search.snackbar)).not.toBeVisible();
+		// トピック生成（AI）の完了は待たない。遷移したことだけをヘッダで確認する
+		await topics.expectHeaderVisible();
+	});
+
+	// ─ テストケース: 候補パネルを開いたままキーボードを閉じても、そのあと候補を選択できる ─
+	// #528 の本質は「キーボードが閉じることで起きるレイアウト再計算が、進行中のタップを潰す」ことだった。
+	// そこでキーボードの開閉を明示的に挟んでから候補を押し、選択が成立することを検証する。
+	//
+	// ⚠️ 「キーボードが閉じたこと」自体は検証していない。理由は 2 つあり、どちらもこの spec の外側の制約:
+	//   - Android の CI/ローカルセットアップは **IME を 1 つも残さず無効化する**
+	//     （scripts/setup-android-locale.sh。日本語 IME の初回セットアップダイアログが画面を覆うため）。
+	//     つまり Android ではそもそもソフトウェアキーボードが出ない
+	//   - Detox にキーボードの可視状態を読む API が無く、iOS でも「閉じたこと」を直接は言えない
+	// そのため観測できるのは **「キーボード都合の操作を挟んでも、候補のタップが潰れない」** という結果になる。
+	//
+	// ## 「背景タップでキーボードを閉じる」経路を検証していない理由
+	// #528 の修正対象である `useBlurModal` の背景タップ（`handleBackdropPress`）は、
+	// 地点オートコンプリートを **BlurModal の中に置いている画面**でしか触れない。
+	// 現在それに該当するのはマイページの「保存した料理カテゴリ」→ 地点検索モーダル
+	//（`features/profile/tabs/SavedTopicsTab.tsx` ＋ `LocationSearchForm`）だけで、到達には
+	//   - ログイン済みセッション（`describeAuthenticated`）
+	//   - **テストユーザーに保存済みカテゴリが 1 件以上あること**（現在シードされておらず、
+	//     用意するには共有 dev DB への書き込み ＝ Tier 3 @mutation の領分になる）
+	//   - グリッド項目ごとの testID（`save/SaveTopicTab.tsx` には現在グリッド全体の testID しか無い）
+	// が必要になる。データのシードが入ったら、この spec の隣に @mutation として移植すること。
+	// 検索タブ側は `keyboardShouldPersistTaps="always"`（search/index.tsx の ScrollView）なので、
+	// 背景タップでは候補もキーボードも閉じない ＝ 同じ検証をここへ寄せることはできない。
+	it("キーボードを閉じる操作を挟んでも候補のタップが潰れない", async () => {
+		await search.clearLocationIfPresent();
+
+		await search.typeLocation("渋谷");
+		await waitUntilVisible(search.locationSuggestions);
+		await waitUntilVisible(search.locationSuggestion(0));
+
+		// リターンキーでキーボードを閉じる（ベストエフォート。IME 無効の Android では何も起きない）。
+		// #528 の事故はこの「閉じる」に伴うレイアウト再計算で起きていた
+		await search.dismissKeyboardIfOpen();
+
+		// 入力欄が blur すると 150ms 後に候補パネルを畳む予約が入る（`BLUR_SUGGESTION_HIDE_DELAY_MS`）。
+		// 畳まれてしまった場合は入力欄をタップし直して開き直す。
+		// ⚠️ ここは「畳まれるのが正しい / 畳まれないのが正しい」を主張しない。閉じ方が
+		// プラットフォーム（IME の有無）に依存するためで、この spec が見たいのは
+		// **開き直したあとのタップが成立するか**である
+		if (!(await search.hasVisibleLocationSuggestions())) {
+			await search.focusLocationInput();
+			await waitUntilVisible(search.locationSuggestions);
+		}
+		await waitUntilVisible(search.locationSuggestion(0));
+
+		await search.selectLocationSuggestion(0);
+
+		// 選択が成立していれば候補パネルは畳まれ、入力は空に戻らない
+		await waitUntilNotVisible(search.locationSuggestions);
+		await expect(element(search.locationClearButton)).toExist();
+
+		const inputText = await search.readLocationInputText();
+		assert.notEqual(
+			inputText,
+			"",
+			"キーボードを閉じたあとに候補をタップしたところ、場所入力欄が空でした（#528 の再発を疑うこと）",
+		);
+	});
+});

--- a/e2e-mobile/tests/search/recent-locations.test.ts
+++ b/e2e-mobile/tests/search/recent-locations.test.ts
@@ -1,0 +1,122 @@
+import { strict as assert } from "node:assert";
+
+import { existsNow, launchAppWithSession, tapWhenVisible } from "../../fixtures/e2e";
+import { SearchScreen } from "../../screens/SearchScreen";
+
+/**
+ * 🕐 「最近使った場所」の並び順テスト（実 API / Tier 2）
+ *
+ * 対象 Issue: #1129「最近使った場所を押下した時上に来て欲しい」（修正: PR #1150）
+ * 対応する e2e-web: tests/search/recent-locations.spec.ts
+ *
+ * 背景: useRecentLocations.addRecentLocation は元から「同一地点を除去して先頭へ積む」実装だったが、
+ * 「最近使った場所」パネルからの再選択（handleSelectRecentLocation）がそれを呼んでいなかったため、
+ * リストから選び直しても順序が永遠に固定されたままだった
+ * （app-expo/app/[locale]/(tabs)/search/index.tsx）。
+ *
+ * 検証する不変条件（web/mobile 共通）:
+ *   1. 2件以上ある状態で2番目を選ぶと、次に開いたときそれが先頭になる（MRU）
+ *   2. 件数が増えない（重複登録されない）
+ *   3. 上限5件が維持される
+ *
+ * ## e2e-web との差分
+ * 実 API の検索結果は地名も件数も事前に確定できないため、入力欄の値やリスト項目のテキストを
+ * 直接アサートするのではなく（Detox の TextInput 値アサーションが不安定という location-autocomplete
+ * の既知の理由に加え、TouchableOpacity は値を持たない）、`recentLocationLabel()` で
+ * accessibilityLabel（= `recent.locationQuery`）を読み取り、選び直し前後で
+ * **一致/変化したこと**を検証する（ResultScreen の likeLabel と同じ方式。reactions.test.ts 参照）。
+ *
+ * 永続化の検証は「アプリを再起動しても順序が保持されること」で行う（tutorialSeen の永続化テストと同じ方式）。
+ * `launchAppWithSession` は既定 `resetState: false` なので、再起動しても AsyncStorage は消えない。
+ */
+describe("最近使った場所（実 API）", () => {
+	const search = new SearchScreen();
+
+	beforeAll(async () => {
+		await launchAppWithSession({ as: "anon" });
+		await search.expectLoaded();
+	});
+
+	// ─ テストケース: 2番目に選んだ地点を選び直すと先頭へ移動し、件数は変わらない ─
+	// 手順:
+	//   1. 「渋谷」で検索し、先頭の候補（1件目）を選ぶ
+	//   2. 再度「渋谷」で検索し、別の候補（2件目、1件目とは異なる地点）を選ぶ
+	//      → 最近使った場所は新しい順で [2件目, 1件目]
+	//   3. パネルを開いて並び順（ラベル）と件数（2件）を確認する
+	//   4. 2番目（=1件目、リストの末尾）を選び直す
+	//   5. 再度パネルを開き、1件目が先頭へ移動し件数が2件のまま（重複登録なし）であることを検証
+	//   6. アプリを再起動し、並び順が永続化（AsyncStorage）されていることを検証
+	it("2番目に選んだ地点を選び直すと先頭へ移動し、件数は変わらない。並び順は再起動後も保持される", async () => {
+		// 1件目
+		await search.clearLocationIfPresent();
+		await search.typeLocation("渋谷");
+		await search.selectLocationSuggestion(0);
+
+		await search.openRecentLocations();
+		const first = await search.recentLocationLabel(0);
+
+		// 2件目（1件目とは異なる候補）
+		await search.typeLocation("渋谷");
+		await search.selectLocationSuggestion(1);
+
+		await search.openRecentLocations();
+		const second = await search.recentLocationLabel(0);
+		assert.notEqual(second, first, "2件目は1件目と異なる地点であるはず");
+		assert.equal(await search.recentLocationLabel(1), first, "新しい順で2番目に1件目が来ているはず");
+		assert.equal(await existsNow(search.recentLocation(2)), false, "この時点では2件しかないはず");
+
+		// リストの2番目（=1件目）を選び直す
+		await tapWhenVisible(search.recentLocation(1));
+
+		// 選び直した1件目が先頭へ。件数は2件のまま（重複登録されていない）
+		await search.openRecentLocations();
+		assert.equal(await search.recentLocationLabel(0), first, "選び直した地点が先頭に来ているはず");
+		assert.equal(await search.recentLocationLabel(1), second, "2件目は2番目のまま残っているはず");
+		assert.equal(await existsNow(search.recentLocation(2)), false, "3件目は存在しない（重複登録されていない）");
+
+		// アプリを再起動しても並び順が保持される
+		await launchAppWithSession({ as: "anon" });
+		await search.expectLoaded();
+		await search.openRecentLocations();
+		assert.equal(await search.recentLocationLabel(0), first, "再起動後も先頭は選び直した地点のまま");
+		assert.equal(await search.recentLocationLabel(1), second, "再起動後も2番目は変わらない");
+	});
+
+	// ─ テストケース: 6件目を登録すると最古の1件が押し出され、上限5件が維持される ─
+	// 手順:
+	//   1. 前のテストと画面状態を切り離すためアプリを再起動する（reactions.test.ts と同じ考え方。
+	//      ストレージは消さない — 上限が既存件数に関係なく効くことの確認も兼ねる）
+	//   2. 異なる6地点を順に検索・選択する（いずれも先頭候補を選ぶ）
+	//   3. パネルを開き、直近5件（新しい順）だけが残り6件に増えていないことを検証
+	//   4. 再起動後も5件のまま保持されることを検証
+	it("6件目を登録すると最古の1件が押し出され、上限5件が維持される", async () => {
+		await launchAppWithSession({ as: "anon" });
+		await search.expectLoaded();
+
+		const queries = ["渋谷駅", "新宿駅", "東京駅", "池袋駅", "品川駅", "上野駅"];
+		const selected: string[] = [];
+
+		for (const query of queries) {
+			await search.clearLocationIfPresent();
+			await search.typeLocation(query);
+			await search.selectLocationSuggestion(0);
+
+			await search.openRecentLocations();
+			selected.push(await search.recentLocationLabel(0));
+		}
+
+		// 新しい順に直近5件（6件目 → 2件目）だけが残り、最古（1件目）は落ちている
+		await search.openRecentLocations();
+		for (let i = 0; i < 5; i += 1) {
+			assert.equal(await search.recentLocationLabel(i), selected[selected.length - 1 - i]);
+		}
+		assert.equal(await existsNow(search.recentLocation(5)), false, "6件目以降は存在しない（上限5件）");
+
+		// 再起動後も5件のまま（6件に増えたり、上限が外れたりしていない）
+		await launchAppWithSession({ as: "anon" });
+		await search.expectLoaded();
+		await search.openRecentLocations();
+		assert.equal(await existsNow(search.recentLocation(4)), true, "再起動後も5件目までは残っているはず");
+		assert.equal(await existsNow(search.recentLocation(5)), false, "再起動後も上限5件が維持される");
+	});
+});

--- a/e2e-web/pages/SearchPage.ts
+++ b/e2e-web/pages/SearchPage.ts
@@ -23,6 +23,10 @@ export class SearchPage {
 	readonly locationClearButton: Locator;
 	/** 場所サジェストのリスト */
 	readonly locationSuggestions: Locator;
+	/** 「最近使った場所」のリスト（#953）。未入力でフォーカスしたときだけ描画される */
+	readonly recentLocationsList: Locator;
+	/** 「最近使った場所」を全件クリアするボタン（1件以上あるときだけ描画される） */
+	readonly recentLocationsClearButton: Locator;
 	/** 検索実行ボタン（FAB） */
 	readonly submitButton: Locator;
 	/** 詳細条件の展開トグル */
@@ -61,6 +65,8 @@ export class SearchPage {
 		this.locationInput = page.getByTestId("search-location-autocomplete-input");
 		this.locationClearButton = page.getByTestId("search-location-autocomplete-clear");
 		this.locationSuggestions = page.getByTestId("search-location-autocomplete-suggestions");
+		this.recentLocationsList = page.getByTestId("search-location-autocomplete-recent-locations");
+		this.recentLocationsClearButton = page.getByTestId("search-location-autocomplete-recent-locations-clear");
 		this.submitButton = page.getByTestId("search-submit-button");
 		this.advancedToggle = page.getByTestId("search-advanced-toggle");
 		this.distanceSlider = page.getByTestId("search-distance-slider");
@@ -124,6 +130,27 @@ export class SearchPage {
 		);
 		await this.locationSuggestion(index).click();
 		await responsePromise;
+	}
+
+	/** n 番目の「最近使った場所」の Locator を返す（0 始まり、先頭が最新） */
+	recentLocation(index: number): Locator {
+		return this.page.getByTestId(`search-location-autocomplete-recent-location-${index}`);
+	}
+
+	/**
+	 * 「最近使った場所」パネルを表示する。
+	 *
+	 * `LocationAutocomplete` は「入力が空 && フォーカス中」のときだけこのパネルを出す
+	 * （showRecentLocations の条件）。クリアボタンは押下後に自身で入力欄へフォーカスを戻すが
+	 * （handleClear の `inputRef.current?.focus()`）、それだけに頼らず明示的に入力欄をクリックして
+	 * フォーカスを確定させる。
+	 */
+	async openRecentLocations(): Promise<void> {
+		if (await this.locationClearButton.isVisible().catch(() => false)) {
+			await this.locationClearButton.click();
+		}
+		await this.locationInput.click();
+		await expect(this.recentLocationsList).toBeVisible();
 	}
 
 	/** 時間帯グリッドの項目の Locator を返す（id は timeSlots 定義の値） */

--- a/e2e-web/tests/search/recent-locations.spec.ts
+++ b/e2e-web/tests/search/recent-locations.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "../../fixtures/test";
+import { SearchPage } from "../../pages/SearchPage";
+
+/**
+ * 🕐 「最近使った場所」の並び順テスト(実 API)
+ *
+ * 対象 Issue: #1129「最近使った場所を押下した時上に来て欲しい」(修正: PR #1150)
+ * 対応する e2e-mobile: tests/search/recent-locations.test.ts
+ *
+ * 背景: useRecentLocations.addRecentLocation は元から「同一地点を除去して先頭へ積む」実装だったが、
+ * 「最近使った場所」パネルからの再選択(handleSelectRecentLocation)がそれを呼んでいなかったため、
+ * リストから選び直しても順序が永遠に固定されたままだった
+ * (app-expo/app/[locale]/(tabs)/search/index.tsx)。
+ *
+ * 検証する不変条件(web/mobile 共通):
+ *   1. 2件以上ある状態で2番目を選ぶと、次に開いたときそれが先頭になる(MRU)
+ *   2. 件数が増えない(重複登録されない)
+ *   3. 上限5件が維持される
+ *
+ * 前提: 実 API(v1/locations/autocomplete, v1/locations/details)を叩く。CORS 前提は
+ * location-autocomplete.spec.ts と同じ(e2e-web/README.md 参照)。
+ */
+test.describe("最近使った場所(実 API)", () => {
+	// ─ テストケース: 2番目に選んだ地点を選び直すと先頭へ移動し、件数は変わらない ─
+	// 手順:
+	//   1. 「渋谷」で検索し、先頭の候補(1件目)を選ぶ
+	//   2. 再度「渋谷」で検索し、別の候補(2件目、1件目とは異なる地点)を選ぶ
+	//      → 最近使った場所は新しい順で [2件目, 1件目]
+	//   3. パネルを開いて並び順と件数(2件)を確認する
+	//   4. 2番目(=1件目、リストの末尾)を選び直す
+	//   5. 再度パネルを開き、1件目が先頭へ移動し件数が2件のまま(重複登録なし)であることを検証
+	//   6. 検索画面へ明示的に goto(「reload ではなく goto」の理由は search-tutorial.spec.ts と同じ:
+	//      expo-router の静的書き出しでは page.reload() だとブラウザの URL バーとズレた別ルートの
+	//      静的 HTML が読み込まれることがあるため)し、並び順が永続化(AsyncStorage)されていることを検証
+	test("2番目に選んだ地点を選び直すと先頭へ移動し、件数は変わらない。並び順はリロード後も保持される", async ({
+		appPage,
+	}) => {
+		const searchPage = new SearchPage(appPage);
+
+		// 1件目
+		if (await searchPage.locationClearButton.isVisible().catch(() => false)) {
+			await searchPage.locationClearButton.click();
+		}
+		await searchPage.typeLocation("渋谷");
+		await searchPage.selectLocationSuggestion(0);
+		const first = await searchPage.locationInput.inputValue();
+
+		// 2件目(1件目とは異なる候補)
+		await searchPage.locationClearButton.click();
+		await searchPage.typeLocation("渋谷");
+		await searchPage.selectLocationSuggestion(1);
+		const second = await searchPage.locationInput.inputValue();
+		expect(second).not.toBe(first);
+
+		// 新しい順: [2件目, 1件目]
+		await searchPage.openRecentLocations();
+		await expect(searchPage.recentLocation(0)).toHaveText(second);
+		await expect(searchPage.recentLocation(1)).toHaveText(first);
+		await expect(searchPage.recentLocation(2)).toHaveCount(0);
+
+		// リストの2番目(=1件目)を選び直す
+		await searchPage.recentLocation(1).click();
+		await expect(searchPage.locationInput).toHaveValue(first);
+
+		// 選び直した1件目が先頭へ。件数は2件のまま(重複登録されていない)
+		await searchPage.openRecentLocations();
+		await expect(searchPage.recentLocation(0)).toHaveText(first);
+		await expect(searchPage.recentLocation(1)).toHaveText(second);
+		await expect(searchPage.recentLocation(2)).toHaveCount(0);
+
+		// リロードしても並び順が保持される
+		await appPage.goto("/ja-JP/search");
+		await searchPage.expectLoaded();
+		await searchPage.openRecentLocations();
+		await expect(searchPage.recentLocation(0)).toHaveText(first);
+		await expect(searchPage.recentLocation(1)).toHaveText(second);
+	});
+
+	// ─ テストケース: 6件目を登録すると最古の1件が押し出され、上限5件が維持される ─
+	// 手順:
+	//   1. 異なる6地点を順に検索・選択する(いずれも先頭候補を選ぶ)
+	//   2. パネルを開き、直近5件(新しい順)だけが残り6件に増えていないことを検証
+	//   3. リロード後も5件のまま保持されることを検証
+	test("6件目を登録すると最古の1件が押し出され、上限5件が維持される", async ({ appPage }) => {
+		const searchPage = new SearchPage(appPage);
+		const queries = ["渋谷駅", "新宿駅", "東京駅", "池袋駅", "品川駅", "上野駅"];
+		const selected: string[] = [];
+
+		for (const query of queries) {
+			if (await searchPage.locationClearButton.isVisible().catch(() => false)) {
+				await searchPage.locationClearButton.click();
+			}
+			await searchPage.typeLocation(query);
+			await searchPage.selectLocationSuggestion(0);
+			selected.push(await searchPage.locationInput.inputValue());
+		}
+
+		// 新しい順に直近5件(6件目 → 2件目)だけが残り、最古(1件目)は落ちている
+		await searchPage.openRecentLocations();
+		for (let i = 0; i < 5; i += 1) {
+			await expect(searchPage.recentLocation(i)).toHaveText(selected[selected.length - 1 - i]);
+		}
+		await expect(searchPage.recentLocation(5)).toHaveCount(0);
+
+		// リロード後も5件のまま(6件に増えたり、上限が外れたりしていない)
+		await appPage.goto("/ja-JP/search");
+		await searchPage.expectLoaded();
+		await searchPage.openRecentLocations();
+		await expect(searchPage.recentLocation(4)).toBeVisible();
+		await expect(searchPage.recentLocation(5)).toHaveCount(0);
+	});
+});


### PR DESCRIPTION
「実機確認が必要」として人間へ投げていた項目のうち、**E2E で書けるものを E2E へ移します**。

実機確認は **回帰テストにならず**（1 回見て通っても次の変更で壊れたら誰も気付かない）、**人間の時間を使う**ため、最終手段であるべきでした。E2E を書く手間を人間へ転嫁していた形です。

## 変更内容

| Issue | 内容 | web (Playwright) | mobile (Detox) |
| --- | --- | --- | --- |
| #528 | 候補タップで地点が選択される | — | ✅ 新規 |
| #1129 | 最近使った場所の MRU 並び替え | ✅ 新規 | ✅ 新規 |

**#528 は本来 Detox でこそ捕まえるべき不具合**でした。「候補をタップしたのにキーボードだけ閉じて無反応」は、まさに E2E のタップ操作で再現できる型です。

#1129 は **web / mobile 両方**を書いています。このリポジトリは `e2e-web` と `e2e-mobile` を原則同じ密度で維持しており、片方だけ書くともう片方が空白になるためです。

## マージ競合の解決

2 つのワーカーが `e2e-mobile/screens/SearchScreen.ts` へそれぞれメソッドを追加したため競合しました。いずれも**独立した追加**なので両方残しています。競合境界で `dismissKeyboardIfOpen` の閉じ括弧が落ちていたのを補いました。

## 検証

- `e2e-mobile` typecheck: OK
- `e2e-web` typecheck: OK
- `pnpm --filter app-expo test`: 全 pass
- `pnpm --filter app-expo typecheck`: exit 0

**Detox / Playwright の実走はこの PR では行っていません。** オーナーから「CI に載せるほどではなく、ローカル検証の位置づけでよい」との方針をいただいているため、spec を書いて型検査を通すところまでです。

## 残り

他の実機確認項目（#1120 #1121 #1122 #1132 #1133 #1136）も同様に E2E 化を進めています。ワーカーのターン切れが続いたため、1 Issue ずつに割り直して再投入中です。

**本当に実機でしか確認できないもの**（自動化が原理的に不可能なもの）だけを最終的に残します。

- #1135: 実 Google IdP との往復（bot 検知・利用規約）
- #1133 の一部: iOS の位置情報許可ダイアログ（OS ネイティブ）
- #1126 の一部: 触り心地の主観評価

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_