### PR TITLE
#514 fix: 原本が保存済みなら photoUri を叩き直さない（#1296 Codex 指摘 P2）

### DIFF
--- a/api/src/internal/dishes/create-dish-media-entry.service.spec.ts
+++ b/api/src/internal/dishes/create-dish-media-entry.service.spec.ts
@@ -120,6 +120,7 @@ describe('CreateDishMediaEntryService', () => {
   });
 
   it('fails the job on a transient photo download error before writing DB rows', async () => {
+    storage.fileExists.mockResolvedValue(false);
     jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: false,
       status: 429,
@@ -132,6 +133,27 @@ describe('CreateDishMediaEntryService', () => {
     expect(storage.uploadFileAtPath).not.toHaveBeenCalled();
     expect(dishesRepository.createOrGetRestaurant).not.toHaveBeenCalled();
     expect(cloudTasksService.enqueueResizeImage).not.toHaveBeenCalled();
+  });
+
+  it('does not re-fetch an expired photoUri when the original is already stored', async () => {
+    // 保存後に DB や enqueue で落ちた retry。photoUri は期限切れで叩けば必ず失敗する。
+    storage.fileExists.mockResolvedValue(true);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 429,
+    } as Response);
+    dishesRepository.findRestaurantImagePathByGooglePlaceId.mockResolvedValue({
+      image_path: mediaPath,
+    });
+
+    await service.processAsyncJob({
+      ...fullPayload,
+      photoUri: ['https://example.com/expired.jpg'],
+    } as CreateDishMediaEntryJobPayload);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(dishesRepository.createOrGetRestaurant).toHaveBeenCalled();
+    expect(cloudTasksService.enqueueResizeImage).toHaveBeenCalled();
   });
 
   it('does not skip a download unless the reused original still exists', async () => {

--- a/api/src/internal/dishes/create-dish-media-entry.service.ts
+++ b/api/src/internal/dishes/create-dish-media-entry.service.ts
@@ -88,23 +88,36 @@ export class CreateDishMediaEntryService {
   private async downloadAndStorePhotos(
     payload: CreateDishMediaEntryJobPayload,
   ): Promise<void> {
+    // #514 【設計】原本の有無を先に見る。photoUri の有無では分岐しない。
+    //
+    // 保存に成功した後、DB transaction や resize enqueue で落ちると、Cloud Tasks は
+    // 同じ payload で再試行する。そのとき Google の photoUri は既に期限切れや 429 に
+    // なっていることがあり、fetch から始めると「GCS には有効な原本があるのに
+    // ダウンロードだけが永久に失敗する」状態になる（リトライ上限まで消費して
+    // processing の行が残る）。原本があるなら download は要らない。
+    //
     // #1053 【課金】bulk-import が「GCS に実体あり」と判定した再利用パスでは photoUri が空。
-    // その場合 download は不要で、upsert と resize のやり直しだけが目的になる。
-    if (payload.photoUri.length === 0) {
-      const originalExists = await this.storage.fileExists(
-        payload.dish_media.media_path,
-      );
-      if (!originalExists) {
-        throw new Error(
-          `Stored photo is missing: ${payload.dish_media.media_path}`,
-        );
-      }
-
+    // その場合も同じ判定に乗る。実体があるのに Photo Media を取り直して課金しない。
+    //
+    // `uploadFileAtPath` は `overwriteIfExists: false` なので、実体がある状態で
+    // download しても保存は no-op になる。先に確認しても結果は変わらない。
+    const originalExists = await this.storage.fileExists(
+      payload.dish_media.media_path,
+    );
+    if (originalExists) {
       this.logger.debug('PhotoDownloadSkipped', 'downloadAndStorePhotos', {
         jobId: payload.jobId,
         mediaPath: payload.dish_media.media_path,
+        hasPhotoUri: payload.photoUri.length > 0,
       });
       return;
+    }
+
+    // 原本が無く、取りに行く先も無い。DB 登録と resize enqueue へ進めてはいけない。
+    if (payload.photoUri.length === 0) {
+      throw new Error(
+        `Stored photo is missing: ${payload.dish_media.media_path}`,
+      );
     }
 
     const downloadPromises = payload.photoUri.map(async (photoUri, index) => {


### PR DESCRIPTION
## 概要

マージ済み PR #1296 に対する [Codex レビューの P2 指摘](https://github.com/Ayato-kosaka/nanitabeyo/pull/1296#discussion_r3778425386)への対応です。#1296 は既にマージ済みのため、新しい PR として起こしています。

## 原因

#1296 で「写真取得の失敗を握り潰さず Cloud Tasks へ返す」ようにした結果、次の経路が塞がりました。

1. 初回実行で Google Photo の取得と GCS への保存に成功する
2. その後の DB transaction または resize enqueue で落ちる
3. Cloud Tasks が**同じ payload**で再試行する
4. このとき Google の `photoUri` が期限切れ・429 になっていると、`fetch` が失敗して throw する

**GCS には有効な原本があるのに、ダウンロードだけが永久に失敗します。** リトライ上限まで消費し、`processing` の行が残ります。#1296 以前は catch が握り潰していたため、この経路だけは通っていました。

## 変更内容

`downloadAndStorePhotos` の分岐条件を `photoUri` の有無から**原本の有無**へ変えます。

- 先に `fileExists(dish_media.media_path)` を見て、実体があれば download を skip して後続へ進む
- 実体が無く `photoUri` も空なら、従来どおり throw して DB 登録・resize enqueue へ進ませない
- 実体が無く `photoUri` があるときだけ download する（従来どおり失敗は Cloud Tasks へ返す）

`uploadFileAtPath` は `overwriteIfExists: false` なので、実体がある状態で download しても保存は no-op でした。先に確認しても保存結果は変わらず、無駄な Photo Media 課金（#1053 と同じ論点）も止まります。

## 影響

一時的な 429 や GCS 障害は従来どおり再試行されます。加えて、保存済みの原本を持つジョブは `photoUri` の寿命に関係なく完走できるようになります。

## 検証

- `create-dish-media-entry.service.spec.ts`: 6 件成功（「期限切れ photoUri を叩かずに完走する」1 件を追加）
- `internal/dishes` / `v1/dishes`: 5 suites / 68 tests 成功
- `tsc --noEmit`: 成功
- `prettier --check`（変更ファイル）: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMvxwbmw2ZcKxnNriwGokw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMvxwbmw2ZcKxnNriwGokw)_