### PR TITLE
#954 / #1131 fix: ?tab= がディープリンク着地で効かない製品バグを直す（＋ iOS の E2E 2 件）

### DIFF
--- a/app-expo/features/profile/containers/ProfileTabsLayout.tsx
+++ b/app-expo/features/profile/containers/ProfileTabsLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { View, StyleSheet, LayoutChangeEvent } from "react-native";
-import { router, useLocalSearchParams } from "expo-router";
+import { router, useGlobalSearchParams, useLocalSearchParams } from "expo-router";
 import { Tabs } from "@/components/collapsible-tabs";
 import { ProfileHeader } from "../components/ProfileHeader";
 import { ProfileTabsBar } from "../components/ProfileTabsBar";
@@ -91,10 +91,17 @@ export function ProfileTabsLayout() {
 	// 「見る」→ tab=saved-topics)。指定が無い/不正な場合は従来通り先頭タブを表示する。
 	// tabRequest は「同じタブへの2回目以降の遷移」でも必ず切り替えるためのリクエスト識別子
 	// (遷移元が Date.now() 等を渡す。値自体に意味はなく、変化の検知にだけ使う)。
-	const { tab: requestedTabParam, tabRequest: tabRequestParam } = useLocalSearchParams<{
-		tab?: string;
-		tabRequest?: string;
-	}>();
+	// ⚠️ `useLocalSearchParams` **だけ**に頼らないこと。
+	// あれは「そのルートが focus された時点の」パラメータしか返さず、
+	// **ディープリンクでこの画面へ直接着地した場合**に取りこぼすことがある。
+	// 実際 iOS の Detox が「マイページには着いているのに先頭タブのまま」で捕まえた
+	// （Android では同じコードで切り替わるため、端末差として現れて切り分けにくい）。
+	// `useGlobalSearchParams` は URL 全体を追うので、着地直後でも値が入る。
+	// 通常遷移では local が正なので local を優先し、無いときだけ global で補う。
+	const localParams = useLocalSearchParams<{ tab?: string; tabRequest?: string }>();
+	const globalParams = useGlobalSearchParams<{ tab?: string; tabRequest?: string }>();
+	const requestedTabParam = localParams.tab ?? globalParams.tab;
+	const tabRequestParam = localParams.tabRequest ?? globalParams.tabRequest;
 	const requestedTab = useMemo(
 		() => (requestedTabParam && tabRoutes.includes(requestedTabParam as RouteName) ? requestedTabParam : undefined),
 		[requestedTabParam, tabRoutes],

--- a/e2e-mobile/screens/SearchScreen.ts
+++ b/e2e-mobile/screens/SearchScreen.ts
@@ -457,9 +457,33 @@ export class SearchScreen {
 	 * 先頭へ戻せば、キーボードが残っていてもトグルは上半分に来る。
 	 */
 	async openAdvancedFilters(): Promise<void> {
+		await this.dismissKeyboardIfPresent();
 		await element(this.scrollView).scrollTo("top");
 		await this.scrollUntilVisible(this.advancedToggle);
 		await tapWhenVisible(this.advancedToggle);
+	}
+
+	/**
+	 * 地点入力にフォーカスが残っていたら外して、ソフトキーボードを閉じる。
+	 *
+	 * ⚠️ **これを省くと `scrollUntilVisible` が «届かない» 形で落ちる。**
+	 * iOS ではキーボードが画面の下半分を占有するため、目的の要素がその領域を
+	 * 通過する瞬間しか画面に入らず、Detox の「面積の 75% 以上が可視」判定を
+	 * 永久に満たせない（`Unable to scroll down ... threshold (75)`）。
+	 * スクロール方向や開始位置の問題に見えるが、原因はキーボードである。
+	 * 実際 `scrollTo("top")` を足しただけでは直らず、失敗時スクリーンショットで確定した。
+	 *
+	 * 閉じる手段は Detox に無いので、フォーカスされている入力の Return を叩く。
+	 * キーボードが出ていない場合に備えて存在チェックしてから行い、失敗は握り潰す
+	 * （閉じられなかったこと自体を赤くしても、後続の本来の失敗が読めなくなるだけ）。
+	 */
+	private async dismissKeyboardIfPresent(): Promise<void> {
+		if (!(await existsNow(this.locationInput))) return;
+		try {
+			await element(this.locationInput).tapReturnKey();
+		} catch {
+			// 閉じられなくても後続の検証は試す
+		}
 	}
 
 	/** おすすめ外の移動時間チップの開閉を切り替える。画面外にある場合はスクロールしてから押す */


### PR DESCRIPTION
## ① 【製品バグ】`?tab=` がディープリンク着地で効かない（#954）

`/{locale}/profile?tab=saved-topics` で開いても、**iOS では先頭タブ（レビュー）のまま**着地します。実利用では「料理カテゴリを保存 → スナックバーの『見る』」が目的のタブに行かない、という形で出ます（#954 の導線そのもの）。

### 原因

`useLocalSearchParams` は **「そのルートが focus された時点の」パラメータ**しか返さず、ディープリンクでこの画面へ直接着地した場合に取りこぼします。URL 全体を追う `useGlobalSearchParams` を **フォールバック**にしました（通常遷移では local が正なので local を優先）。

### 切り分けの経緯（2 回外しています）

| 見立て | 結果 |
| --- | --- |
| `jumpToTab` を ref が生えるまでリトライすれば直る | ✗ 直らず。失敗時スクリーンショットが前回と**まったく同じ**（先頭タブのまま）だった |
| `tab=saved-topics` が `tabRoutes` に無い | ✗ `saved-topics` は `isGuest` に関わらず必ず push される（`ProfileTabsLayout`） |
| → 消去法で **`requestedTab` が `undefined`** ＝ パラメータ不達 | ← 今回の修正対象 |

⚠️ リトライ自体は残しています（ref 未設定時に `?.()` が黙って捨てられ再試行されないのは別個の穴のため）。

## ② 【テスト】詳細条件トグルに届かない（#1131）

製品側の不具合ではありません。**iOS のソフトキーボードが画面下半分を占有**しており、目的の要素がその領域を通過する瞬間しか画面に入らないため、Detox の「面積の 75% 以上が可視」を永久に満たせませんでした（`Unable to scroll down ... threshold (75)`）。

スクロール方向・開始位置の問題に見えますが原因はキーボードで、`scrollTo("top")` を足しただけでは直りませんでした。開く前にフォーカス中の地点入力の Return を叩いて閉じます。

## 検証

| | 結果 |
| --- | --- |
| Detox **Android**（[run 31580112375](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/31580112375)） | ✅ success |
| Detox **iOS** | 実行中 |
| `pnpm --filter app-expo typecheck` | exit 0 |
| `pnpm --filter e2e-mobile typecheck` | exit 0 |

⚠️ ①が iOS で実際に直ったかは **まだ確認できていません**（同 run の iOS ジョブが実行中）。Android で退行しないことは確認済みで、製品バグの修正を早く出す判断で先にマージします。iOS が緑にならなければ追加で直します。

## 残件

- `smoke/search-tutorial.test.ts` が iOS で 1 度落ちた（前回 run では落ちていない）。実行順依存のフレークの疑いで切り分け中
- `e2e-web/utils/shareLinks.ts` が `GET /v1/dish-media?limit=1`（`ids` 必須なので必ず 400）を呼んでいる

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCQxrSy3xmD74QKtWEetCA)_