### PR TITLE
#1156 fix: iOS のフォトピッカーが HEIC を返して投稿が処理落ちするのを直す

### DIFF
--- a/app-expo/lib/mediaSelection.test.ts
+++ b/app-expo/lib/mediaSelection.test.ts
@@ -1,0 +1,85 @@
+// #1156 【設計】iOS のフォトピッカーが HEIC を返してしまう回帰を赤で守るテスト。
+//
+// 背景（#1156 実機確認）:
+// `launchImageLibraryAsync` の `preferredAssetRepresentationMode` は既定が `Automatic` で、
+// iOS はこのとき端末が撮った写真を **HEIC のまま**返す。HEIC は API 側の EXTENSION_TABLE
+// （api/src/core/storage/storage.utils.ts）に無いため `getExt()` が "bin" を返し、
+// `..._media.bin` という名前で GCS へ上がる。**アップロード自体は HTTP 200 で成功する**ので
+// UI 上は投稿できたように見えるが、後段の resize（sharp → webp）がデコードできず
+// `media_processing_status = "failed"` になり、フィードには
+// 「このメディアは現在ご利用いただけません」とだけ表示される。
+//
+// 実測（dev の frontend_event_logs, 2026-08-07 17:55:48）:
+//   mimeType "image/heic" / objectPath ".../image-heic/..._media.bin"
+//
+// ## なぜ E2E ではなくユニットテストなのか
+// E2E（Detox）は `lib/e2e/selectMediaStub.ts` が OS のピッカーを迂回して固定画像を返す。
+// ピッカーはアプリ外プロセスで動き Detox から操作できないためで、**実ピッカーの
+// 表現モードは E2E では原理的に踏めない**。したがってこの不変条件はここで固定する。
+import * as ImagePicker from "expo-image-picker";
+
+import { selectMedia } from "@/lib/mediaSelection";
+
+jest.mock("expo-image-picker", () => ({
+	launchImageLibraryAsync: jest.fn(),
+	requestMediaLibraryPermissionsAsync: jest.fn(),
+	VideoExportPreset: { Passthrough: "Passthrough" },
+	UIImagePickerPreferredAssetRepresentationMode: {
+		Automatic: "automatic",
+		Compatible: "compatible",
+		Current: "current",
+	},
+}));
+
+// サムネイル生成は画像では走らないが、import 時に native module を触らせないためスタブ化する
+jest.mock("expo-video-thumbnails", () => ({ getThumbnailAsync: jest.fn() }));
+
+// E2E スタブは通常ビルドでは metro の resolver が noop へ差し替える。
+// jest は resolver を通らないので、ここで明示的に「素通り（null）」へ寄せる。
+jest.mock("@/lib/e2e/selectMediaStub", () => ({ selectMediaForE2E: jest.fn(async () => null) }));
+
+const mockedPicker = ImagePicker as jest.Mocked<typeof ImagePicker>;
+
+describe("selectMedia", () => {
+	beforeEach(() => {
+		mockedPicker.requestMediaLibraryPermissionsAsync.mockResolvedValue({
+			status: "granted",
+		} as never);
+		mockedPicker.launchImageLibraryAsync.mockResolvedValue({
+			canceled: false,
+			assets: [
+				{
+					uri: "file:///tmp/photo.jpg",
+					width: 100,
+					height: 100,
+					mimeType: "image/jpeg",
+					type: "image",
+				},
+			],
+		} as never);
+	});
+
+	// ─ テストケース: iOS のフォトピッカーへ「互換表現」を要求する ─
+	// これが Automatic に戻ると、iOS は HEIC をそのまま返し、投稿は成功したように見えて
+	// サーバ側のメディア処理だけが落ちる（＝ ユーザーからは「このメディアは現在ご利用いただけません」）。
+	it("フォトピッカーへ互換表現（HEIC ではなく JPEG）を要求する", async () => {
+		await selectMedia(["images"]);
+
+		expect(mockedPicker.launchImageLibraryAsync).toHaveBeenCalledTimes(1);
+
+		const options = mockedPicker.launchImageLibraryAsync.mock.calls[0][0];
+		expect(options?.preferredAssetRepresentationMode).toBe(
+			ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Compatible,
+		);
+	});
+
+	// ─ テストケース: 選んだアセットの mimeType がそのまま伝わる ─
+	// アップロード先のオブジェクト拡張子は API 側がこの mimeType から決める。
+	// ここが取りこぼされると、上と同じ「拡張子 .bin で上がって処理が落ちる」経路に戻る。
+	it("選択したアセットの mimeType をそのまま返す", async () => {
+		const result = await selectMedia(["images"]);
+
+		expect(result.success).toBe(true);
+		expect(result.media?.mimeType).toBe("image/jpeg");
+	});
+});

--- a/app-expo/lib/mediaSelection.ts
+++ b/app-expo/lib/mediaSelection.ts
@@ -183,6 +183,22 @@ export async function selectMedia(
 			videoExportPreset: ImagePicker.VideoExportPreset.Passthrough,
 			allowsEditing: options?.allowsEditing,
 			aspect: options?.aspect,
+			// #1156 【バグ】既定の `Automatic` だと、iOS は端末が撮った写真を **HEIC のまま**返す。
+			//
+			// HEIC は API 側の EXTENSION_TABLE（api/src/core/storage/storage.utils.ts）に無いため
+			// `getExt()` が "bin" を返し、`....bin` という名前で GCS へ上がる。アップロード自体は
+			// 200 で成功するので UI 上は成功したように見えるが、後段の resize（sharp → webp）が
+			// デコードできず `media_processing_status = "failed"` になり、フィードには
+			// 「このメディアは現在ご利用いただけません」とだけ表示される。
+			//
+			// 実測（dev の frontend_event_logs, 2026-08-07 17:55:48）:
+			//   mimeType "image/heic" / objectPath ".../image-heic/..._media.bin"
+			// 同日 17:38 の "image/jpeg" は ".jpg" で正常に処理されている。
+			//
+			// `Compatible` は PHPickerConfigurationAssetRepresentationMode.compatible へ直接マップされ、
+			// 「最も互換性の高い表現」＝ 画像なら JPEG へ変換して返す。iOS 14+ 専用オプションで、
+			// Android / Web では無視されるため分岐は要らない。
+			preferredAssetRepresentationMode: ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Compatible,
 		});
 
 		if (result.canceled) {

--- a/app-expo/lib/mediaSelection.ts
+++ b/app-expo/lib/mediaSelection.ts
@@ -198,6 +198,12 @@ export async function selectMedia(
 			// `Compatible` は PHPickerConfigurationAssetRepresentationMode.compatible へ直接マップされ、
 			// 「最も互換性の高い表現」＝ 画像なら JPEG へ変換して返す。iOS 14+ 専用オプションで、
 			// Android / Web では無視されるため分岐は要らない。
+			//
+			// ⚠️ 画像限定にはできない。バグを踏んだのはレビュー投稿の
+			// `selectMedia(["images", "videos"])`（features/map/components/ReviewForm.tsx）なので、
+			// 動画を含む呼び出しにも効かせないと直らない。その結果 **動画側の表現も変わる**
+			// （HEVC ではなく互換表現が返りうる）が、動画の MIME は video/mp4・video/quicktime とも
+			// EXTENSION_TABLE にあり、どちらでも壊れないため許容する。
 			preferredAssetRepresentationMode: ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Compatible,
 		});
 


### PR DESCRIPTION
[実機確認の報告](https://github.com/Ayato-kosaka/nanitabeyo/issues/1156#issuecomment-5220251486)で挙がった 4 件のうち、**この PR が扱うのは iOS の投稿失敗 1 件だけ**です。残り 3 件の扱いは末尾に書きました。

## 症状

iOS で画像レビューを投稿すると、投稿自体は成功したように見えるのに、フィードには「このメディアは現在ご利用いただけません」とだけ表示される。

## 原因

`launchImageLibraryAsync` の `preferredAssetRepresentationMode` は既定が `Automatic` で、iOS はこのとき端末が撮った写真を **HEIC のまま**返します。HEIC は API 側の `EXTENSION_TABLE`（`api/src/core/storage/storage.utils.ts`）に無いため `getExt()` が `"bin"` を返し、`..._media.bin` という名前で GCS へ上がります。

**アップロード自体は HTTP 200 で成功する**ので UI 上は投稿できたように見えますが、後段の resize（sharp → webp）がデコードできず `media_processing_status = "failed"` になり、`DishMediaContent` が当該メッセージだけを表示します。

dev の `frontend_event_logs` に実測が残っていました。

| 時刻 (UTC) | mimeType | objectPath | 結果 |
|---|---|---|---|
| 2026-08-07 17:38:44 | `image/jpeg` | `.../image-jpeg/....jpg` | 正常 |
| 2026-08-07 17:55:48 | `image/heic` | `.../image-heic/..._media.bin` | 処理失敗 |

## 対処

`Compatible` は [`PHPickerConfigurationAssetRepresentationMode.compatible`](https://developer.apple.com/documentation/photokit/phpickerconfigurationassetrepresentationmode) へ直接マップされ、「最も互換性の高い表現」＝ 画像なら JPEG へ変換して返します。iOS 14+ 専用オプションで Android / Web では無視されるため分岐は不要、依存追加も不要です。

## テスト（E2E ではなくユニットにした理由）

E2E は `lib/e2e/selectMediaStub.ts` が OS のピッカーを迂回して固定画像を返します。ピッカーはアプリ外プロセスで動き Detox から操作できないためで、**実ピッカーの表現モードは E2E では原理的に踏めません**。この不変条件はユニットで固定しました。`preferredAssetRepresentationMode` を外すと落ちることを実測済みです。

## この PR に入れていないもの

**お知らせタブのステータスバー食い込み** — #1130 / #1174 が既に同じ修正（`react-native-safe-area-context` の `SafeAreaView` + `edges={["top"]}`）と Detox テスト（`e2e-mobile/tests/mutation/notifications-safe-area.test.ts`）、Screen Object（`e2e-mobile/screens/NotificationsScreen.ts`）を持っていました。当初この PR にも入れていましたが、**同じファイル・同じ行を触り確実に衝突する**ため取り下げ、#1174 に委ねます。

**画像読み込みの遅さ / DishMediaMap のカクつき** — 実機に入れたビルドは EAS の `development` プロファイル、つまり `developmentClient: true` の開発ビルドです。`__DEV__` が true で最適化・ミニファイが効かず、React も開発時チェック付きで描画されるため、性能の判定材料になりません。`preview` ビルド（release JS・ネイティブ構成は同じ）での再測定をお願いします。Target SDK 36 の確認でどのみち必要なので、そのついでで判定できます。そこでも再現するなら `expo-image` 2.4 → 3.0 と `react-native-maps` 1.18 → 1.20 の差分から追います。

## 検証

- `pnpm --filter app-expo test -- lib/mediaSelection.test.ts` → 2 tests pass
- 修正を戻すと該当テストが赤になることを実測

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHkFwY329RHjkc6J7ypiai