### PR TITLE
#1132 test(e2e-web): ブロック済み料理カテゴリの文言を E2E で固定する

### DIFF
--- a/e2e-web/tests/profile/blocked-categories-wording.spec.ts
+++ b/e2e-web/tests/profile/blocked-categories-wording.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "../../fixtures/test";
+import { SettingsPage } from "../../pages/SettingsPage";
+
+/**
+ * 🈁 ブロック済み料理カテゴリの文言（#1132）
+ *
+ * #1132 は「ブロック済み料理トピック」という文言が不自然だったため、
+ * 8 言語分を「料理カテゴリ」へ統一した変更（PR #1148）。
+ *
+ * ## なぜ E2E で守るのか
+ * 文言の統一は locales/*.json の 8 ファイルへ散らばるので、
+ * 1 ファイルだけ直し漏れても型検査もユニットテストも通ってしまう。
+ * 「画面に旧文言が出ていないこと」は実際に描画しないと分からないため E2E で見る。
+ *
+ * ## 言語を 2 つに絞っている理由
+ * 8 言語すべてを起動すると遅い。ja-JP（変更の主対象）と ar-SA（RTL で
+ * レイアウトが崩れやすい）だけを回し、残りは locales の値を直接読む
+ * ユニットテスト側で担保する方針。
+ */
+test.describe("ブロック済み料理カテゴリの文言(#1132)", () => {
+	// ─ テストケース: ja-JP で新文言が出て、旧文言が残っていない ─
+	// 手順:
+	//   1. /ja-JP/profile/blocked-topics へ直接遷移する
+	//   2. ScreenHeader の pageTitle が「ブロック済みの料理カテゴリ」であることを検証
+	//   3. 画面のどこにも「トピック」が残っていないことを検証（これが #1132 の本体）
+	test("ja-JP で「料理カテゴリ」と表示され、旧文言「トピック」が残っていない", async ({ appPage }) => {
+		await appPage.goto("/ja-JP/profile/blocked-topics");
+
+		// locales/ja-JP.json の Settings.blockedTopics.pageTitle と同じ文字列
+		await expect(appPage.getByText("ブロック済みの料理カテゴリ", { exact: true })).toBeVisible();
+
+		// ⚠️ ここが本題。1 ファイルでも直し漏れると旧文言が画面へ出る。
+		//    exact: false で「トピック」を含む要素が 1 つも無いことを見る。
+		await expect(appPage.getByText("トピック")).toHaveCount(0);
+	});
+
+	// ─ テストケース: 設定メニューの導線も新文言になっている ─
+	// 手順:
+	//   1. /ja-JP/profile/settings を開く
+	//   2. ブロック済み項目（settings-blocked-topics）が表示されることを検証
+	//   3. 設定画面にも旧文言「トピック」が残っていないことを検証
+	//      （導線側のキーだけ直し漏れる事故を防ぐ）
+	test("設定メニューの導線にも旧文言が残っていない", async ({ appPage }) => {
+		const settingsPage = new SettingsPage(appPage);
+		await settingsPage.goto();
+		await settingsPage.expectLoaded();
+
+		await expect(settingsPage.blockedTopicsItem).toBeVisible();
+		await expect(appPage.getByText("トピック")).toHaveCount(0);
+	});
+
+	// ─ テストケース: ar-SA(RTL) でも表示が崩れていない ─
+	// 手順:
+	//   1. /ar-SA/profile/blocked-topics へ直接遷移する
+	//   2. アラビア語の pageTitle が表示されることを検証
+	//      （RTL で要素が画面外へ出ると toBeVisible が落ちる）
+	//   3. 日本語が混入していないことを検証（フォールバックで ja-JP へ落ちる事故の検知）
+	test("ar-SA(RTL) でも翻訳が表示され、日本語へフォールバックしていない", async ({ appPage }) => {
+		await appPage.goto("/ar-SA/profile/blocked-topics");
+
+		// locales/ar-SA.json の Settings.blockedTopics.pageTitle
+		await expect(appPage.getByText("فئات الأطباق المحظورة", { exact: true })).toBeVisible();
+
+		// ロケール解決が壊れると ja-JP の文言が出る（#721 の症状 b と同じ型の事故）
+		await expect(appPage.getByText("ブロック済みの料理カテゴリ")).toHaveCount(0);
+	});
+});

--- a/e2e-web/tests/profile/settings.spec.ts
+++ b/e2e-web/tests/profile/settings.spec.ts
@@ -14,7 +14,7 @@ test.describe("設定画面(匿名ユーザー)", () => {
 	//      - ご意見・不具合(settings-feedback)
 	//      - 利用規約(settings-terms)
 	//      - プライバシーポリシー(settings-privacy)
-	//      - ブロック済みの料理トピック(settings-blocked-topics)
+	//      - ブロック済みの料理カテゴリ(settings-blocked-topics) ← #1132 で「トピック」から改称
 	//   3. 「レビューを書く」(ストア誘導)は Web では表示されないことを検証
 	test("設定メニューの各項目が表示される", async ({ appPage }) => {
 		const settingsPage = new SettingsPage(appPage);


### PR DESCRIPTION
実機確認へ回していた #1132 を E2E 化します。ワーカーが 2 度ターン切れしたため、内容が単純なのでリーダーが直接書きました。

## なぜ E2E で守るのか

文言統一は `locales/*.json` の **8 ファイルへ散らばる**ため、**1 ファイル直し漏れても型検査もユニットテストも通ってしまいます。** 「画面に旧文言が出ていないこと」は実際に描画しないと分からないので E2E の担当です。

## 固定した内容

| テスト | 見るもの |
| --- | --- |
| ja-JP | 新文言「ブロック済みの料理カテゴリ」が表示され、**「トピック」が画面に 1 つも無い** |
| 設定メニュー | 導線側にも旧文言が残っていない（導線のキーだけ直し漏れる事故の検知） |
| ar-SA(RTL) | アラビア語の翻訳が表示され、**ja-JP へフォールバックしていない** |

3 つ目は #721 の症状 (b)（ロケール解決が壊れて全言語が ja-JP になる）と同じ型の事故を検知します。

**8 言語すべてを起動すると遅いので ja-JP と ar-SA に絞りました。** 残り 6 言語は locales の値を直接読むユニットテスト側で担保する方針です。

## ついでに直したもの

`e2e-web/tests/profile/settings.spec.ts` のコメントに**旧文言「ブロック済みの料理トピック」が残っていた**ので更新しました。テスト自体は表示確認のみで影響はありませんが、次に読む人が混乱します。

## 検証

`npx tsc --noEmit -p e2e-web/tsconfig.json` exit 0。

**Playwright の実走は行っていません**（ローカル検証の位置づけ、という方針に従っています）。

## 未着手

**Detox 側は未着手**です。web / mobile 同密度の原則から、別途書きます。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_