### PR TITLE
#1156 fix: EAS 代替検証の iOS ビルドを EAS と同じ Xcode 26.2 で組む

### DIFF
--- a/.github/workflows/app-expo-check.yml
+++ b/.github/workflows/app-expo-check.yml
@@ -166,6 +166,17 @@ jobs:
       - name: リポジトリを取得
         uses: actions/checkout@v4
 
+      # #1156 【重要】このジョブは「EAS の代替検証」を名乗る以上、EAS と同じツールチェインで
+      # 組まなければ意味が無い。macos-15 の既定 Xcode は 16.4 だが、eas.json の iOS プロファイルは
+      # development / preview / production のいずれも `macos-sequoia-15.6-xcode-26.2` を指定している。
+      # 選択しないままだと **Xcode 26.2 でしか出ないネイティブのコンパイル失敗を取りこぼしたまま
+      # success を返す**（＝ EAS を消費してから初めて気付く）。
+      # e2e-mobile-test.yml が同じ runner で明示切り替えしているのと同じ理由・同じバージョンに揃える。
+      - name: Xcode 26.2 を選択
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.2"
+
       - name: PNPMをセットアップ
         uses: pnpm/action-setup@v2
         with:
@@ -194,9 +205,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: app-expo/ios/Pods
-          key: pods-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          # #1156 キャッシュ対象は spec リポジトリではなく `pod install` の生成物なので、
+          # Xcode を切り替えると前のツールチェインで生成した Pods を引き当てうる。
+          # キーにも restore-keys にも Xcode バージョンを含めて世代を分ける。
+          key: pods-${{ runner.os }}-xcode26.2-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            pods-${{ runner.os }}-
+            pods-${{ runner.os }}-xcode26.2-
 
       - name: Podをインストール
         working-directory: app-expo/ios


### PR DESCRIPTION
#1171 の [Codex レビュー指摘](https://github.com/Ayato-kosaka/nanitabeyo/pull/1171#discussion_r3732081738)への対応です。#1171 はマージ済みのため、`main` から切り直したブランチで直しています。

## 問題

`app-expo-check.yml` の iOS ジョブは **「EAS の代替検証」を名乗りながら、EAS とは別のツールチェインでビルドしていました。**

`runs-on: macos-15` を指定しているだけで Xcode を選んでおらず、runner 既定の 16.4 で組んでいます。一方 `app-expo/eas.json` の iOS プロファイルは development / preview / production のいずれも `macos-sequoia-15.6-xcode-26.2` を指定しています。

このジョブの存在理由は「EAS を消費する前にネイティブビルドの失敗を捕まえる」ことなので、これでは目的を果たしません。**Xcode 26.2 でしか出ないコンパイル失敗を取りこぼしたまま success を返す**（＝ EAS を消費してから初めて気付く）状態でした。

同じ runner を使う `e2e-mobile-test.yml` は既にこの問題を踏んでおり、`maxim-lobanov/setup-xcode` で 26.2 へ明示切り替えしたうえで、その理由をコメントに残しています（#1029）。

```
# macos-15 の既定 Xcode は 16.4 のため、eas.json の EAS ビルドと同じ 26.2 へ明示的に切り替える
# （「EAS では通るが CI では落ちる/その逆」を防ぐ。#1029）
```

## 変更内容

**1. iOS ジョブで Xcode 26.2 を明示選択する**

checkout の直後に `maxim-lobanov/setup-xcode@v1` / `xcode-version: "26.2"` を追加しました。`e2e-mobile-test.yml` と同じ理由・同じバージョンです。

**2. CocoaPods キャッシュのキーへ Xcode バージョンを含める**

1 の副作用への対処です。このワークフローがキャッシュしているのは spec リポジトリ（`~/Library/Caches/CocoaPods`）ではなく `pod install` の**生成物**（`app-expo/ios/Pods`）なので、キーを据え置くと Xcode 16.4 時代に生成した Pods を引き当てます。`key` と `restore-keys` の両方へ `xcode26.2-` を入れて世代を分けました。

## 検証

この PR 自身の `iOS ネイティブビルド（EAS の代替検証）` が、修正が効いているかどうかの検証そのものになります。Xcode 26.2 でも `pod install` + `xcodebuild` が通ることをこの run で確認できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHkFwY329RHjkc6J7ypiai

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHkFwY329RHjkc6J7ypiai)_