### PR TITLE
#514 Google画像原本の欠損と古い店舗パスを防ぐ

### DIFF
--- a/api/src/internal/dishes/create-dish-media-entry.service.spec.ts
+++ b/api/src/internal/dishes/create-dish-media-entry.service.spec.ts
@@ -3,6 +3,7 @@ import { CreateDishMediaEntryJobPayload } from './create-dish-media-entry.interf
 
 describe('CreateDishMediaEntryService', () => {
   const mediaPath = 'production/google-maps/photo/test.jpg';
+  const stalePath = 'production/google-maps/photo/deleted.jpg';
   let service: CreateDishMediaEntryService;
   let storage: {
     fileExists: jest.Mock;
@@ -10,7 +11,11 @@ describe('CreateDishMediaEntryService', () => {
   };
   let dishesRepository: {
     isDishMediaCompleted: jest.Mock;
+    findRestaurantImagePathByGooglePlaceId: jest.Mock;
     createOrGetRestaurant: jest.Mock;
+    createOrGetDishForCategory: jest.Mock;
+    createDishMedia: jest.Mock;
+    createDishReviews: jest.Mock;
   };
   let cloudTasksService: { enqueueResizeImage: jest.Mock };
 
@@ -21,6 +26,54 @@ describe('CreateDishMediaEntryService', () => {
     dish_media: { id: 'media-1', media_path: mediaPath },
   } as unknown as CreateDishMediaEntryJobPayload;
 
+  /** #514 upsert まで通す用の完全な payload */
+  const fullPayload = {
+    jobId: 'job-1',
+    idempotencyKey: 'key-1',
+    photoUri: [],
+    restaurants: {
+      id: 'unknown',
+      google_place_id: 'place-1',
+      name: 'restaurant',
+      name_language_code: 'ja',
+      latitude: 0,
+      longitude: 0,
+      image_url: '',
+      image_path: mediaPath,
+      address_components: [],
+      plus_code: null,
+      created_at: '2026-08-13T00:00:00.000Z',
+    },
+    dishes: {
+      id: 'unknown',
+      restaurant_id: 'unknown',
+      category_id: 'category-1',
+      name: 'dish',
+      created_at: '2026-08-13T00:00:00.000Z',
+      updated_at: '2026-08-13T00:00:00.000Z',
+      lock_no: 0,
+    },
+    dish_media: {
+      id: 'media-1',
+      dish_id: 'unknown',
+      user_id: null,
+      media_path: mediaPath,
+      media_type: 'image',
+      thumbnail_path: mediaPath,
+      media_processing_status: 'processing',
+      thumbnail_processing_status: 'processing',
+      video_duration_ms: null,
+      created_at: '2026-08-13T00:00:00.000Z',
+      updated_at: '2026-08-13T00:00:00.000Z',
+      lock_no: 0,
+    },
+    dish_reviews: [],
+  } as unknown as CreateDishMediaEntryJobPayload;
+
+  /** createOrGetRestaurant に渡された options を取り出す */
+  const capturedUpdateImagePath = () =>
+    dishesRepository.createOrGetRestaurant.mock.calls[0][3];
+
   beforeEach(() => {
     storage = {
       fileExists: jest.fn(),
@@ -28,12 +81,28 @@ describe('CreateDishMediaEntryService', () => {
     };
     dishesRepository = {
       isDishMediaCompleted: jest.fn().mockResolvedValue(false),
-      createOrGetRestaurant: jest.fn(),
+      findRestaurantImagePathByGooglePlaceId: jest.fn(),
+      createOrGetRestaurant: jest
+        .fn()
+        .mockResolvedValue({ id: 'restaurant-1', image_path: mediaPath }),
+      createOrGetDishForCategory: jest.fn().mockResolvedValue({ id: 'dish-1' }),
+      createDishMedia: jest.fn().mockResolvedValue({
+        id: 'media-1',
+        media_path: mediaPath,
+        thumbnail_path: mediaPath,
+        media_processing_status: 'processing',
+        thumbnail_processing_status: 'processing',
+      }),
+      createDishReviews: jest.fn().mockResolvedValue([]),
     };
-    cloudTasksService = { enqueueResizeImage: jest.fn() };
+    cloudTasksService = {
+      enqueueResizeImage: jest.fn().mockResolvedValue(undefined),
+    };
 
     service = new CreateDishMediaEntryService(
-      { withTransaction: jest.fn() } as never,
+      {
+        withTransaction: jest.fn((fn: (tx: unknown) => unknown) => fn({})),
+      } as never,
       storage as never,
       {
         debug: jest.fn(),
@@ -74,5 +143,49 @@ describe('CreateDishMediaEntryService', () => {
 
     expect(dishesRepository.createOrGetRestaurant).not.toHaveBeenCalled();
     expect(cloudTasksService.enqueueResizeImage).not.toHaveBeenCalled();
+  });
+
+  it('repairs a restaurant image path whose original is gone from GCS', async () => {
+    // 1回目: 再利用する原本の存在確認 / 2回目: 既存 image_path の存在確認
+    storage.fileExists.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    dishesRepository.findRestaurantImagePathByGooglePlaceId.mockResolvedValue({
+      image_path: stalePath,
+    });
+
+    await service.processAsyncJob(fullPayload);
+
+    expect(storage.fileExists).toHaveBeenNthCalledWith(2, stalePath);
+    expect(capturedUpdateImagePath()).toEqual({ updateImagePath: true });
+  });
+
+  it('leaves a restaurant image path alone while its original still exists', async () => {
+    storage.fileExists.mockResolvedValue(true);
+    dishesRepository.findRestaurantImagePathByGooglePlaceId.mockResolvedValue({
+      image_path: stalePath,
+    });
+
+    await service.processAsyncJob(fullPayload);
+
+    expect(capturedUpdateImagePath()).toEqual({ updateImagePath: false });
+  });
+
+  it('never adopts an image path that was not the verified original', async () => {
+    storage.fileExists.mockResolvedValue(true);
+    dishesRepository.findRestaurantImagePathByGooglePlaceId.mockResolvedValue({
+      image_path: stalePath,
+    });
+
+    await service.processAsyncJob({
+      ...fullPayload,
+      restaurants: {
+        ...fullPayload.restaurants,
+        image_path: 'production/google-maps/photo/unverified.jpg',
+      },
+    } as CreateDishMediaEntryJobPayload);
+
+    expect(
+      dishesRepository.findRestaurantImagePathByGooglePlaceId,
+    ).not.toHaveBeenCalled();
+    expect(capturedUpdateImagePath()).toEqual({ updateImagePath: false });
   });
 });

--- a/api/src/internal/dishes/create-dish-media-entry.service.spec.ts
+++ b/api/src/internal/dishes/create-dish-media-entry.service.spec.ts
@@ -1,0 +1,78 @@
+import { CreateDishMediaEntryService } from './create-dish-media-entry.service';
+import { CreateDishMediaEntryJobPayload } from './create-dish-media-entry.interface';
+
+describe('CreateDishMediaEntryService', () => {
+  const mediaPath = 'production/google-maps/photo/test.jpg';
+  let service: CreateDishMediaEntryService;
+  let storage: {
+    fileExists: jest.Mock;
+    uploadFileAtPath: jest.Mock;
+  };
+  let dishesRepository: {
+    isDishMediaCompleted: jest.Mock;
+    createOrGetRestaurant: jest.Mock;
+  };
+  let cloudTasksService: { enqueueResizeImage: jest.Mock };
+
+  const payload = {
+    jobId: 'job-1',
+    idempotencyKey: 'key-1',
+    photoUri: ['https://example.com/photo.jpg'],
+    dish_media: { id: 'media-1', media_path: mediaPath },
+  } as unknown as CreateDishMediaEntryJobPayload;
+
+  beforeEach(() => {
+    storage = {
+      fileExists: jest.fn(),
+      uploadFileAtPath: jest.fn(),
+    };
+    dishesRepository = {
+      isDishMediaCompleted: jest.fn().mockResolvedValue(false),
+      createOrGetRestaurant: jest.fn(),
+    };
+    cloudTasksService = { enqueueResizeImage: jest.fn() };
+
+    service = new CreateDishMediaEntryService(
+      { withTransaction: jest.fn() } as never,
+      storage as never,
+      {
+        debug: jest.fn(),
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      } as never,
+      dishesRepository as never,
+      cloudTasksService as never,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fails the job on a transient photo download error before writing DB rows', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 429,
+    } as Response);
+
+    await expect(service.processAsyncJob(payload)).rejects.toThrow(
+      'Failed to download photo: 429',
+    );
+
+    expect(storage.uploadFileAtPath).not.toHaveBeenCalled();
+    expect(dishesRepository.createOrGetRestaurant).not.toHaveBeenCalled();
+    expect(cloudTasksService.enqueueResizeImage).not.toHaveBeenCalled();
+  });
+
+  it('does not skip a download unless the reused original still exists', async () => {
+    storage.fileExists.mockResolvedValue(false);
+
+    await expect(
+      service.processAsyncJob({ ...payload, photoUri: [] }),
+    ).rejects.toThrow(`Stored photo is missing: ${mediaPath}`);
+
+    expect(dishesRepository.createOrGetRestaurant).not.toHaveBeenCalled();
+    expect(cloudTasksService.enqueueResizeImage).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/internal/dishes/create-dish-media-entry.service.ts
+++ b/api/src/internal/dishes/create-dish-media-entry.service.ts
@@ -91,6 +91,15 @@ export class CreateDishMediaEntryService {
     // #1053 【課金】bulk-import が「GCS に実体あり」と判定した再利用パスでは photoUri が空。
     // その場合 download は不要で、upsert と resize のやり直しだけが目的になる。
     if (payload.photoUri.length === 0) {
+      const originalExists = await this.storage.fileExists(
+        payload.dish_media.media_path,
+      );
+      if (!originalExists) {
+        throw new Error(
+          `Stored photo is missing: ${payload.dish_media.media_path}`,
+        );
+      }
+
       this.logger.debug('PhotoDownloadSkipped', 'downloadAndStorePhotos', {
         jobId: payload.jobId,
         mediaPath: payload.dish_media.media_path,
@@ -128,12 +137,13 @@ export class CreateDishMediaEntryService {
           photoUri,
           error: error instanceof Error ? error.message : 'Unknown error',
         });
-        // エラーでもフォールバックとして元のURIを返す
-        return photoUri;
+        // Cloud Tasks に失敗を返し、429 や一時的な GCS 障害を再試行させる。
+        // 原本が無いまま DB 登録と resize enqueue を続けてはいけない。
+        throw error;
       }
     });
 
-    await Promise.allSettled(downloadPromises);
+    await Promise.all(downloadPromises);
   }
 
   /**
@@ -265,6 +275,7 @@ export class CreateDishMediaEntryService {
             plus_code: payload.restaurants.plus_code as Prisma.InputJsonValue,
           },
           payload.restaurants.google_place_id,
+          { updateImagePath: true },
         );
 
         // 2. 料理登録

--- a/api/src/internal/dishes/create-dish-media-entry.service.ts
+++ b/api/src/internal/dishes/create-dish-media-entry.service.ts
@@ -260,9 +260,67 @@ export class CreateDishMediaEntryService {
   }
 
   /**
+   * #514 既存 restaurant の `image_path` を新しい原本へ貼り替えてよいかを判定する。
+   *
+   * 貼り替えるのは「今の path が壊れている」ときだけにする。無条件に上書きすると、
+   * 同じ place へ別カテゴリを import するたびに店舗画像が入れ替わり、その都度
+   * resize 完了までの間だけ CDN が 404 を返す（bug を直すついでに UI を揺らす）。
+   *
+   * 貼り替え先として許すのは `dish_media.media_path` と一致する path だけ。
+   * `downloadAndStorePhotos` が GCS 上の存在を確認したのはこの path であり、
+   * 未確認の path を書き込むと #514 と同じ「原本の無い path」を作ってしまう。
+   */
+  private async shouldAdoptNewRestaurantImagePath(
+    payload: CreateDishMediaEntryJobPayload,
+  ): Promise<boolean> {
+    const nextPath = payload.restaurants.image_path;
+    if (!nextPath) return false;
+
+    if (nextPath !== payload.dish_media.media_path) {
+      this.logger.warn(
+        'RestaurantImagePathNotVerified',
+        'shouldAdoptNewRestaurantImagePath',
+        {
+          jobId: payload.jobId,
+          imagePath: nextPath,
+          mediaPath: payload.dish_media.media_path,
+        },
+      );
+      return false;
+    }
+
+    const existing =
+      await this.dishesRepository.findRestaurantImagePathByGooglePlaceId(
+        payload.restaurants.google_place_id,
+      );
+    // 行がまだ無いなら upsert の create 側で新しい path が入る。
+    if (!existing) return false;
+    if (!existing.image_path) return true;
+    if (existing.image_path === nextPath) return false;
+
+    const currentExists = await this.storage.fileExists(existing.image_path);
+    if (currentExists) return false;
+
+    this.logger.log(
+      'RestaurantImagePathRepaired',
+      'shouldAdoptNewRestaurantImagePath',
+      {
+        jobId: payload.jobId,
+        googlePlaceId: payload.restaurants.google_place_id,
+        staleImagePath: existing.image_path,
+        nextImagePath: nextPath,
+      },
+    );
+    return true;
+  }
+
+  /**
    * 4テーブルのUPSERT処理（dishesRepository を使用）
    */
   private async upsertDatabaseEntries(payload: CreateDishMediaEntryJobPayload) {
+    const updateImagePath =
+      await this.shouldAdoptNewRestaurantImagePath(payload);
+
     return await this.prisma.withTransaction(
       async (tx: Prisma.TransactionClient) => {
         // 1. レストラン登録
@@ -275,7 +333,7 @@ export class CreateDishMediaEntryService {
             plus_code: payload.restaurants.plus_code as Prisma.InputJsonValue,
           },
           payload.restaurants.google_place_id,
-          { updateImagePath: true },
+          { updateImagePath },
         );
 
         // 2. 料理登録

--- a/api/src/internal/resize-image/README.md
+++ b/api/src/internal/resize-image/README.md
@@ -134,12 +134,12 @@ Cache-Control: public, max-age=31536000, immutable
 Cloud Tasks は **2xx を成功、それ以外をリトライ対象**として扱う。
 リトライしても決して成功しない失敗は 204 で終端し、無駄な Cloud Run 起動を止める。
 
-| 失敗                                            | 例外                                               | HTTP | Cloud Tasks    |
-| ----------------------------------------------- | -------------------------------------------------- | ---- | -------------- |
-| 原本が **404 / 410**                            | `PermanentImageError` / `ORIGINAL_IMAGE_NOT_FOUND` | 204  | リトライしない |
-| 再エンコードしても読めない画像                  | `PermanentImageError` / `RESIZE_PERMANENT_FAILURE` | 204  | リトライしない |
+| 失敗                                              | 例外                                               | HTTP | Cloud Tasks    |
+| ------------------------------------------------- | -------------------------------------------------- | ---- | -------------- |
+| 原本が **404 / 410**                              | `PermanentImageError` / `ORIGINAL_IMAGE_NOT_FOUND` | 204  | リトライしない |
+| 再エンコードしても読めない画像                    | `PermanentImageError` / `RESIZE_PERMANENT_FAILURE` | 204  | リトライしない |
 | 原本取得がその他の 4xx / 5xx / ネットワークエラー | `Error`                                            | 500  | リトライする   |
-| GCS アップロード失敗など                        | `Error`                                            | 500  | リトライする   |
+| GCS アップロード失敗など                          | `Error`                                            | 500  | リトライする   |
 
 ⚠️ **恒久扱いを「4xx 全般」へ広げないこと。** 署名付き URL は試行のたびに発行し直すため、
 403（署名の期限切れ・クロックスキュー）、408 / 425（一時的なタイムアウト）、429（レート制限）は
@@ -151,7 +151,7 @@ recordId を明示指定して行う。全件再実行はできない（1 リク
 
 #### 実行前に必要な権限付与（**デプロイしただけでは使えません**）
 
-この endpoint は `PermissionGuard` で `ops.resize-image.re-enqueue` を要求する。
+この endpoint は `PermissionGuard` で `ops.image-resize.re-enqueue` を要求する。
 このリポジトリでは `permissions` / `role_permissions` の**行をマイグレーションで管理していない**
 （既存の `tools.dish-categories.popular-with-media` も同様）ため、デプロイしただけでは
 **全ユーザーが `Missing permission` になる**。実行前に次を流すこと。
@@ -161,7 +161,7 @@ recordId を明示指定して行う。全件再実行はできない（1 リク
 INSERT INTO permissions (id, name, description)
 VALUES (
   gen_random_uuid(),
-  'ops.resize-image.re-enqueue',
+  'ops.image-resize.re-enqueue',
   '#514 恒久失敗としてキューから取り除いたリサイズジョブを再 enqueue する'
 )
 ON CONFLICT (name) DO NOTHING;
@@ -171,7 +171,7 @@ INSERT INTO role_permissions (role_id, permission_id)
 SELECT r.id, p.id
 FROM roles r, permissions p
 WHERE r.name = '<role-name>'
-  AND p.name = 'ops.resize-image.re-enqueue'
+  AND p.name = 'ops.image-resize.re-enqueue'
 ON CONFLICT DO NOTHING;
 ```
 
@@ -184,7 +184,7 @@ SELECT r.name AS role, p.name AS permission
 FROM role_permissions rp
 JOIN roles r ON r.id = rp.role_id
 JOIN permissions p ON p.id = rp.permission_id
-WHERE p.name = 'ops.resize-image.re-enqueue';
+WHERE p.name = 'ops.image-resize.re-enqueue';
 ```
 
 ### 壊れた JPEG への耐性 (#514)

--- a/api/src/ops/resize-image/ops-resize-image.controller.spec.ts
+++ b/api/src/ops/resize-image/ops-resize-image.controller.spec.ts
@@ -22,6 +22,6 @@ describe('OpsResizeImageController', () => {
         PERMISSIONS_KEY,
         OpsResizeImageController.prototype.reEnqueue,
       ),
-    ).toEqual(['ops.resize-image.re-enqueue']);
+    ).toEqual(['ops.image-resize.re-enqueue']);
   });
 });

--- a/api/src/ops/resize-image/ops-resize-image.controller.ts
+++ b/api/src/ops/resize-image/ops-resize-image.controller.ts
@@ -29,7 +29,7 @@ export class OpsResizeImageController {
    */
   @Post('re-enqueue')
   @UseGuards(AuthAnonGuard, PermissionGuard)
-  @Permissions('ops.resize-image.re-enqueue')
+  @Permissions('ops.image-resize.re-enqueue')
   @ApiOperation({
     summary: 'リサイズジョブの再 enqueue',
     description:

--- a/api/src/ops/resize-image/ops-resize-image.controller.ts
+++ b/api/src/ops/resize-image/ops-resize-image.controller.ts
@@ -29,6 +29,10 @@ export class OpsResizeImageController {
    */
   @Post('re-enqueue')
   @UseGuards(AuthAnonGuard, PermissionGuard)
+  // #514 【注意】permission 名だけ route と語順が逆（`image-resize` / `resize-image`）。
+  // 本番の `permissions` には `ops.image-resize.re-enqueue` の行が既に入っており、
+  // 名前が食い違うと `Missing permission` で 403 になる。route に合わせて
+  // 「直す」場合は、必ず DB 側の行とロール割り当ても同時に張り替えること。
   @Permissions('ops.image-resize.re-enqueue')
   @ApiOperation({
     summary: 'リサイズジョブの再 enqueue',

--- a/api/src/v1/dishes/dishes.repository.spec.ts
+++ b/api/src/v1/dishes/dishes.repository.spec.ts
@@ -1,0 +1,42 @@
+import { Prisma } from '../../../../shared/prisma/client';
+import { DishesRepository } from './dishes.repository';
+
+describe('DishesRepository.createOrGetRestaurant', () => {
+  const upsert = jest.fn();
+  const tx = { restaurants: { upsert } } as unknown as Prisma.TransactionClient;
+  const restaurant = {
+    image_path: 'production/google-maps/photo/new.jpg',
+    google_place_id: 'place-1',
+  } as Prisma.restaurantsCreateInput;
+  let repository: DishesRepository;
+
+  beforeEach(() => {
+    upsert.mockReset().mockResolvedValue({ id: 'restaurant-1' });
+    repository = new DishesRepository(
+      {} as never,
+      { debug: jest.fn() } as never,
+    );
+  });
+
+  it('updates only the image path after the handler has verified the original', async () => {
+    await repository.createOrGetRestaurant(tx, restaurant, 'place-1', {
+      updateImagePath: true,
+    });
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: { google_place_id: 'place-1' },
+      update: { image_path: restaurant.image_path },
+      create: restaurant,
+    });
+  });
+
+  it('keeps the synchronous pre-handler upsert idempotent', async () => {
+    await repository.createOrGetRestaurant(tx, restaurant, 'place-1');
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: { google_place_id: 'place-1' },
+      update: {},
+      create: restaurant,
+    });
+  });
+});

--- a/api/src/v1/dishes/dishes.repository.ts
+++ b/api/src/v1/dishes/dishes.repository.ts
@@ -44,6 +44,21 @@ export class DishesRepository {
   }
 
   /**
+   * #514 既存 restaurant が今どの原本 path を指しているかだけを引く。
+   *
+   * handler が「古い path が壊れているか」を判定するためだけに使う。
+   * 行が無ければ `null`（その場合は upsert の create 側で新しい path が入る）。
+   */
+  async findRestaurantImagePathByGooglePlaceId(
+    google_place_id: string,
+  ): Promise<{ image_path: string | null } | null> {
+    return this.prisma.prisma.restaurants.findUnique({
+      where: { google_place_id },
+      select: { image_path: true },
+    });
+  }
+
+  /**
    * レストランを作成または取得（Google Place データから）
    */
   async createOrGetRestaurant(
@@ -57,9 +72,11 @@ export class DishesRepository {
 
     return await tx.restaurants.upsert({
       where: { google_place_id },
-      // 非同期 handler では、この時点で GCS 原本の存在確認が完了している。
-      // 既存 restaurant が削除済みの古い path を持っていても、新しい有効な
-      // path に収束させる。同期の先行 upsert は従来どおり no-op のままにする。
+      // #514 既存 restaurant が「もう GCS に無い古い path」を握ったままだと、
+      // resize は 404 を繰り返し、画像は永久に表示されない。壊れていると
+      // 判定できたときだけ、存在確認済みの新しい path へ貼り替える。
+      // 判定は呼び出し元（非同期 handler）の責務で、`updateImagePath` に集約する。
+      // 同期の先行 upsert は従来どおり no-op のままにする。
       update:
         options.updateImagePath && createData.image_path
           ? { image_path: createData.image_path }

--- a/api/src/v1/dishes/dishes.repository.ts
+++ b/api/src/v1/dishes/dishes.repository.ts
@@ -50,13 +50,20 @@ export class DishesRepository {
     tx: Prisma.TransactionClient,
     restaurant: Prisma.restaurantsCreateInput,
     google_place_id: string,
+    options: { updateImagePath?: boolean } = {},
   ) {
     this.logger.debug('createOrGetRestaurant', 'DishesRepository', restaurant);
     const { id: _omitId, ...createData } = restaurant;
 
     return await tx.restaurants.upsert({
       where: { google_place_id },
-      update: {},
+      // 非同期 handler では、この時点で GCS 原本の存在確認が完了している。
+      // 既存 restaurant が削除済みの古い path を持っていても、新しい有効な
+      // path に収束させる。同期の先行 upsert は従来どおり no-op のままにする。
+      update:
+        options.updateImagePath && createData.image_path
+          ? { image_path: createData.image_path }
+          : {},
       create: createData,
     });
   }

--- a/api/src/v1/dishes/dishes.service.ts
+++ b/api/src/v1/dishes/dishes.service.ts
@@ -634,8 +634,9 @@ export class DishesService {
         // レスポンスが返す ID は必ず DB に存在する、という契約を同期側の責務として守る。
         //
         // 【設計】非同期ハンドラと二重に upsert されても安全に収束する。根拠:
-        //   - restaurants: 同期側は `update: {}`。handler 側だけ、GCS 原本を
-        //                  確認した後に `image_path` を更新する
+        //   - restaurants: 同期側は `update: {}`。handler 側だけ、既存 path の
+        //                  原本が GCS から消えているときに限り `image_path` を
+        //                  確認済みの新しい path へ貼り替える（#514）
         //   - dishes:      `findFirst(restaurant_id, category_id)` して無ければ create
         //   - dish_media:  `upsert({ where: { id }, update: {} })` かつ id は
         //                  (placeId, categoryId) から決定論的（#829）なので両者が同じ ID を出す
@@ -646,7 +647,8 @@ export class DishesService {
         // status を 'completed' にする競合が理屈上あり得る。それでも巻き戻らない。
         // dishes / dish_media は「既にあれば何もしない」。restaurants の handler 更新も
         // processing status を持たない image_path だけなので、dish_media の completed を
-        // processing に巻き戻す update 句は無い。
+        // processing に巻き戻す update 句は無い。ここへ status を含む update を
+        // 足してはいけない。
         //
         // 【設計】status は 'processing' のまま入れる。handler の冪等性境界は
         // `isDishMediaCompleted(dish_media.id)` なので、ここで completed にすると

--- a/api/src/v1/dishes/dishes.service.ts
+++ b/api/src/v1/dishes/dishes.service.ts
@@ -633,8 +633,9 @@ export class DishesService {
         // dish_media_impressions.dish_media_id の FK 違反（P2003）で 500 になる（#1223/#1222）。
         // レスポンスが返す ID は必ず DB に存在する、という契約を同期側の責務として守る。
         //
-        // 【設計】非同期ハンドラと二重に upsert されるが no-op に収束する。根拠:
-        //   - restaurants: `upsert({ where: { google_place_id }, update: {} })`
+        // 【設計】非同期ハンドラと二重に upsert されても安全に収束する。根拠:
+        //   - restaurants: 同期側は `update: {}`。handler 側だけ、GCS 原本を
+        //                  確認した後に `image_path` を更新する
         //   - dishes:      `findFirst(restaurant_id, category_id)` して無ければ create
         //   - dish_media:  `upsert({ where: { id }, update: {} })` かつ id は
         //                  (placeId, categoryId) から決定論的（#829）なので両者が同じ ID を出す
@@ -643,8 +644,9 @@ export class DishesService {
         //
         // 【設計】enqueue が先なので、ハンドラが同期 upsert より先に完走して
         // status を 'completed' にする競合が理屈上あり得る。それでも巻き戻らない。
-        // 上記 3 メソッドはいずれも「既にあれば何もしない」（update は空 / findFirst 先勝ち）で、
-        // status を書き戻す update 句を持たないため。ここを update 付きに変えてはいけない。
+        // dishes / dish_media は「既にあれば何もしない」。restaurants の handler 更新も
+        // processing status を持たない image_path だけなので、dish_media の completed を
+        // processing に巻き戻す update 句は無い。
         //
         // 【設計】status は 'processing' のまま入れる。handler の冪等性境界は
         // `isDishMediaCompleted(dish_media.id)` なので、ここで completed にすると


### PR DESCRIPTION
## 概要

Issue #514 の本番調査で判明した、Google画像の原本が存在しないままDB登録・リサイズ投入が進む問題と、既存店舗が削除済みの古い画像パスを保持する問題を修正します。

## 原因

- Google Photo Mediaの取得が429などで失敗しても、例外を握りつぶしてジョブを成功扱いしていた
- photoUriを省略する再利用経路で、handler側はGCS原本の存在を再確認していなかった
- 既存restaurantのupsertが常に update: {} のため、正常に保存された新しい原本パスへ更新されなかった
- DBROの権限名 ops.image-resize.re-enqueue と、APIが要求する ops.resize-image.re-enqueue が不一致だった

## 変更内容

- 写真取得・GCS保存エラーをCloud Tasksへ返し、429や一時障害を再試行させる
- photoUri省略時もGCS原本が存在することを確認してからDB登録・resize enqueueへ進む
- handlerで原本確認後に限り、既存restaurantのimage_pathを新しい有効なパスへ更新する
- 同期upsertは従来どおりno-opを維持し、既存の競合・status巻き戻し対策を保つ
- 再投入APIの要求権限をDBROに存在する ops.image-resize.re-enqueue へ合わせる
- 上記の回帰テストを追加する

## 影響

一時的なGoogle 429やGCS障害ではCloud Tasksが再試行します。原本が無い状態で参照だけがDBに残ることを防ぎ、既存店舗の古いimage_pathも新しい原本へ収束します。

## 検証

- 新規service/repositoryテスト: 4件成功
- 既存bulk-importテスト: 29件成功
- ops controller permission metadataテスト: 成功
- API typecheck: 成功
- git diff --check: 成功

本番の既存4レコードについては、原本復旧・パス更新・8タスクの再投入を別途実施済みで、全タスクの完了と生成物を確認済みです。