### PR TITLE
ci: db-migrate のスキーマ検算 SQL が型解決で落ちるのを直す

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -149,8 +149,13 @@ jobs:
           set -euo pipefail
           psql "${DATABASE_URL}" -tAc "select 'user=' || current_user || ' db=' || current_database()"
           psql "${DATABASE_URL}" -tAc "
-            select md5(string_agg(sig, '|' order by sig)) from (
-              select c.relkind || ':' || c.relname || ':' || coalesce(count(a.attname)::text,'0') as sig
+            select coalesce(md5(string_agg(sig, '|' order by sig)), '(empty)') from (
+              -- pg_class.relkind は text ではなく char 型。裸の || は複数の演算子候補に
+              -- 一致してしまい ERROR: operator is not unique ... || unknown で落ちる。
+              -- 連結する全項を ::text へ明示キャストすること。
+              -- また string_agg は 0 行だと NULL を返し md5(NULL) も NULL になるので、
+              -- 空スキーマでも before/after を比較できるよう外側で coalesce する。
+              select c.relkind::text || ':' || c.relname::text || ':' || count(a.attname)::text as sig
               from pg_class c
               join pg_namespace n on n.oid = c.relnamespace
               left join pg_attribute a on a.attrelid = c.oid and a.attnum > 0
@@ -184,8 +189,13 @@ jobs:
         run: |
           set -euo pipefail
           psql "${DATABASE_URL}" -tAc "
-            select md5(string_agg(sig, '|' order by sig)) from (
-              select c.relkind || ':' || c.relname || ':' || coalesce(count(a.attname)::text,'0') as sig
+            select coalesce(md5(string_agg(sig, '|' order by sig)), '(empty)') from (
+              -- pg_class.relkind は text ではなく char 型。裸の || は複数の演算子候補に
+              -- 一致してしまい ERROR: operator is not unique ... || unknown で落ちる。
+              -- 連結する全項を ::text へ明示キャストすること。
+              -- また string_agg は 0 行だと NULL を返し md5(NULL) も NULL になるので、
+              -- 空スキーマでも before/after を比較できるよう外側で coalesce する。
+              select c.relkind::text || ':' || c.relname::text || ':' || count(a.attname)::text as sig
               from pg_class c
               join pg_namespace n on n.oid = c.relnamespace
               left join pg_attribute a on a.attrelid = c.oid and a.attnum > 0


### PR DESCRIPTION
#1201 で入れた `db-migrate.yml` は、**実行すると必ず落ちる状態**でした。1 ファイル 1 論点の追い修正です。

## 症状

「接続先と対象外スキーマのスナップショットを取る」ステップで必ず失敗します（[run 31204256959](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/31204256959)）。

```
ERROR:  operator is not unique: "char" || unknown
LINE 3:     select c.relkind || ':' || c.relname || ':' || coalesce(...
HINT:  Could not choose a best candidate operator. You might need to add explicit type casts.
```

## 原因

`pg_class.relkind` は `text` ではなく `"char"` 型です。`||` の右辺が `unknown`（引用符リテラル）のため、`"char" || unknown` とも `text || unknown` とも解釈でき、PostgreSQL が演算子を一つに決められません。連結する全項を `::text` へ明示キャストします。

あわせて外側の `md5` を `coalesce` します。`string_agg` は 0 行だと `NULL` を返し `md5(NULL)` も `NULL` になるため、空スキーマでは before / after が両方空文字になり、「変化していない」ことを積極的に確認できていませんでした。

## 検証

ローカル PostgreSQL 16 で修正前後を再現しました。

| ケース | 結果 |
| --- | --- |
| 修正前 | `ERROR: operator is not unique` |
| 修正後（table / index / view のあるスキーマ） | `i:t1_a:1｜r:t1:2｜v:v1:1` を md5 して返す（列数まで検知） |
| 修正後（空スキーマ） | `(empty)` |

さらに、修正版でこのリポジトリの dev スキーマへ **dry run と実適用の両方を通しました**。

- dry run: [run 31204666574](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/31204666574) — 全ステップ success
- 実適用: [run 31204757855](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/31204757855) — `share_links` が dev に作成され、「対象外スキーマが変わっていないことを検算」も success（`public` は不変）

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_