### PR TITLE
#721 / #1131 / #1133 fix: マージ後の main で赤くなった E2E を直す（製品バグ 1 件＋一度も緑になっていなかった Detox 3 spec）

### DIFF
--- a/.github/workflows/evidence-collect.yml
+++ b/.github/workflows/evidence-collect.yml
@@ -22,6 +22,11 @@ on:
         description: "オーケストレーターが照合済みのテスト対象commit SHA"
         required: true
         type: string
+      allow_failed_run:
+        description: "失敗した元runからも収集する（原因調査用。既定は success のみ）"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -38,6 +43,7 @@ jobs:
       SOURCE_RUN_ID: ${{ inputs.run_id }}
       ARTIFACT_NAME: ${{ inputs.artifact_name }}
       SOURCE_SHA: ${{ inputs.source_sha }}
+      ALLOW_FAILED_RUN: ${{ inputs.allow_failed_run }}
       # 元runが信頼できるWorkflowであることを .path で判定する（.name は run-name のため使えない）
       # - claude-worker.yml: テストエビデンス収集の本来の入力
       # - e2e-web-test.yml    : 手動実行で収集したUIカタログのスクリーンショット（Web）
@@ -104,9 +110,26 @@ jobs:
             exit 1
           fi
 
-          if [[ "$STATUS" != "completed" || "$CONCLUSION" != "success" ]]; then
-            echo "::error::元runが成功完了していません（status=$STATUS, conclusion=$CONCLUSION）。"
+          # 【設計】既定では success の元runだけを通す。
+          # 「緑の run から採ったエビデンス」であることが、このワークフローの出力の意味そのものだから。
+          #
+          # ただし **赤い run の原因調査**にはスクリーンショットが要る（Artifact の直リンクは
+          # 署名付き blob storage で、環境によっては到達できない）。そこで allow_failed_run で
+          # 明示的にオプトインしたときだけ、完了済みの失敗runも許す。
+          # ⚠️ このとき出力は «エビデンス» ではなく «調査用» である。ログに警告を残し、
+          # PR へ貼るときは必ず「失敗runのスクリーンショット」と明記すること。
+          if [[ "$STATUS" != "completed" ]]; then
+            echo "::error::元runが完了していません（status=$STATUS）。"
             exit 1
+          fi
+
+          if [[ "$CONCLUSION" != "success" ]]; then
+            if [[ "$ALLOW_FAILED_RUN" != "true" ]]; then
+              echo "::error::元runが成功完了していません（status=$STATUS, conclusion=$CONCLUSION）。"
+              echo "::error::原因調査で失敗runから収集したい場合は allow_failed_run=true を指定してください。"
+              exit 1
+            fi
+            echo "::warning::元runは $CONCLUSION です。この出力は «合格エビデンス» ではなく原因調査用です。"
           fi
 
           echo "sha=${SOURCE_SHA,,}" >> "$GITHUB_OUTPUT"

--- a/app-expo/app/[locale]/(tabs)/posts.tsx
+++ b/app-expo/app/[locale]/(tabs)/posts.tsx
@@ -56,8 +56,10 @@ export default function PostsScreen() {
 		};
 	}, [callBackend, entriesKey, ids]);
 
+	// #721 testID は共有リンク（/s/:token）が «捨てられず投稿画面へ着地したか» を E2E から見るための目印。
+	// 解決画面は resolve の往復の間しか出ず観測できないため、着地先そのものを観測点にしている。見た目には影響しない
 	return (
-		<LinearGradient colors={["#FFFFFF", "#F8F9FA"]} style={styles.container}>
+		<LinearGradient colors={["#FFFFFF", "#F8F9FA"]} style={styles.container} testID="posts-screen">
 			{/* #688 【設計】Web Deep Linking バナー（アプリ未インストール時の導線） */}
 			<OpenInAppBanner path="posts" params={{ ids, entriesKey }} />
 			<DishMediaMap entriesKey={entriesKey} idType="dish_media" />

--- a/app-expo/app/[locale]/(tabs)/profile/settings.tsx
+++ b/app-expo/app/[locale]/(tabs)/profile/settings.tsx
@@ -307,7 +307,12 @@ export default function SettingsScreen() {
 		<LinearGradient colors={["#FFFFFF", "#F8F9FA"]} style={styles.container}>
 			<SafeAreaView style={styles.safeArea} edges={[]}>
 				<ScreenHeader title={i18n.t("Settings.title")} onPressBack={handleBack} />
-				<ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
+				{/* #1131 E2E から「ログアウト行まで送る」ためのスクロール対象。見た目には影響しない。
+				    ログアウト行は最下段のカードにあり、端末によっては初期表示で画面外にいる */}
+				<ScrollView
+					style={styles.scrollView}
+					contentContainerStyle={styles.scrollContent}
+					testID="settings-scroll">
 					{/* Card 1: フィードバック・レビュー・ブロック済みトピック */}
 					<Card style={styles.card}>
 						<SettingsMenuItem

--- a/app-expo/app/s/[token].tsx
+++ b/app-expo/app/s/[token].tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { ActivityIndicator, StyleSheet, View } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 
-import { useAPICall } from "@/hooks/useAPICall";
+import { fetchWithAuth } from "@/lib/fetchWithAuth";
 import { useLocale } from "@/hooks/useLocale";
 import { resolvePublicLocale } from "@/constants/seoLocales";
 import { toShareLinkHref } from "@/lib/shareLinkRoute";
@@ -28,11 +28,24 @@ import type { ResolveShareLinkResponse } from "@shared/api/v1/res";
  * revoked / 期限切れ / 未知の target / 通信失敗のいずれでも、**この画面に留まらない**。
  * 共有リンクは «アプリを初めて触る人» が踏む導線なので、
  * 白い画面で止まるのが一番損失が大きい。
+ *
+ * ## ⚠️ `useAPICall` を使ってはいけない（Detox が捕まえた実バグ）
+ * この画面は `app/[locale]/` の **外**にあり、`AuthProvider` / `DialogProvider` は
+ * `app/[locale]/_layout.tsx` の中にある。`useAPICall` は内部で `useAuth()` と
+ * `useDialog()` を呼ぶため、ここで使うと **レンダー時に例外**になる。
+ *
+ * 症状は「共有リンクでアプリに着地した瞬間に落ちる」で、#721 の核心そのもの。
+ * dev では App Links が本番ドメインにしか紐付いておらず **実機で踏めない**経路なので、
+ * Detox（`tests/smoke/share-link.test.ts`）でしか検出できない。
+ *
+ * `GET /v1/share-links/:token/resolve` は `AuthAnonGuard` を持たない **公開エンドポイント**
+ * なので、認証は不要。`fetchWithAuth` を素の関数として直接呼ぶ
+ * （`x-app-version` を付ける必要があるので素の `fetch` にはしない。
+ *  グローバルの `MaintenanceGuard` がこのヘッダを見る）。
  */
 export default function ShareLinkResolverScreen() {
 	const { token } = useLocalSearchParams<{ token?: string | string[] }>();
 	const router = useRouter();
-	const { callBackend } = useAPICall();
 	const { locale } = useLocale();
 	// #1027 と同じ理由でナビゲータの準備を待つ必要はないが、
 	// resolve が二重に走らないよう「1 回だけ実行した」ことは持つ
@@ -51,10 +64,15 @@ export default function ShareLinkResolverScreen() {
 			if (!cancelled) router.replace(`/${fallbackLocale}`);
 		};
 
-		callBackend<Record<string, never>, ResolveShareLinkResponse>(
-			`v1/share-links/${encodeURIComponent(rawToken)}/resolve`,
-			{ method: "GET", requestPayload: {} },
-		)
+		// 認証不要の公開エンドポイント。accessToken は空文字で良い
+		// （このルートに AuthAnonGuard は付いていないため Authorization は参照されない）
+		fetchWithAuth(`v1/share-links/${encodeURIComponent(rawToken)}/resolve`, { method: "GET", requestPayload: {} }, "")
+			.then(async ({ response }) => {
+				if (!response.ok) throw new Error(`resolve failed: ${response.status}`);
+				const body = (await response.json()) as { data?: ResolveShareLinkResponse };
+				if (!body?.data) throw new Error("resolve returned no data");
+				return body.data;
+			})
 			.then((resolved) => {
 				if (cancelled) return;
 				// 遷移先の組み立てはアプリ側の allowlist で行う。
@@ -72,7 +90,7 @@ export default function ShareLinkResolverScreen() {
 		return () => {
 			cancelled = true;
 		};
-	}, [token, callBackend, router, locale, fallbackLocale]);
+	}, [token, router, locale, fallbackLocale]);
 
 	// resolve は 1 往復で終わるので、専用のエラー画面は作らない（失敗時はホームへ落とす）
 	return (

--- a/app-expo/features/profile/containers/ProfileTabsLayout.tsx
+++ b/app-expo/features/profile/containers/ProfileTabsLayout.tsx
@@ -107,7 +107,30 @@ export function ProfileTabsLayout() {
 	const tabsContainerRef = useRef<{ jumpToTab?: (name: string) => void } | null>(null);
 	useEffect(() => {
 		if (!requestedTab) return;
-		tabsContainerRef.current?.jumpToTab?.(requestedTab);
+
+		// ⚠️ 1 回呼んで終わりにしないこと。**ディープリンクで直接この画面へ着地した場合**、
+		// この effect が走る時点で ref がまだ埋まっていないことがあり、`?.()` が黙って
+		// 捨てられて二度と再試行されない。結果「?tab= が効く端末と効かない端末がある」
+		// という切り分けの難しい形で壊れる（iOS の Detox が先頭タブのまま止まって捕まえた）。
+		// 効いたかどうかは外から観測できないので、ref が生えるまで短間隔で試し、
+		// 生えたら 1 度だけ呼んで止める。
+		if (tabsContainerRef.current?.jumpToTab) {
+			tabsContainerRef.current.jumpToTab(requestedTab);
+			return;
+		}
+
+		let attempts = 0;
+		const timer = setInterval(() => {
+			attempts += 1;
+			if (tabsContainerRef.current?.jumpToTab) {
+				tabsContainerRef.current.jumpToTab(requestedTab);
+				clearInterval(timer);
+			} else if (attempts >= 20) {
+				// 2 秒待っても生えないのは別の異常。無限に回さない
+				clearInterval(timer);
+			}
+		}, 100);
+		return () => clearInterval(timer);
 	}, [requestedTab, tabRequestParam]);
 
 	const handleHeaderLayout = useCallback((event: LayoutChangeEvent) => {

--- a/e2e-mobile/screens/SavedTopicLocationSearchScreen.ts
+++ b/e2e-mobile/screens/SavedTopicLocationSearchScreen.ts
@@ -92,7 +92,10 @@ export class SavedTopicLocationSearchScreen {
 	 *   モーダルの入口はこのカードしかないため、ここで素通しにすると
 	 *   「テストは緑だがモーダルを一度も開いていない」という嘘の緑になる（fail-loud の方針）。
 	 *   e2e-web は `stubSavedDishCategories` で一覧 API を固定して同じ問題を回避しているが、
-	 *   Detox にネットワークをスタブする手段は無いため、テストユーザーのデータに依存する。
+	 *   Detox にネットワークをスタブする手段は無いため、spec の `beforeAll` が
+	 *   `utils/savedDishCategory.ts` で **前提そのものを作ってから**ここへ来る。
+	 *   つまりここで落ちたら「種まきはできたのに一覧に出ていない」＝ 保存導線側の異常であり、
+	 *   人手でデータを足して回避してはいけない。
 	 */
 	async openLocationSearchFromFirstTopic(): Promise<void> {
 		await this.expectTabLoaded();
@@ -102,7 +105,9 @@ export class SavedTopicLocationSearchScreen {
 				[
 					"保存した料理カテゴリが 0 件のため、地点検索モーダルを開けませんでした（save-topic-tab-item-0 が存在しない）。",
 					"  このモーダルの入口は保存料理カテゴリのカードだけです。",
-					"  TEST_USER_* のテストユーザーで料理カテゴリを 1 件以上保存しておいてください。",
+					"  spec の beforeAll（utils/savedDishCategory.ts）が reactions へ save を 1 件入れているはずなので、",
+					"  ここで 0 件なら「保存はあるのに一覧に出ない」側の異常です。",
+					"  GET /v1/users/me/saved-dish-categories が dish_categories を join できているか確認してください。",
 				].join("\n"),
 			);
 		}

--- a/e2e-mobile/screens/SearchScreen.ts
+++ b/e2e-mobile/screens/SearchScreen.ts
@@ -446,8 +446,18 @@ export class SearchScreen {
 		await tapWhenVisible(this.scene(id));
 	}
 
-	/** 詳細条件（距離・フードスタイル等）を展開する。画面外にある場合はスクロールしてから押す */
+	/**
+	 * 詳細条件（距離・フードスタイル等）を展開する。画面外にある場合はスクロールしてから押す。
+	 *
+	 * ⚠️ **まず先頭へ戻すこと。** `scrollUntilVisible` は «下方向» にしか送らないので、
+	 * 既に詳細条件より下まで進んでいる状態から呼ぶと永久に届かない。
+	 * iOS の Detox がここで落ちて分かった: 直前の地点入力でソフトキーボードが出たまま
+	 * 画面下半分を覆っており、かつ画面は詳細条件の内側まで下がっていた
+	 * （`Unable to scroll down ... does not pass visibility percent threshold (75)`）。
+	 * 先頭へ戻せば、キーボードが残っていてもトグルは上半分に来る。
+	 */
 	async openAdvancedFilters(): Promise<void> {
+		await element(this.scrollView).scrollTo("top");
 		await this.scrollUntilVisible(this.advancedToggle);
 		await tapWhenVisible(this.advancedToggle);
 	}

--- a/e2e-mobile/screens/SettingsScreen.ts
+++ b/e2e-mobile/screens/SettingsScreen.ts
@@ -4,6 +4,7 @@ import {
 	element,
 	existsNow,
 	tapWhenVisible,
+	waitFor,
 	waitUntilVisible,
 } from "../fixtures/e2e";
 
@@ -110,6 +111,26 @@ export class SettingsScreen {
 	}
 
 	/**
+	 * ログアウト行が **見える位置まで** 設定画面をスクロールする（#1131）。
+	 *
+	 * ## なぜ要るのか（CI で実際に赤くなった）
+	 * ログアウト行は設定画面の最下段のカードにあり、エミュレータの画面高では
+	 * **初期表示で画面外**にいる。Detox の `toBeVisible()` は「面積の 75% 以上が可視」を
+	 * 要求するので、`toExist()` は真でも `toBeVisible()` は永久に偽のまま 25 秒待って落ちる。
+	 * `hasLogoutItem()` が `existsNow`（= `toExist`）なのは匿名側で「無い」ことを見るためで、
+	 * **押せるかどうか**を見るこちらとは要求が違う。
+	 *
+	 * `whileElement(...).scroll()` は「見つかるまでスクロールする」Detox の標準手段で、
+	 * 既に見えている場合は 1 度も動かさずに返る（画面が大きい端末でも安全）。
+	 */
+	async scrollToLogout(): Promise<void> {
+		await waitFor(element(this.logoutItem))
+			.toBeVisible()
+			.whileElement(by.id("settings-scroll"))
+			.scroll(300, "down");
+	}
+
+	/**
 	 * ログアウト行をタップし、確認ダイアログを「ログアウト」で確定する（#1131）。
 	 *
 	 * ⚠️ **セッションを破壊する操作。** 共有セッション（globalSetup 発行）で呼んではいけない
@@ -117,6 +138,7 @@ export class SettingsScreen {
 	 * 呼び出す spec の設計上の注意は tests/authenticated/logout.test.ts の冒頭コメントを参照すること。
 	 */
 	async logout(): Promise<void> {
+		await this.scrollToLogout();
 		await tapWhenVisible(this.logoutItem);
 		// Portal 経由でマウントされるため、ダイアログの描画完了（タイトル）を待ってから押す
 		await waitUntilVisible(this.logoutConfirmTitle);

--- a/e2e-mobile/tests/authenticated/logout.test.ts
+++ b/e2e-mobile/tests/authenticated/logout.test.ts
@@ -122,6 +122,11 @@ describeAuthenticated("ログアウト（ログイン済みユーザー）", () 
 
 		// ログアウト行の表示 ＝ AuthProvider が「ログイン済み(非匿名)」で決着した合図。
 		// ここが出ない場合はセッション注入自体が効いていない（= 検証の前提が崩れている）
+		//
+		// ⚠️ 先にスクロールすること。ログアウト行は最下段のカードにあり、エミュレータの画面高では
+		// **初期表示で画面外**にいる。素の `waitUntilVisible` だと「注入が効いていない」と
+		// 区別が付かない形で 25 秒待って落ちる（CI で実際に踏んだ）
+		await settingsScreen.scrollToLogout();
 		await waitUntilVisible(settingsScreen.logoutItem);
 
 		await settingsScreen.logout();

--- a/e2e-mobile/tests/profile/saved-topic-location-search.test.ts
+++ b/e2e-mobile/tests/profile/saved-topic-location-search.test.ts
@@ -7,6 +7,11 @@ import {
 import { SavedTopicLocationSearchScreen } from "../../screens/SavedTopicLocationSearchScreen";
 import { SearchScreen } from "../../screens/SearchScreen";
 import { TabBar } from "../../screens/TabBar";
+import {
+	cleanupSeededDishCategory,
+	ensureSavedDishCategory,
+	type SeededDishCategory,
+} from "../../utils/savedDishCategory";
 
 /**
  * 📌 保存した料理カテゴリからの地点検索（#1133）
@@ -38,12 +43,22 @@ import { TabBar } from "../../screens/TabBar";
  * 入口は保存した料理カテゴリのカードだけで、匿名ユーザーには保存が無いのでモーダルを開けない。
  * `describeAuthenticated` は TEST_USER_* が無い環境で spec ごと skip する（fixtures/e2e.ts）。
  * さらに **テストユーザーが料理カテゴリを 1 件以上保存している**ことも前提になる。
- * e2e-web は一覧 API をスタブして環境依存を消しているが、Detox にネットワークをスタブする
- * 手段が無いため、0 件のときは Screen Object が前提条件の不足として名指しで落とす（fail-loud）。
+ *
+ * ## 前提を「人」ではなく「テスト」が用意する（CI で赤くなった反省）
+ * 当初この前提は「TEST_USER_* で 1 件保存しておくこと」という *依頼* で表現していた。
+ * 結果、誰かがマイページから保存を外しただけで **コード変更ゼロで CI が赤くなった**。
+ * 環境に前提を置くテストは、いずれ必ずその環境の変化で落ちる。
+ * そこで `beforeAll` で `ensureSavedDishCategory()` を呼び、保存が 0 件なら
+ * 推薦 API から実在のカテゴリを 1 つ取って `reactions` へ save を入れる。
+ * e2e-web が `stubSavedDishCategories` でやっていることの、スタブできない環境版。
  *
  * ## 書き込みについて（Tier の位置づけ）
- * dev DB へは書き込まない。「最近使った場所」の追記先は端末の AsyncStorage だけで、
- * 他のテストと共有する状態ではないため Tier 2（読み取り + 端末ローカル）に収まる。
+ * 「最近使った場所」の追記先は端末の AsyncStorage だけなので本体は Tier 2 のままだが、
+ * 上記の前提づくりだけは **dev DB の reactions へ 1 行書く**。ただし
+ * - 書くのは **保存が 0 件のときだけ**（元からあれば触らない）
+ * - 書いた 1 行は `afterAll` で **自分が入れた分だけ**消す
+ * - 対象は RLS で自分の行に限定される（他ユーザー・他テーブルへは影響しない）
+ * ため、run をまたいで共有される状態は残さない。`@mutation` タグは付けず tier1-2 に置く。
  */
 describeAuthenticated("保存した料理カテゴリからの地点検索", () => {
 	/**
@@ -55,6 +70,18 @@ describeAuthenticated("保存した料理カテゴリからの地点検索", () 
 	 * 実装済みの経路にそのまま乗る（#1031 B4 のディープリンク方針）。
 	 */
 	const savedTopicsDeepLink = localeDeepLink("profile?tab=saved-topics");
+
+	/** このテストが入れた保存行（元から保存があった場合は null = 後始末不要） */
+	let seeded: SeededDishCategory = null;
+
+	// 推薦 API はスコアリング + 翻訳を挟むため、既定の 120s では足りないことがある
+	beforeAll(async () => {
+		seeded = await ensureSavedDishCategory();
+	}, 180_000);
+
+	afterAll(async () => {
+		await cleanupSeededDishCategory(seeded);
+	}, 60_000);
 
 	// #1031 【バグ】beforeAll だと前のテストが残した画面状態（開いたままのモーダル等）を次が引き継ぎ、
 	// タップがオーバーレイに阻まれて落ちる。セッション注入起動は匿名クォータを消費しないため、

--- a/e2e-mobile/tests/profile/saved-topic-location-search.test.ts
+++ b/e2e-mobile/tests/profile/saved-topic-location-search.test.ts
@@ -7,11 +7,7 @@ import {
 import { SavedTopicLocationSearchScreen } from "../../screens/SavedTopicLocationSearchScreen";
 import { SearchScreen } from "../../screens/SearchScreen";
 import { TabBar } from "../../screens/TabBar";
-import {
-	cleanupSeededDishCategory,
-	ensureSavedDishCategory,
-	type SeededDishCategory,
-} from "../../utils/savedDishCategory";
+import { ensureSavedDishCategory } from "../../utils/savedDishCategory";
 
 /**
  * 📌 保存した料理カテゴリからの地点検索（#1133）
@@ -55,10 +51,10 @@ import {
  * ## 書き込みについて（Tier の位置づけ）
  * 「最近使った場所」の追記先は端末の AsyncStorage だけなので本体は Tier 2 のままだが、
  * 上記の前提づくりだけは **dev DB の reactions へ 1 行書く**。ただし
- * - 書くのは **保存が 0 件のときだけ**（元からあれば触らない）
- * - 書いた 1 行は `afterAll` で **自分が入れた分だけ**消す
+ * - 書くのは **保存が 0 件のときだけ**（元からあれば触らない = 2 回目以降は書き込みゼロ）
  * - 対象は RLS で自分の行に限定される（他ユーザー・他テーブルへは影響しない）
- * ため、run をまたいで共有される状態は残さない。`@mutation` タグは付けず tier1-2 に置く。
+ * - 作るのは run ごとの一時データではなく «テストユーザーに保存が 1 件ある» という恒常的な前提
+ * なので `@mutation` タグは付けず tier1-2 に置く。消さない理由は utils/savedDishCategory.ts に書いた。
  */
 describeAuthenticated("保存した料理カテゴリからの地点検索", () => {
 	/**
@@ -71,17 +67,11 @@ describeAuthenticated("保存した料理カテゴリからの地点検索", () 
 	 */
 	const savedTopicsDeepLink = localeDeepLink("profile?tab=saved-topics");
 
-	/** このテストが入れた保存行（元から保存があった場合は null = 後始末不要） */
-	let seeded: SeededDishCategory = null;
-
-	// 推薦 API はスコアリング + 翻訳を挟むため、既定の 120s では足りないことがある
+	// 推薦 API はスコアリング + 翻訳を挟むため、既定の 120s では足りないことがある。
+	// ⚠️ 入れた行は消さない（後始末を «しない» のが正しい理由は utils/savedDishCategory.ts の冒頭）
 	beforeAll(async () => {
-		seeded = await ensureSavedDishCategory();
+		await ensureSavedDishCategory();
 	}, 180_000);
-
-	afterAll(async () => {
-		await cleanupSeededDishCategory(seeded);
-	}, 60_000);
 
 	// #1031 【バグ】beforeAll だと前のテストが残した画面状態（開いたままのモーダル等）を次が引き継ぎ、
 	// タップがオーバーレイに阻まれて落ちる。セッション注入起動は匿名クォータを消費しないため、

--- a/e2e-mobile/tests/smoke/share-link.test.ts
+++ b/e2e-mobile/tests/smoke/share-link.test.ts
@@ -1,4 +1,4 @@
-import { by, launchAppWithSession, waitUntilVisible } from "../../fixtures/e2e";
+import { by, device, launchAppWithSession, waitUntilExists, waitUntilVisible } from "../../fixtures/e2e";
 import { APP_SCHEME } from "../../utils/locale";
 
 /**
@@ -38,6 +38,34 @@ describe("共有リンクからの起動 @smoke", () => {
 	 */
 	const WELL_FORMED_TOKEN = "s1_0123456789abcdefghijkl";
 
+	/**
+	 * ⚠️ **解決画面は «消える» 画面である。** ここを踏み外して 1 度 CI を赤くした。
+	 *
+	 * `app/s/[token].tsx` は mount した瞬間に resolve を投げ、返ってきたら即 `router.replace` する。
+	 * つまり `share-link-resolver` が出ているのは **resolve の往復の間だけ**。
+	 * 素直に書くと 2 か所で「往復の完了を待ってから」観測してしまい、必ず取り逃がす:
+	 *
+	 * 1. `launchAppWithSession` の既定 `waitForReady: true` は **タブバー**を待つ。
+	 *    タブバーは解決画面には無く、ホームへ落ちて初めて現れる。
+	 *    → 起動ヘルパを抜けた時点で解決画面は既に無い。だから `waitForReady: false` にする。
+	 * 2. Detox の同期機構は **進行中のネットワーク要求がある間アプリを busy と見なす**ため、
+	 *    matcher の評価を resolve 完了まで待ってしまう。
+	 *    → `setURLBlacklist` で resolve の URL だけ同期対象から外す（要求自体は普通に飛ぶ）。
+	 *
+	 * この 2 つを外して初めて「往復の最中」を観測できる。
+	 * 観測は `toExist` で行う（`toBeVisible` の 75% 面積判定は spinner 1 個の画面では余計な変数になる）。
+	 */
+	const RESOLVE_URL_PATTERN = ".*share-links.*";
+
+	beforeAll(async () => {
+		await device.setURLBlacklist([RESOLVE_URL_PATTERN]);
+	});
+
+	afterAll(async () => {
+		// 他の spec の同期を壊さないよう必ず戻す（Detox のこの設定はデバイス単位で残る）
+		await device.setURLBlacklist([]);
+	});
+
 	// ─ テストケース: /s/:token で起動すると解決画面まで届く ─
 	// 手順:
 	//   1. "nanitabeyo:///s/s1_..." を組み立てる（ロケールセグメントを持たない URL）
@@ -47,9 +75,14 @@ describe("共有リンクからの起動 @smoke", () => {
 	// 修正前はここで検索タブ（ホーム）が出る。つまりこのアサーションが
 	// 「ディープリンクが捨てられていない」ことの直接の証拠になる
 	it("ロケールを持たない /s/:token でもホームへ落ちず、解決画面まで届く", async () => {
-		await launchAppWithSession({ as: "anon", url: `${APP_SCHEME}:///s/${WELL_FORMED_TOKEN}` });
+		// waitForReady: false の理由は RESOLVE_URL_PATTERN のコメントを参照
+		await launchAppWithSession({
+			as: "anon",
+			url: `${APP_SCHEME}:///s/${WELL_FORMED_TOKEN}`,
+			waitForReady: false,
+		});
 
-		await waitUntilVisible(by.id("share-link-resolver"));
+		await waitUntilExists(by.id("share-link-resolver"));
 	});
 
 	// ─ テストケース: 解決に失敗しても白い画面で止まらない ─
@@ -60,10 +93,16 @@ describe("共有リンクからの起動 @smoke", () => {
 	// 共有リンクは «アプリを初めて触る人» が踏む導線なので、
 	// 解決できないときに解決画面で固まるのが一番損失が大きい
 	it("解決できないトークンではホームへ落とす（解決画面で固まらない）", async () => {
-		await launchAppWithSession({ as: "anon", url: `${APP_SCHEME}:///s/${WELL_FORMED_TOKEN}` });
+		await launchAppWithSession({
+			as: "anon",
+			url: `${APP_SCHEME}:///s/${WELL_FORMED_TOKEN}`,
+			waitForReady: false,
+		});
 
-		await waitUntilVisible(by.id("share-link-resolver"));
-		// deep-link.test.ts と同じ観測点。ここへ来ていれば「固まっていない」ことが言える
+		// deep-link.test.ts と同じ観測点。ここへ来ていれば「解決画面で固まっていない」ことが言える。
+		// ⚠️ ここで解決画面を先に待たないこと。1 本目が既にそれを見ており、
+		// このテストが見たいのは «その後ホームへ抜けるか» だけ。
+		// 往復が速い run では解決画面を取り逃がしうるので、待つと理由の無い flaky を足すことになる
 		await waitUntilVisible(by.id("search-header-title"));
 	});
 });

--- a/e2e-mobile/tests/smoke/share-link.test.ts
+++ b/e2e-mobile/tests/smoke/share-link.test.ts
@@ -73,7 +73,8 @@ describe("共有リンクからの起動 @smoke", () => {
 
 	beforeAll(async () => {
 		realToken = await createShareLinkToken();
-	}, 120_000);
+		// 推薦 + 検索 + 作成の 3 往復。カテゴリが 0 件なら次を試すので長めに取る
+	}, 300_000);
 
 	// ─ テストケース: 実在する /s/:token で起動すると、その行き先まで届く ─
 	// 手順:

--- a/e2e-mobile/tests/smoke/share-link.test.ts
+++ b/e2e-mobile/tests/smoke/share-link.test.ts
@@ -1,5 +1,6 @@
-import { by, launchAppWithSession, waitUntilExists, waitUntilVisible } from "../../fixtures/e2e";
+import { by, launchAppWithSession, waitUntilVisible } from "../../fixtures/e2e";
 import { APP_SCHEME } from "../../utils/locale";
+import { createShareLinkToken } from "../../utils/shareLink";
 
 /**
  * 🔗 共有リンク `/s/:token` からの起動（#721）@smoke
@@ -22,12 +23,18 @@ import { APP_SCHEME } from "../../utils/locale";
  * 判定そのものは `app-expo/lib/deepLinkTarget.test.ts` が純関数として全分岐を固定している。
  * ここで見るのは **その判定が実際の起動経路に効いているか**（ルーティングまで込みの結合）。
  *
- * ## なぜ「実在する共有リンク」を作らないのか
- * 実在トークンを使うには dev DB へ 1 行 INSERT する必要があり、@smoke の階層
- *（読み取りのみ・全ブラウザ相当で回す層）から外れてしまう。
- * ここで守りたい不変条件は「`/s/...` が **捨てられずに解決画面まで届く**」ことなので、
- * 解決に失敗するトークンでも成立する（解決画面は必ず 1 度描画される）。
- * 解決結果の遷移先は `app-expo/lib/shareLinkRoute.test.ts` が固定している。
+ * ## 「実在する共有リンク」を作る（当初は避けていた）
+ * 最初は dev DB への書き込みを避けたくて **解決できないトークン**で書いていたが、
+ * それでは「捨てられた」と「受け取って解決に失敗した」を区別できない（どちらもホームへ着地する）。
+ * 区別できる唯一の観測点だった «途中の解決画面» は速すぎて取り逃がす（下の JSDoc 参照）。
+ *
+ * そこで `POST /v1/share-links` で実在するリンクを 1 本作り、**着地先**を観測する。
+ * 共有リンクは API 経由でしか作れない（`preview_title` / `preview_image_path` を
+ * サーバ側 Resolver が作るため DB を直接いじる代替がない）。e2e-web の
+ * `tests/share/share-link-ogp.spec.ts` も同じことをしている。
+ * 追記されるのは共有リンク 1 行だけで他のテストと共有する状態は作らないため、@smoke に置いたままにする。
+ *
+ * 解決結果 → 遷移先の変換そのものは `app-expo/lib/shareLinkRoute.test.ts` が固定している。
  */
 describe("共有リンクからの起動 @smoke", () => {
 	/**
@@ -39,49 +46,47 @@ describe("共有リンクからの起動 @smoke", () => {
 	const WELL_FORMED_TOKEN = "s1_0123456789abcdefghijkl";
 
 	/**
-	 * ⚠️ **解決画面は «消える» 画面である。** ここを踏み外して 2 度 CI を赤くした。
+	 * ⚠️ **解決画面を観測点にしないこと。** ここを踏み外して 2 度 CI を赤くした。
 	 *
 	 * `app/s/[token].tsx` は mount した瞬間に resolve を投げ、返ってきたら即 `router.replace` する。
-	 * つまり `share-link-resolver` が出ているのは **resolve の往復の間だけ**。
+	 * つまり `share-link-resolver` が出ているのは **resolve の往復の間だけ**で、実測で数秒。
+	 * Detox は「アプリが idle になってから」matcher を評価するため **原理的に取り逃がす**
+	 * （`waitForReady` を外し `toExist` にしても 25 秒待って落ちた）。
 	 *
-	 * ## 1 度目: `waitForReady` が往復の完了を待っていた
-	 * `launchAppWithSession` の既定 `waitForReady: true` は **タブバー**を待つ。
-	 * タブバーは解決画面には無く、ホームへ落ちて初めて現れる。
-	 * つまり起動ヘルパを抜けた時点で解決画面は既に無く、その後 25 秒待っても出てこない。
-	 * → このファイルでは `waitForReady: false` で起動する。
+	 * ⚠️ `device.setURLBlacklist` で直そうとしないこと。あれは «実行中のアプリへの invoke» なので
+	 * `beforeAll`（まだアプリを起動していない）では届かず suite ごと落ちる。実際に落とした。
+	 * そもそも赤い run のログで Detox は待機中に「The app seems to be idle」と出しており、
+	 * 同期機構は往復をブロックしていない。原因は «速すぎる» ことだけである。
 	 *
-	 * ## 2 度目: `device.setURLBlacklist` を beforeAll で呼んだ
-	 * 「Detox の同期機構が resolve の往復の間アプリを busy と見なすのでは」と考えて
-	 * `beforeAll` で `setURLBlacklist` を呼んだが、**これはアプリへの invoke** であり、
-	 * まだアプリを起動していない `beforeAll` では届かず suite ごと 6 秒で落ちた
-	 * （`The following package could not be delivered: { type: 'invoke' }`）。
+	 * ## だから «実在する共有リンク» を使う
+	 * 解決できないトークンでは「捨てられた」と「受け取って解決に失敗した」を区別できない
+	 * （どちらもホームへ着地する）。実在するリンクなら着地先そのものが変わる:
 	 *
-	 * そもそもこの心配は不要だった。赤かった run のログで Detox は待機中に
-	 * **「The app seems to be idle」**と出しており（busy ではない）、
-	 * 同期機構は往復をブロックしていない。ブロッカーは `waitForReady` だけだった。
-	 * ⚠️ 同じ発想で `setURLBlacklist` を足し直さないこと。必要なら
-	 * `launchApp` の `detoxURLBlacklistRegex` 起動引数を使う（起動前に効かせられる唯一の口）。
+	 * - 捨てられた → ホーム（検索タブ）
+	 * - 受け取れた → 投稿画面（`posts-screen`）
 	 *
-	 * 観測は `toExist` で行う（`toBeVisible` の 75% 面積判定は spinner 1 個の画面では余計な変数になる）。
+	 * 着地先は過渡状態ではなく **留まる状態**なので、待てば必ず観測できる。
 	 */
 
-	// ─ テストケース: /s/:token で起動すると解決画面まで届く ─
+	/** この spec 用に作る実在の共有リンク（dish_media を 1 件指す） */
+	let realToken: string;
+
+	beforeAll(async () => {
+		realToken = await createShareLinkToken();
+	}, 120_000);
+
+	// ─ テストケース: 実在する /s/:token で起動すると、その行き先まで届く ─
 	// 手順:
-	//   1. "nanitabeyo:///s/s1_..." を組み立てる（ロケールセグメントを持たない URL）
-	//   2. そのディープリンクから直接起動する
-	//   3. 共有リンク解決画面（share-link-resolver）が描画されることを検証
+	//   1. 実在する dish_media を指す共有リンクを API で作る（beforeAll）
+	//   2. "nanitabeyo:///s/<token>" から直接起動する（ロケールセグメントを持たない URL）
+	//   3. 投稿画面（posts-screen）が表示されることを検証
 	//
 	// 修正前はここで検索タブ（ホーム）が出る。つまりこのアサーションが
 	// 「ディープリンクが捨てられていない」ことの直接の証拠になる
-	it("ロケールを持たない /s/:token でもホームへ落ちず、解決画面まで届く", async () => {
-		// waitForReady: false の理由は RESOLVE_URL_PATTERN のコメントを参照
-		await launchAppWithSession({
-			as: "anon",
-			url: `${APP_SCHEME}:///s/${WELL_FORMED_TOKEN}`,
-			waitForReady: false,
-		});
+	it("ロケールを持たない /s/:token でもホームへ落ちず、共有先まで届く", async () => {
+		await launchAppWithSession({ as: "anon", url: `${APP_SCHEME}:///s/${realToken}` });
 
-		await waitUntilExists(by.id("share-link-resolver"));
+		await waitUntilVisible(by.id("posts-screen"));
 	});
 
 	// ─ テストケース: 解決に失敗しても白い画面で止まらない ─
@@ -92,16 +97,10 @@ describe("共有リンクからの起動 @smoke", () => {
 	// 共有リンクは «アプリを初めて触る人» が踏む導線なので、
 	// 解決できないときに解決画面で固まるのが一番損失が大きい
 	it("解決できないトークンではホームへ落とす（解決画面で固まらない）", async () => {
-		await launchAppWithSession({
-			as: "anon",
-			url: `${APP_SCHEME}:///s/${WELL_FORMED_TOKEN}`,
-			waitForReady: false,
-		});
+		await launchAppWithSession({ as: "anon", url: `${APP_SCHEME}:///s/${WELL_FORMED_TOKEN}` });
 
 		// deep-link.test.ts と同じ観測点。ここへ来ていれば「解決画面で固まっていない」ことが言える。
-		// ⚠️ ここで解決画面を先に待たないこと。1 本目が既にそれを見ており、
-		// このテストが見たいのは «その後ホームへ抜けるか» だけ。
-		// 往復が速い run では解決画面を取り逃がしうるので、待つと理由の無い flaky を足すことになる
+		// ⚠️ ここで解決画面を先に待たないこと。速すぎて取り逃がすだけで、理由の無い flaky になる
 		await waitUntilVisible(by.id("search-header-title"));
 	});
 });

--- a/e2e-mobile/tests/smoke/share-link.test.ts
+++ b/e2e-mobile/tests/smoke/share-link.test.ts
@@ -1,4 +1,4 @@
-import { by, device, launchAppWithSession, waitUntilExists, waitUntilVisible } from "../../fixtures/e2e";
+import { by, launchAppWithSession, waitUntilExists, waitUntilVisible } from "../../fixtures/e2e";
 import { APP_SCHEME } from "../../utils/locale";
 
 /**
@@ -39,32 +39,31 @@ describe("共有リンクからの起動 @smoke", () => {
 	const WELL_FORMED_TOKEN = "s1_0123456789abcdefghijkl";
 
 	/**
-	 * ⚠️ **解決画面は «消える» 画面である。** ここを踏み外して 1 度 CI を赤くした。
+	 * ⚠️ **解決画面は «消える» 画面である。** ここを踏み外して 2 度 CI を赤くした。
 	 *
 	 * `app/s/[token].tsx` は mount した瞬間に resolve を投げ、返ってきたら即 `router.replace` する。
 	 * つまり `share-link-resolver` が出ているのは **resolve の往復の間だけ**。
-	 * 素直に書くと 2 か所で「往復の完了を待ってから」観測してしまい、必ず取り逃がす:
 	 *
-	 * 1. `launchAppWithSession` の既定 `waitForReady: true` は **タブバー**を待つ。
-	 *    タブバーは解決画面には無く、ホームへ落ちて初めて現れる。
-	 *    → 起動ヘルパを抜けた時点で解決画面は既に無い。だから `waitForReady: false` にする。
-	 * 2. Detox の同期機構は **進行中のネットワーク要求がある間アプリを busy と見なす**ため、
-	 *    matcher の評価を resolve 完了まで待ってしまう。
-	 *    → `setURLBlacklist` で resolve の URL だけ同期対象から外す（要求自体は普通に飛ぶ）。
+	 * ## 1 度目: `waitForReady` が往復の完了を待っていた
+	 * `launchAppWithSession` の既定 `waitForReady: true` は **タブバー**を待つ。
+	 * タブバーは解決画面には無く、ホームへ落ちて初めて現れる。
+	 * つまり起動ヘルパを抜けた時点で解決画面は既に無く、その後 25 秒待っても出てこない。
+	 * → このファイルでは `waitForReady: false` で起動する。
 	 *
-	 * この 2 つを外して初めて「往復の最中」を観測できる。
+	 * ## 2 度目: `device.setURLBlacklist` を beforeAll で呼んだ
+	 * 「Detox の同期機構が resolve の往復の間アプリを busy と見なすのでは」と考えて
+	 * `beforeAll` で `setURLBlacklist` を呼んだが、**これはアプリへの invoke** であり、
+	 * まだアプリを起動していない `beforeAll` では届かず suite ごと 6 秒で落ちた
+	 * （`The following package could not be delivered: { type: 'invoke' }`）。
+	 *
+	 * そもそもこの心配は不要だった。赤かった run のログで Detox は待機中に
+	 * **「The app seems to be idle」**と出しており（busy ではない）、
+	 * 同期機構は往復をブロックしていない。ブロッカーは `waitForReady` だけだった。
+	 * ⚠️ 同じ発想で `setURLBlacklist` を足し直さないこと。必要なら
+	 * `launchApp` の `detoxURLBlacklistRegex` 起動引数を使う（起動前に効かせられる唯一の口）。
+	 *
 	 * 観測は `toExist` で行う（`toBeVisible` の 75% 面積判定は spinner 1 個の画面では余計な変数になる）。
 	 */
-	const RESOLVE_URL_PATTERN = ".*share-links.*";
-
-	beforeAll(async () => {
-		await device.setURLBlacklist([RESOLVE_URL_PATTERN]);
-	});
-
-	afterAll(async () => {
-		// 他の spec の同期を壊さないよう必ず戻す（Detox のこの設定はデバイス単位で残る）
-		await device.setURLBlacklist([]);
-	});
 
 	// ─ テストケース: /s/:token で起動すると解決画面まで届く ─
 	// 手順:

--- a/e2e-mobile/utils/savedDishCategory.ts
+++ b/e2e-mobile/utils/savedDishCategory.ts
@@ -1,0 +1,246 @@
+import * as path from "node:path";
+
+import { createClient } from "@supabase/supabase-js";
+import * as dotenv from "dotenv";
+
+import { readSessionFromEnv } from "./sessionEnv";
+
+/**
+ * 🍽 「テストユーザーが料理カテゴリを 1 件以上保存している」という前提を **テスト自身が作る**（#1133）
+ *
+ * ## なぜ要るのか（CI で実際に赤くなった）
+ * `tests/profile/saved-topic-location-search.test.ts` の入口は
+ * **保存した料理カテゴリのカードだけ**で、0 件だとモーダルを開けない。
+ * 当初は「TEST_USER_* に 1 件保存しておくこと」を fail-loud のメッセージで人へ依頼していたが、
+ * これは **環境に前提を置いたテスト**で、次の 2 つの意味で壊れる:
+ *
+ * - 誰かがマイページから保存を外すと、コード変更ゼロで CI が赤くなる
+ * - 新しく作られた dev 環境／別のテストユーザーでは最初から赤い
+ *
+ * e2e-web 側は一覧 API をスタブしてこの依存を消しているが、Detox に
+ * ネットワークをスタブする手段が無い。そこで **前提そのものをテストが用意する**。
+ *
+ * ## どうやって保存するか（アプリと同じ経路）
+ * 「保存」は API ではなく **supabase の `reactions` へ直接 INSERT** で表現されている
+ * （app-expo/lib/reactions.ts / target_type=dish_categories, action_type=save）。
+ * 一覧 API 側も `reactions` を引いて `dish_categories` を join するだけ
+ * （api/src/v1/dish-categories/dish-categories.repository.ts）。
+ * よってここでも同じ形の行を 1 件入れる。RLS は「自分の行だけ」を許可しているので、
+ * テストユーザーのアクセストークンをそのまま使えば、他人のデータには触れない。
+ *
+ * ## カテゴリ ID の入手先
+ * `dish_categories` は RLS 有効かつポリシー未定義（= anon/authenticated からは読めない）ため、
+ * supabase 経由では 1 件も引けない。実在する ID は
+ * `GET /v1/dish-categories/recommendations` から取る（アプリの検索画面と同じ API）。
+ * 適当な UUID を入れても一覧 API の join で消えるだけなので、**実在の ID である必要がある**。
+ *
+ * ## 後始末（ここが肝）
+ * 入れた行は spec の `afterAll` で **自分が入れた 1 件だけ**消す。
+ * 元から保存があった場合は **何も書かない / 何も消さない**。
+ * テストが dev DB の状態を恒久的に変えないようにするための約束で、
+ * `ensureSavedDishCategory()` の戻り値（= 入れたかどうか）を必ず
+ * `cleanupSeededDishCategory()` へ渡すこと。
+ *
+ * ## セキュリティ
+ * トークンは **ログへ出さない**（このモジュールは成否と件数しか出力しない）。
+ */
+
+/** 保存リアクションの形（アプリ側 lib/reactions.ts と同じ組み合わせ） */
+const SAVE_REACTION = {
+	target_type: "dish_categories",
+	action_type: "save",
+} as const;
+
+/**
+ * 推薦 API へ渡す住所トークン。
+ *
+ * 実在の料理カテゴリを 1 件返してくれさえすればよいので、候補が枯れない都市を固定で使う。
+ * `country:` だけだと候補の当たり外れが大きいため locality まで指定する
+ * （形式は QueryDishCategoryRecommendationsDto の doc コメントに準拠）。
+ */
+const SEED_ADDRESS = "country:JP, administrative_area_level_1:Tokyo, locality:Tokyo";
+
+/** 種まきの結果。`null` は「元から保存があったので何もしなかった」を意味する */
+export type SeededDishCategory = { categoryId: string } | null;
+
+type SeedEnv = {
+	supabaseUrl: string;
+	supabaseAnonKey: string;
+	dbSchema: string;
+	backendBaseUrl: string;
+};
+
+/**
+ * 接続情報を環境変数から読む。
+ *
+ * globalSetup が既に読み込み済みだが、ワーカー単独起動でも動くよう同じ 2 ファイルを読む
+ * （dotenv は既存値を上書きしないため CI の secrets が常に優先される。utils/disposableSession.ts と同じ）。
+ */
+function loadSeedEnv(): SeedEnv {
+	dotenv.config({ path: path.resolve(__dirname, "../../app-expo/.env") });
+	dotenv.config({ path: path.resolve(__dirname, "../.env") });
+
+	const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+	const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+	// ⚠️ アプリの supabase client は `db.schema` を Env.DB_SCHEMA で切り替える（app-expo/lib/supabase.ts）。
+	// ここで同じスキーマを見ないと「書いたのにアプリからは見えない」という最悪の食い違いになる
+	const dbSchema = process.env.EXPO_PUBLIC_DB_SCHEMA;
+	const backendBaseUrl = process.env.EXPO_PUBLIC_BACKEND_BASE_URL;
+
+	const missing = [
+		["EXPO_PUBLIC_SUPABASE_URL", supabaseUrl],
+		["EXPO_PUBLIC_SUPABASE_ANON_KEY", supabaseAnonKey],
+		["EXPO_PUBLIC_DB_SCHEMA", dbSchema],
+		["EXPO_PUBLIC_BACKEND_BASE_URL", backendBaseUrl],
+	]
+		.filter(([, value]) => !value)
+		.map(([name]) => name);
+
+	if (missing.length > 0) {
+		throw new Error(
+			[
+				`保存済み料理カテゴリの種まきに必要な環境変数が足りません: ${missing.join(", ")}`,
+				"  ローカルでは `cd app-expo && pnpx eas-cli env:pull development --path .env` を実行してください。",
+			].join("\n"),
+		);
+	}
+
+	return {
+		supabaseUrl: supabaseUrl!,
+		supabaseAnonKey: supabaseAnonKey!,
+		dbSchema: dbSchema!,
+		backendBaseUrl: backendBaseUrl!,
+	};
+}
+
+/**
+ * テストユーザーとして PostgREST を叩く client を作る。
+ *
+ * `setSession()` ではなく **Authorization ヘッダ直挿し**にしているのは、
+ * client にセッションを持たせると refresh token をローテーションしてしまい、
+ * 端末へ注入済みのセッションを失効させうるため（utils/disposableSession.ts の M-4 と同じ理由）。
+ */
+function createUserScopedClient(env: SeedEnv, accessToken: string) {
+	return createClient(env.supabaseUrl, env.supabaseAnonKey, {
+		auth: { persistSession: false, autoRefreshToken: false },
+		db: { schema: env.dbSchema },
+		global: { headers: { Authorization: `Bearer ${accessToken}` } },
+	});
+}
+
+/** 推薦 API から実在する料理カテゴリ ID を 1 つ取る */
+async function fetchAnyDishCategoryId(env: SeedEnv, accessToken: string): Promise<string> {
+	const url = new URL(`${env.backendBaseUrl}/v1/dish-categories/recommendations`);
+	url.searchParams.set("address", SEED_ADDRESS);
+	url.searchParams.set("languageTag", "ja-JP");
+	url.searchParams.set("localLanguageCode", "ja");
+
+	const response = await fetch(url, {
+		method: "GET",
+		headers: { Authorization: `Bearer ${accessToken}` },
+		// 推薦はスコアリング + 翻訳を挟むので素の fetch の既定より長めに待つ
+		signal: AbortSignal.timeout(60_000),
+	});
+
+	if (!response.ok) {
+		throw new Error(
+			`料理カテゴリの推薦取得に失敗しました（status=${response.status}）。` +
+				` API（${env.backendBaseUrl}）が起きているか、EXPO_PUBLIC_BACKEND_BASE_URL の向き先を確認してください。`,
+		);
+	}
+
+	const body = (await response.json()) as { data?: { categoryId?: string }[] };
+	const categoryId = body.data?.find((item) => typeof item.categoryId === "string" && item.categoryId)?.categoryId;
+
+	if (!categoryId) {
+		throw new Error(
+			"料理カテゴリの推薦が 0 件でした。dev の dish_categories / dish_category_features が空でないか確認してください。",
+		);
+	}
+
+	return categoryId;
+}
+
+/**
+ * テストユーザーに保存済み料理カテゴリが 1 件以上ある状態を保証する。
+ *
+ * @returns このテストが入れた行（`{ categoryId }`）。元から保存があった場合は `null`
+ * @失敗時 日本語メッセージで例外を投げる（fail-loud）。前提が作れないまま本体を走らせても
+ *         「保存が 0 件」と同じ分かりにくい失敗になるだけなので、ここで止める
+ */
+export async function ensureSavedDishCategory(): Promise<SeededDishCategory> {
+	const session = readSessionFromEnv("authenticated");
+	if (!session) {
+		throw new Error(
+			"認証済みセッションが確立されていません。TEST_USER_EMAIL / TEST_USER_PASSWORD を設定してください（describeAuthenticated で skip されるはずの経路です）。",
+		);
+	}
+
+	const env = loadSeedEnv();
+	const client = createUserScopedClient(env, session.accessToken);
+
+	// 既に保存があるなら書かない。dev DB を触る回数は少ないほどよい
+	const { data: existing, error: selectError } = await client
+		.from("reactions")
+		.select("target_id")
+		.eq("user_id", session.userId)
+		.eq("target_type", SAVE_REACTION.target_type)
+		.eq("action_type", SAVE_REACTION.action_type)
+		.limit(1);
+
+	if (selectError) {
+		throw new Error(`保存済み料理カテゴリの確認に失敗しました: ${selectError.message}`);
+	}
+	if (existing && existing.length > 0) return null;
+
+	const categoryId = await fetchAnyDishCategoryId(env, session.accessToken);
+
+	const { error: insertError } = await client.from("reactions").insert({
+		user_id: session.userId,
+		target_type: SAVE_REACTION.target_type,
+		target_id: categoryId,
+		action_type: SAVE_REACTION.action_type,
+		created_at: new Date().toISOString(),
+		// アプリは Env.APP_VERSION を入れる。ここは「E2E が入れた行」だと一目で分かる値にする
+		created_version: "e2e-mobile",
+		lock_no: 0,
+	});
+
+	if (insertError) {
+		throw new Error(`保存済み料理カテゴリの種まきに失敗しました: ${insertError.message}`);
+	}
+
+	return { categoryId };
+}
+
+/**
+ * `ensureSavedDishCategory()` が入れた行を消す。
+ *
+ * @param seeded `ensureSavedDishCategory()` の戻り値をそのまま渡す。`null` なら何もしない
+ * @失敗時 例外を投げずに警告だけ出す。後始末の失敗でテスト結果を赤くすると
+ *         **本体の合否が読めなくなる**ため（残っても次回は「元から保存あり」として扱われるだけ）
+ */
+export async function cleanupSeededDishCategory(seeded: SeededDishCategory): Promise<void> {
+	if (!seeded) return;
+
+	const session = readSessionFromEnv("authenticated");
+	if (!session) return;
+
+	try {
+		const env = loadSeedEnv();
+		const client = createUserScopedClient(env, session.accessToken);
+		const { error } = await client
+			.from("reactions")
+			.delete()
+			.eq("user_id", session.userId)
+			.eq("target_type", SAVE_REACTION.target_type)
+			.eq("target_id", seeded.categoryId)
+			.eq("action_type", SAVE_REACTION.action_type);
+
+		if (error) {
+			console.warn(`⚠️ 種まきした保存済み料理カテゴリの削除に失敗しました: ${error.message}`);
+		}
+	} catch (error) {
+		console.warn(`⚠️ 種まきした保存済み料理カテゴリの削除に失敗しました: ${(error as Error).message}`);
+	}
+}

--- a/e2e-mobile/utils/savedDishCategory.ts
+++ b/e2e-mobile/utils/savedDishCategory.ts
@@ -139,8 +139,17 @@ function createUserScopedClient(env: SeedEnv, accessToken: string) {
 	});
 }
 
-/** 推薦 API から実在する料理カテゴリ ID を 1 つ取る */
-async function fetchAnyDishCategoryId(env: SeedEnv, accessToken: string): Promise<string> {
+/**
+ * 推薦 API から実在する料理カテゴリ ID を取る。
+ *
+ * ⚠️ `dish_categories` は RLS 有効かつポリシー未定義（anon/authenticated からは 1 件も読めない）ため、
+ * **実在の ID を得る経路はこの API しかない**。共有リンクの spec（utils/shareLink.ts）も
+ * dish_media の検索に categoryId が要るのでこれを使う。だから export している。
+ *
+ * @param max 返す件数の上限。呼び出し側が «当たり» を探して回れるように複数返せるようにしている
+ */
+export async function fetchDishCategoryIds(accessToken: string, max = 5): Promise<string[]> {
+	const env = loadSeedEnv();
 	const url = new URL(`${env.backendBaseUrl}/v1/dish-categories/recommendations`);
 	url.searchParams.set("address", SEED_ADDRESS);
 	url.searchParams.set("languageTag", "ja-JP");
@@ -161,15 +170,18 @@ async function fetchAnyDishCategoryId(env: SeedEnv, accessToken: string): Promis
 	}
 
 	const body = (await response.json()) as { data?: { categoryId?: string }[] };
-	const categoryId = body.data?.find((item) => typeof item.categoryId === "string" && item.categoryId)?.categoryId;
+	const ids = (body.data ?? [])
+		.map((item) => item.categoryId)
+		.filter((id): id is string => typeof id === "string" && id.length > 0)
+		.slice(0, max);
 
-	if (!categoryId) {
+	if (ids.length === 0) {
 		throw new Error(
 			"料理カテゴリの推薦が 0 件でした。dev の dish_categories / dish_category_features が空でないか確認してください。",
 		);
 	}
 
-	return categoryId;
+	return ids;
 }
 
 /**
@@ -204,7 +216,7 @@ export async function ensureSavedDishCategory(): Promise<SeededDishCategory> {
 	}
 	if (existing && existing.length > 0) return null;
 
-	const categoryId = await fetchAnyDishCategoryId(env, session.accessToken);
+	const [categoryId] = await fetchDishCategoryIds(session.accessToken, 1);
 
 	const { error: insertError } = await client.from("reactions").insert({
 		user_id: session.userId,

--- a/e2e-mobile/utils/savedDishCategory.ts
+++ b/e2e-mobile/utils/savedDishCategory.ts
@@ -34,12 +34,20 @@ import { readSessionFromEnv } from "./sessionEnv";
  * `GET /v1/dish-categories/recommendations` から取る（アプリの検索画面と同じ API）。
  * 適当な UUID を入れても一覧 API の join で消えるだけなので、**実在の ID である必要がある**。
  *
- * ## 後始末（ここが肝）
- * 入れた行は spec の `afterAll` で **自分が入れた 1 件だけ**消す。
- * 元から保存があった場合は **何も書かない / 何も消さない**。
- * テストが dev DB の状態を恒久的に変えないようにするための約束で、
- * `ensureSavedDishCategory()` の戻り値（= 入れたかどうか）を必ず
- * `cleanupSeededDishCategory()` へ渡すこと。
+ * ## ⚠️ 入れた行は «消さない»（後始末をしない方が正しい理由）
+ * 最初は `afterAll` で自分が入れた 1 件を消す設計にしていたが、これは壊れる。
+ * `e2e-mobile-test.yml` は Android と iOS の 2 ジョブを **同時に**走らせるため、
+ *
+ * - 両方が同じカテゴリを引くと 2 本目の INSERT が UNIQUE 制約に当たる
+ * - 片方の `afterAll` が、まだ走っている **もう片方が使っている行**を消してしまう
+ *
+ * という競合が起きる。そもそもここで作りたいのは「テストユーザーが料理カテゴリを
+ * 1 件以上保存している」という **恒常的な前提**であって、run ごとの一時データではない。
+ * 消さなければ状態は «前提が満たされている» に収束し、2 回目以降の run は
+ * 「元から保存がある」経路を通って **書き込みすら発生しない**。
+ *
+ * 残るのは dev のテストユーザーに保存が 1 件増えることだけで、これは
+ * 以前この spec が «人手でやっておいてください» と依頼していた状態そのものである。
  *
  * ## セキュリティ
  * トークンは **ログへ出さない**（このモジュールは成否と件数しか出力しない）。
@@ -60,7 +68,10 @@ const SAVE_REACTION = {
  */
 const SEED_ADDRESS = "country:JP, administrative_area_level_1:Tokyo, locality:Tokyo";
 
-/** 種まきの結果。`null` は「元から保存があったので何もしなかった」を意味する */
+/** PostgreSQL の unique_violation。「既に保存済み」＝ 前提が満たされている、と読み替える */
+const UNIQUE_VIOLATION = "23505";
+
+/** 種まきの結果。`null` は「元から保存があったので何もしなかった」を意味する（ログ用） */
 export type SeededDishCategory = { categoryId: string } | null;
 
 type SeedEnv = {
@@ -206,41 +217,11 @@ export async function ensureSavedDishCategory(): Promise<SeededDishCategory> {
 		lock_no: 0,
 	});
 
-	if (insertError) {
+	// ⚠️ Android / iOS ジョブが同時に同じカテゴリを引くと UNIQUE (user_id, target_type,
+	// target_id, action_type) に当たる。これは «既に前提が満たされた» と同じ意味なので成功扱いにする
+	if (insertError && insertError.code !== UNIQUE_VIOLATION) {
 		throw new Error(`保存済み料理カテゴリの種まきに失敗しました: ${insertError.message}`);
 	}
 
-	return { categoryId };
-}
-
-/**
- * `ensureSavedDishCategory()` が入れた行を消す。
- *
- * @param seeded `ensureSavedDishCategory()` の戻り値をそのまま渡す。`null` なら何もしない
- * @失敗時 例外を投げずに警告だけ出す。後始末の失敗でテスト結果を赤くすると
- *         **本体の合否が読めなくなる**ため（残っても次回は「元から保存あり」として扱われるだけ）
- */
-export async function cleanupSeededDishCategory(seeded: SeededDishCategory): Promise<void> {
-	if (!seeded) return;
-
-	const session = readSessionFromEnv("authenticated");
-	if (!session) return;
-
-	try {
-		const env = loadSeedEnv();
-		const client = createUserScopedClient(env, session.accessToken);
-		const { error } = await client
-			.from("reactions")
-			.delete()
-			.eq("user_id", session.userId)
-			.eq("target_type", SAVE_REACTION.target_type)
-			.eq("target_id", seeded.categoryId)
-			.eq("action_type", SAVE_REACTION.action_type);
-
-		if (error) {
-			console.warn(`⚠️ 種まきした保存済み料理カテゴリの削除に失敗しました: ${error.message}`);
-		}
-	} catch (error) {
-		console.warn(`⚠️ 種まきした保存済み料理カテゴリの削除に失敗しました: ${(error as Error).message}`);
-	}
+	return insertError ? null : { categoryId };
 }

--- a/e2e-mobile/utils/shareLink.ts
+++ b/e2e-mobile/utils/shareLink.ts
@@ -1,0 +1,119 @@
+import * as path from "node:path";
+
+import * as dotenv from "dotenv";
+
+import { readSessionFromEnv } from "./sessionEnv";
+
+/**
+ * 🔗 Detox から «実在する共有リンク» を 1 本作る（#721）
+ *
+ * ## なぜ実在するリンクが要るのか（2 度 CI を赤くして辿り着いた）
+ * 「`/s/:token` がディープリンクとして捨てられていないこと」を見たいのだが、
+ * **解決に失敗するトークンでは «捨てられた» と «受け取って解決に失敗した» を区別できない**。
+ * どちらも最終的にホームへ着地するからである。
+ *
+ * 当初は途中に一瞬出る解決画面（`share-link-resolver`）を観測して区別していたが、
+ * あの画面は resolve の往復の間しか存在せず、実測で往復は数秒。
+ * Detox は「アプリが idle になってから」matcher を評価するため、
+ * **原理的に取り逃がす**（実際に 25 秒待って 2 回落ちた）。
+ *
+ * 実在するリンクなら着地先が変わる:
+ * - 捨てられた → ホーム（検索タブ）
+ * - 受け取れた → 投稿画面（`posts-screen`）
+ *
+ * これは過渡状態ではなく **留まる状態**なので、待てば必ず観測できる。
+ *
+ * ## 書き込みについて
+ * `POST /v1/share-links` は dev DB へ 1 行 append する。
+ * e2e-web の `tests/share/share-link-ogp.spec.ts` も同じことをしており
+ * （`e2e-web/utils/shareLinks.ts`）、共有リンクは **API 経由でしか作れない**
+ * （`preview_title` / `preview_image_path` をサーバ側 Resolver が作るため、
+ *  DB を直接いじる代替がない）。他のテストと共有する状態は作らないので tier は据え置く。
+ *
+ * ## セキュリティ
+ * トークン（Supabase / 共有リンクとも）は **ログへ出さない**。
+ */
+
+/** 環境変数から API のベース URL を読む。app へ焼き込まれるものと同じ値 */
+function apiBase(): string {
+	dotenv.config({ path: path.resolve(__dirname, "../../app-expo/.env") });
+	dotenv.config({ path: path.resolve(__dirname, "../.env") });
+
+	const base = process.env.EXPO_PUBLIC_BACKEND_BASE_URL;
+	if (!base) {
+		throw new Error(
+			[
+				"EXPO_PUBLIC_BACKEND_BASE_URL が未設定です。",
+				"  ローカルでは `cd app-expo && pnpx eas-cli env:pull development --path .env` を実行してください。",
+			].join("\n"),
+		);
+	}
+	return base.replace(/\/+$/, "");
+}
+
+/**
+ * 検索レスポンスから dish_media の ID を 1 件取り出す。
+ *
+ * レスポンス形（`data.data[].dish_media.id` か `data[].id` か）は API の版で揺れるので、
+ * どちらでも拾えるようにしておく。ここで固定すると、無関係な API 変更でこの spec が落ちる
+ * （e2e-web/utils/shareLinks.ts と同じ判断。写しであることを承知で置いている）。
+ */
+function extractFirstDishMediaId(body: unknown): string | null {
+	const data = (body as { data?: unknown }).data;
+	const list = Array.isArray(data) ? data : ((data as { data?: unknown[] })?.data ?? []);
+	const first = Array.isArray(list) ? list[0] : undefined;
+	if (!first || typeof first !== "object") return null;
+	const nested = (first as { dish_media?: { id?: string } }).dish_media?.id;
+	return nested ?? (first as { id?: string }).id ?? null;
+}
+
+/**
+ * 実在する dish_media を 1 件拾って共有リンクを作る。
+ *
+ * ⚠️ ID を固定値でハードコードしないこと。dev DB の中身は入れ替わるため、
+ * 固定 ID は「ある日突然 404 で落ちる」テストになる。
+ *
+ * @returns 作成した共有リンクの token
+ * @失敗時 日本語メッセージで例外を投げる（fail-loud）
+ */
+export async function createShareLinkToken(): Promise<string> {
+	const session = readSessionFromEnv("anon");
+	if (!session) {
+		throw new Error("匿名セッションが確立されていません（fixtures/globalSetup.ts を確認してください）。");
+	}
+
+	const base = apiBase();
+	const headers = {
+		Authorization: `Bearer ${session.accessToken}`,
+		"Content-Type": "application/json",
+	};
+
+	const searchResponse = await fetch(`${base}/v1/dish-media?limit=1`, {
+		method: "GET",
+		headers,
+		signal: AbortSignal.timeout(60_000),
+	});
+	if (!searchResponse.ok) {
+		throw new Error(`dish_media の取得に失敗しました: status=${searchResponse.status}`);
+	}
+	const dishMediaId = extractFirstDishMediaId(await searchResponse.json());
+	if (!dishMediaId) {
+		throw new Error("dev の dish_media が 0 件のため共有リンクを作れません（前提条件の不足であってバグではない）。");
+	}
+
+	const createResponse = await fetch(`${base}/v1/share-links`, {
+		method: "POST",
+		headers,
+		body: JSON.stringify({ target: { type: "dish_media", params: { ids: [dishMediaId] } }, locale: "ja-JP" }),
+		signal: AbortSignal.timeout(60_000),
+	});
+	if (!createResponse.ok) {
+		throw new Error(`共有リンクの作成に失敗しました: status=${createResponse.status}`);
+	}
+
+	const created = (await createResponse.json()) as { data?: { token?: string } };
+	const token = created.data?.token;
+	if (!token) throw new Error("共有リンクの作成レスポンスに token がありません。");
+
+	return token;
+}

--- a/e2e-mobile/utils/shareLink.ts
+++ b/e2e-mobile/utils/shareLink.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 
 import * as dotenv from "dotenv";
 
+import { fetchDishCategoryIds } from "./savedDishCategory";
 import { readSessionFromEnv } from "./sessionEnv";
 
 /**
@@ -51,12 +52,16 @@ function apiBase(): string {
 	return base.replace(/\/+$/, "");
 }
 
+/** 検索の中心。dev にデータが集まっている都心を固定で使う（東京駅） */
+const SEARCH_LOCATION = "35.681236,139.767125";
+/** 検索半径 (m)。狭すぎると 0 件になり、広すぎても API が重くなるだけ */
+const SEARCH_RADIUS = 5000;
+
 /**
  * 検索レスポンスから dish_media の ID を 1 件取り出す。
  *
  * レスポンス形（`data.data[].dish_media.id` か `data[].id` か）は API の版で揺れるので、
- * どちらでも拾えるようにしておく。ここで固定すると、無関係な API 変更でこの spec が落ちる
- * （e2e-web/utils/shareLinks.ts と同じ判断。写しであることを承知で置いている）。
+ * どちらでも拾えるようにしておく。ここで固定すると、無関係な API 変更でこの spec が落ちる。
  */
 function extractFirstDishMediaId(body: unknown): string | null {
 	const data = (body as { data?: unknown }).data;
@@ -65,6 +70,45 @@ function extractFirstDishMediaId(body: unknown): string | null {
 	if (!first || typeof first !== "object") return null;
 	const nested = (first as { dish_media?: { id?: string } }).dish_media?.id;
 	return nested ?? (first as { id?: string }).id ?? null;
+}
+
+/**
+ * 実在する dish_media を 1 件探す。
+ *
+ * ⚠️ `GET /v1/dish-media` は **ids 指定の取得専用**で、`limit` だけ渡すと 400 になる
+ * （`QueryDishMediaByIdsDto.ids` が必須。e2e-web/utils/shareLinks.ts はここを間違えている）。
+ * 一覧は `GET /v1/dish-media/search` で、`location` / `radius` / `categoryId` が必須。
+ *
+ * カテゴリによっては 0 件のことがあるので、推薦の上位いくつかを順に試す。
+ */
+async function findAnyDishMediaId(base: string, headers: Record<string, string>, accessToken: string): Promise<string> {
+	const categoryIds = await fetchDishCategoryIds(accessToken, 5);
+	const tried: string[] = [];
+
+	for (const categoryId of categoryIds) {
+		const url = new URL(`${base}/v1/dish-media/search`);
+		url.searchParams.set("location", SEARCH_LOCATION);
+		url.searchParams.set("radius", String(SEARCH_RADIUS));
+		url.searchParams.set("categoryId", categoryId);
+		url.searchParams.set("limit", "1");
+
+		const response = await fetch(url, { method: "GET", headers, signal: AbortSignal.timeout(60_000) });
+		if (!response.ok) {
+			tried.push(`${categoryId}: status=${response.status}`);
+			continue;
+		}
+		const id = extractFirstDishMediaId(await response.json());
+		if (id) return id;
+		tried.push(`${categoryId}: 0 件`);
+	}
+
+	throw new Error(
+		[
+			"共有リンクの対象にできる dish_media が見つかりませんでした（前提条件の不足であってバグではない）。",
+			`  検索: location=${SEARCH_LOCATION} radius=${SEARCH_RADIUS}`,
+			...tried.map((line) => `  - ${line}`),
+		].join("\n"),
+	);
 }
 
 /**
@@ -88,18 +132,7 @@ export async function createShareLinkToken(): Promise<string> {
 		"Content-Type": "application/json",
 	};
 
-	const searchResponse = await fetch(`${base}/v1/dish-media?limit=1`, {
-		method: "GET",
-		headers,
-		signal: AbortSignal.timeout(60_000),
-	});
-	if (!searchResponse.ok) {
-		throw new Error(`dish_media の取得に失敗しました: status=${searchResponse.status}`);
-	}
-	const dishMediaId = extractFirstDishMediaId(await searchResponse.json());
-	if (!dishMediaId) {
-		throw new Error("dev の dish_media が 0 件のため共有リンクを作れません（前提条件の不足であってバグではない）。");
-	}
+	const dishMediaId = await findAnyDishMediaId(base, headers, session.accessToken);
 
 	const createResponse = await fetch(`${base}/v1/share-links`, {
 		method: "POST",

--- a/e2e-web/tests/profile/saved-topic-location-search.spec.ts
+++ b/e2e-web/tests/profile/saved-topic-location-search.spec.ts
@@ -104,7 +104,9 @@ test.describe("保存料理カテゴリからの地点検索(#1133)", () => {
 			[1, 2, 3, 4, 5].map((n) => ({
 				locationQuery: `テスト地点${n}`,
 				location: { latitude: 35.6 + n / 100, longitude: 139.7 + n / 100 },
-				address: `東京都テスト区${n}`,
+				// ⚠️ 表示用の住所ではなく «推薦 API 用のトークン列»。#1196 以降、正規形式でない
+				// エントリはアプリが読み出し時に捨てるため、ここを崩すとパネルが 0 件になる
+				address: `country:JP, administrative_area_level_1:Tokyo, locality:Test${n}`,
 				localLanguageCode: "ja",
 			})),
 		);
@@ -150,7 +152,10 @@ test.describe("保存料理カテゴリからの地点検索(#1133)", () => {
 		// Card の overflow: hidden で本当にクリップされたら scrollIntoViewIfNeeded では出てこない。
 		const lastItem = profilePage.locationModalRecentLocation(4);
 		await lastItem.scrollIntoViewIfNeeded();
-		await expect(lastItem, "5 件目の「最近使った場所」がスクロールしても見えない（Card に切り取られている）").toBeVisible();
+		await expect(
+			lastItem,
+			"5 件目の「最近使った場所」がスクロールしても見えない（Card に切り取られている）",
+		).toBeVisible();
 
 		const lastItemBox = await lastItem.boundingBox();
 		expect(lastItemBox, "5 件目の「最近使った場所」が描画されていない").not.toBeNull();

--- a/e2e-web/utils/storage.ts
+++ b/e2e-web/utils/storage.ts
@@ -68,9 +68,38 @@ export const RECENT_LOCATIONS_STORAGE_KEY = "recent_locations_v1";
 export type SeededRecentLocation = {
 	locationQuery: string;
 	location: { latitude: number; longitude: number };
+	/**
+	 * ⚠️ **推薦 API 用の «機械可読なトークン列»。表示用の住所ではない。**
+	 * 例: `"country:JP, administrative_area_level_1:Tokyo, locality:Shibuya"`
+	 * 詳細と判定の正は `app-expo/lib/addressFormat.ts`（`isCanonicalAddress`）。
+	 */
 	address?: string;
 	localLanguageCode?: string;
 };
+
+/**
+ * シードした address が、アプリに «読み捨てられない» 形式かどうか。
+ *
+ * ## なぜこの検査が要るのか（実際に踏んだ）
+ * #1196 で `useRecentLocations` は読み出し時に `isCanonicalAddress` で検査し、
+ * 正規形式でないエントリを **黙って捨てる**ようになった。
+ * `address: "東京都テスト区1"` のような «表示用に見える» 文字列でシードすると、
+ * 5 件積んだつもりでも 0 件になり、症状は
+ * **「最近使った場所パネルが出てこない」というタイムアウトだけ**になる。
+ * seed 側が原因だと気付けず、実際にマージ後の nightly を 1 回赤くした。
+ *
+ * ⚠️ 判定の正は `app-expo/lib/addressFormat.ts` にある。e2e-web からは app-expo の
+ * モジュールを参照できない（tsconfig の paths は `@shared/*` だけ）ため、
+ * ここでは **最小要件（`country:` + 大文字 2 文字）だけ**を写している。
+ * アプリ側の条件が厳しくなったらここも追随すること。
+ * 写しであっても «黙って 0 件» よりは桁違いにましなので置いている。
+ */
+const hasCanonicalAddress = (address: string | undefined): boolean =>
+	!!address &&
+	address
+		.split(",")
+		.map((token) => token.trim())
+		.some((token) => /^country:[A-Z]{2}$/.test(token));
 
 /**
  * 「最近使った場所」を事前シードする（#1133）。
@@ -84,10 +113,18 @@ export type SeededRecentLocation = {
  * @param context ブラウザコンテキスト（ページ生成前に呼ぶこと）
  * @param locations 新しい順に並べた地点（先頭が最新。アプリ側の上限は5件）
  */
-export async function seedRecentLocations(
-	context: BrowserContext,
-	locations: SeededRecentLocation[],
-): Promise<void> {
+export async function seedRecentLocations(context: BrowserContext, locations: SeededRecentLocation[]): Promise<void> {
+	// アプリが読み捨てる形式でシードしても «パネルが出ない» としか観測できないので、
+	// ここで即座に、原因の分かる形で落とす
+	const discarded = locations.filter((location) => !hasCanonicalAddress(location.address));
+	if (discarded.length > 0) {
+		throw new Error(
+			`seedRecentLocations: address が正規形式でないエントリがあります（アプリ側が読み出し時に捨てるため、` +
+				`パネルは 0 件になります）: ${discarded.map((l) => `${l.locationQuery}=${JSON.stringify(l.address)}`).join(", ")}\n` +
+				`正規形式の例: "country:JP, administrative_area_level_1:Tokyo, locality:Shibuya"（app-expo/lib/addressFormat.ts）`,
+		);
+	}
+
 	await context.addInitScript(
 		([key, value]) => {
 			window.localStorage.setItem(key as string, value as string);


### PR DESCRIPTION
## なぜこの PR があるか

PR #1174 をマージしたあと、**マージ commit `1b0e8311` に対して初めて Detox / Playwright を実走**したところ、両方が赤くなりました。

⚠️ **`e2e-mobile-test.yml` は `workflow_dispatch` を持っており、#1174 の作業中に回せたはずでした。回していません。** main の nightly が緑だったのは `fdbb678e`（マージ前）に対するもので、今回の変更が壊していない証拠にはなっていませんでした。#1174 §8-6 で自分が書いた「main の nightly が green なのは退行していない証拠ではない」と同じ形の誤りです。

結果として、**#1174 で追加した Detox 3 spec は一度も緑になったことがありませんでした**。

---

## ① 【製品バグ】共有リンクでアプリに着地した瞬間に落ちる（#721 の核心）

Detox のスタックが決定的でした。

```
useDialog ← useAPICall ← ShareLinkResolverScreen ← renderWithHooks
```

`app/s/[token].tsx` は **`app/[locale]/` の外**にあります（ロケールを持たない URL なので意図的にそう置いた）。しかし `AuthProvider` / `DialogProvider` は `app/[locale]/_layout.tsx` の中にあり、`useAPICall` は内部で `useAuth()` と `useDialog()` を呼びます。結果、**この画面はレンダー時に必ず例外**になります。

**#721 の目的そのもの（アプリを入れた端末が共有リンクでアプリへ着地する）が、一度も動いていませんでした。**

しかも dev では App Links が `app.nanitabeyo.net` にしか紐付いておらず、api-development が発行する共有 URL のホストは `nanitabeyo-dev.web.app` なので、**実機では原理的に踏めない**経路です。Detox でしか検出できませんでした。

### 直し方

`GET /v1/share-links/:token/resolve` は `AuthAnonGuard` を持たない**公開エンドポイント**なので、そもそも認証は要りません。`fetchWithAuth` を素の関数として直接呼ぶ形にし、プロバイダ依存を外しました。

&gt; ⚠️ **素の `fetch` にはしないこと。** グローバルの `MaintenanceGuard` が `x-app-version` を見るため、そのヘッダを付ける `fetchWithAuth` を通す必要があります。理由はファイルの JSDoc に残しました。

---

## ② 【テスト】#1133 保存料理カテゴリからの地点検索 — 前提を「人」ではなく「テスト」が用意する

このモーダルの入口は保存した料理カテゴリのカードだけで、0 件だと開けません。その前提を **「TEST_USER_* に 1 件保存しておいてください」という依頼**（fail-loud メッセージ）で表現していたため、誰かがマイページから保存を外すだけで**コード変更ゼロで CI が赤くなる**状態でした。

`beforeAll` で前提そのものを作るようにしました。

- 推薦 API から**実在する**カテゴリ ID を取り、`reactions`（`target_type=dish_categories` / `action_type=save`）へ 1 件入れる
- `dish_categories` は RLS 有効かつポリシー未定義で supabase からは 1 件も読めないため、実在 ID の入手経路は推薦 API しかない
- 書くのは**保存が 0 件のときだけ**（元からあれば触らない ＝ 2 回目以降は書き込みゼロ）

&gt; ⚠️ **入れた行は消しません。** 最初は `afterAll` で消す設計にしましたが、`e2e-mobile-test.yml` は Android と iOS を**同時に**走らせるため、(a) 両方が同じカテゴリを引くと 2 本目の INSERT が UNIQUE 制約に当たる、(b) 片方の `afterAll` がまだ走っているもう片方の行を消す、という競合が起きます。ここで作りたいのは run ごとの一時データではなく「テストユーザーに保存が 1 件ある」という**恒常的な前提**なので、消さない方が正しい。UNIQUE 違反（23505）も「既に前提が満たされている」と読み替えて成功扱いにしています。

---

## ③ 【テスト】#1131 ログアウト — 画面外の行を `toBeVisible` で待っていた

ログアウト行は設定画面の最下段のカードにあり、エミュレータの画面高では**初期表示で画面外**にいます。`toBeVisible()` は「面積の 75% 以上が可視」を要求するので、`toExist()` は真でも永久に偽のまま 25 秒待って落ちていました。しかもその失敗は**「セッション注入が効いていない」と区別が付きません**。

`whileElement().scroll()` で送ってから見るようにし、`ScrollView` に `testID="settings-scroll"` を足しました。

---

## ④ 【テスト】#721 共有リンク — 観測点を「過渡状態」から「留まる状態」へ

ここは 3 回間違えたので経緯を残します。

| 試したこと | 結果 |
| --- | --- |
| 解決画面（`share-link-resolver`）を待つ | ✗ `launchAppWithSession` の既定 `waitForReady` が**タブバー**を待つ。タブバーは解決画面に無くホームへ落ちて初めて出るので、ヘルパを抜けた時点で解決画面は既に無い |
| `waitForReady: false` ＋ `setURLBlacklist` | ✗ `setURLBlacklist` は**実行中のアプリへの invoke**。まだアプリを起動していない `beforeAll` では届かず suite ごと 6 秒で落ちる |
| `waitForReady: false` のみ（同期機構は無関係と判断） | ✗ 25 秒待って失敗。同 run の 2 本目は 7 秒で pass しており、**往復が速すぎて過渡状態を取り逃がしている**ことが確定 |

そもそも**解決できないトークンでは「捨てられた」と「受け取って解決に失敗した」を区別できません**（どちらもホームへ着地する）。区別できる唯一の観測点だった解決画面が原理的に観測できない以上、この設計では守れません。

そこで `POST /v1/share-links` で**実在するリンクを 1 本作り、着地先そのもの**を観測点にしました。

- 捨てられた → ホーム（検索タブ）
- 受け取れた → 投稿画面（`posts-screen`）

着地先は過渡状態ではなく**留まる状態**なので、待てば必ず観測できます。`posts.tsx` に `testID` を足しました。

&gt; ⚠️ 対象の `dish_media` は `GET /v1/dish-media/search`（`location` / `radius` / `categoryId` 必須）から取ります。`GET /v1/dish-media` は **ids 指定の取得専用**で、`limit` だけ渡すと 400 です。`e2e-web/utils/shareLinks.ts` は同じ誤った呼び方をしており、別途直す必要があります。

---

## ⑤ 【テスト】e2e-web のシードが #1196 の検査に落ちていた

製品の退行ではありません。main の #1196 で `useRecentLocations` が読み出し時に `isCanonicalAddress` で検査するようになり、この spec のシード `address: "東京都テスト区1"` が **5 件すべて読み捨てられて**いました。

症状が「パネルが出てこないタイムアウト」にしかならず seed 側が原因だと分からないため、`seedRecentLocations` 自体に検査を入れ、捨てられる形式を渡した時点で原因の分かるメッセージで落とすようにしています。

---

## 検証

| 検証 | 結果 |
| --- | --- |
| E2E Web（[run 31483330747](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/31483330747)） | ✅ success |
| Detox Android（[run 31502319797](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/31502319797)） | ✅ success |
| Detox iOS | 実行中（結果が出次第このセクションを更新します） |
| `pnpm --filter app-expo typecheck` | exit 0 |
| `pnpm --filter e2e-mobile typecheck` | exit 0 |
| PR Check | ✅ success |

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_