### PR TITLE
test: 共有リンクの OGP が動的に出ているかを実環境で検証する workflow を追加

### DIFF
--- a/.github/workflows/verify-share-link-seo.yml
+++ b/.github/workflows/verify-share-link-seo.yml
@@ -1,0 +1,136 @@
+name: Verify Share Link SEO
+
+# ==============================================================================
+# #721 共有リンク `/s/:token` の OGP が «実データから動的に» 出ているかを、
+# デプロイ済みの環境に対して実 HTTP で確認する。
+#
+# ## なぜ独立した workflow なのか
+# この検証は Firebase Hosting の rewrite（`/s/** -> Cloud Run`）が効いているかに
+# 依存する。e2e-web は `scripts/serve-dist.mjs` で dist をローカル配信するため
+# rewrite が存在せず、**構造的にこの経路を検証できない**。
+# 実際にデプロイされた Hosting の URL を叩く必要がある。
+#
+# ## ⚠️ development 専用
+# `web_base_url` の既定は開発環境（nanitabeyo-dev）。**本番 URL を入れないこと。**
+# この workflow は共有リンクを実際に作成する（＝ DB へ書き込む）ので、
+# 本番へ向けると本番 DB に検証用の行が残る。
+# 対象の dish_media も `secrets.POSTGRES_DATABASE_URL`（development Environment）
+# の dev スキーマから拾うため、本番の Hosting へ向けても対象が存在せず
+# 404 になるだけで、意味のある検証にはならない。
+# ==============================================================================
+
+on:
+  workflow_dispatch:
+    inputs:
+      web_base_url:
+        description: "検証する Hosting の URL（開発環境のみ。本番を入れないこと）"
+        required: true
+        default: "https://nanitabeyo-dev.web.app"
+        type: string
+
+concurrency:
+  group: verify-share-link-seo
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: 共有リンクの OGP を実 HTTP で確認
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # POSTGRES_DATABASE_URL（dev スキーマ）と EXPO_TOKEN を使う
+    environment: development
+
+    steps:
+      - name: 本番 URL でないことを確認
+        shell: bash
+        env:
+          WEB_BASE_URL: ${{ inputs.web_base_url }}
+        run: |
+          # 本番ドメインを弾く。既定値のまま流す想定だが、手で書き換えられる以上ここで止める
+          case "${WEB_BASE_URL}" in
+            *app.nanitabeyo.net*|*food-scroll*)
+              echo "::error::この workflow は開発環境専用です（共有リンクを実際に作成するため）。指定: ${WEB_BASE_URL}"
+              exit 1
+              ;;
+          esac
+          echo "検証対象: ${WEB_BASE_URL}"
+
+      - name: リポジトリを取得
+        uses: actions/checkout@v4
+
+      - name: pnpm をセットアップ
+        uses: pnpm/action-setup@v4
+
+      - name: Node をセットアップ
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: 依存関係をインストール
+        run: pnpm install --frozen-lockfile
+
+      - name: Expo & EAS CLI をセットアップ
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      # EXPO_PUBLIC_BACKEND_BASE_URL / SUPABASE_URL / SUPABASE_ANON_KEY を取る。
+      # ここを手書きの secret にしないのは、development の接続先が EAS 側で
+      # 一元管理されており、二重管理するとどちらが正かが分からなくなるため
+      - name: development の環境変数を EAS から取得
+        working-directory: app-expo
+        run: pnpx eas-cli env:pull development --non-interactive --path .env
+
+      - name: psql をインストール
+        shell: bash
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client
+
+      # 実データを 2 件拾う。«別内容の 2 本» を突き合わせることが動的性の根拠なので、
+      # 別々の dishes に紐づく行を選ぶ（同じ料理の別カットだと title が同じになりうる）
+      - name: dev から dish_media を 2 件拾う
+        shell: bash
+        env:
+          DATABASE_URL: ${{ secrets.POSTGRES_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DATABASE_URL}" ]; then
+            echo "::error::secrets.POSTGRES_DATABASE_URL が未設定です"
+            exit 1
+          fi
+          IDS=$(psql "${DATABASE_URL}" -tAc "
+            set search_path to dev;
+            select string_agg(id::text, ',') from (
+              select distinct on (m.dish_id) m.id
+              from dish_media m
+              join dishes d on d.id = m.dish_id
+              where m.thumbnail_path is not null and m.thumbnail_path <> ''
+              order by m.dish_id, m.created_at desc
+              limit 2
+            ) t")
+          if [ -z "${IDS}" ] || [ "$(echo "${IDS}" | tr -cd ',' | wc -c)" -lt 1 ]; then
+            echo "::error::dev に検証可能な dish_media が 2 件ありません（取得結果: '${IDS}'）"
+            exit 1
+          fi
+          # ID 自体は dev の公開データなので伏せない（後段の判定を追えるようにする）
+          echo "DISH_MEDIA_IDS=${IDS}" >> "$GITHUB_ENV"
+          echo "対象 dish_media: ${IDS}"
+
+      - name: 共有リンクを作って OGP を確認する
+        shell: bash
+        env:
+          WEB_BASE_URL: ${{ inputs.web_base_url }}
+        run: |
+          set -euo pipefail
+          # env:pull が書いた app-expo/.env から必要な 3 つだけを取り出す。
+          # `set -a; source` はしない（.env に想定外のキーがあると環境を汚すため）
+          get() { grep -m1 "^$1=" app-expo/.env | cut -d= -f2- | tr -d '"'; }
+          export BACKEND_BASE_URL="$(get EXPO_PUBLIC_BACKEND_BASE_URL)"
+          export SUPABASE_URL="$(get EXPO_PUBLIC_SUPABASE_URL)"
+          export SUPABASE_ANON_KEY="$(get EXPO_PUBLIC_SUPABASE_ANON_KEY)"
+          # anon key はログへ出さない。値そのものは公開鍵だが、習慣として伏せる
+          echo "::add-mask::${SUPABASE_ANON_KEY}"
+          node scripts/verify-share-link-seo.mjs

--- a/scripts/verify-share-link-seo.mjs
+++ b/scripts/verify-share-link-seo.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+// scripts/verify-share-link-seo.mjs
+//
+// #721 共有リンク `/s/:token` の OGP が «実データから動的に» 生成されているかを、
+// デプロイ済みの環境に対して実 HTTP で確認する。
+//
+// ## なぜユニットテスト / E2E では足りないのか
+// - ユニットテストは `renderSharePage()` の出力を見るだけで、Firebase Hosting の
+//   rewrite が `/s/**` を Cloud Run へ回しているかを検証できない。rewrite が
+//   catch-all（`** -> /index.html`）に食われると、**200 でアプリのシェルが返る**。
+//   これは「壊れている」のに一見成功して見える、最もたちの悪い壊れ方になる。
+// - e2e-web は `scripts/serve-dist.mjs` で dist をローカル配信するため、
+//   そもそも rewrite が存在しない。
+//
+// したがって、この検証は «実際にデプロイされた Hosting の URL» を叩く必要がある。
+//
+// ## 何を «動的» の証拠とするか
+// 「200 が返った」「title タグがある」では足りない。静的な index.html でも
+// その両方を満たすため。ここでは次を根拠にする。
+//
+//   1. 同じ形の 2 本のリンク（別 locale・別 dish_media）が **別々の** title /
+//      description / og:locale を返すこと（＝ token ごとに内容が変わる）
+//   2. title が DB 由来の文字列（店名・料理名）を含むこと
+//   3. og:image が `/s/<token>/og-image` を指し、それが 302 で署名 URL へ飛ぶこと
+//   4. 存在しない token が 404 になること（index.html の 200 ではない）
+//   5. 通常のアプリのパスは今までどおり index.html の 200 であること
+//      （＝ `/s/**` の rewrite が SPA の catch-all を壊していない）
+//
+// ## 出力
+// 判定はすべて標準出力へ書く。Artifact に頼らない（ログだけで結論が読める形にする）。
+// 共有 token は伏せ字にする。公開リポジトリの Actions ログに残るため。
+
+const WEB_BASE_URL = requireEnv('WEB_BASE_URL').replace(/\/+$/, '');
+const BACKEND_BASE_URL = requireEnv('BACKEND_BASE_URL').replace(/\/+$/, '');
+const SUPABASE_URL = requireEnv('SUPABASE_URL').replace(/\/+$/, '');
+const SUPABASE_ANON_KEY = requireEnv('SUPABASE_ANON_KEY');
+/** dev の実データから拾った dish_media.id（カンマ区切りで 2 件以上） */
+const DISH_MEDIA_IDS = requireEnv('DISH_MEDIA_IDS')
+	.split(',')
+	.map((v) => v.trim())
+	.filter(Boolean);
+
+function requireEnv(name) {
+	const value = process.env[name];
+	if (!value) {
+		console.error(`::error::${name} が未設定です`);
+		process.exit(1);
+	}
+	return value;
+}
+
+/* ------------------------------------------------------------------ */
+/*                             判定の記録                             */
+/* ------------------------------------------------------------------ */
+
+const results = [];
+
+/** 1 件の判定を記録する。`actual` は伏せ字済みの文字列を渡すこと */
+function check(name, ok, expected, actual) {
+	results.push({ name, ok, expected, actual });
+	console.log(`${ok ? "✅" : "❌"} ${name}`);
+	console.log(`     期待: ${expected}`);
+	console.log(`     実測: ${actual}`);
+}
+
+/** 共有 token を伏せる。ログは公開されるため、本文へそのまま出さない */
+let redactions = [];
+function redact(text) {
+	let out = String(text);
+	for (const token of redactions) {
+		out = out.split(token).join(`${token.slice(0, 6)}…<redacted>`);
+	}
+	return out;
+}
+
+/* ------------------------------------------------------------------ */
+/*                              HTTP                                  */
+/* ------------------------------------------------------------------ */
+
+/** meta タグを 1 つ抜き出す。属性の順序は実装依存なので両方の並びを許す */
+function meta(html, key) {
+	const attr = key.startsWith("og:") || key.startsWith("article:") ? "property" : "name";
+	const patterns = [
+		new RegExp(`<meta\\s+${attr}="${key}"\\s+content="([^"]*)"`, "i"),
+		new RegExp(`<meta\\s+content="([^"]*)"\\s+${attr}="${key}"`, "i"),
+	];
+	for (const re of patterns) {
+		const m = html.match(re);
+		if (m) return m[1];
+	}
+	return null;
+}
+
+function title(html) {
+	const m = html.match(/<title>([\s\S]*?)<\/title>/i);
+	return m ? m[1].trim() : null;
+}
+
+/**
+ * expo export が吐いた静的 HTML かどうか。
+ *
+ * ⚠️ 「title タグがあるか」では判定できない。#281 / #721 のプリレンダで
+ * 静的側にも title と OGP が入っているため、両者は表面的にはよく似ている。
+ * 見分けられるのは «アプリのバンドルを読み込んでいるか» だけ。
+ * SSR 側（share-page.html.ts）は script を 1 つも吐かない。
+ */
+function looksLikeExpoStatic(html) {
+	return /_expo\/static\//.test(html) || /id="root"/.test(html);
+}
+
+async function anonymousSignIn() {
+	// supabase-js の signInAnonymously() と同じ要求。SDK を入れずに済ませる
+	const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+		method: "POST",
+		headers: {
+			apikey: SUPABASE_ANON_KEY,
+			Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ data: {}, gotrue_meta_security: {} }),
+	});
+	const body = await res.text();
+	if (!res.ok) {
+		// token を含みうるので body はそのまま出さない
+		console.error(`::error::匿名サインインに失敗しました (${res.status})`);
+		console.error(body.slice(0, 300));
+		process.exit(1);
+	}
+	const json = JSON.parse(body);
+	const accessToken = json.access_token;
+	if (!accessToken) {
+		console.error("::error::匿名サインインのレスポンスに access_token がありません");
+		process.exit(1);
+	}
+	return accessToken;
+}
+
+async function createShareLink(accessToken, ids, locale) {
+	const res = await fetch(`${BACKEND_BASE_URL}/v1/share-links`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ target: { type: "dish_media", params: { ids } }, locale }),
+	});
+	const body = await res.text();
+	if (res.status !== 201 && res.status !== 200) {
+		console.error(`::error::共有リンクの作成に失敗しました (${res.status}) locale=${locale}`);
+		console.error(body.slice(0, 500));
+		process.exit(1);
+	}
+	// ResponseWrapInterceptor で { success, data } に包まれる
+	const json = JSON.parse(body);
+	const data = json.data ?? json;
+	if (!data.token) {
+		console.error("::error::作成レスポンスに token がありません");
+		console.error(body.slice(0, 500));
+		process.exit(1);
+	}
+	redactions.push(data.token);
+	return data;
+}
+
+/* ------------------------------------------------------------------ */
+/*                              本体                                  */
+/* ------------------------------------------------------------------ */
+
+async function main() {
+	console.log("=== 検証対象 ===");
+	console.log(`WEB_BASE_URL     : ${WEB_BASE_URL}`);
+	console.log(`BACKEND_BASE_URL : ${BACKEND_BASE_URL}`);
+	console.log(`dish_media 件数  : ${DISH_MEDIA_IDS.length}`);
+	console.log("");
+
+	if (DISH_MEDIA_IDS.length < 2) {
+		console.error("::error::dish_media が 2 件必要です（別内容の 2 本を突き合わせて動的性を判定するため）");
+		process.exit(1);
+	}
+
+	const accessToken = await anonymousSignIn();
+	console.log("匿名サインイン: OK");
+
+	// ── 別 dish_media・別 locale で 2 本作る ──
+	const a = await createShareLink(accessToken, [DISH_MEDIA_IDS[0]], "ja-JP");
+	const b = await createShareLink(accessToken, [DISH_MEDIA_IDS[1]], "en-US");
+	console.log(`共有リンクを 2 本作成: ${redact(a.token)} / ${redact(b.token)}`);
+	console.log("");
+
+	// ── 1. Hosting 経由で SSR が返るか ──
+	const pages = {};
+	for (const [label, link] of [
+		["A(ja-JP)", a],
+		["B(en-US)", b],
+	]) {
+		const url = `${WEB_BASE_URL}/s/${link.token}`;
+		const res = await fetch(url, { redirect: "manual" });
+		const html = await res.text();
+		pages[label] = { res, html, link };
+
+		check(
+			`${label} /s/:token が 200 を返す`,
+			res.status === 200,
+			"200",
+			String(res.status),
+		);
+		check(
+			`${label} Content-Type が HTML`,
+			(res.headers.get("content-type") ?? "").includes("text/html"),
+			"text/html を含む",
+			res.headers.get("content-type") ?? "(なし)",
+		);
+		// 静的な index.html が返っていないことの直接的な証拠。
+		// rewrite の順序を間違えると catch-all（`** -> /index.html`）に食われ、
+		// **200 でアプリのシェルが返る**。これは一見成功して見える壊れ方なので必ず見る
+		check(
+			`${label} 静的 index.html ではない`,
+			!looksLikeExpoStatic(html),
+			"アプリのバンドル(_expo/static/)を含まない",
+			looksLikeExpoStatic(html) ? "アプリのシェルが返っている（catch-all に食われている）" : "SSR の HTML",
+		);
+		// token 固有の値が HTML に埋まっていること。静的 HTML では原理的に不可能
+		check(
+			`${label} HTML に token 固有の canonical が入っている`,
+			html.includes(`${WEB_BASE_URL}/s/${link.token}`),
+			"canonical / og:url が この token を指す",
+			redact(meta(html, "og:url") ?? "(なし)"),
+		);
+	}
+
+	// ── 2. OGP が実データから作られているか ──
+	const titleA = title(pages["A(ja-JP)"].html);
+	const titleB = title(pages["B(en-US)"].html);
+	const descA = meta(pages["A(ja-JP)"].html, "og:description");
+	const descB = meta(pages["B(en-US)"].html, "og:description");
+
+	check("A の <title> が空でない", Boolean(titleA), "1 文字以上", JSON.stringify(titleA));
+	check("B の <title> が空でない", Boolean(titleB), "1 文字以上", JSON.stringify(titleB));
+	check(
+		"og:title が <title> と一致する",
+		meta(pages["A(ja-JP)"].html, "og:title") === titleA,
+		"一致",
+		JSON.stringify(meta(pages["A(ja-JP)"].html, "og:title")),
+	);
+
+	// ★ これが «動的更新» の中心的な根拠。
+	//   静的 HTML なら token が違っても同じ内容が返る
+	check(
+		"token ごとに <title> が変わる（＝動的）",
+		Boolean(titleA) && Boolean(titleB) && titleA !== titleB,
+		"A と B で異なる",
+		`A=${JSON.stringify(titleA)} / B=${JSON.stringify(titleB)}`,
+	);
+	check(
+		"token ごとに og:description が変わる（＝動的）",
+		Boolean(descA) && Boolean(descB) && descA !== descB,
+		"A と B で異なる",
+		`A=${JSON.stringify(descA)} / B=${JSON.stringify(descB)}`,
+	);
+
+	// ── 3. locale が共有時点で固定されているか ──
+	check(
+		"A の og:locale が ja_JP",
+		meta(pages["A(ja-JP)"].html, "og:locale") === "ja_JP",
+		"ja_JP",
+		String(meta(pages["A(ja-JP)"].html, "og:locale")),
+	);
+	check(
+		"B の og:locale が en_US",
+		meta(pages["B(en-US)"].html, "og:locale") === "en_US",
+		"en_US",
+		String(meta(pages["B(en-US)"].html, "og:locale")),
+	);
+	// ラベルは locale ごとの定数なので、HTML 本体まで locale が効いていることを見る
+	check(
+		"A の本文が日本語ラベル、B が英語ラベル",
+		pages["A(ja-JP)"].html.includes("アプリで開く") && pages["B(en-US)"].html.includes("Open in app"),
+		"A に「アプリで開く」/ B に「Open in app」",
+		`A:${pages["A(ja-JP)"].html.includes("アプリで開く")} B:${pages["B(en-US)"].html.includes("Open in app")}`,
+	);
+
+	// ── 4. og:url / canonical が Hosting のドメインを指すか ──
+	// ここが API のドメインになっていると、SNS のカードから API が露出する
+	const ogUrlA = meta(pages["A(ja-JP)"].html, "og:url") ?? "";
+	check(
+		"og:url が WEB_BASE_URL 起点",
+		ogUrlA.startsWith(`${WEB_BASE_URL}/s/`),
+		`${WEB_BASE_URL}/s/... で始まる`,
+		redact(ogUrlA),
+	);
+
+	// ── 5. og:image が /s/:token/og-image を指し、302 で署名 URL へ飛ぶか ──
+	const ogImageA = meta(pages["A(ja-JP)"].html, "og:image") ?? "";
+	check(
+		"og:image が /s/:token/og-image",
+		ogImageA === `${ogUrlA}/og-image`,
+		"og:url + /og-image",
+		redact(ogImageA),
+	);
+	if (ogImageA) {
+		const imgRes = await fetch(ogImageA, { redirect: "manual" });
+		const location = imgRes.headers.get("location") ?? "";
+		check(
+			"og-image が 302 でリダイレクトする",
+			imgRes.status === 302,
+			"302",
+			String(imgRes.status),
+		);
+		check(
+			"og-image のリダイレクト先が署名 URL",
+			/^https:\/\//.test(location) && location.includes("?"),
+			"https の署名付き URL",
+			location ? `${location.split("?")[0]}?<signature redacted>` : "(Location なし)",
+		);
+	}
+
+	// ── 6. 存在しない token が 404（index.html の 200 ではない） ──
+	const bogus = "s1_0123456789abcdefghijkl";
+	const notFound = await fetch(`${WEB_BASE_URL}/s/${bogus}`, { redirect: "manual" });
+	const notFoundBody = await notFound.text();
+	check(
+		"存在しない token は 404",
+		notFound.status === 404,
+		"404",
+		`${notFound.status}${notFound.status === 200 && looksLikeExpoStatic(notFoundBody) ? "（index.html が返っている＝rewrite 未適用）" : ""}`,
+	);
+
+	// ── 7. 通常のアプリのパスは今までどおり index.html ──
+	//    `/s/**` の rewrite が catch-all より «前» にある以上、順序を間違えると
+	//    こちらが壊れる。両方を同時に見ないと片側の破壊に気付けない
+	const spa = await fetch(`${WEB_BASE_URL}/ja-JP/posts`, { redirect: "manual" });
+	const spaBody = await spa.text();
+	check(
+		"通常パスは今までどおり静的 HTML",
+		spa.status === 200 && looksLikeExpoStatic(spaBody),
+		"200 かつアプリのバンドルを含む",
+		`${spa.status} / アプリのバンドル: ${looksLikeExpoStatic(spaBody)}`,
+	);
+
+	/* ---------------------------------------------------------------- */
+	/*                            まとめ                                */
+	/* ---------------------------------------------------------------- */
+
+	console.log("");
+	console.log("=== 判定一覧 ===");
+	console.log("| 判定 | 項目 | 期待 | 実測 |");
+	console.log("| --- | --- | --- | --- |");
+	for (const r of results) {
+		const cell = (v) => String(v).replace(/\|/g, "\\|").replace(/\n/g, " ");
+		console.log(`| ${r.ok ? "OK" : "NG"} | ${cell(r.name)} | ${cell(r.expected)} | ${cell(r.actual)} |`);
+	}
+
+	const failed = results.filter((r) => !r.ok);
+	console.log("");
+	console.log(`合計 ${results.length} 件 / 失敗 ${failed.length} 件`);
+	if (failed.length > 0) {
+		for (const r of failed) console.log(`::error::${r.name}: 期待 ${r.expected} / 実測 ${r.actual}`);
+		process.exit(1);
+	}
+	console.log("✅ すべて期待どおり");
+}
+
+main().catch((err) => {
+	console.error(`::error::検証中に例外が発生しました: ${err?.message ?? err}`);
+	console.error(err?.stack ?? "");
+	process.exit(1);
+});


### PR DESCRIPTION
#721 の SEO 検証用です。**新規ファイル 2 つだけ**で、既存のどの workflow / スクリプトも変更しません。

## なぜ main へ先に入れる必要があるか

`workflow_dispatch` は **default branch に存在しないファイルを dispatch できません**。feature ブランチに置いても実行できないため、#1201 と同じ事情で先に main へ入れる必要があります。（ファイルの所在は main で解決されますが、実行されるのは dispatch した ref の内容です。）

マージ後、`ref: claude/parallel-dev-orchestration-7he5dw` で dispatch して #721 の検証を行います。

## なぜこの検証が要るのか

`/s/:token` の OGP は「Firebase Hosting の rewrite が Cloud Run へ回っているか」に依存します。ここが catch-all（`** -> /index.html`）に食われると **200 でアプリのシェルが返ります**。一見成功して見える壊れ方なので、既存のテストでは検知できません。

- ユニットテストは `renderSharePage()` の出力を見るだけで、rewrite を通りません
- e2e-web は `scripts/serve-dist.mjs` で dist をローカル配信するため、**そもそも rewrite が存在しません**（構造的に検証不能）

実際にデプロイされた Hosting の URL を叩くしかないので、独立した workflow として切り出しています。

## 何を「動的」の根拠とするか

「200 が返った」「title タグがある」では足りません。#281 / #721 のプリレンダで静的側にも title と OGP が入っており、表面的にはよく似ているためです。別 dish_media・別 locale の 2 本を作り、次を突き合わせます。

| # | 判定 | なぜそれが根拠になるか |
| --- | --- | --- |
| 1 | 2 本の `<title>` / `og:description` が互いに異なる | token ごとに内容が変わっている＝静的ではない |
| 2 | `og:locale` が `ja_JP` / `en_US` に分かれ、本文ラベルも locale どおり | 共有時点の locale が固定されている |
| 3 | HTML に **その token 固有の canonical** が入っている | 静的 HTML では原理的に不可能 |
| 4 | `og:image` が `/s/:token/og-image` を指し、302 で署名 URL へ飛ぶ | 画像も動的に解決されている |
| 5 | 存在しない token が 404 | index.html の 200 ではない＝ rewrite が効いている |
| 6 | 通常のアプリのパスは今までどおり静的 HTML | `/s/**` を catch-all より前に置いた副作用で SPA を壊していない |

5 と 6 は対になっています。片方だけ見ても rewrite の順序ミスには気付けません。

## 安全側の作り

- `environment: development`。**本番ドメインを入れると最初のステップで落とします**（この workflow は共有リンクを実際に作成する＝ DB へ書き込むため）
- 結果は標準出力へ表で出します。Artifact に頼りません（ログだけで結論が読める形）
- 共有 token は伏せ字にします（公開リポジトリの Actions ログに残るため）。Supabase anon key も `::add-mask::` します

## 検証済みのこと

抽出関数（`meta` / `title` / `looksLikeExpoStatic`）を、実際の `api/src/share/share-page.html.ts` が返す HTML に対してローカルで実行し、次を確認しました。

```
og:title           "博多とんこつ &quot;極&quot; ラーメン / 麺屋 &lt;A&amp;B&gt;"
og:description     "福岡市博多区の麺屋 &lt;A&amp;B&gt; の一皿"
og:url             "https://nanitabeyo-dev.web.app/s/s1_…"
og:locale          "ja_JP"
og:image           "https://nanitabeyo-dev.web.app/s/s1_…/og-image"
robots             "noindex,follow"
looksLikeExpoStatic(SSR)    false  ← SSR を静的と誤判定しない
looksLikeExpoStatic(static) true
```

エスケープ済みの値（`&quot;` / `&lt;`）も正しく拾えています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_