### PR TITLE
#1121 #1136 test(e2e-web): 外部リンクの別タブ起動と投稿中ローディングを E2E で固定する

### DIFF
--- a/e2e-web/pages/GoogleMapsFallbackDialog.ts
+++ b/e2e-web/pages/GoogleMapsFallbackDialog.ts
@@ -1,0 +1,45 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/**
+ * 🗺 Google マップ fallback ダイアログの Page Object
+ *
+ * 対応実装:
+ * - app-expo/features/search/hooks/useGoogleMapsFallback.ts（ダイアログ表示・openExternalUrl 呼び出し）
+ * - app-expo/contexts/DialogProvider.tsx（共通ダイアログ。OK/キャンセルの testID を持つ）
+ *
+ * 検索結果が 0 件のときに「条件に合うお店を Googleマップ上でご確認頂けます。」という
+ * 退避導線として表示される共通ダイアログ。DialogProvider は OK/キャンセルに
+ * `dialog-confirm-button` / `dialog-cancel-button` の既定 testID を与えるため（#1131）、
+ * ボタンはラベル文字列ではなく testID で特定する。
+ *
+ * ⚠️ このダイアログはアプリ全体の Portal に描画されるため、どの画面が表示中かに
+ * 依存しない。0 件確定時は search/result 側が `handleClose()` も呼ぶので、
+ * ダイアログが出た時点で背後の画面はトピック画面に戻っている（#828）。
+ */
+export class GoogleMapsFallbackDialog {
+	readonly page: Page;
+	/** ダイアログ本文（ja-JP: Search.googleMapsFallback.message） */
+	readonly message: Locator;
+	/** 「Google マップで開く」ボタン */
+	readonly confirmButton: Locator;
+	/** 「閉じる」ボタン */
+	readonly cancelButton: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.message = page.getByText("条件に合うお店を Googleマップ上でご確認頂けます。");
+		this.confirmButton = page.getByTestId("dialog-confirm-button");
+		this.cancelButton = page.getByTestId("dialog-cancel-button");
+	}
+
+	/**
+	 * fallback ダイアログが表示されるまで待つ。
+	 *
+	 * 0 件確定は「dish-media 検索 → bulk-import」の 2 リクエストを経てから決まるため、
+	 * 既定の 10 秒では足りないことがある。ここだけ長めに待つ。
+	 */
+	async expectVisible(): Promise<void> {
+		await expect(this.message).toBeVisible({ timeout: 30_000 });
+		await expect(this.confirmButton).toBeVisible();
+	}
+}

--- a/e2e-web/tests/authenticated/review-submit-loading.spec.ts
+++ b/e2e-web/tests/authenticated/review-submit-loading.spec.ts
@@ -1,0 +1,202 @@
+import * as path from "node:path";
+import { test, expect } from "../../fixtures/test";
+import type { Locator, Page } from "@playwright/test";
+import { TabBar } from "../../pages/TabBar";
+import { ReviewPage } from "../../pages/ReviewPage";
+
+/**
+ * ⏳ レビュー投稿中のローディング表示テスト @mutation(#1136 / PR #1166)
+ *
+ * 目的: 投稿処理が数秒〜数十秒かかる間、ユーザーが「押せたのか分からないまま連打する」状態を
+ * 作らないこと、かつ **失敗してもローディングが解除されて再投稿できる**ことを保証する。
+ *
+ * ## 何を守っているか(#1136)
+ * `ReviewForm.handleSubmit` はメディアアップロードと 3 本の API 呼び出しを直列で行うため、
+ * 完了まで無反応に見える時間が長い。#1136 で `isSubmitting`(useState)を追加し、
+ * `PrimaryButton` の `loading` に渡すことで **ボタン内にスピナー(Lottie)を出しつつ
+ * 押下も止める**(`PrimaryButton` は `isDisabled = disabled || loading`)。
+ * 解除は `finally` に置かれており、成功・失敗・例外のいずれでも必ず通る。
+ * ここが try 側へ散ると「スピナー固着 = 二度と投稿できない」不具合になるため、
+ * 失敗ケースこそがこの spec の主目的である。
+ *
+ * ## 観測点
+ * - **スピナー**: `components/LoadingIndicator/index.web.tsx` は web で `role="status"` を
+ *   出すため、投稿ボタン配下の `role=status` の有無で判定できる(testID 追加は不要)
+ * - **押下不可**: react-native-web の Pressable は `disabled` から `aria-disabled` を生成する
+ *   (`PrimaryButton` の #930 コメント参照)。加えて **force クリックしても POST が増えない**
+ *   ことを直接数えて、見た目だけでなく実際に発火しないことまで確認する
+ * - **解除**: 失敗後に **もう一度ふつうに click できる**ことで判定する。Playwright の click は
+ *   要素が enabled になるまで待つため、スピナーが固着していればここでタイムアウトする
+ *
+ * ## なぜ実投稿を待たないか / dev DB への影響
+ * POST `v1/dishes`(handleSubmit が最初に呼ぶ API)を `page.route()` で **遅延 / 失敗**させる。
+ * これにより:
+ * - ローディングの出現・解除を任意のタイミングで観測できる(外部 API の実測時間に依存しない)
+ * - dish / dish-media / dish-review は 1 件も作られず、メディアアップロードにも到達しない
+ *
+ * ただしフォームへ辿り着くまでの導線でレストラン作成(POST `v1/restaurants`)が実際に走るため、
+ * review-post.spec.ts と同じ理由で `@mutation` に分類する(同一 Place は upsert され重複しない)。
+ */
+test.skip(
+	() => !process.env.TEST_USER_EMAIL || !process.env.TEST_USER_PASSWORD,
+	"TEST_USER_EMAIL / TEST_USER_PASSWORD(e2e-web/.env)が未設定のためスキップ",
+);
+
+const TEST_IMAGE_PATH = path.resolve(__dirname, "../../fixtures/assets/test-dish.png");
+
+/**
+ * handleSubmit が最初に叩く API。ここを止めれば「投稿中」の状態を任意の長さで維持できる。
+ * `v1/dish-media` / `v1/dish-reviews` はこの後ろに居るため、この 1 本を抑えれば以降は走らない。
+ */
+const CREATE_DISH_URL = "**/v1/dishes*";
+
+/** ja-JP: Map.errors.reviewSubmitFailed */
+const SUBMIT_FAILED_MESSAGE = "レビューの投稿に失敗しました";
+
+/**
+ * 投稿ボタンが押せる状態（`isValid` 成立）のレビューフォームまで進める。
+ *
+ * 手順は review-double-submit.spec.ts と同一。外部 API(Google Places / 料理カテゴリ検索)の
+ * 応答内容に依存するため、失敗時はまずサジェスト結果の中身を確認すること。
+ *
+ * @returns 投稿ボタンの Locator
+ */
+async function openFilledReviewForm(appPage: Page, comment: string): Promise<Locator> {
+	const tabBar = new TabBar(appPage);
+	const reviewPage = new ReviewPage(appPage);
+
+	await tabBar.gotoReview();
+	await reviewPage.postReviewButton.click();
+	await appPage.getByTestId("location-autocomplete-input").fill("スターバックス");
+	await appPage.getByTestId("location-autocomplete-suggestions").waitFor({ state: "visible" });
+	await appPage.getByTestId("location-autocomplete-suggestion-0").click();
+	await expect(appPage.getByTestId("restaurant-detail-post-photo-button")).toBeVisible({ timeout: 20_000 });
+
+	// レビューフォーム画面(review.tsx)へ遷移すると同時に写真選択(filechooser)が自動的に走る
+	const fileChooserPromise = appPage.waitForEvent("filechooser");
+	await appPage.getByTestId("restaurant-detail-post-photo-button").click();
+	const fileChooser = await fileChooserPromise;
+	await fileChooser.setFiles(TEST_IMAGE_PATH);
+
+	await appPage.getByTestId("review-comment-input").fill(comment.slice(0, 100));
+
+	// 料理カテゴリを選択する
+	await appPage.getByTestId("review-dish-category-row").click();
+	await appPage.getByTestId("dish-category-search-input").fill("コーヒー");
+	await appPage.getByTestId("dish-category-search-suggestions").waitFor({ state: "visible" });
+	await appPage.getByTestId("dish-category-search-suggestion-0").click();
+
+	await appPage.getByTestId("review-price-input").fill("500");
+	await appPage.getByTestId("review-star-5").click();
+
+	const submitButton = appPage.getByTestId("review-submit-button");
+	await expect(submitButton).toBeVisible();
+	return submitButton;
+}
+
+/** 投稿ボタン内のスピナー（LoadingIndicator が web で出す role="status"） */
+function submitSpinner(submitButton: Locator): Locator {
+	return submitButton.getByRole("status");
+}
+
+test.describe("レビュー投稿中のローディング @mutation", () => {
+	// レストラン作成・料理カテゴリ検索・画像選択など実 API 呼び出しを直列で行うため、
+	// review-post.spec.ts と同じ理由で既定の 30 秒テストタイムアウトを延長する
+	test.setTimeout(90_000);
+
+	// ─ テストケース: 投稿中はスピナーが出てボタンが押せない ─
+	// 手順:
+	//   1. レビューフォームを投稿可能な状態まで埋める
+	//   2. POST v1/dishes を「ゲートを開けるまで応答しない」ルートで差し替える(= 投稿中を維持)
+	//   3. 投稿ボタンを押し、POST が 1 回飛んだことを確認する
+	//   4. ボタン内にスピナー(role=status)が出ていることを検証
+	//   5. ボタンが aria-disabled であることを検証
+	//   6. force クリックを 2 回打っても POST が増えない(= 実際に押下が届かない)ことを検証
+	//   7. ゲートを開けて投稿処理を失敗で終わらせ、後片付けする
+	test("投稿中はボタンにスピナーが出て押下も届かない", async ({ appPage }) => {
+		const submitButton = await openFilledReviewForm(appPage, `[E2E] ローディング表示テスト ${new Date().toISOString()}`);
+
+		/** POST v1/dishes の着弾回数。ローディング中に増えなければ「押せていない」ことの直接証拠になる */
+		let createDishRequests = 0;
+		/** 保留中のリクエストを一斉に解放するゲート（テスト側から任意のタイミングで開ける） */
+		let openGate!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			openGate = resolve;
+		});
+
+		await appPage.route(CREATE_DISH_URL, async (route) => {
+			if (route.request().method() !== "POST") {
+				await route.continue();
+				return;
+			}
+			createDishRequests += 1;
+			await gate;
+			// #1090 の教訓どおり POST は useAPICall に自動リトライされないため、abort しても 1 回で終わる
+			await route.abort("failed");
+		});
+
+		await submitButton.click();
+
+		// 押下が API まで届いた時点まで待つ（ここまで来れば isSubmitting は true になっている）
+		await expect.poll(() => createDishRequests).toBe(1);
+
+		await expect(submitSpinner(submitButton)).toBeVisible();
+		await expect(submitButton).toHaveAttribute("aria-disabled", "true");
+
+		// 通常の click は「enabled になるまで待つ」ため disabled 検証と重複してしまう。
+		// force で actionability を飛ばし、**押下イベント自体は届いた上で** ハンドラが弾くことを見る
+		await submitButton.click({ force: true });
+		await submitButton.click({ force: true });
+
+		// 弾かれずに通っていれば、この待機の間に 2 本目の POST が着弾する
+		// (handleSubmit はガードを抜けた直後に v1/dishes を呼ぶため、遅れて現れることはない)
+		await appPage.waitForTimeout(1_000);
+		expect(createDishRequests, "投稿中にもかかわらず 2 回目の投稿が発火している").toBe(1);
+
+		// 後片付け: 保留中のリクエストを解放し、アプリを投稿失敗の状態まで進めてから unroute する
+		openGate();
+		await expect(appPage.getByText(SUBMIT_FAILED_MESSAGE, { exact: true })).toBeVisible();
+		await appPage.unroute(CREATE_DISH_URL);
+	});
+
+	// ─ テストケース: 投稿に失敗してもローディングが解除される ─
+	// 手順:
+	//   1. レビューフォームを投稿可能な状態まで埋める
+	//   2. POST v1/dishes を常に失敗させるルートを仕込む
+	//   3. 投稿ボタンを押し、失敗スナックバー「レビューの投稿に失敗しました」が出ることを検証
+	//   4. ボタン内のスピナーが消えていることを検証(= ローディング固着していない)
+	//   5. **もう一度ふつうに click** して再投稿できることを検証
+	//      (Playwright の click は enabled になるまで待つため、固着していればここで失敗する)
+	test("投稿に失敗してもローディングが解除され、再投稿できる", async ({ appPage }) => {
+		const submitButton = await openFilledReviewForm(appPage, `[E2E] 投稿失敗時の解除テスト ${new Date().toISOString()}`);
+
+		let createDishRequests = 0;
+		await appPage.route(CREATE_DISH_URL, async (route) => {
+			if (route.request().method() !== "POST") {
+				await route.continue();
+				return;
+			}
+			createDishRequests += 1;
+			await route.abort("failed");
+		});
+
+		await submitButton.click();
+
+		const failedSnackbar = appPage.getByText(SUBMIT_FAILED_MESSAGE, { exact: true });
+		await expect(failedSnackbar).toBeVisible();
+		await expect(submitSpinner(submitButton)).toHaveCount(0);
+		await expect(submitButton).toBeEnabled();
+
+		// スナックバーは画面下部（投稿ボタンと同じ領域）に 4 秒間出るため、
+		// 消えるまで待ってから押し直す。待たないと click がオーバーレイに吸われて誤検知になる
+		await expect(failedSnackbar).toBeHidden({ timeout: 15_000 });
+
+		// 再投稿できること = isSubmitting / isSubmittingRef の両方が解除されていること。
+		// disabled のままなら click が actionability 待ちでタイムアウトし、
+		// ref だけ解除漏れなら POST が飛ばず下の poll がタイムアウトする
+		await submitButton.click();
+		await expect.poll(() => createDishRequests).toBe(2);
+
+		await appPage.unroute(CREATE_DISH_URL);
+	});
+});

--- a/e2e-web/tests/search/google-maps-fallback.spec.ts
+++ b/e2e-web/tests/search/google-maps-fallback.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "../../fixtures/test";
 import { SearchPage } from "../../pages/SearchPage";
 import { TopicsPage } from "../../pages/TopicsPage";
 import { GoogleMapsFallbackDialog } from "../../pages/GoogleMapsFallbackDialog";
+import { stubEmptyDishMediaResults, stubGoogleMaps } from "../../utils/network";
 
 /**
  * 🗺 Google マップ fallback は別タブで開く（#1121 の回帰テスト）
@@ -9,25 +10,24 @@ import { GoogleMapsFallbackDialog } from "../../pages/GoogleMapsFallbackDialog";
  * ## 背景 (#1121)
  * `/ja-JP/search/topics` で検索結果が 0 件だったときに出る Google マップ fallback ダイアログの
  * 「Google マップで開く」を Web で押すと、`Linking.openURL()` が **同一タブ**を遷移させていた。
- * SPA から離脱するため、ブラウザバックで戻ってくると復元に失敗して画面が壊れる、というのが
- * 報告された不具合。PR #1151 で `openExternalUrl()` を導入し、Web では
+ * SPA から離脱するため、ブラウザバックで戻ってくると復元に失敗して壊れる、というのが報告された不具合。
+ * PR #1151 で `app-expo/lib/openExternalUrl.ts` を導入し、Web では
  * `window.open(url, "_blank", "noopener,noreferrer")` で別タブに開くよう修正済み。
  *
  * ## このテストの検証内容
  * 1. 「Google マップで開く」で **新しいタブ**が開き、その URL が Google マップの検索 URL であること
- * 2. **元のページの URL が変わらない**こと（= SPA を離脱していない。主症状の回帰）
+ * 2. **元のページの URL が変わらない**こと（= SPA を離脱していない。#1121 の主症状）
  *
  * 修正前は (1) で新しいタブが開かず `waitForEvent("page")` がタイムアウトし、
- * (2) も元タブの URL が www.google.com に変わるため落ちる。
+ * (2) も元タブの URL が www.google.com へ変わるため落ちる。
  *
- * ## 実 Google へは通信しない
- * 別タブが開く URL を検証したいだけなので、`https://www.google.com/**` は
- * `context.route()` でスタブ HTML に差し替える。Google Maps へのリクエストは 1 度も出ない。
+ * ## 外部への実通信はしない
+ * 検証したいのは「別タブが開いたこと」と「その URL」だけなので、Google へのリクエストは
+ * `stubGoogleMaps()` でスタブ HTML に差し替える。実 Google Maps へは 1 度も飛ばない。
  *
  * ## 0 件状態の作り方
- * 実 API で確実に 0 件になる検索条件を作るのは不可能なため、0 件判定に使う 2 つの
- * エンドポイントだけ空配列に差し替える（トピック提案までは実 API のまま）。
- * `v1/dishes/bulk-import` も潰すので **dev DB への書き込みは発生しない**（@mutation 不要）。
+ * `stubEmptyDishMediaResults()` で dish-media 検索 / bulk-import だけを空配列に固定する
+ * （トピック提案までは実 API のまま。dev DB への書き込みも発生しないので `@mutation` は不要）。
  */
 test.describe("Google マップ fallback (#1121)", () => {
 	// トピック生成は実 API（AI）で実測 30 秒近くかかるため、topics-flow.spec.ts と同様に延長する
@@ -38,47 +38,23 @@ test.describe("Google マップ fallback (#1121)", () => {
 
 	// ─ テストケース: 「Google マップで開く」は別タブで開き、元ページの URL を変えない ─
 	// 手順:
-	//   1. 料理メディア検索 / bulk-import を空配列に固定し、結果が必ず 0 件になるようにする
-	//   2. www.google.com へのリクエストをスタブ HTML に差し替える（実通信の遮断）
-	//   3. 渋谷で検索 → トピック提案 → 先頭のトピックを選択
-	//   4. 0 件のため Google マップ fallback ダイアログが表示される
-	//   5. 「Google マップで開く」を押す
-	//   6. 新しいタブが開き、その URL が Google マップの検索 URL であることを検証
-	//   7. 元のページの URL が押下前から変わっていないことを検証（#1121 の主症状）
+	//   1. 検索結果が必ず 0 件になるようスタブし、Google への実通信も遮断する
+	//   2. 渋谷で検索 → トピック提案 → 先頭のトピックを選択
+	//   3. 0 件のため Google マップ fallback ダイアログが表示される
+	//   4. 「Google マップで開く」を押し、新しいタブ (page イベント) を捕まえる
+	//   5. 新しいタブの URL が Google マップの検索 URL であることを検証
+	//   6. 元のページの URL が押下前から変わっていないことを検証（#1121 の主症状）
+	//   7. 開いたタブがちょうど 1 枚であることを検証（同一タブ遷移でも二重起動でもない）
 	test("「Google マップで開く」は新しいタブで開き、元のページの URL は変わらない", async ({ appPage }) => {
 		const context = appPage.context();
 
-		// ── 1. 検索結果を必ず 0 件にする ──────────────────────────────
-		// バックエンドは別オリジン (Cloud Run) のため、fulfill するレスポンスにも CORS ヘッダが要る。
-		// fetchWithAuth は web で `credentials: "include"` を使うので、`*` ではなく
-		// リクエスト元 origin をそのまま返し、allow-credentials も付ける必要がある。
-		const fulfillEmptyList = async (route: import("@playwright/test").Route): Promise<void> => {
-			const origin = (await route.request().headerValue("origin")) ?? "*";
-			await route.fulfill({
-				status: 200,
-				contentType: "application/json",
-				headers: {
-					"access-control-allow-origin": origin,
-					"access-control-allow-credentials": "true",
-				},
-				body: "[]",
-			});
-		};
-		await context.route("**/v1/dish-media/search*", fulfillEmptyList);
-		await context.route("**/v1/dishes/bulk-import*", fulfillEmptyList);
+		await stubEmptyDishMediaResults(context);
+		await stubGoogleMaps(context);
 
-		// ── 2. 実 Google へは通信させない ─────────────────────────────
-		// abort だと新しいタブの URL が about:blank のままになりうるので、
-		// ナビゲーションが commit されるようスタブ HTML を返す。
-		await context.route("https://www.google.com/**", async (route) => {
-			await route.fulfill({
-				status: 200,
-				contentType: "text/html",
-				body: "<html><body>stubbed google maps</body></html>",
-			});
-		});
+		// 「押したときだけ 1 枚開く」ことを見るため、テスト全体で開いたタブを数える
+		const openedPages: unknown[] = [];
+		context.on("page", (opened) => openedPages.push(opened));
 
-		// ── 3. 検索 → トピック提案 → トピック選択 ─────────────────────
 		const searchPage = new SearchPage(appPage);
 		const topicsPage = new TopicsPage(appPage);
 
@@ -88,77 +64,31 @@ test.describe("Google マップ fallback (#1121)", () => {
 		await topicsPage.expectLoaded();
 		await topicsPage.chooseFirstTopic();
 
-		// ── 4. 0 件 fallback ダイアログ ───────────────────────────────
+		// 0 件確定で fallback ダイアログが出る。#828 の実装は同時に result 画面を閉じるため、
+		// このときの背後の画面はトピック画面に戻っている
 		const fallbackDialog = new GoogleMapsFallbackDialog(appPage);
 		await fallbackDialog.expectVisible();
 
-		// ── 5〜6. 押下 → 新しいタブを捕まえる ─────────────────────────
-		// 押下**前**の URL を控える。expo-router の静的書き出しではタブグループ内の
-		// ネスト遷移で URL が画面と一致しないことがある（TopicsPage のコメント参照）ため、
-		// 期待値を決め打ちせず「押す前後で変わらないこと」を見る。
+		// 押下**前**の URL を控える。expo-router の静的書き出しではタブグループ内のネスト遷移で
+		// URL バーが表示内容と一致しないことがある（TopicsPage のコメント参照）ため、
+		// 期待値を決め打ちせず「押す前後で変わらないこと」で判定する
 		const urlBeforeClick = appPage.url();
 
 		const [newPage] = await Promise.all([context.waitForEvent("page"), fallbackDialog.confirmButton.click()]);
 
-		// window.open 直後は about:blank のことがあるため、URL の確定を待ってから検証する
+		// window.open 直後は about:blank のことがあるため、URL が確定するまで待ってから検証する
 		await newPage.waitForURL(GOOGLE_MAPS_SEARCH_URL, { timeout: 15_000 });
 		expect(newPage.url()).toMatch(GOOGLE_MAPS_SEARCH_URL);
-		// 検索地点の言語（ja）が引き継がれていること（buildGoogleMapsSearchUrl の hl）
+		// 検索地点の言語 (ja) が Google マップ側にも引き継がれていること（buildGoogleMapsSearchUrl の hl）
 		expect(newPage.url()).toContain("hl=ja");
 
-		// ── 7. 元のページは離脱していない（#1121 の主症状） ───────────
-		// 修正前はここが www.google.com/... に変わり、戻ると壊れていた。
+		// ここが #1121 の主症状。修正前は元タブが www.google.com/... へ遷移し、戻ると壊れていた
 		expect(appPage.url()).toBe(urlBeforeClick);
-		// 元タブがアプリのまま生きていること（別タブ起動なので閉じられていない）
-		expect(appPage.isClosed()).toBe(false);
+		// 元タブがアプリを表示したまま生きていること（別タブ起動なので離脱していない）
 		await expect(topicsPage.headerTitle.last()).toBeVisible();
 
+		expect(openedPages).toHaveLength(1);
+
 		await newPage.close();
-	});
-
-	// ─ テストケース: 「閉じる」では新しいタブが開かない ─
-	// 手順:
-	//   1. 上と同じ手順で fallback ダイアログを表示する
-	//   2. 「閉じる」を押す
-	//   3. ダイアログが閉じ、新しいタブが 1 つも開いていないことを検証
-	// 補足: 「押せば必ず新タブが開く」のではなく「確定操作のときだけ開く」ことを担保し、
-	//       (1) のテストが偶発的な popup を拾っていないことの裏取りにする。
-	test("「閉じる」では新しいタブは開かない", async ({ appPage }) => {
-		const context = appPage.context();
-
-		const fulfillEmptyList = async (route: import("@playwright/test").Route): Promise<void> => {
-			const origin = (await route.request().headerValue("origin")) ?? "*";
-			await route.fulfill({
-				status: 200,
-				contentType: "application/json",
-				headers: {
-					"access-control-allow-origin": origin,
-					"access-control-allow-credentials": "true",
-				},
-				body: "[]",
-			});
-		};
-		await context.route("**/v1/dish-media/search*", fulfillEmptyList);
-		await context.route("**/v1/dishes/bulk-import*", fulfillEmptyList);
-
-		const openedPages: string[] = [];
-		context.on("page", (opened) => openedPages.push(opened.url()));
-
-		const searchPage = new SearchPage(appPage);
-		const topicsPage = new TopicsPage(appPage);
-
-		await searchPage.typeLocation("渋谷");
-		await searchPage.selectLocationSuggestion(0);
-		await searchPage.submitButton.click();
-		await topicsPage.expectLoaded();
-		await topicsPage.chooseFirstTopic();
-
-		const fallbackDialog = new GoogleMapsFallbackDialog(appPage);
-		await fallbackDialog.expectVisible();
-
-		await fallbackDialog.cancelButton.click();
-
-		await expect(fallbackDialog.message).toBeHidden();
-		expect(openedPages).toEqual([]);
 	});
 });

--- a/e2e-web/tests/search/google-maps-fallback.spec.ts
+++ b/e2e-web/tests/search/google-maps-fallback.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from "../../fixtures/test";
+import { SearchPage } from "../../pages/SearchPage";
+import { TopicsPage } from "../../pages/TopicsPage";
+import { GoogleMapsFallbackDialog } from "../../pages/GoogleMapsFallbackDialog";
+
+/**
+ * 🗺 Google マップ fallback は別タブで開く（#1121 の回帰テスト）
+ *
+ * ## 背景 (#1121)
+ * `/ja-JP/search/topics` で検索結果が 0 件だったときに出る Google マップ fallback ダイアログの
+ * 「Google マップで開く」を Web で押すと、`Linking.openURL()` が **同一タブ**を遷移させていた。
+ * SPA から離脱するため、ブラウザバックで戻ってくると復元に失敗して画面が壊れる、というのが
+ * 報告された不具合。PR #1151 で `openExternalUrl()` を導入し、Web では
+ * `window.open(url, "_blank", "noopener,noreferrer")` で別タブに開くよう修正済み。
+ *
+ * ## このテストの検証内容
+ * 1. 「Google マップで開く」で **新しいタブ**が開き、その URL が Google マップの検索 URL であること
+ * 2. **元のページの URL が変わらない**こと（= SPA を離脱していない。主症状の回帰）
+ *
+ * 修正前は (1) で新しいタブが開かず `waitForEvent("page")` がタイムアウトし、
+ * (2) も元タブの URL が www.google.com に変わるため落ちる。
+ *
+ * ## 実 Google へは通信しない
+ * 別タブが開く URL を検証したいだけなので、`https://www.google.com/**` は
+ * `context.route()` でスタブ HTML に差し替える。Google Maps へのリクエストは 1 度も出ない。
+ *
+ * ## 0 件状態の作り方
+ * 実 API で確実に 0 件になる検索条件を作るのは不可能なため、0 件判定に使う 2 つの
+ * エンドポイントだけ空配列に差し替える（トピック提案までは実 API のまま）。
+ * `v1/dishes/bulk-import` も潰すので **dev DB への書き込みは発生しない**（@mutation 不要）。
+ */
+test.describe("Google マップ fallback (#1121)", () => {
+	// トピック生成は実 API（AI）で実測 30 秒近くかかるため、topics-flow.spec.ts と同様に延長する
+	test.setTimeout(90_000);
+
+	/** Google マップの検索 URL（app-expo/lib/googleMaps.ts の buildGoogleMapsSearchUrl 準拠） */
+	const GOOGLE_MAPS_SEARCH_URL = /^https:\/\/www\.google\.com\/maps\/search\//;
+
+	// ─ テストケース: 「Google マップで開く」は別タブで開き、元ページの URL を変えない ─
+	// 手順:
+	//   1. 料理メディア検索 / bulk-import を空配列に固定し、結果が必ず 0 件になるようにする
+	//   2. www.google.com へのリクエストをスタブ HTML に差し替える（実通信の遮断）
+	//   3. 渋谷で検索 → トピック提案 → 先頭のトピックを選択
+	//   4. 0 件のため Google マップ fallback ダイアログが表示される
+	//   5. 「Google マップで開く」を押す
+	//   6. 新しいタブが開き、その URL が Google マップの検索 URL であることを検証
+	//   7. 元のページの URL が押下前から変わっていないことを検証（#1121 の主症状）
+	test("「Google マップで開く」は新しいタブで開き、元のページの URL は変わらない", async ({ appPage }) => {
+		const context = appPage.context();
+
+		// ── 1. 検索結果を必ず 0 件にする ──────────────────────────────
+		// バックエンドは別オリジン (Cloud Run) のため、fulfill するレスポンスにも CORS ヘッダが要る。
+		// fetchWithAuth は web で `credentials: "include"` を使うので、`*` ではなく
+		// リクエスト元 origin をそのまま返し、allow-credentials も付ける必要がある。
+		const fulfillEmptyList = async (route: import("@playwright/test").Route): Promise<void> => {
+			const origin = (await route.request().headerValue("origin")) ?? "*";
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				headers: {
+					"access-control-allow-origin": origin,
+					"access-control-allow-credentials": "true",
+				},
+				body: "[]",
+			});
+		};
+		await context.route("**/v1/dish-media/search*", fulfillEmptyList);
+		await context.route("**/v1/dishes/bulk-import*", fulfillEmptyList);
+
+		// ── 2. 実 Google へは通信させない ─────────────────────────────
+		// abort だと新しいタブの URL が about:blank のままになりうるので、
+		// ナビゲーションが commit されるようスタブ HTML を返す。
+		await context.route("https://www.google.com/**", async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: "text/html",
+				body: "<html><body>stubbed google maps</body></html>",
+			});
+		});
+
+		// ── 3. 検索 → トピック提案 → トピック選択 ─────────────────────
+		const searchPage = new SearchPage(appPage);
+		const topicsPage = new TopicsPage(appPage);
+
+		await searchPage.typeLocation("渋谷");
+		await searchPage.selectLocationSuggestion(0);
+		await searchPage.submitButton.click();
+		await topicsPage.expectLoaded();
+		await topicsPage.chooseFirstTopic();
+
+		// ── 4. 0 件 fallback ダイアログ ───────────────────────────────
+		const fallbackDialog = new GoogleMapsFallbackDialog(appPage);
+		await fallbackDialog.expectVisible();
+
+		// ── 5〜6. 押下 → 新しいタブを捕まえる ─────────────────────────
+		// 押下**前**の URL を控える。expo-router の静的書き出しではタブグループ内の
+		// ネスト遷移で URL が画面と一致しないことがある（TopicsPage のコメント参照）ため、
+		// 期待値を決め打ちせず「押す前後で変わらないこと」を見る。
+		const urlBeforeClick = appPage.url();
+
+		const [newPage] = await Promise.all([context.waitForEvent("page"), fallbackDialog.confirmButton.click()]);
+
+		// window.open 直後は about:blank のことがあるため、URL の確定を待ってから検証する
+		await newPage.waitForURL(GOOGLE_MAPS_SEARCH_URL, { timeout: 15_000 });
+		expect(newPage.url()).toMatch(GOOGLE_MAPS_SEARCH_URL);
+		// 検索地点の言語（ja）が引き継がれていること（buildGoogleMapsSearchUrl の hl）
+		expect(newPage.url()).toContain("hl=ja");
+
+		// ── 7. 元のページは離脱していない（#1121 の主症状） ───────────
+		// 修正前はここが www.google.com/... に変わり、戻ると壊れていた。
+		expect(appPage.url()).toBe(urlBeforeClick);
+		// 元タブがアプリのまま生きていること（別タブ起動なので閉じられていない）
+		expect(appPage.isClosed()).toBe(false);
+		await expect(topicsPage.headerTitle.last()).toBeVisible();
+
+		await newPage.close();
+	});
+
+	// ─ テストケース: 「閉じる」では新しいタブが開かない ─
+	// 手順:
+	//   1. 上と同じ手順で fallback ダイアログを表示する
+	//   2. 「閉じる」を押す
+	//   3. ダイアログが閉じ、新しいタブが 1 つも開いていないことを検証
+	// 補足: 「押せば必ず新タブが開く」のではなく「確定操作のときだけ開く」ことを担保し、
+	//       (1) のテストが偶発的な popup を拾っていないことの裏取りにする。
+	test("「閉じる」では新しいタブは開かない", async ({ appPage }) => {
+		const context = appPage.context();
+
+		const fulfillEmptyList = async (route: import("@playwright/test").Route): Promise<void> => {
+			const origin = (await route.request().headerValue("origin")) ?? "*";
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				headers: {
+					"access-control-allow-origin": origin,
+					"access-control-allow-credentials": "true",
+				},
+				body: "[]",
+			});
+		};
+		await context.route("**/v1/dish-media/search*", fulfillEmptyList);
+		await context.route("**/v1/dishes/bulk-import*", fulfillEmptyList);
+
+		const openedPages: string[] = [];
+		context.on("page", (opened) => openedPages.push(opened.url()));
+
+		const searchPage = new SearchPage(appPage);
+		const topicsPage = new TopicsPage(appPage);
+
+		await searchPage.typeLocation("渋谷");
+		await searchPage.selectLocationSuggestion(0);
+		await searchPage.submitButton.click();
+		await topicsPage.expectLoaded();
+		await topicsPage.chooseFirstTopic();
+
+		const fallbackDialog = new GoogleMapsFallbackDialog(appPage);
+		await fallbackDialog.expectVisible();
+
+		await fallbackDialog.cancelButton.click();
+
+		await expect(fallbackDialog.message).toBeHidden();
+		expect(openedPages).toEqual([]);
+	});
+});

--- a/e2e-web/utils/network.ts
+++ b/e2e-web/utils/network.ts
@@ -1,4 +1,4 @@
-import type { Page, Route } from "@playwright/test";
+import type { BrowserContext, Page, Route } from "@playwright/test";
 
 /**
  * 🌐 ネットワーク観測ユーティリティ
@@ -59,4 +59,57 @@ export async function countRequests(
 		count: () => count,
 		stop: () => page.unroute(urlGlob, handler),
 	};
+}
+
+/**
+ * 料理メディアの検索結果を **常に 0 件**に固定する（#828 の Google マップ fallback 到達用）。
+ *
+ * 実 API で「必ず 0 件になる検索条件」を用意することはできないため、0 件判定に使う
+ * 2 エンドポイントだけを空配列に差し替える。トピック提案までは実 API のまま動く。
+ * - `v1/dish-media/search` (GET) : 既存 dish_media の検索。0 件だと import へ進む
+ * - `v1/dishes/bulk-import` (POST): 店舗候補の初回取り込み。ここも 0 件で 0 件確定
+ *   （**差し替えにより dev DB への書き込みは発生しない**ので `@mutation` は不要）
+ *
+ * ⚠️ CORS: バックエンドは別オリジン (Cloud Run) なので、fulfill するレスポンスにも
+ * CORS ヘッダが要る。`app-expo/lib/fetchWithAuth.ts` は web で `credentials: "include"` を
+ * 使うため、`access-control-allow-origin: *` は**使えない**。リクエスト元 origin を
+ * そのまま返し `access-control-allow-credentials` を付ける。
+ * プリフライト (OPTIONS) は route に載らず実サーバへ出るが、dev の CORS_ORIGIN に
+ * ローカルサーバのオリジンが登録済みのため通る。
+ *
+ * @param context ルートを仕掛ける BrowserContext（ポップアップにも効かせるため page ではなく context）
+ */
+export async function stubEmptyDishMediaResults(context: BrowserContext): Promise<void> {
+	const fulfillEmptyList = async (route: Route): Promise<void> => {
+		const origin = (await route.request().headerValue("origin")) ?? "*";
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			headers: {
+				"access-control-allow-origin": origin,
+				"access-control-allow-credentials": "true",
+			},
+			body: "[]",
+		});
+	};
+
+	await context.route("**/v1/dish-media/search*", fulfillEmptyList);
+	await context.route("**/v1/dishes/bulk-import*", fulfillEmptyList);
+}
+
+/**
+ * `https://www.google.com/**` をスタブ HTML に差し替え、**実 Google への通信を遮断**する。
+ *
+ * 別タブが開いたことと、その URL さえ分かれば十分なので Google Maps 本体は読み込ませない。
+ * `route.abort()` ではなく `fulfill()` にしているのは、ナビゲーションが commit されないと
+ * 新しいタブの URL が `about:blank` のままになりうるため。
+ */
+export async function stubGoogleMaps(context: BrowserContext): Promise<void> {
+	await context.route("https://www.google.com/**", async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "text/html",
+			body: "<html><body>stubbed google maps</body></html>",
+		});
+	});
 }


### PR DESCRIPTION
実機確認へ回していた項目の E2E 化、第 2 弾です。

## 変更内容

| Issue | 内容 | web (Playwright) | mobile (Detox) |
| --- | --- | --- | --- |
| #1121 | 外部リンクの別タブ起動 | ✅ 新規 | — （後述） |
| #1136 | レビュー投稿中のローディング | ✅ 新規 | ⚠️ **未着手** |

### #1121

`context.waitForEvent('page')` で新しいタブを捕まえ、URL を検証します。**元のページの URL が変わらない**（＝主症状の「戻るとエラー」が起きない）ことも固定しました。実際に Google Map へは通信させていません。

### #1136

`page.route()` で `POST v1/dishes` を保留・失敗させ、**実投稿を待たずに**次を検証します。

- 投稿中はスピナーが出て、押下が届かない
- **失敗してもローディングが解除され、再投稿できる**（固まらない）

dish / dish-media / dish-review は 1 件も作られません（フォーム到達までのレストラン upsert のみ書き込むため `@mutation`）。

## ⚠️ 未着手を明示します

- **#1136 の Detox 側**: ワーカーが時間内に到達できず、commit メッセージにも「mobile 側は未着手」と明記されています
- **#1132（ブロック済み料理カテゴリの文言）**: 同じ run に含めましたが未着手です

このリポジトリは `e2e-web` と `e2e-mobile` を原則同じ密度で維持しているので、**#1136 の mobile 側は別途書きます。** 黙って落とさないため、ここに残します。

## 検証

- `e2e-web` typecheck: exit 0
- `e2e-mobile` typecheck: exit 0
- `pnpm --filter app-expo test`: **37 suites / 276 tests 全 pass**
- `pnpm --filter app-expo typecheck`: exit 0

**Playwright の実走はこの PR では行っていません**（ローカル検証の位置づけ、という方針に従っています）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_