### PR TITLE
#1120 #1122 test(e2e): モーダル遷移とゲスト UI ちらつきを web / mobile 両方で固定する

### DIFF
--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCandidateCard.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCandidateCard.tsx
@@ -32,7 +32,11 @@ export function DishCategoryGroupVoteCandidateCard({
 	const hasEmptyDishMedia = candidate.dishMediaSearchStatus === "empty";
 
 	return (
-		<Pressable style={styles.card} onPress={() => onPressCandidate(candidate)}>
+		<Pressable
+			style={styles.card}
+			onPress={() => onPressCandidate(candidate)}
+			// #1122 E2E から「一覧カード導線」と「詳細モーダル導線」を撃ち分けるための識別子
+			testID={`dish-category-group-vote-candidate-${candidate.id}`}>
 			<Image source={{ uri: candidate.imageUrl }} style={styles.image} contentFit="cover" />
 			<View style={styles.rankBadge}>
 				{/* #941 【仕様】総投票数0はBEが全候補同率rank(=1)で返すため、UI側で「未投票」に統一する */}
@@ -67,7 +71,8 @@ export function DishCategoryGroupVoteCandidateCard({
 					event.stopPropagation();
 					onPressDishMedia(candidate);
 				}}
-				activeOpacity={0.85}>
+				activeOpacity={0.85}
+				testID={`dish-category-group-vote-candidate-dish-media-${candidate.id}`}>
 				<Text style={[styles.secondaryButtonText, hasEmptyDishMedia && styles.disabledButtonText]} numberOfLines={1}>
 					{isDishMediaLoading
 						? i18n.t("DishCategoryGroupVotes.loadingRestaurants")

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCandidateDetailModal.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCandidateDetailModal.tsx
@@ -33,7 +33,9 @@ export function DishCategoryGroupVoteCandidateDetailModal({
 	const hasEmptyDishMedia = candidate.dishMediaSearchStatus === "empty";
 
 	return (
-		<View style={styles.modal}>
+		// #1122 「モーダルが閉じてから遷移する」を E2E で観測するための識別子。
+		// この要素が DOM から消えること = Portal がアンマウントされたこと。
+		<View style={styles.modal} testID="dish-category-group-vote-candidate-detail">
 			<ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
 				<View style={styles.hero}>
 					<Image source={{ uri: candidate.imageUrl }} style={styles.image} contentFit="cover" />
@@ -70,6 +72,7 @@ export function DishCategoryGroupVoteCandidateDetailModal({
 					disabled={hasEmptyDishMedia || isDishMediaLoading}
 					onPress={() => onPressDishMedia(candidate)}
 					style={styles.viewRestaurantsButton}
+					testID="dish-category-group-vote-detail-dish-media"
 				/>
 				{hasEmptyDishMedia ? (
 					<Text style={styles.emptyText}>{i18n.t("DishCategoryGroupVotes.noRestaurantsFound")}</Text>

--- a/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCompletionModal.tsx
+++ b/app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCompletionModal.tsx
@@ -98,9 +98,10 @@ export function DishCategoryGroupVoteCompletionModal({ usedDisplayNames, isSubmi
 	}
 
 	return (
-		<View style={styles.modal}>
+		<View testID="dish-category-group-vote-completion-form" style={styles.modal}>
 			<Text style={styles.title}>{i18n.t("DishCategoryGroupVotes.completionTitle")}</Text>
 			<TextInput
+				testID="dish-category-group-vote-display-name-input"
 				style={styles.input}
 				value={displayName}
 				onChangeText={(text) => {

--- a/e2e-mobile/.env.example
+++ b/e2e-mobile/.env.example
@@ -18,6 +18,14 @@
 #TEST_USER_EMAIL=
 #TEST_USER_PASSWORD=
 
+# --- 友達投票（#1120 の回帰テスト）-----------------------------------------
+# dev 環境に存在し、かつ **テストユーザーも匿名ユーザーもまだ投票していない** 投票セッションの
+# shareToken。共有 URL（.../search/dish-category-group-votes/<shareToken>/vote）の末尾の値。
+# Detox には page.route() 相当が無く detail API をモックできないため、実データが要る。
+# 未設定の場合、dish-category-group-vote-completion-*.test.ts は自動的にスキップされる。
+# 投票済みのトークンを指定すると画面が結果画面へ遷移し、投票カードに到達できず失敗する。
+#TEST_GROUP_VOTE_SHARE_TOKEN=
+
 # --- ミューテーションテスト -------------------------------------------------
 # dev DB へ書き込むテスト（tests/mutation/）を実行する場合のみ 1 を設定する。
 # 通常は pnpm test:mutation:android / test:all:android が内部で設定するため手動設定は不要。

--- a/e2e-mobile/screens/DishCategoryGroupVoteResultScreen.ts
+++ b/e2e-mobile/screens/DishCategoryGroupVoteResultScreen.ts
@@ -1,0 +1,56 @@
+import { by, tapWhenVisible, waitUntilGone, waitUntilVisible } from "../fixtures/e2e";
+
+/**
+ * 🗳 友達投票の結果画面の Screen Object
+ *
+ * 対応画面: app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteResultScreen.tsx
+ * 対応する e2e-web の spec: e2e-web/tests/search/dish-category-group-vote-navigation.spec.ts
+ *
+ * ## 観測点
+ * - 候補カード: `dish-category-group-vote-candidate-<candidateId>`（押すと詳細モーダルが開く）
+ * - カード内「店を見る」: `dish-category-group-vote-candidate-dish-media-<candidateId>`（モーダルを介さない導線）
+ * - 詳細モーダル本体: `dish-category-group-vote-candidate-detail`
+ * - モーダル内「店を見る」: `dish-category-group-vote-detail-dish-media`
+ *
+ * 詳細モーダルは `useBlurModal`（react-native-paper の Portal）で描かれるため、
+ * **モーダル本体の testID が消えたこと = Portal がアンマウントされたこと**になる。
+ * #1122 の「閉じてから遷移する」はこの観測点で検証する。
+ */
+export class DishCategoryGroupVoteResultScreen {
+	/** 候補カード（押下で詳細モーダルを開く） */
+	candidateCard(candidateId: string) {
+		return by.id(`dish-category-group-vote-candidate-${candidateId}`);
+	}
+
+	/** 一覧カード内の「店を見る」（詳細モーダルを介さない導線） */
+	candidateDishMediaButton(candidateId: string) {
+		return by.id(`dish-category-group-vote-candidate-dish-media-${candidateId}`);
+	}
+
+	/** 候補詳細モーダル本体 */
+	readonly detailModal = by.id("dish-category-group-vote-candidate-detail");
+
+	/** 詳細モーダル内の「店を見る」 */
+	readonly detailDishMediaButton = by.id("dish-category-group-vote-detail-dish-media");
+
+	/** 候補一覧が表示されるまで待つ */
+	async expectLoaded(candidateId: string, timeout?: number): Promise<void> {
+		await waitUntilVisible(this.candidateCard(candidateId), timeout);
+	}
+
+	/** 候補カードを押して詳細モーダルを開く */
+	async openCandidateDetail(candidateId: string): Promise<void> {
+		await tapWhenVisible(this.candidateCard(candidateId));
+		await waitUntilVisible(this.detailModal);
+	}
+
+	/** 詳細モーダル内の「店を見る」を押す */
+	async pressDetailDishMedia(): Promise<void> {
+		await tapWhenVisible(this.detailDishMediaButton);
+	}
+
+	/** 詳細モーダルが閉じ切る（Portal がアンマウントされる）まで待つ */
+	async expectDetailClosed(): Promise<void> {
+		await waitUntilGone(this.detailModal);
+	}
+}

--- a/e2e-mobile/screens/DishCategoryGroupVoteScreen.ts
+++ b/e2e-mobile/screens/DishCategoryGroupVoteScreen.ts
@@ -1,0 +1,50 @@
+import { by, waitUntilGone, waitUntilVisible } from "../fixtures/e2e";
+
+/**
+ * 🗳 友達投票（dish category group vote）画面の Screen Object
+ *
+ * 対応画面:
+ * - app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteVoteScreen.tsx
+ * - app-expo/features/dishCategoryGroupVotes/components/DishCategoryGroupVoteCompletionModal.tsx
+ *
+ * 対応する e2e-web のユーティリティ: e2e-web/utils/dishCategoryGroupVote.ts
+ * （web 側は Page Object ではなく「API モック + 直接 getByTestId」で構成している。
+ *   モックの組み立てが本体で、画面要素は数個しか触らないため）
+ */
+export class DishCategoryGroupVoteScreen {
+	/** 投票カードの「良い」ボタン */
+	readonly likeButton = by.id("dish-category-group-vote-like-button");
+	/** 投票カードの「いまいち」ボタン */
+	readonly dislikeButton = by.id("dish-category-group-vote-dislike-button");
+
+	/**
+	 * ログイン状態の確定待ちに描かれるローディング（#1120）。
+	 * これが出ている間は「ゲスト用 / ログイン済み用」どちらの分岐も描かれない。
+	 */
+	readonly completionLoading = by.id("dish-category-group-vote-completion-loading");
+	/** 確定後に描かれる完了モーダルのフォーム本体 */
+	readonly completionForm = by.id("dish-category-group-vote-completion-form");
+	/** 表示名の入力欄 */
+	readonly displayNameInput = by.id("dish-category-group-vote-display-name-input");
+	/**
+	 * ゲスト向けの名前サジェスト（絵文字候補）。
+	 * #1120 で「ログイン済みユーザーにも一瞬だけ出ていた」当該 UI。
+	 */
+	readonly nameSuggestions = by.id("dish-category-group-vote-name-suggestions");
+
+	/** 投票カードが操作できる状態になるまで待つ */
+	async expectVoteCardLoaded(timeout?: number): Promise<void> {
+		await waitUntilVisible(this.likeButton, timeout);
+	}
+
+	/**
+	 * 完了モーダルが「確定後の状態」に落ち着くまで待つ。
+	 *
+	 * ローディングが消えてフォームが出た時点を「安定した」とみなす。
+	 * ここを観測点にすることで、後続のアサーションが確定前の一瞬を見てしまうことがない。
+	 */
+	async expectCompletionSettled(timeout?: number): Promise<void> {
+		await waitUntilVisible(this.completionForm, timeout);
+		await waitUntilGone(this.completionLoading, timeout);
+	}
+}

--- a/e2e-mobile/tests/authenticated/dish-category-group-vote-completion-identity.test.ts
+++ b/e2e-mobile/tests/authenticated/dish-category-group-vote-completion-identity.test.ts
@@ -1,0 +1,92 @@
+import {
+	describeAuthenticated,
+	element,
+	existsNow,
+	expect,
+	launchAppWithSession,
+	localeDeepLink,
+} from "../../fixtures/e2e";
+import { DishCategoryGroupVoteScreen } from "../../screens/DishCategoryGroupVoteScreen";
+
+/**
+ * 🗳 友達投票の完了モーダル / ログイン済みユーザー（#1120 の回帰テスト）
+ *
+ * 対応する e2e-web の spec:
+ * - tests/authenticated/dish-category-group-vote-completion-identity.spec.ts
+ * - tests/dish-category-group-votes/vote-completion-guest.spec.ts
+ *
+ * ## 何を守るテストか
+ * #1120: ログイン済みユーザーが友達投票を完了すると、**一瞬だけゲスト用の絵文字候補**
+ * （名前サジェスト）が出てから nickname 初期入力へ差し替わっていた。
+ * 修正（PR #1157）は「ログイン状態 + プロフィールが確定するまでどちらの分岐も描かない」もの。
+ *
+ * ## ⚠️ web 側とスコープが違う（重要）
+ * 「**一瞬だけ**出る」ことの検知は **web 側の spec だけ** が行っている。
+ * web は `page.route()` でプロフィール取得 API を止めて確定待ちの窓を人為的に広げ、
+ * さらに MutationObserver で「出て消えた」まで拾えるが、Detox には
+ *
+ * - ネットワークを差し込む仕組み（`page.route()` 相当）が無い
+ *   （このリポジトリの e2e-mobile にもネットワーク制御の仕組みは無い。
+ *     セッション注入は `launchArgs` 経由で、HTTP レイヤには介入していない）
+ * - DOM の MutationObserver 相当が無く、観測は Detox の matcher によるポーリングだけ
+ *
+ * ため、数百 ms の窓を安定して観測できない。そこでネイティブ側は
+ * **「完了モーダルが開いて安定したあと、ゲスト用 UI が存在しない」** という
+ * 弱い（しかし確実に判定できる）不変条件に絞る。
+ * 「確定を待たずゲスト用を描いてから差し替える」実装へ戻った場合、最終状態は
+ * ログイン済み用に落ち着くためこのテストでは捕まらない。そこは web 側が担保する。
+ *
+ * ## 前提データ（TEST_GROUP_VOTE_SHARE_TOKEN）
+ * ネイティブは detail API をモックできないため、**実在する投票セッション** が要る。
+ * `TEST_GROUP_VOTE_SHARE_TOKEN` に、テストユーザーが **まだ投票していない** dev 環境の
+ * shareToken を渡すこと（投票済みだと画面が結果画面へ router.replace され、投票カードに
+ * 到達できない）。未設定ならスキップする。
+ *
+ * ## dev DB への影響
+ * 無し。完了モーダルを開くところまでで、送信（POST vote）は行わない。
+ * 投票の下書きはクライアント側の state にしか無いため、アプリを終了すれば消える。
+ */
+const SHARE_TOKEN = process.env.TEST_GROUP_VOTE_SHARE_TOKEN;
+
+const describeWithShareToken = SHARE_TOKEN ? describeAuthenticated : describe.skip;
+
+describeWithShareToken("友達投票の完了モーダル（ログイン済みユーザー）", () => {
+	const voteScreen = new DishCategoryGroupVoteScreen();
+
+	beforeAll(async () => {
+		// ログイン済みセッションを注入して、投票画面へディープリンクで直接入る。
+		// （トピック提案 → グループ投票作成 → 共有 の導線を毎回通ると AI 生成待ちで不安定になるため）
+		await launchAppWithSession({
+			as: "authenticated",
+			url: localeDeepLink(`search/dish-category-group-votes/${SHARE_TOKEN}/vote`),
+		});
+	});
+
+	// ─ テストケース: 完了モーダルにゲスト用の絵文字候補が出ない ─
+	// 手順:
+	//   1. ログイン済みセッションで投票画面へディープリンクする
+	//   2. 全候補へ投票して完了モーダルを開く
+	//   3. 確定待ちのローディングが消えてフォームが出る（= 安定した）まで待つ
+	//   4. ゲスト用の名前サジェストが存在しないことを検証
+	//   5. 表示名がログインユーザーの display_name で初期入力されていることを検証
+	//      （「サジェストが無い」だけだと、単に描画が壊れていても通ってしまうため）
+	it("完了モーダルにゲスト用の絵文字候補が表示されない", async () => {
+		await voteScreen.expectVoteCardLoaded();
+
+		// 候補数は dev 環境のセッション次第なので、投票カードが消える（= 完了モーダルが開く）まで
+		// 「良い」を押し続ける。候補数の上限（app-expo 側は最大 10 件）を超えないよう回数で打ち切る
+		for (let i = 0; i < 10; i += 1) {
+			if (!(await existsNow(voteScreen.likeButton))) break;
+			await element(voteScreen.likeButton).tap();
+		}
+
+		await voteScreen.expectCompletionSettled();
+
+		// #1120 の本体: ログイン済みユーザーにゲスト用 UI は出ない
+		await expect(element(voteScreen.nameSuggestions)).not.toExist();
+
+		// 「サジェストが出ない」の裏返しとして、ログイン済み用の初期入力が効いていること。
+		// display_name はテストユーザー依存なので値は問わず「空でないこと」だけを見る
+		await expect(element(voteScreen.displayNameInput)).not.toHaveText("");
+	});
+});

--- a/e2e-mobile/tests/review/dish-category-group-vote-completion-guest.test.ts
+++ b/e2e-mobile/tests/review/dish-category-group-vote-completion-guest.test.ts
@@ -1,0 +1,59 @@
+import { element, existsNow, expect, launchAppWithSession, localeDeepLink } from "../../fixtures/e2e";
+import { DishCategoryGroupVoteScreen } from "../../screens/DishCategoryGroupVoteScreen";
+
+/**
+ * 🗳 友達投票の完了モーダル / ゲストユーザー（#1120 の対になるテスト）
+ *
+ * 対応する e2e-web の spec: tests/dish-category-group-votes/vote-completion-guest.spec.ts
+ *
+ * ## 何を守るテストか
+ * #1120 の修正は「ログイン状態が確定するまでどちらの分岐も描かない」というもので、
+ * やり過ぎるとゲストにも絵文字候補が出なくなる（= 名前を自分で考えないと投票を送信できない）
+ * という別の劣化になりうる。このテストはその方向の回帰を防ぐ。
+ *
+ * ゲストは `isGuestUser(user) === true` が確定した時点で分岐でき、プロフィール取得の完了を
+ * 待つ必要が無い（参照しないため）。よって完了モーダルが開いた時点で絵文字候補まで描かれるのが正しい。
+ *
+ * ## 前提データ / スコープ
+ * ネイティブは detail API をモックできないため、実在する未投票の shareToken を
+ * `TEST_GROUP_VOTE_SHARE_TOKEN` で渡す必要がある（未設定ならスキップ）。
+ * 「一瞬だけゲスト用 UI が出る」ことの検知は web 側の spec だけが行う。理由は
+ * tests/authenticated/dish-category-group-vote-completion-identity.test.ts の冒頭コメントを参照。
+ *
+ * ## dev DB への影響
+ * 無し（完了モーダルを開くところまでで、送信は行わない）。
+ */
+const SHARE_TOKEN = process.env.TEST_GROUP_VOTE_SHARE_TOKEN;
+
+const describeWithShareToken = SHARE_TOKEN ? describe : describe.skip;
+
+describeWithShareToken("友達投票の完了モーダル（ゲストユーザー）", () => {
+	const voteScreen = new DishCategoryGroupVoteScreen();
+
+	beforeAll(async () => {
+		// Node 側で確立済みの匿名セッションを注入して起動する（匿名サインインのクォータを消費しない）
+		await launchAppWithSession({
+			as: "anon",
+			url: localeDeepLink(`search/dish-category-group-votes/${SHARE_TOKEN}/vote`),
+		});
+	});
+
+	// ─ テストケース: ゲストには絵文字の名前候補が表示される ─
+	// 手順:
+	//   1. 匿名セッションで投票画面へディープリンクする
+	//   2. 全候補へ投票して完了モーダルを開く
+	//   3. 確定待ちのローディングが消えてフォームが出るまで待つ
+	//   4. ゲスト向けの名前サジェスト（絵文字候補）が表示されることを検証
+	it("ゲストユーザーには従来どおり絵文字の名前候補が表示される", async () => {
+		await voteScreen.expectVoteCardLoaded();
+
+		for (let i = 0; i < 10; i += 1) {
+			if (!(await existsNow(voteScreen.likeButton))) break;
+			await element(voteScreen.likeButton).tap();
+		}
+
+		await voteScreen.expectCompletionSettled();
+
+		await expect(element(voteScreen.nameSuggestions)).toBeVisible();
+	});
+});

--- a/e2e-mobile/tests/search/dish-category-group-vote-navigation.test.ts
+++ b/e2e-mobile/tests/search/dish-category-group-vote-navigation.test.ts
@@ -1,0 +1,80 @@
+import { launchAppWithSession, localeDeepLink, waitUntilVisible } from "../../fixtures/e2e";
+import { DishCategoryGroupVoteResultScreen } from "../../screens/DishCategoryGroupVoteResultScreen";
+import { ResultScreen } from "../../screens/ResultScreen";
+
+/**
+ * 🗳 友達投票の結果画面 →「店を見る」導線（#1122 の回帰テスト / ネイティブ）
+ *
+ * 目的: 候補詳細モーダル（`useBlurModal` = react-native-paper の `Portal`）を開いたまま
+ *       DishMediaMap へ遷移すると、遷移先の上にバックドロップが残って**一切タップできない**
+ *       という #1122 の不具合が、Android で再発していないことを保証する。
+ *       修正は PR #1158（モーダルのクローズ完了を待ってから遷移する）。
+ *       対応する e2e-web: e2e-web/tests/search/dish-category-group-vote-navigation.spec.ts
+ *
+ * ## e2e-web から落とした検証（意図的な差分）
+ * - **「検索中にモーダルを閉じる → 別候補を開閉 → 無関係な店へ飛ばない」は対象外**。
+ *   このシナリオは「未検索候補の dish-media 検索が完了する前にユーザーが操作する」という
+ *   タイミングの作り込みが要で、web では `page.route()` で検索 API を保留して再現している。
+ *   Detox にはネイティブアプリのリクエストを保留する手段が無く、実 API の応答時間に賭ける
+ *   テストはフレークにしかならないため、この回帰は **web 側 1 本で担保する**（同一のロジックが
+ *   共通コンポーネントに入っており、プラットフォーム差の無い部分）。
+ * - iOS は #1122 の再現対象外（遷移先が `presentation: "transparentModal"` で Portal より上に載る）。
+ *   本 spec は Android で回すことに意味がある。
+ *
+ * ## 実行条件（共有セッションの seed）
+ * 結果画面には有効な shareToken が要るが、dev DB に固定の共有セッションを播く仕組みは
+ * まだ無い。そのため以下の環境変数が揃っているときだけ実行し、無ければ理由を出して skip する。
+ * - `E2E_VOTE_SHARE_TOKEN`: 共有リンクの shareToken
+ * - `E2E_VOTE_CANDIDATE_ID`: その中の候補 id（dishMediaSearchStatus が "found" のもの）
+ * seed の仕組みが入ったら、この env ガードを seed 呼び出しへ置き換えること。
+ */
+const SHARE_TOKEN = process.env.E2E_VOTE_SHARE_TOKEN;
+const CANDIDATE_ID = process.env.E2E_VOTE_CANDIDATE_ID;
+
+/** 共有セッションの seed が用意されているときだけ実行する describe */
+const describeWithVoteSession: typeof describe = (() => {
+	if (!SHARE_TOKEN || !CANDIDATE_ID) {
+		console.warn(
+			"⚠️ E2E_VOTE_SHARE_TOKEN / E2E_VOTE_CANDIDATE_ID が未設定のため、友達投票の遷移 spec を skip します。",
+		);
+		return describe.skip;
+	}
+	return describe;
+})();
+
+describeWithVoteSession("友達投票の結果画面から店舗画面への遷移 (#1122)", () => {
+	const voteResult = new DishCategoryGroupVoteResultScreen();
+	const result = new ResultScreen();
+
+	beforeAll(async () => {
+		await launchAppWithSession({
+			as: "anon",
+			url: localeDeepLink(`search/dish-category-group-votes/${SHARE_TOKEN}`),
+		});
+		await voteResult.expectLoaded(CANDIDATE_ID!);
+	});
+
+	// ─ テストケース: モーダルが閉じてから店舗画面へ遷移し、すぐ操作できる ─
+	// 手順:
+	//   1. 候補カードをタップして詳細モーダルを開く
+	//   2. モーダル内の「店を見る」をタップする
+	//   3. 詳細モーダル（dish-category-group-vote-candidate-detail）が消えることを検証
+	//      = Portal がアンマウント済み。バックドロップが遷移先に残らない
+	//   4. 結果画面（result-close-button）が表示されることを検証
+	//   5. 閉じるボタンを**実際にタップ**して操作できることを検証
+	//      → 修正前はバックドロップが上に残るため、このタップが結果画面へ届かない
+	it("モーダルが閉じてから店舗画面へ遷移し、すぐ操作できる", async () => {
+		await voteResult.openCandidateDetail(CANDIDATE_ID!);
+
+		await voteResult.pressDetailDishMedia();
+
+		// 「閉じてから遷移」の順序そのもの
+		await voteResult.expectDetailClosed();
+
+		await result.expectLoaded();
+
+		// #1122 の本体: 遷移先が「見えている」だけでなく「押せる」こと
+		await result.close();
+		await waitUntilVisible(voteResult.candidateCard(CANDIDATE_ID!));
+	});
+});

--- a/e2e-web/tests/authenticated/dish-category-group-vote-completion-identity.spec.ts
+++ b/e2e-web/tests/authenticated/dish-category-group-vote-completion-identity.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "../../fixtures/test";
+import {
+	GUEST_SUGGESTION_TEST_ID,
+	delayOwnProfile,
+	hasGuestSuggestionEverAppeared,
+	mockVoteDetail,
+	voteScreenPath,
+	watchGuestSuggestionFlash,
+} from "../../utils/dishCategoryGroupVote";
+
+/**
+ * 🗳 友達投票の完了モーダル / ログイン済みユーザー（#1120 の回帰テスト）
+ *
+ * 実行プロジェクト: desktop-chrome-authenticated（storageState 注入済み）
+ *
+ * ## 何を守るテストか
+ * #1120: ログイン済みユーザーが友達投票を完了すると、**一瞬だけゲスト用の絵文字候補**
+ * （名前サジェスト）が出てから nickname 初期入力へ差し替わっていた。
+ * 修正（PR #1157）は「ログイン状態 + プロフィールが確定するまで、どちらの分岐も描かない」もの。
+ * つまり守るべき不変条件は
+ *
+ *   ログイン済みユーザーには、ゲスト用の絵文字候補が **一度も** 描画されない
+ *
+ * で、「最終的に出ていない」ではなく「途中でも出ていない」が本質。
+ *
+ * ## 「一瞬出る」をどう安定して捕まえるか
+ * 素の実行だと確定までの窓が数百 ms しかなく、そのままでは観測がフレークする。そこで
+ *
+ * 1. プロフィール取得 API（`v1/users/:id`）を `page.route()` で **止める**（= 窓を無限に広げる）
+ * 2. 窓が開いている間、ゲスト用 UI が出ていないことを検証する
+ * 3. MutationObserver の見張り（utils/dishCategoryGroupVote.ts）で
+ *    「ポーリングの隙間に出て消えた」パターンも取りこぼさない
+ *
+ * 回帰すると 1 の遅延中にゲスト用 UI が描かれるため、確実に落ちる。
+ *
+ * ## dev DB への影響
+ * 無し。投票セッションの取得はモックで、投票の送信（POST）までは進めないため
+ * 書き込みは一切発生しない（@mutation タグを付けていないのはこのため）。
+ */
+test.skip(
+	() => !process.env.TEST_USER_EMAIL || !process.env.TEST_USER_PASSWORD,
+	"TEST_USER_EMAIL / TEST_USER_PASSWORD（e2e-web/.env）が未設定のためスキップ",
+);
+
+test.describe("友達投票の完了モーダル（ログイン済みユーザー）", () => {
+	// ─ テストケース: ログイン状態が確定するまでゲスト用 UI を描かない ─
+	// 手順:
+	//   1. ゲスト用 UI 出現の見張り（MutationObserver）を仕込む
+	//   2. 投票セッション detail をモックし、プロフィール取得 API を止める
+	//   3. 投票画面を開き、候補へ 1 回投票して完了モーダルを開く
+	//   4. 確定待ちのローディング（dish-category-group-vote-completion-loading）が出ることを検証
+	//   5. 窓が開いている間、ゲスト用の絵文字候補が出ていないことを検証（静止確認）
+	//   6. プロフィール取得を解放 → 入力フォームへ差し替わることを検証
+	//   7. 見張りが「一度も出なかった」と記録していることを検証（本命のアサーション）
+	test("ログイン状態が確定するまでゲスト用の絵文字候補を描画しない", async ({ appPage }) => {
+		await watchGuestSuggestionFlash(appPage);
+		await mockVoteDetail(appPage);
+		const releaseProfile = await delayOwnProfile(appPage);
+
+		await appPage.goto(voteScreenPath());
+
+		// 候補は 1 件だけなので、1 回投票すればそのまま完了モーダルが開く
+		await appPage.getByTestId("dish-category-group-vote-like-button").click();
+
+		// 確定待ちの間に描かれるのは「ローディング」であって、ゲスト用 UI ではない
+		const loading = appPage.getByTestId("dish-category-group-vote-completion-loading");
+		await expect(loading).toBeVisible();
+
+		const guestSuggestions = appPage.getByTestId(GUEST_SUGGESTION_TEST_ID);
+		await expect(guestSuggestions).toHaveCount(0);
+
+		// 窓を開いたまま少し待ち、「遅れて出てくる」パターンも潰す。
+		// （待つ側の理由がある固定 wait なので、ここでは意図的に waitForTimeout を使う）
+		await appPage.waitForTimeout(2_000);
+		await expect(guestSuggestions).toHaveCount(0);
+		await expect(loading).toBeVisible();
+
+		// 確定させると、ゲスト用ではなく通常のフォームへ差し替わる
+		releaseProfile();
+		await expect(appPage.getByTestId("dish-category-group-vote-completion-form")).toBeVisible();
+		await expect(loading).toHaveCount(0);
+
+		// #1120 本命。ここまでの間に一度でも描かれていれば false にならない
+		expect(await hasGuestSuggestionEverAppeared(appPage)).toBe(false);
+	});
+
+	// ─ テストケース: 確定後もゲスト用 UI は出ない（差し替え後の最終状態） ─
+	// 手順:
+	//   1. detail をモックし、プロフィール取得は遅延させずに投票画面を開く
+	//   2. 1 回投票して完了モーダルを開く
+	//   3. 入力フォームが表示され、ゲスト用の絵文字候補が無いことを検証
+	//      （ログイン済みユーザーは表示名が初期入力される = サジェストの出番が無い）
+	test("確定後もゲスト用の絵文字候補は表示されない", async ({ appPage }) => {
+		await watchGuestSuggestionFlash(appPage);
+		await mockVoteDetail(appPage);
+
+		await appPage.goto(voteScreenPath());
+		await appPage.getByTestId("dish-category-group-vote-like-button").click();
+
+		await expect(appPage.getByTestId("dish-category-group-vote-completion-form")).toBeVisible();
+		await expect(appPage.getByTestId(GUEST_SUGGESTION_TEST_ID)).toHaveCount(0);
+		expect(await hasGuestSuggestionEverAppeared(appPage)).toBe(false);
+	});
+});

--- a/e2e-web/tests/dish-category-group-votes/vote-completion-guest.spec.ts
+++ b/e2e-web/tests/dish-category-group-votes/vote-completion-guest.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "../../fixtures/test";
+import { GUEST_SUGGESTION_TEST_ID, mockVoteDetail, voteScreenPath } from "../../utils/dishCategoryGroupVote";
+
+/**
+ * 🗳 友達投票の完了モーダル / ゲストユーザー（#1120 の対になるテスト）
+ *
+ * 実行プロジェクト: desktop-chrome（匿名 storageState）
+ *
+ * ## 何を守るテストか
+ * #1120 の修正は「ログイン状態が確定するまでどちらの分岐も描かない」というもので、
+ * やり過ぎるとゲストユーザーにも絵文字候補が出なくなる（= 名前を自分で考えないと
+ * 投票を送信できない）という別の劣化になりうる。
+ * このテストは **ゲストには従来どおり絵文字候補が出る** ことを固定して、その方向の回帰を防ぐ。
+ *
+ * ゲストは `isGuestUser(user) === true` が確定した時点で分岐でき、プロフィール取得を
+ * 待つ必要が無い（参照しないため）。したがってログイン済み側と違い、完了モーダルが
+ * 開いた時点で絵文字候補まで描かれるのが正しい挙動。
+ *
+ * ## dev DB への影響
+ * 無し（detail はモック、投票の送信までは進めない）。詳細は utils/dishCategoryGroupVote.ts を参照。
+ */
+test.describe("友達投票の完了モーダル（ゲストユーザー）", () => {
+	// ─ テストケース: ゲストには絵文字候補が表示される ─
+	// 手順:
+	//   1. 投票セッション detail をモックして投票画面を開く
+	//   2. 候補へ 1 回投票して完了モーダルを開く
+	//   3. 入力フォームと、ゲスト向けの名前サジェスト（絵文字候補）が表示されることを検証
+	//   4. サジェストを 1 つタップすると表示名入力へ反映されることを検証
+	test("ゲストユーザーには従来どおり絵文字の名前候補が表示される", async ({ appPage }) => {
+		await mockVoteDetail(appPage);
+
+		await appPage.goto(voteScreenPath());
+
+		// 候補は 1 件だけなので、1 回投票すればそのまま完了モーダルが開く
+		await appPage.getByTestId("dish-category-group-vote-like-button").click();
+
+		await expect(appPage.getByTestId("dish-category-group-vote-completion-form")).toBeVisible();
+
+		const guestSuggestions = appPage.getByTestId(GUEST_SUGGESTION_TEST_ID);
+		await expect(guestSuggestions).toBeVisible();
+
+		// ゲストは display_name を持たないので、確定待ちのローディングで止まらないこと
+		await expect(appPage.getByTestId("dish-category-group-vote-completion-loading")).toHaveCount(0);
+
+		// 候補は「選べば表示名になる」ことまで確認する（表示だけして機能していない状態を弾く）
+		const nameInput = appPage.getByTestId("dish-category-group-vote-display-name-input");
+		const firstSuggestion = guestSuggestions.getByRole("button").first();
+		const suggestionText = (await firstSuggestion.innerText()).trim();
+		await firstSuggestion.click();
+		await expect(nameInput).toHaveValue(suggestionText);
+	});
+});

--- a/e2e-web/tests/search/dish-category-group-vote-navigation.spec.ts
+++ b/e2e-web/tests/search/dish-category-group-vote-navigation.spec.ts
@@ -1,0 +1,304 @@
+import type { Page, Route } from "@playwright/test";
+import { test, expect } from "../../fixtures/test";
+import { waitForAnonymousSession } from "../../utils/auth";
+import { ResultPage } from "../../pages/ResultPage";
+
+/**
+ * 🗳 友達投票の結果画面 →「店を見る」導線 (#1122 の回帰テスト)
+ *
+ * ## 背景 (#1122 / 修正 PR #1158)
+ * 候補の詳細モーダル（`useBlurModal` = react-native-paper の `Portal` 配下）を開いたまま
+ * `router.push` で DishMediaMap（`/[locale]/search/result`）へ遷移すると、`Portal` は
+ * `Portal.Host` 直下（= Stack より上のレイヤー）に描かれるため、遷移先の画面の上に
+ * バックドロップ（`StyleSheet.absoluteFill` の `Pressable`）が残り続け、**遷移先を一切
+ * タップできない**状態になっていた（web / Android で再現。iOS は遷移先が
+ * `presentation: "transparentModal"` で Portal より上に載るため無事）。
+ *
+ * PR #1158 は「モーダルのクローズ完了を待ってから遷移する」順序へ直した。
+ * この spec はその順序を **ブラウザ上の実挙動**（＝遷移先が実際にクリックできること）で固定する。
+ *
+ * ## この spec が API をモックする理由
+ * 結果画面には有効な shareToken が要る。dev DB に固定の共有セッションを播く仕組みは無く、
+ * 播いたとしても「未検索(not_searched)候補の検索が数秒かかる」という**タイミング**は
+ * 実 API では制御できない。#1122 の潜在バグ（後述の 2 本目）は、まさにその待ち時間の
+ * 割り込みで起きるため、`page.route()` で経路ごと差し替えて再現性を担保する。
+ *
+ * ⚠️ `utils/network.ts` は「リクエスト回数を数える用途では `fulfill()` を使うな」と書いているが、
+ * それは実 API の応答をそのまま観測したい計測系の話。ここは**画面遷移の順序**が検証対象で、
+ * バックエンドの実データには一切依存しないため、意図して全面モックにしている。
+ * バックエンドは別オリジン（Cloud Run）なので、`fulfill()` の応答には CORS ヘッダを自前で付ける
+ * （プリフライト `OPTIONS` は Playwright の route に載らず実サーバが応答する）。
+ */
+
+/** モックする共有セッションのトークン。実 DB のどのセッションとも衝突しない値にしてある */
+const SHARE_TOKEN = "e2e-1122-share-token";
+const SESSION_ID = "e2e-1122-session";
+/** 検索済み（dishMediaSearchStatus: "found"）= 押したら即遷移する候補 */
+const CANDIDATE_FOUND = "e2e-1122-candidate-found";
+/** 未検索（"not_searched"）= 押すと dish-media 検索を挟んでから遷移する候補 */
+const CANDIDATE_NOT_SEARCHED = "e2e-1122-candidate-not-searched";
+/** 割り込み用のもう 1 つの候補（無関係な店へ飛んでいないかの判定に使う） */
+const CANDIDATE_OTHER = "e2e-1122-candidate-other";
+
+const RESULT_URL_PATTERN = /\/search\/result/;
+
+/** `callBackend` は `BaseResponse<R>`（`{ success, data }`）を厳密にパースするため同じ封筒で返す */
+async function fulfillJson(route: Route, data: unknown): Promise<void> {
+	await route.fulfill({
+		status: 200,
+		contentType: "application/json",
+		headers: {
+			// バックエンドは別オリジンのため、モック応答にも CORS ヘッダが要る
+			"access-control-allow-origin": "*",
+		},
+		body: JSON.stringify({ success: true, data }),
+	});
+}
+
+/** 任意のタイミングで解放できる門。未検索候補の「検索中」を再現するために使う */
+function createGate(): { wait: Promise<void>; open: () => void } {
+	let open!: () => void;
+	const wait = new Promise<void>((resolve) => {
+		open = resolve;
+	});
+	return { wait, open };
+}
+
+type CandidateOverrides = {
+	id: string;
+	displayName: string;
+	dishMediaSearchStatus: "not_searched" | "found";
+	dishMediaIds: string[];
+	displayOrder: number;
+};
+
+function buildCandidate({ id, displayName, dishMediaSearchStatus, dishMediaIds, displayOrder }: CandidateOverrides) {
+	return {
+		id,
+		dishCategoryId: `${id}-category`,
+		displayName,
+		tagline: `${displayName}のタグライン`,
+		imageUrl: "https://example.com/e2e-1122.jpg",
+		dishMediaIds,
+		dishMediaSearchStatus,
+		displayOrder,
+		deletedAt: null,
+		likeCount: 1,
+		dislikeCount: 0,
+		rank: displayOrder,
+		votes: [{ participantId: "e2e-1122-participant", displayName: "E2E", reaction: "like" }],
+	};
+}
+
+/** GET /v1/dish-category-group-votes/:shareToken の応答 */
+function buildDetail() {
+	return {
+		session: {
+			id: SESSION_ID,
+			shareToken: SHARE_TOKEN,
+			hostUserId: "e2e-1122-host",
+			searchContext: {
+				location: { latitude: 35.658, longitude: 139.7016 },
+				radius: 1000,
+				priceLevels: [],
+				localLanguageCode: "ja",
+			},
+			// isHost=false: 削除ボタンを描かない = 押し間違いの余地を減らす
+			isHost: false,
+			hasVoted: true,
+			participantCount: 1,
+			createdAt: "2026-01-01T00:00:00.000Z",
+			updatedAt: "2026-01-01T00:00:00.000Z",
+		},
+		candidates: [
+			buildCandidate({
+				id: CANDIDATE_FOUND,
+				displayName: "E2E 検索済みカテゴリ",
+				dishMediaSearchStatus: "found",
+				dishMediaIds: ["e2e-1122-dish-media-found"],
+				displayOrder: 1,
+			}),
+			buildCandidate({
+				id: CANDIDATE_NOT_SEARCHED,
+				displayName: "E2E 未検索カテゴリ",
+				dishMediaSearchStatus: "not_searched",
+				dishMediaIds: [],
+				displayOrder: 2,
+			}),
+			buildCandidate({
+				id: CANDIDATE_OTHER,
+				displayName: "E2E 別候補カテゴリ",
+				dishMediaSearchStatus: "found",
+				dishMediaIds: ["e2e-1122-dish-media-other"],
+				displayOrder: 3,
+			}),
+		],
+		participants: [
+			{ id: "e2e-1122-participant", displayName: "E2E", comment: null, createdAt: "2026-01-01T00:00:00.000Z" },
+		],
+	};
+}
+
+type MockOptions = {
+	/**
+	 * 未検索候補の dish-media 検索（GET /v1/dish-media/search）を保留させる門。
+	 * 省略時は保留せず即応答する。
+	 */
+	searchGate?: { wait: Promise<void> };
+};
+
+/**
+ * 結果画面が触るバックエンド呼び出しを丸ごと差し替える。
+ * `page.goto` より前に呼ぶこと。
+ */
+async function mockVoteBackend(page: Page, options: MockOptions = {}): Promise<void> {
+	// ⚠️ Playwright の route は「後から登録したものが優先」。
+	// より具体的なパターンを後に登録すること（detail の glob に食われないようにする）。
+	await page.route(`**/v1/dish-category-group-votes/${SHARE_TOKEN}*`, async (route) => {
+		await fulfillJson(route, buildDetail());
+	});
+
+	// 未検索候補の検索本体。ここを保留すると「検索中」の窓が作れる。
+	await page.route("**/v1/dish-media/search*", async (route) => {
+		await options.searchGate?.wait;
+		// createDishItemsForCategory は 1 件でも返れば bulk-import に進まず、
+		// `item.dish_media.id` しか見ない。E2E に必要な最小形だけ返す。
+		await fulfillJson(route, [
+			{
+				dish_media: { id: "e2e-1122-dish-media-searched" },
+				restaurant: { google_place_id: "e2e-1122-place" },
+			},
+		]);
+	});
+
+	// 検索結果のキャッシュ（PATCH .../candidates/:id/dish-media）。
+	// ここが "found" を返した時点で画面が遷移を要求する。
+	await page.route("**/v1/dish-category-group-votes/*/candidates/*/dish-media*", async (route) => {
+		const candidateId = new URL(route.request().url()).pathname.split("/candidates/")[1]?.split("/")[0] ?? "";
+		await fulfillJson(route, {
+			candidateId,
+			dishMediaIds: ["e2e-1122-dish-media-searched"],
+			dishMediaSearchStatus: "found",
+			updated: true,
+		});
+	});
+
+	// 遷移先（DishMediaMap）が id 指定で引く一覧。
+	// 中身は本 spec の検証対象ではない（見たいのは「操作できること」）ので空で返す。
+	await page.route("**/v1/dish-media?*", async (route) => {
+		await fulfillJson(route, { items: [] });
+	});
+}
+
+/** 結果画面を開き、候補一覧が出るまで待つ */
+async function openVoteResult(page: Page): Promise<void> {
+	await page.goto(`/ja-JP/search/dish-category-group-votes/${SHARE_TOKEN}`);
+	await waitForAnonymousSession(page);
+	await expect(page.getByTestId(`dish-category-group-vote-candidate-${CANDIDATE_FOUND}`)).toBeVisible({
+		timeout: 30_000,
+	});
+}
+
+const candidateCard = (page: Page, id: string) => page.getByTestId(`dish-category-group-vote-candidate-${id}`);
+const detailModal = (page: Page) => page.getByTestId("dish-category-group-vote-candidate-detail");
+const detailViewRestaurants = (page: Page) => page.getByTestId("dish-category-group-vote-detail-dish-media");
+/** BlurModal 右上の X（accessibilityLabel は ja-JP の Common.close = 「閉じる」） */
+const modalCloseButton = (page: Page) => page.getByRole("button", { name: "閉じる" });
+
+test.describe("友達投票の結果画面から店舗画面への遷移 (#1122)", () => {
+	// ─ テストケース: モーダルが閉じてから遷移し、遷移先をすぐ操作できる ─
+	// 手順:
+	//   1. 検索済み候補のカードを押して詳細モーダルを開く
+	//   2. モーダル内の「店を見る」を押す
+	//   3. 詳細モーダルが DOM から消えている(= Portal がアンマウント済み)ことを検証
+	//   4. 結果画面(DishMediaMap)へ遷移していることを検証
+	//   5. 結果画面の閉じるボタンを**実際にクリック**して、操作できることを検証
+	//      → 修正前はモーダルのバックドロップが上に残るため、Playwright の
+	//        actionability チェック(pointer-events を受け取れるか)で必ず失敗する
+	test("モーダルが閉じてから店舗画面へ遷移し、すぐ操作できる", async ({ page }) => {
+		await mockVoteBackend(page);
+		await openVoteResult(page);
+
+		await candidateCard(page, CANDIDATE_FOUND).click();
+		await expect(detailModal(page)).toBeVisible();
+
+		await detailViewRestaurants(page).click();
+
+		// 「閉じてから遷移」の順序そのもの。遷移先に着いた時点でモーダルは残っていてはいけない
+		await expect(detailModal(page)).toBeHidden();
+
+		const result = new ResultPage(page);
+		await result.expectLoaded();
+		await expect(page).toHaveURL(RESULT_URL_PATTERN);
+
+		// #1122 の本体: 遷移先が「見えている」だけでなく「押せる」こと
+		await result.close();
+		await expect(result.closeButton).toBeHidden();
+	});
+
+	// ─ テストケース: 検索中にモーダルを閉じたら、その後の開閉で無関係な店へ飛ばない ─
+	//
+	// #1122 のレビューで見つかった潜在バグの回帰テスト（本 spec で最も価値が高い）。
+	// 未検索候補は「押す → 検索 → キャッシュ → 遷移」と数秒かかる。その待ち時間に
+	// ユーザーがモーダルを閉じられるため、素朴な実装だと
+	//   (a) 遷移が黙って消える
+	//   (b) pending に積んだ navigate が残留し、**次に別候補のモーダルを開いて閉じただけで発火する**
+	// という 2 つの事故が起きる。(b) は「別候補を見ていたのに、さっき押した候補の店へ飛ぶ」
+	// という最悪の見え方になる。修正版は表示セッションの世代番号で、押下時と完了時の
+	// セッションが違えば遷移をキャンセルする。
+	//
+	// 手順:
+	//   1. dish-media 検索を保留する門を仕掛けて結果画面を開く
+	//   2. 未検索候補のモーダルを開き「店を見る」を押す（検索が始まり、保留される）
+	//   3. 検索中に X でモーダルを閉じる
+	//   4. 別候補のモーダルを開いて閉じる（残留 navigate があればここで発火する）
+	//   5. 門を開けて検索を完了させる
+	//   6. 結果画面へ遷移していないこと（= 結果画面に留まっていること）を検証
+	test("検索中にモーダルを閉じたあと別候補を開閉しても、無関係な店へ飛ばない", async ({ page }) => {
+		const searchGate = createGate();
+		await mockVoteBackend(page, { searchGate });
+		await openVoteResult(page);
+
+		// 2. 未検索候補で「店を見る」→ 検索が保留される
+		await candidateCard(page, CANDIDATE_NOT_SEARCHED).click();
+		await expect(detailModal(page)).toBeVisible();
+		await detailViewRestaurants(page).click();
+
+		// 3. 検索の完了を待たずにユーザーが自分でモーダルを閉じる
+		await modalCloseButton(page).click();
+		await expect(detailModal(page)).toBeHidden();
+
+		// 4. 別候補のモーダルを開閉する。
+		//    バグ版はここの close で、手順 2 で積まれた navigate が発火してしまう
+		await candidateCard(page, CANDIDATE_OTHER).click();
+		await expect(detailModal(page)).toBeVisible();
+		await modalCloseButton(page).click();
+		await expect(detailModal(page)).toBeHidden();
+		await expect(page).not.toHaveURL(RESULT_URL_PATTERN);
+
+		// 5. 保留していた検索を完了させる（キャッシュ API まで走り、遷移が要求される経路に入る）
+		searchGate.open();
+
+		// 6. ユーザーは自分でモーダルを閉じている。遷移はキャンセルされ、結果画面に留まる
+		await expect(candidateCard(page, CANDIDATE_NOT_SEARCHED)).toBeVisible();
+		await expect(new ResultPage(page).closeButton).toBeHidden();
+		await expect(page).not.toHaveURL(RESULT_URL_PATTERN);
+	});
+
+	// ─ テストケース: 一覧カードの「店を見る」（モーダルを介さない導線）は従来どおり遷移する ─
+	// 手順:
+	//   1. モーダルを開かずに、カード内の「店を見る」を押す
+	//   2. 結果画面へ遷移し、操作できることを検証
+	//      → 「閉じるのを待つ」修正が、待つモーダルが無い経路を止めていないことの確認
+	test("一覧カードからの「店を見る」はモーダルを介さずに遷移できる", async ({ page }) => {
+		await mockVoteBackend(page);
+		await openVoteResult(page);
+
+		await page.getByTestId(`dish-category-group-vote-candidate-dish-media-${CANDIDATE_FOUND}`).click();
+
+		await expect(detailModal(page)).toBeHidden();
+		const result = new ResultPage(page);
+		await result.expectLoaded();
+		await result.close();
+	});
+});

--- a/e2e-web/tsconfig.json
+++ b/e2e-web/tsconfig.json
@@ -7,7 +7,14 @@
 		"module": "ESNext",
 		"moduleResolution": "Bundler",
 		"types": ["node"],
-		"noEmit": true
+		"noEmit": true,
+		"baseUrl": ".",
+		// #1120 API モックのレスポンスを手書きの型ではなく shared の公開型で組み立てるため。
+		// 型が変わったらモックが型エラーで落ちる = 実 API とモックの乖離に気づける
+		// （app-expo/tsconfig.json と同じ別名にそろえている）
+		"paths": {
+			"@shared/*": ["../shared/*"]
+		}
 	},
 	"include": ["playwright.config.ts", "tests/**/*.ts", "fixtures/**/*.ts", "pages/**/*.ts", "utils/**/*.ts"]
 }

--- a/e2e-web/utils/dishCategoryGroupVote.ts
+++ b/e2e-web/utils/dishCategoryGroupVote.ts
@@ -1,0 +1,176 @@
+import type { Page } from "@playwright/test";
+import type { DishCategoryGroupVoteDetailResponse } from "@shared/api/v1/res";
+
+/**
+ * 🗳 友達投票（dish category group vote）の E2E 用ユーティリティ
+ *
+ * ## なぜ API をモックするのか（#1120）
+ * 検証対象は「ログイン状態が確定する前にゲスト用 UI を描かない」という **描画順序の不変条件** であって、
+ * 投票セッションそのものの生成・集計ではない。実データで検証しようとすると
+ *
+ * - 事前に dev DB へ投票セッションを作る（= @mutation 相当の書き込み）
+ * - shareToken を環境変数などでテストへ受け渡す
+ * - セッションが「未投票」状態であることを毎回保証する（hasVoted なら結果画面へ redirect される）
+ *
+ * という前提が必要になり、不変条件と無関係な理由でフレークする。
+ * detail API を `page.route()` で固定レスポンスに差し替えれば、候補 1 件の投票画面を決定論的に
+ * 開けるうえ dev DB を一切汚さない（このテストが @mutation 扱いにならない理由でもある）。
+ */
+
+/** 固定 shareToken。モックするので実在しなくてよい */
+export const MOCK_SHARE_TOKEN = "e2e-1120-share-token";
+
+/** 固定 sessionId。投票送信 API のパスに現れる */
+export const MOCK_SESSION_ID = "00000000-0000-4000-8000-000000000120";
+
+/** detail API のパス（末尾に追加セグメントを持つ vote/candidates 系とは一致させない） */
+const DETAIL_URL_PATTERN = /\/v1\/dish-category-group-votes\/[^/?]+(\?.*)?$/;
+
+/** ログインユーザーのプロフィール取得 API（useEnsureOwnProfileLoaded が叩く） */
+const OWN_PROFILE_URL_PATTERN = /\/v1\/users\/[^/?]+(\?.*)?$/;
+
+/**
+ * 投票画面の URL。
+ * `app/[locale]/(tabs)/search/dish-category-group-votes/[shareToken]/vote.tsx` に対応する
+ * （`(tabs)` は Expo Router のグループなので URL には現れない）。
+ */
+export function voteScreenPath(shareToken: string = MOCK_SHARE_TOKEN): string {
+	return `/ja-JP/search/dish-category-group-votes/${shareToken}/vote`;
+}
+
+/**
+ * 候補 1 件だけの detail レスポンスを組み立てる。
+ *
+ * 候補を 1 件にしているのは、`DishCategoryGroupVoteVoteScreen` が
+ * 「最後の候補に投票した時点で完了モーダルを開く」実装のため、
+ * **1 回タップするだけで完了モーダルへ到達できる** から（操作が増えるほどフレーク要因も増える）。
+ */
+export function buildVoteDetail(): DishCategoryGroupVoteDetailResponse {
+	const now = "2026-01-01T00:00:00.000Z";
+	return {
+		session: {
+			id: MOCK_SESSION_ID,
+			shareToken: MOCK_SHARE_TOKEN,
+			hostUserId: "00000000-0000-4000-8000-0000000001a0",
+			searchContext: {
+				location: { latitude: 35.6595, longitude: 139.7005 },
+				radius: 1000,
+				priceLevels: [],
+				localLanguageCode: "ja",
+			},
+			isHost: false,
+			// #1120 true だと結果画面へ router.replace されて投票画面に居られない
+			hasVoted: false,
+			participantCount: 0,
+			createdAt: now,
+			updatedAt: now,
+		},
+		candidates: [
+			{
+				id: "00000000-0000-4000-8000-0000000002a0",
+				dishCategoryId: "00000000-0000-4000-8000-0000000003a0",
+				displayName: "ラーメン",
+				tagline: "こってり系",
+				imageUrl: "https://example.invalid/e2e-1120.jpg",
+				dishMediaIds: [],
+				dishMediaSearchStatus: "not_searched",
+				displayOrder: 0,
+				deletedAt: null,
+				likeCount: 0,
+				dislikeCount: 0,
+				rank: null,
+				votes: [],
+			},
+		],
+		participants: [],
+	};
+}
+
+/**
+ * detail API をモックに差し替える。
+ * 画像は example.invalid を指しているので読み込みは失敗するが、
+ * 検証対象は完了モーダルの描画順序なのでカードの画像有無は問わない。
+ */
+export async function mockVoteDetail(page: Page): Promise<void> {
+	await page.route(DETAIL_URL_PATTERN, async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify(buildVoteDetail()),
+		});
+	});
+}
+
+/**
+ * ログインユーザーのプロフィール取得 API を **意図的に遅延** させる。
+ *
+ * #1120 の不具合は「ログイン状態が確定するまでの数百 ms だけゲスト用の絵文字候補が出る」もので、
+ * 素の実行では競合窓が短すぎて「出ていないこと」を安定して観測できない。
+ * ここで窓を人為的に広げることで、回帰したときに **必ず** 検知できるようにする。
+ *
+ * @returns 遅延を解除して本来のレスポンスへ進ませる関数（呼ぶまで応答は返らない）
+ */
+export async function delayOwnProfile(page: Page): Promise<() => void> {
+	let release = () => {};
+	const released = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+
+	await page.route(OWN_PROFILE_URL_PATTERN, async (route) => {
+		await released;
+		await route.continue();
+	});
+
+	return release;
+}
+
+/** ゲスト用の絵文字候補（名前サジェスト）が一度でも DOM に現れたかを記録するグローバル変数名 */
+export const GUEST_SUGGESTION_SEEN_FLAG = "__e2e1120GuestSuggestionSeen";
+
+/** ゲスト用 UI の testID */
+export const GUEST_SUGGESTION_TEST_ID = "dish-category-group-vote-name-suggestions";
+
+/**
+ * ゲスト用 UI の出現を **MutationObserver で常時監視** する見張りを仕込む。
+ *
+ * `expect(locator).toHaveCount(0)` のポーリングだけでは、ポーリングとポーリングの
+ * 隙間に現れて消えた「一瞬の描画」を取りこぼす。#1120 の不具合はまさにその形なので、
+ * DOM 変更を漏らさず拾う MutationObserver を併用して「一度も現れていない」ことを保証する。
+ *
+ * `page.goto()` より前（= addInitScript）に仕込む必要がある。
+ */
+export async function watchGuestSuggestionFlash(page: Page): Promise<void> {
+	await page.addInitScript(
+		([flag, testId]) => {
+			const selector = `[data-testid="${testId}"]`;
+			const win = window as unknown as Record<string, boolean>;
+			win[flag] = false;
+
+			const check = () => {
+				if (document.querySelector(selector)) {
+					win[flag] = true;
+				}
+			};
+
+			const start = () => {
+				check();
+				new MutationObserver(check).observe(document.body, { childList: true, subtree: true });
+			};
+
+			if (document.body) {
+				start();
+			} else {
+				document.addEventListener("DOMContentLoaded", start, { once: true });
+			}
+		},
+		[GUEST_SUGGESTION_SEEN_FLAG, GUEST_SUGGESTION_TEST_ID] as const,
+	);
+}
+
+/** watchGuestSuggestionFlash が記録した「一度でも現れたか」を読み出す */
+export async function hasGuestSuggestionEverAppeared(page: Page): Promise<boolean> {
+	return page.evaluate(
+		(flag) => Boolean((window as unknown as Record<string, boolean>)[flag]),
+		GUEST_SUGGESTION_SEEN_FLAG,
+	);
+}


### PR DESCRIPTION
実機確認へ回していた項目の E2E 化、第 3 弾です。

## 変更内容

| Issue | 内容 | web (Playwright) | mobile (Detox) |
| --- | --- | --- | --- |
| #1122 | モーダルを閉じてから店舗画面へ遷移 | ✅ 新規 | ✅ 新規 |
| #1120 | ログイン時にゲスト用 UI が一瞬出る | ✅ 新規 | ✅ 新規（限定的・後述） |

（#1132 は先に PR #1188 でマージ済みです）

## #1122 — 「閉じてから遷移」を時間待ちでごまかしていません

**`Portal` のアンマウント完了**を観測点にしています。モーダル本体の testID が消えることを「閉じ切った」の判定に使うので、`waitForTimeout` に頼らずに順序を固定できます。

`app-expo` 側は **testID の追加のみ**（候補カード、カード内「店を見る」、詳細モーダル本体、モーダル内「店を見る」）で、見た目は変えていません。

共有セッションの seed 手段がまだ無いため、`E2E_VOTE_SHARE_TOKEN` / `E2E_VOTE_CANDIDATE_ID` が揃うときだけ実行し、**無ければ理由を出して skip** します。黙って緑にはなりません。

## #1120 — web と mobile で検出力が違うことを明記します

**web（Playwright）**: ユーザー情報 API を `page.route()` で遅延させ、**その間にゲスト用 UI が描画されていないこと**をアサートします。遅延させないと競合窓が短すぎて flaky になるため、意図的に window を広げています。

**mobile（Detox）**: Detox には `page.route()` 相当が無く detail をモックできないため、**「最終状態にゲスト用 UI が無い」という弱い不変条件**に絞っています。

> ⚠️ **ゲスト用を描いてから差し替える実装へ戻った場合、最終状態は正しくなるため mobile では捕まりません（web が担保します）。**

ワーカーがこの限界を正確に報告してきたので、そのまま残します。**「両方書いた」で検出力の差を隠さない**ためです。

mobile は実データが要るため、未投票の shareToken を `TEST_GROUP_VOTE_SHARE_TOKEN` で渡します（未設定ならスキップ）。`.env.example` に追記済みです。

`app-expo` 側は完了モーダルへ testID を 2 つ追加しただけで、見た目は変えていません。

## 検証

- `e2e-web` typecheck: exit 0
- `e2e-mobile` typecheck: exit 0
- `pnpm --filter app-expo test`: **37 suites / 276 tests 全 pass**
- `pnpm --filter app-expo typecheck`: exit 0

**Playwright / Detox の実走は行っていません**（ローカル検証の位置づけ、という方針に従っています）。