### PR TITLE
#1249 fix: oauth_callback_error が空文字しか残さず診断不能だった問題を直す

### DIFF
--- a/app-expo/app/[locale]/auth/callback.tsx
+++ b/app-expo/app/[locale]/auth/callback.tsx
@@ -28,6 +28,7 @@ import { useProfile } from "@/features/profile/hooks/useProfile";
 import { useBlurModal } from "@/features/blurModal/hooks/useBlurModal";
 import { Card } from "@/components/Card";
 import { describeOAuthUrl, pickOAuthResultUrl, type OAuthUrlCandidate } from "@/lib/oauthResultUrl";
+import { toErrorLogMessage } from "@/lib/errorMessage";
 
 /**
  * router のパラメータを URL の形に載せるための器。
@@ -148,7 +149,20 @@ export default function AuthCallbackScreen() {
 					event_name: "oauth_callback_error",
 					error_level: "error",
 					payload: {
-						error: error instanceof Error ? error.message : String(error),
+						// #1249 【バグ】旧実装は `error instanceof Error ? error.message : String(error)` で、
+						// message が空の Error / plain object が来ると本文に何も残らず、
+						// 「サインインが失敗したのに理由が永久に分からない」ログが本番に出ていた。
+						// toErrorLogMessage(#1092) は message → String(error) の順に拾うので最低でも名前が残る。
+						error: toErrorLogMessage(error),
+						// #1249 【観測】message が空でも原因を辿れるよう、Supabase AuthError / ApiError が
+						// 持つ構造化フィールドを個別に残す（無ければ null）。
+						error_name: typeof err?.name === "string" ? err.name : null,
+						error_code: err?.error_code ?? err?.code ?? null,
+						status: err?.status ?? null,
+						// どのログイン動線か。兄弟ログ(oauth_callback_no_result / oauth_link_conflict)は
+						// 以前から積んでおり、ここだけ欠けていた。
+						intent: rest.intent ?? null,
+						provider: rest.provider ?? null,
 						// #1062 【設計】生の URL は code / access_token を含むため記録しない
 						source: picked.source,
 						url_shape: describeOAuthUrl(picked.url),


### PR DESCRIPTION
Closes #1249

## 何が起きていたか

本番で `oauth_callback_error` の `payload.error` が**空文字**のログが観測され（1件/1人・日）、サインイン失敗の原因が BigQuery から辿れませんでした。`auth/callback` は OAuth ログインの最終地点なので、件数が少なくても「失敗理由が永久に分からない」状態は直す価値があります。

## 原因と修正（フロントのログ品質のみ・1 ファイル）

旧実装は `error instanceof Error ? error.message : String(error)` で、**message が空の Error が来ると本文に何も残りません**でした。これは #1092 で `toErrorLogMessage` へ寄せることになっている (B) パターンそのものだったので、既定のユーティリティへ置換しました（message が空でも `String(error)` にフォールバックし、最低でもエラー名が残ります）。

あわせて `error_name` / `error_code` / `status` / `intent` / `provider` を payload へ追加。兄弟ログ（`oauth_callback_no_result` / `oauth_link_conflict`）は以前から `intent` / `provider` を積んでおり、`oauth_callback_error` だけ欠けていました。

API・共通経路・他画面には触れていません。

## 検証

| 対象 | 結果 |
|---|---|
| `pnpm --filter app-expo typecheck` | green |
| `pnpm --filter app-expo test` | 23 suites / **228 tests green** |

## 副次効果

#1249 が close されると、fpalgo 移行の「突合できなかった fpalgo 1 open Issue」保留リスト（#1232 / #1241 / #1244 / #1249 / #1252）が 1 件減り、frontend の新規起票保留の解除が近づきます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoysKNnizjrnvz2dQGhjRr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoysKNnizjrnvz2dQGhjRr)_