### PR TITLE
#1132 #1136 test(e2e-mobile): Detox 側を追加して web と同密度にする

### DIFF
--- a/app-expo/app/[locale]/(tabs)/profile/blocked-topics.tsx
+++ b/app-expo/app/[locale]/(tabs)/profile/blocked-topics.tsx
@@ -244,7 +244,13 @@ export default function BlockedTopicsScreen() {
 	return (
 		<LinearGradient colors={["#FFFFFF", "#F8F9FA"]} style={styles.container}>
 			<SafeAreaView style={styles.safeArea} edges={[]}>
-				<ScreenHeader title={i18n.t("Settings.blockedTopics.pageTitle")} onPressBack={handleBack} />
+				{/* #1132 【設計】ヘッダーのタイトル文言そのものが検証対象のため testID を付与する
+				    （ScreenHeader はタイトル Text へ `${testID}-title` を付ける。見た目は変わらない） */}
+				<ScreenHeader
+					testID="blocked-topics-header"
+					title={i18n.t("Settings.blockedTopics.pageTitle")}
+					onPressBack={handleBack}
+				/>
 
 				<View style={styles.blockedTopicsContainer}>
 					<View style={styles.sheet}>

--- a/app-expo/components/LoadingIndicator/index.tsx
+++ b/app-expo/components/LoadingIndicator/index.tsx
@@ -20,11 +20,11 @@ import { SIZE_MAP, LoadingIndicatorProps, dualBallLottie } from "./shared";
  * <LoadingIndicator size="large" style={{ marginTop: 20 }} />
  */
 export const LoadingIndicator: React.FC<LoadingIndicatorProps> = React.memo(
-	({ size = "large", style, accessibilityLabel = "Loading" }) => {
+	({ size = "large", style, accessibilityLabel = "Loading", testID }) => {
 		const dimension = SIZE_MAP[size];
 
 		return (
-			<View style={[styles.container, style]} pointerEvents="none">
+			<View style={[styles.container, style]} testID={testID} pointerEvents="none">
 				<LottieView source={dualBallLottie} autoPlay loop style={{ width: dimension, height: dimension }} />
 			</View>
 		);

--- a/app-expo/components/LoadingIndicator/index.web.tsx
+++ b/app-expo/components/LoadingIndicator/index.web.tsx
@@ -20,7 +20,7 @@ import { dualBallLottie, SIZE_MAP, LoadingIndicatorProps } from "./shared";
  * <LoadingIndicator size="large" style={{ marginTop: 20 }} />
  */
 export const LoadingIndicator: React.FC<LoadingIndicatorProps> = React.memo(
-	({ size = "large", style, accessibilityLabel = "Loading" }) => {
+	({ size = "large", style, accessibilityLabel = "Loading", testID }) => {
 		const dimension = SIZE_MAP[size];
 
 		const dualBallData = JSON.stringify(dualBallLottie);
@@ -28,6 +28,7 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = React.memo(
 		return (
 			<View
 				style={[styles.container, style]}
+				testID={testID}
 				{...(Platform.OS === "web"
 					? {
 							// #690 【設計】Web アクセシビリティ対応 - role="status" / aria-live="polite"

--- a/app-expo/components/LoadingIndicator/shared.ts
+++ b/app-expo/components/LoadingIndicator/shared.ts
@@ -9,6 +9,14 @@ export type LoadingIndicatorProps = {
 	style?: ViewStyle | ViewStyle[];
 	/** Web 用アクセシビリティラベル（指定がなければ "Loading" をデフォルトとする） */
 	accessibilityLabel?: string;
+	/**
+	 * E2E 用の testID（#1136）。
+	 *
+	 * web は `role="status"` から Playwright で特定できるが、ネイティブには相当する手掛かりが無く
+	 * 「ローディング中かどうか」を Detox から観測できなかった。指定された場合のみコンテナ View へ付与する
+	 * （既定は undefined。付けても見た目・レイアウトは変わらない）。
+	 */
+	testID?: string;
 };
 
 // #690 【設計】サイズマップ - small: 24px, large: 48px

--- a/app-expo/components/PrimaryButton.tsx
+++ b/app-expo/components/PrimaryButton.tsx
@@ -104,15 +104,22 @@ const PrimaryButtonComponent: React.FC<PrimaryButtonProps> = ({
 		[style, borderRadius, isDisabled],
 	);
 
+	// #1136 【設計】ボタン内スピナーの testID。web は LoadingIndicator が出す `role="status"` で
+	// 特定できるが、ネイティブには相当する手掛かりが無く「投稿中かどうか」を Detox から観測できない。
+	// 呼び出し側が testID を渡しているボタンでだけ `${testID}-loading` を派生させる（見た目は変わらない）。
+	const loadingTestID = testID ? `${testID}-loading` : undefined;
+
 	const renderLoading = () => {
 		if (!loading) return null;
 
 		if (loadingIndicatorType === "native") {
 			const flattenedLabelStyle = StyleSheet.flatten(labelStyle) as TextStyle | undefined;
 			const defaultNativeColor = flattenedLabelStyle?.color ?? "#FFFFFF";
-			return <ActivityIndicator size={"small"} color={nativeLoadingColor ?? defaultNativeColor} />;
+			return (
+				<ActivityIndicator size={"small"} color={nativeLoadingColor ?? defaultNativeColor} testID={loadingTestID} />
+			);
 		}
-		return <LoadingIndicator size="small" />;
+		return <LoadingIndicator size="small" testID={loadingTestID} />;
 	};
 
 	return (

--- a/e2e-mobile/screens/BlockedTopicsScreen.ts
+++ b/e2e-mobile/screens/BlockedTopicsScreen.ts
@@ -1,0 +1,51 @@
+import { DEFAULT_TIMEOUT, by, element, expect as detoxExpect, existsNow, waitUntilVisible } from "../fixtures/e2e";
+
+/**
+ * 🚫 ブロック済み料理カテゴリ画面の Screen Object（e2e-web には対応 Page が無く、spec 内で直接 locator を組んでいる）
+ *
+ * 対応画面: app-expo/app/[locale]/(tabs)/profile/blocked-topics.tsx
+ *
+ * ## ファイル名・testID が "topics" のままな理由（#1132）
+ * #1132 で変わったのは **ユーザーに見える文言だけ**（「料理トピック」→「料理カテゴリ」）で、
+ * ルート（`profile/blocked-topics`）や既存 testID（`settings-blocked-topics` /
+ * `blocked-topics-empty-state`）は据え置かれている。ここもアプリ側の識別子に合わせる。
+ *
+ * ## 文言の検証を Detox でどう行うか
+ * Playwright の `getByText("トピック")` は **部分一致**だが、Detox の `by.text()` は
+ * **完全一致**しか無く「〇〇を含む要素が 0 件」は表現できない。
+ * そのため旧文言の残存チェックは「旧文言の完全一致文字列が存在しないこと」で行う
+ * （locales の旧値を定数化してあるので、直し漏れがあればそのまま一致して落ちる）。
+ */
+export class BlockedTopicsScreen {
+	/**
+	 * ヘッダーのタイトル（`Settings.blockedTopics.pageTitle`）。
+	 * #1132 で app-expo 側の `ScreenHeader` へ `testID="blocked-topics-header"` を渡すようにしたため、
+	 * タイトル Text は `blocked-topics-header-title` で取れる（ScreenHeader が `${testID}-title` を付与する）。
+	 */
+	readonly headerTitle = by.id("blocked-topics-header-title");
+	/** 0 件時の空表示（既存 testID。ブロック 0 件のテストユーザーではこちらが出る） */
+	readonly emptyState = by.id("blocked-topics-empty-state");
+
+	/** 画面が表示されるまで待つ（ヘッダーの描画完了 = 遷移完了） */
+	async expectLoaded(timeout: number = DEFAULT_TIMEOUT): Promise<void> {
+		await waitUntilVisible(this.headerTitle, timeout);
+	}
+
+	/**
+	 * ヘッダーのタイトル文言を検証する。
+	 * @param text 期待する文言（ロケール依存。呼び出し側が locales の値をそのまま渡す）
+	 */
+	async expectHeaderTitle(text: string): Promise<void> {
+		await detoxExpect(element(this.headerTitle)).toHaveText(text);
+	}
+
+	/**
+	 * 指定した文言の要素が **画面に無い**ことを判定する（待たずに即判定）。
+	 *
+	 * 旧文言の残存チェック専用。`existsNow` は「一致 0 件」も「複数一致」も false 以外にせず
+	 * 素直に真偽を返すため、SettingsScreen.hasLogoutItem() と同じ使い方ができる。
+	 */
+	async hasText(text: string): Promise<boolean> {
+		return existsNow(by.text(text));
+	}
+}

--- a/e2e-mobile/screens/ReviewScreen.ts
+++ b/e2e-mobile/screens/ReviewScreen.ts
@@ -2,6 +2,7 @@ import {
 	DEFAULT_TIMEOUT,
 	by,
 	element,
+	existsNow,
 	tapWhenVisible,
 	waitUntilGone,
 	waitUntilVisible,
@@ -61,6 +62,15 @@ export class ReviewScreen {
 	readonly priceInput = by.id("review-price-input");
 	/** 投稿ボタン（`ReviewForm.tsx:706`） */
 	readonly submitButton = by.id("review-submit-button");
+	/**
+	 * 投稿ボタン内のローディングスピナー（#1136）。
+	 *
+	 * `PrimaryButton` は `testID` を渡されたとき、内側の `LoadingIndicator` へ `${testID}-loading` を
+	 * 派生させる（app-expo/components/PrimaryButton.tsx）。**`loading` が false の間は
+	 * そもそもレンダリングされない**ため、この要素の有無がそのまま `isSubmitting` の観測点になる。
+	 * e2e-web が `role="status"` で見ているものと同じ実体を指す。
+	 */
+	readonly submitLoadingIndicator = by.id("review-submit-button-loading");
 
 	/**
 	 * 星評価ボタン（`ReviewForm.tsx:671`）。1〜5 の整数を渡す。
@@ -138,6 +148,32 @@ export class ReviewScreen {
 	/** 投稿ボタンをタップする */
 	async submit(): Promise<void> {
 		await tapWhenVisible(this.submitButton);
+	}
+
+	/**
+	 * 投稿ボタンにスピナーが出ている（= `isSubmitting` が true）かを **待たずに** 判定する（#1136）。
+	 * 「出るまで待つ」側は `waitUntil` と組み合わせて spec 側で行う。
+	 */
+	async isSubmitting(): Promise<boolean> {
+		return existsNow(this.submitLoadingIndicator, 1_000);
+	}
+
+	/**
+	 * 投稿ボタンが押下可能かを `getAttributes()` で読み取る（#1136）。
+	 *
+	 * Detox には `accessibilityState` を直接検証するマッチャが無い（utils/waits.ts の `waitUntil` 参照）。
+	 * `PrimaryButton` は `disabled={isDisabled}` を `Pressable` へ渡しており、React Native は
+	 * これを各プラットフォームのネイティブな「無効」状態へ落とすため、`enabled` 属性として観測できる。
+	 *
+	 * @returns 押下可能なら true / 無効なら false / **属性自体が取れなかった場合は null**
+	 *          （プラットフォーム差で欠ける可能性があるため、呼び出し側が「観測できなかった」と
+	 *          「押せてしまう」を区別できるようにする）
+	 */
+	async isSubmitButtonEnabled(): Promise<boolean | null> {
+		// getAttributes() の戻り値は iOS / Android・単一 / 複数一致で型が分かれるため、
+		// SearchScreen / ResultScreen と同じく必要なキーだけに絞ってキャストする
+		const attributes = (await element(this.submitButton).getAttributes()) as { enabled?: boolean };
+		return attributes.enabled ?? null;
 	}
 
 	/**

--- a/e2e-mobile/screens/SettingsScreen.ts
+++ b/e2e-mobile/screens/SettingsScreen.ts
@@ -34,7 +34,10 @@ export class SettingsScreen {
 	readonly feedbackItem = by.id("settings-feedback");
 	/** レビューを書く（ストア誘導）行。ネイティブのみ表示（既存 testID） */
 	readonly leaveReviewItem = by.id("settings-leave-review");
-	/** ブロック済みの料理トピック行（既存 testID） */
+	/**
+	 * ブロック済みの料理カテゴリ行（既存 testID）。
+	 * #1132 で文言は「料理トピック」→「料理カテゴリ」へ変わったが、testID は据え置かれている。
+	 */
 	readonly blockedTopicsItem = by.id("settings-blocked-topics");
 	/** コミュニティガイドライン行（既存 testID） */
 	readonly guidelinesItem = by.id("settings-guidelines");
@@ -82,6 +85,23 @@ export class SettingsScreen {
 	 */
 	async hasLogoutItem(): Promise<boolean> {
 		return existsNow(this.logoutItem);
+	}
+
+	/**
+	 * 指定した文言の要素が設定画面に **無い**ことを判定する（待たずに即判定）。
+	 * #1132 の「旧文言が導線側に残っていないこと」の検証に使う。
+	 */
+	async hasText(text: string): Promise<boolean> {
+		return existsNow(by.text(text));
+	}
+
+	/**
+	 * ブロック済みの料理カテゴリ行をタップして一覧画面へ遷移する（#1132）。
+	 * e2e-web は `/ja-JP/profile/blocked-topics` へ URL 直遷移するが、
+	 * ネイティブには代替経路が無いため settings.test.ts と同じく実 UI 導線をタップする。
+	 */
+	async openBlockedTopics(): Promise<void> {
+		await tapWhenVisible(this.blockedTopicsItem);
 	}
 
 	/** プライバシーポリシー行をタップしてリーガルドキュメントのモーダルを開く */

--- a/e2e-mobile/tests/mutation/review-submit-loading.test.ts
+++ b/e2e-mobile/tests/mutation/review-submit-loading.test.ts
@@ -1,0 +1,108 @@
+import { strict as assert } from "node:assert";
+
+import { describeMutation, device, launchAppWithSession, waitUntil } from "../../fixtures/e2e";
+import { ReviewScreen } from "../../screens/ReviewScreen";
+import { SelectRestaurantScreen } from "../../screens/SelectRestaurantScreen";
+import { TabBar } from "../../screens/TabBar";
+
+/**
+ * ⏳ レビュー投稿中のローディング表示テスト @mutation（#1136 / PR #1166）
+ *
+ * e2e-web の tests/authenticated/review-submit-loading.spec.ts に対応する。
+ *
+ * ## 何を守っているか（#1136）
+ * `ReviewForm.handleSubmit` はメディアアップロードと 3 本の API 呼び出しを直列で行うため、
+ * 完了まで無反応に見える時間が長い。#1136 で `isSubmitting`(useState) を追加し、
+ * `PrimaryButton` の `loading` に渡すことで **ボタン内にスピナー(Lottie)を出しつつ押下も止める**
+ * （`PrimaryButton` は `isDisabled = disabled || loading`）。
+ *
+ * ## ⚠️ web 側とのカバレッジ差（意図的）
+ * e2e-web は `page.route()` で POST `v1/dishes` を遅延・失敗させ、
+ * 「投稿中の維持」と **「失敗時にローディングが解除されること」** の 2 本を持つ。
+ * **Detox には `page.route()` に相当する仕組みが無い。**
+ * app-expo 側の E2E フックも `lib/e2e/` にある 4 つ（セッション注入・チュートリアル種・
+ * メディア選択差し替え・先読みプローブ）だけで、**ネットワークを差し替えるものは存在しない**。
+ * そのため mobile 側は **実投稿の途中でスピナーが出て押下が止まること**だけを見る。
+ * `finally` での解除（失敗時の解除）は **web 側だけで担保している**。
+ *
+ * ## dev DB への影響
+ * ネットワークを止められない = 投稿は最後まで実際に走るため、この spec は
+ * tests/mutation/review-post.test.ts と同じく **不可逆**（レビューが 1 件積み上がる）。
+ * `RUN_MUTATION=1` を明示した手動実行でのみ走らせること。本文には `[E2E]` を付ける。
+ *
+ * ## 同期機構を切っている理由
+ * Android の Detox は **通信中を「busy」とみなして待つ**ため、既定のままだと
+ * 「投稿中」のアサーションが投稿完了まで待たされ、**見たかったスピナーが消えた後に評価される**。
+ * 投稿ボタンを押す直前に `device.disableSynchronization()` を呼び、検証後に戻す
+ * （iOS は fixtures/e2e.ts の `detoxEnableSynchronization: 0` により元から無効）。
+ */
+describeMutation("レビュー投稿中のローディング @mutation", () => {
+	const tabBar = new TabBar();
+	const review = new ReviewScreen();
+	const selectRestaurant = new SelectRestaurantScreen();
+
+	// #1031 【バグ】beforeAll だと前のテストが残した画面状態を次が引き継ぎ、タップがオーバーレイに阻まれる
+	beforeEach(async () => {
+		await launchAppWithSession({ as: "authenticated" });
+	});
+
+	// 同期機構を切ったまま次のテストへ持ち越さない（切りっぱなしだと後続が全て前のめりに評価される）
+	afterEach(async () => {
+		await device.enableSynchronization();
+	});
+
+	// ─ テストケース: 投稿中はボタンにスピナーが出て押下も止まる ─
+	// 手順:
+	//   1. レビューフォームを投稿可能な状態まで埋める（review-post.test.ts と同一の導線）
+	//   2. 同期機構を切ってから投稿ボタンを押す
+	//   3. ボタン内スピナー（review-submit-button-loading）が出るまで待つ
+	//      = `isSubmitting` が true になった瞬間を捉える
+	//   4. その状態でボタンが無効（enabled=false）であることを検証
+	//   5. 投稿が完了してフォームが閉じることを検証（後片付けを兼ねる）
+	it("投稿中はボタンにスピナーが出て押下も止まる @mutation", async () => {
+		await tabBar.gotoReview();
+		await review.gotoPostReview();
+
+		// #1031 実在のチェーン店名を使う。`isFoodAndDrinkPlaceForUser()` が true の候補でないと
+		// 地図移動だけで終わり、お店の詳細（= 投稿導線）へ進めないため
+		await selectRestaurant.expectLoaded();
+		await selectRestaurant.searchRestaurant("スターバックスコーヒー 渋谷");
+		await selectRestaurant.selectSuggestion(0);
+
+		await selectRestaurant.gotoReviewForm(ReviewScreen.FORM_TIMEOUT);
+		await review.expectFormLoaded(ReviewScreen.FORM_TIMEOUT);
+
+		await review.fillComment("[E2E] 投稿中ローディング表示テストです");
+		await review.chooseDishCategory("コーヒー");
+		await review.fillPrice("500");
+		await review.rate(5);
+
+		// 通信中を待たれるとスピナーが消えた後の状態しか見えない（冒頭コメント参照）
+		await device.disableSynchronization();
+		await review.submit();
+
+		// スピナーは `loading` が true の間しかマウントされないため、出現したこと自体が
+		// 「isSubmitting が立った」証跡になる。画像アップロードから始まるので数秒は維持される
+		await waitUntil(() => review.isSubmitting(), {
+			timeout: ReviewScreen.FORM_TIMEOUT,
+			interval: 250,
+			description: "投稿ボタン内のスピナー（投稿中の表示）",
+		});
+
+		// 見た目だけでなく押下も止まっていること。`PrimaryButton` が `Pressable` へ渡す
+		// `disabled`（= loading）がネイティブの enabled 属性へ落ちる
+		const enabled = await review.isSubmitButtonEnabled();
+		assert.notEqual(
+			enabled,
+			true,
+			"投稿中にもかかわらず投稿ボタンが押下可能なままになっている（PrimaryButton の loading→disabled 連動が壊れている疑い）",
+		);
+		// null（属性が取れなかった）を黙って通すと「押せてしまう」退行を見逃すため、その場合は明示的に落とす
+		assert.notEqual(enabled, null, "投稿ボタンの enabled 属性を取得できず、押下可否を判定できなかった");
+
+		// 後片付け: 投稿を最後まで走らせ、フォームが閉じる（= 成功）ところまで見届ける。
+		// ここは通信完了待ちなので同期機構を戻してから待つ
+		await device.enableSynchronization();
+		await review.expectFormClosed(ReviewScreen.FORM_TIMEOUT);
+	});
+});

--- a/e2e-mobile/tests/profile/blocked-categories-wording.test.ts
+++ b/e2e-mobile/tests/profile/blocked-categories-wording.test.ts
@@ -1,0 +1,101 @@
+import { strict as assert } from "node:assert";
+
+import { describeJapaneseLocale, launchAppWithSession, waitUntilVisible } from "../../fixtures/e2e";
+import { BlockedTopicsScreen } from "../../screens/BlockedTopicsScreen";
+import { ProfileScreen } from "../../screens/ProfileScreen";
+import { SettingsScreen } from "../../screens/SettingsScreen";
+import { TabBar } from "../../screens/TabBar";
+
+/**
+ * 🈁 ブロック済み料理カテゴリの文言（#1132）
+ *
+ * e2e-web の tests/profile/blocked-categories-wording.spec.ts に対応する。
+ *
+ * #1132 は「ブロック済み料理トピック」という文言が不自然だったため、
+ * 8 言語分を「料理カテゴリ」へ統一した変更（PR #1148）。
+ *
+ * ## なぜ E2E で守るのか（web 側と同じ理由）
+ * 文言の統一は locales/*.json の 8 ファイルへ散らばるので、1 ファイルだけ直し漏れても
+ * 型検査もユニットテストも通ってしまう。「画面に旧文言が出ていないこと」は
+ * 実際に描画しないと分からないため E2E で見る。
+ *
+ * ## Web 版からの変更点
+ * - **導線**: e2e-web は `page.goto("/ja-JP/profile/blocked-topics")` で URL 直遷移するが、
+ *   ネイティブには代替経路が無いため、マイページ → 歯車 → ブロック済み行、と実 UI をタップして遷移する
+ *   （tests/profile/settings.test.ts と同じ方針）。
+ * - **旧文言の残存チェック**: Playwright の `getByText("トピック")` は部分一致で
+ *   「含む要素が 0 件」を直接書けるが、Detox の `by.text()` は **完全一致しか無い**。
+ *   そのため #1132 以前の locales の値（`OLD_*`）を定数として持ち、
+ *   **その完全一致文字列が存在しないこと**で代替する。直し漏れがあればそのまま一致して落ちる。
+ * - **ar-SA(RTL) のケースは移植していない**。Detox のロケール指定は iOS が
+ *   `launchApp({ languageAndLocale })`、Android が端末の `persist.sys.locale` と
+ *   プラットフォームで別物で、しかも Android は起動時に切り替えられない（fixtures/e2e.ts の
+ *   `platformLaunchOptions` / utils/locale.ts 参照）。**この spec だけのために CI の端末ロケールを
+ *   動かすと他の全 spec を巻き込む**ため、多言語の担保は web 側と locales のユニットテストに委ねる。
+ */
+
+/** locales/ja-JP.json の `Settings.blockedTopics.pageTitle`（= navigationLabel と同値） */
+const NEW_WORDING = "ブロック済みの料理カテゴリ";
+
+/**
+ * #1132 以前の `Settings.blockedTopics.pageTitle` / `navigationLabel`。
+ * これが画面に出ていたら直し漏れ。**locales を戻さない限り一致しない**ので、
+ * ここを直すのは「旧文言をもう一度変える」ときだけ。
+ */
+const OLD_WORDING = "ブロック済みの料理トピック";
+
+describeJapaneseLocale("ブロック済み料理カテゴリの文言(#1132)", () => {
+	// #1031 【バグ】beforeAll だと前のテストが残した画面状態（開いたままのモーダル等）を次が引き継ぎ、
+	// タップがオーバーレイに阻まれて落ちる。セッション注入起動は匿名クォータを消費しないため、
+	// テストごとに起動し直して独立性を担保する
+	beforeEach(async () => {
+		await launchAppWithSession({ as: "anon" });
+	});
+
+	// ─ テストケース: ja-JP で新文言が出て、旧文言が残っていない ─
+	// 手順:
+	//   1. マイページタブ → 歯車 → ブロック済み行、の実導線で一覧画面へ遷移する
+	//   2. ScreenHeader のタイトル（blocked-topics-header-title）が
+	//      「ブロック済みの料理カテゴリ」であることを検証
+	//   3. 画面に旧文言「ブロック済みの料理トピック」が残っていないことを検証（これが #1132 の本体）
+	it("ja-JP で「料理カテゴリ」と表示され、旧文言「トピック」が残っていない", async () => {
+		const tabBar = new TabBar();
+		const profileScreen = new ProfileScreen();
+		const settingsScreen = new SettingsScreen();
+		const blockedTopicsScreen = new BlockedTopicsScreen();
+
+		await tabBar.gotoProfile();
+		await profileScreen.gotoSettings();
+		await settingsScreen.expectLoaded();
+		await settingsScreen.openBlockedTopics();
+
+		await blockedTopicsScreen.expectLoaded();
+		// locales/ja-JP.json の Settings.blockedTopics.pageTitle と同じ文字列であること
+		await blockedTopicsScreen.expectHeaderTitle(NEW_WORDING);
+
+		// ⚠️ ここが本題。1 ファイルでも直し漏れると旧文言が画面へ出る
+		const hasOldWording = await blockedTopicsScreen.hasText(OLD_WORDING);
+		assert.equal(hasOldWording, false, `ブロック済み一覧に旧文言「${OLD_WORDING}」が残っている`);
+	});
+
+	// ─ テストケース: 設定メニューの導線も新文言になっている ─
+	// 手順:
+	//   1. マイページタブ → 歯車ボタンで設定画面へ遷移する
+	//   2. ブロック済み項目（settings-blocked-topics）が表示されることを検証
+	//   3. 設定画面にも旧文言が残っていないことを検証
+	//      （pageTitle だけ直して navigationLabel を直し漏れる事故を防ぐ）
+	it("設定メニューの導線にも旧文言が残っていない", async () => {
+		const tabBar = new TabBar();
+		const profileScreen = new ProfileScreen();
+		const settingsScreen = new SettingsScreen();
+
+		await tabBar.gotoProfile();
+		await profileScreen.gotoSettings();
+		await settingsScreen.expectLoaded();
+
+		await waitUntilVisible(settingsScreen.blockedTopicsItem);
+
+		const hasOldWording = await settingsScreen.hasText(OLD_WORDING);
+		assert.equal(hasOldWording, false, `設定メニューの導線に旧文言「${OLD_WORDING}」が残っている`);
+	});
+});


### PR DESCRIPTION
先に web 側だけ入れてしまった 2 件について、**Detox 側を埋めて同密度に揃えます。**

このリポジトリは `e2e-web`（Playwright）と `e2e-mobile`（Detox）を原則同じ密度で維持しているのに、私が web だけ書いて mobile を放置していました。その穴埋めです。

## 変更内容

| Issue | web（既存） | mobile（この PR） |
| --- | --- | --- |
| #1132 | `blocked-categories-wording.spec.ts` | ✅ `blocked-categories-wording.test.ts` |
| #1136 | `review-submit-loading.spec.ts` | ✅ `review-submit-loading.test.ts` |

対応する web 側の spec を先に読ませ、**同じ不変条件を見る**ように揃えています。

## app-expo 側の変更（testID の追加のみ・見た目は変わりません）

ネイティブ側にスピナーを掴む手掛かりが無かったため、観測点を足しました。

- `LoadingIndicator` に任意の `testID` prop（native / web 両実装）
- `PrimaryButton` が `testID` を持つとき `${testID}-loading` を派生させる
  - 投稿ボタンのスピナーは `review-submit-button-loading` で取れる
  - **web は `role="status"` で取れていたが、ネイティブには手掛かりが無かった**

## 押下可否の判定について

Detox には `accessibilityState` のマッチャが無いため、`getAttributes()` の `enabled` を読んでいます。
**属性が取れなかった場合も黙って通さず落とす**作りです（取得失敗を「押せない」と誤判定しないため）。

## 検証

- `e2e-mobile` typecheck: exit 0
- `e2e-web` typecheck: exit 0
- `pnpm --filter app-expo test`: **37 suites / 276 tests 全 pass**
- `pnpm --filter app-expo typecheck`: exit 0

**Detox の実走は行っていません**（ローカル検証の位置づけ、という方針に従っています）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_