### PR TITLE
#1323 feat: liveness 用の /livez と、API デプロイ直後のスモークテストを足す

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -96,3 +96,67 @@ jobs:
       - name: Show Service URL
         run: |
           echo "✅ Deployed: ${{ steps.deploy.outputs.url }}"
+
+      # ---------- デプロイ直後のスモークテスト ----------
+      # デプロイした ref に対して、実際に HTTP が返ることを確認する。
+      #
+      # 【設計】これは「通知」であって「ゲート」ではない。上の deploy は
+      # revision_traffic: LATEST=100 なので、ここへ来た時点で全トラフィックは
+      # 既に新リビジョンへ移っている。ここが落ちても本番は差し戻らない。
+      # ゲートにするなら no_traffic + tag でデプロイ → ここでタグ付き URL を
+      # 叩く → 通ってから update-traffic、という順序に変える必要がある。
+      #
+      # 【設計】叩けるのは認証不要な 2 本だけ。/v1/** は AuthAnonGuard が
+      # 付くのでトークン無しでは検証できない。それでも「コンテナが起動して
+      # Nest のルーティングとグローバル Interceptor まで通る」ことは確認できる。
+      - name: 🔥 Smoke test
+        env:
+          BASE_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          set -euo pipefail
+
+          # コールドスタートで初回が落ちることがあるためリトライする。
+          # 第 3 引数に allow-maintenance を渡したパスだけ、メンテ中の 503 を許容する。
+          probe() {
+            local path="$1" jq_expr="${2:-}" maintenance="${3:-}" code
+            for i in $(seq 1 5); do
+              code=$(curl -sS -o /tmp/smoke.json -w '%{http_code}' \
+                       --max-time 20 "${BASE_URL}${path}" || echo 000)
+
+              if [ "$code" = "200" ]; then
+                if [ -z "$jq_expr" ] || jq -e "$jq_expr" /tmp/smoke.json >/dev/null; then
+                  echo "✅ ${path} → 200"
+                  return 0
+                fi
+                echo "❌ ${path} → 200 だが本文が期待と違う"
+                cat /tmp/smoke.json
+                return 1
+              fi
+
+              # MaintenanceGuard による 503 は「サーバは応答している」と見なす。
+              # メンテナンス中のデプロイでスモークが誤検知しないようにするため。
+              if [ "$maintenance" = "allow-maintenance" ] && [ "$code" = "503" ] &&
+                 grep -q SERVICE_MAINTENANCE /tmp/smoke.json; then
+                echo "⚠️ ${path} → 503（メンテナンスモード）"
+                return 0
+              fi
+
+              echo "… ${path} → ${code}（retry ${i}/5）"
+              sleep 5
+            done
+
+            echo "❌ ${path} → ${code}"
+            cat /tmp/smoke.json || true
+            return 1
+          }
+
+          # レスポンスは ResponseWrapInterceptor で BaseResponse に包まれるので
+          # 判定は .status ではなく .data.status を見る。
+          #
+          # /livez だけメンテナンスを許容しない。この path は MaintenanceGuard の
+          # allowedPaths にあり、メンテ中でも 200 のはずだからである。ここで 503 を
+          # 見逃すと、allowedPaths から /livez が外れた事故に気付けなくなる。
+          probe /livez  '.data.status == "ok"'
+          probe /health '.data.status == "ok"' allow-maintenance
+          probe /       ''                     allow-maintenance
+      # -------------------------------------------

--- a/api/src/core/guards/maintenance.guard.spec.ts
+++ b/api/src/core/guards/maintenance.guard.spec.ts
@@ -61,6 +61,20 @@ describe('MaintenanceGuard', () => {
       expect(remoteConfigService.getRemoteConfigValue).not.toHaveBeenCalled();
     });
 
+    // 外形監視 (uptime check) が叩くパス。メンテ中に 503 を返したり、
+    // RemoteConfig(GCS) を読みに行ったりするようになると監視が誤検知する。
+    it('should allow /livez without reading remote config, even during maintenance', async () => {
+      remoteConfigService.getRemoteConfigValue.mockResolvedValue('true'); // is_maintenance
+
+      const request = createMockRequest('/livez');
+      const context = createMockContext(request);
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(remoteConfigService.getRemoteConfigValue).not.toHaveBeenCalled();
+    });
+
     it('should allow access when maintenance is false and version is supported', async () => {
       remoteConfigService.getRemoteConfigValue
         .mockResolvedValueOnce('false') // is_maintenance

--- a/api/src/core/guards/maintenance.guard.ts
+++ b/api/src/core/guards/maintenance.guard.ts
@@ -23,8 +23,16 @@ import { CLS_KEY_APP_VERSION } from '../cls/cls.constants';
  */
 @Injectable()
 export class MaintenanceGuard implements CanActivate {
-  /** 許可するパス（メンテナンス・バージョンチェックを行わない） */
-  private readonly allowedPaths = ['/metrics'];
+  /**
+   * 許可するパス（メンテナンス・バージョンチェックを行わない）
+   *
+   * `/livez` は外形監視専用の liveness エンドポイント。ここから外すと 2 つ壊れる。
+   *   1. 計画メンテのたびに 503 になり、本番障害としてページャが鳴る
+   *   2. この guard が毎回読む RemoteConfig（GCS）に監視が依存してしまい、
+   *      GCS の一時障害を「API 停止」と誤検知する
+   * 「正常に配信できるか」を見たい用途は `/health`（= ガード対象）を使うこと。
+   */
+  private readonly allowedPaths = ['/metrics', '/livez'];
 
   constructor(
     private readonly remoteConfigService: RemoteConfigService,

--- a/api/src/health/health.controller.spec.ts
+++ b/api/src/health/health.controller.spec.ts
@@ -1,0 +1,18 @@
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+  const controller = new HealthController();
+
+  it('returns ok with a timestamp from /health', () => {
+    const result = controller.getHealth();
+
+    expect(result.status).toBe('ok');
+    expect(Number.isNaN(Date.parse(result.timestamp))).toBe(false);
+  });
+
+  // 外形監視が content matcher でこの形を見る。壊すと uptime check が
+  // 「本文が期待と違う」で落ちるため、返り値の形を固定する。
+  it('returns a dependency-free ok from /livez', () => {
+    expect(controller.getLivez()).toEqual({ status: 'ok' });
+  });
+});

--- a/api/src/health/health.controller.ts
+++ b/api/src/health/health.controller.ts
@@ -7,16 +7,26 @@ interface HealthData {
   timestamp: string;
 }
 
+interface LivezData {
+  status: 'ok';
+}
+
 /**
  * HealthController
  *
- * フロントの起動直後チェック用の軽量エンドポイント
+ * 2 つのエンドポイントは目的が違う。用途に応じて叩き分けること。
+ *
+ * | path     | 意味                       | 想定利用者                   | メンテ中 |
+ * | -------- | -------------------------- | ---------------------------- | -------- |
+ * | /health  | 正常に配信できる (readiness) | フロントの起動時チェック等   | 503      |
+ * | /livez   | プロセスが応答する (liveness) | 外形監視 (uptime check)      | 200      |
+ *
  * - 平常時：200（実装規定のフォーマットで）
  * - メンテ時：グローバル検査で 503
  * - 旧バージョン：グローバル検査で 426
  *
- * 注意：このエンドポイントは MaintenanceGuard の対象であり、
- * 許可パスには登録しない（= ガードが効く）
+ * 注意：/health は MaintenanceGuard の対象であり、許可パスには登録しない
+ * （= ガードが効く）。/livez は逆に許可パスへ登録してある。
  */
 @Controller()
 export class HealthController {
@@ -26,5 +36,21 @@ export class HealthController {
       status: 'ok',
       timestamp: new Date().toISOString(),
     };
+  }
+
+  /**
+   * 外形監視 (Cloud Monitoring の uptime check) 専用の liveness エンドポイント。
+   *
+   * 【設計】依存を一切持たせない。DB も GCS も RemoteConfig も参照しない。
+   * MaintenanceGuard は毎リクエストで RemoteConfig（= GCS 読み）を叩くため、
+   * このパスを `allowedPaths` に登録して依存から外してある。監視対象が外部依存を
+   * 持つと、GCS の一時障害を「API 停止」としてページャに流してしまう。
+   *
+   * 【設計】メンテナンス中も 200 を返す。計画メンテのたびに本番障害として鳴るのを
+   * 防ぐため。「正常に配信できるか」を知りたい用途では /health を使うこと。
+   */
+  @Get('livez')
+  getLivez(): LivezData {
+    return { status: 'ok' };
   }
 }


### PR DESCRIPTION
Closes #1323

## 概要

本番デプロイの成否が「workflow が緑」以外に確認できず、実際に HTTP が返っているかは人手で見に行くしかありませんでした。#514 の本番適用後に「API が生きているか確認できるか」となったのが実例です。

`api-deploy.yml` にデプロイ直後のスモークテストを足し、あわせて外形監視用の liveness エンドポイント `/livez` を追加します。

## 変更内容

### `/livez`（liveness 専用エンドポイント）

| path | 意味 | 想定利用者 | メンテ中 |
| --- | --- | --- | --- |
| `/health` | 正常に配信できる (readiness) | フロントの起動時チェック | 503 |
| `/livez` | プロセスが応答する (liveness) | 外形監視 (uptime check) | 200 |

`MaintenanceGuard` の `allowedPaths` に `/livez` を登録します。これは料金や利便性の話ではなく要件です。この guard は**毎リクエストで RemoteConfig（= GCS 読み）を叩く**ため、登録しないと監視が GCS に依存し、GCS の一時障害を「API 停止」としてページャに流してしまいます。計画メンテのたびに鳴る問題も同時に消えます。

`/health` は現状維持（メンテ状態を反映）です。

### デプロイ直後のスモークテスト

`Show Service URL` の直後に、`steps.deploy.outputs.url` に対して認証不要な 3 経路を叩きます。`/v1/**` は `AuthAnonGuard` が付くのでトークン無しでは検証できませんが、この 3 本でも「コンテナが起動し、Nest のルーティングとグローバル Interceptor まで通る」ことは確認できます。

- コールドスタート対策に 5 回リトライ
- 判定は `.data.status`（`ResponseWrapInterceptor` が `BaseResponse` に包むため）
- `/health` と `/` はメンテ中の 503 を許容し、**`/livez` だけは許容しない**（`allowedPaths` から外れた事故を握り潰さないため）

### これは「通知」であって「ゲート」ではない

deploy ステップは `revision_traffic: LATEST=100` なので、スモークが走る時点で全トラフィックは既に新リビジョンへ移っています。**落ちても本番は差し戻りません。** ゲート化するには `no_traffic` + `tag` でデプロイ → タグ付き URL でスモーク → 通ってから `update-traffic`、という順序変更が必要で、これは別途とします。意図はコメントとして workflow 内に残してあります。

## 検証

- `health.controller.spec.ts`（新規）/ `maintenance.guard.spec.ts`（追加 1 件）: 9 件成功
- api 全体: 35 suites 成功 / 4 suites 失敗。失敗は本 PR 以前から red の既知 4 件（`pr-check.yml` 冒頭に記載）で、失敗数は 15 件のまま増減なし
- `tsc --noEmit` / `prettier --check`（変更ファイル）/ `git diff --check`: 成功
- YAML パース: 成功（13 steps）
- **スモークの bash はスタブ HTTP サーバで終了コードを実測**:

| シナリオ | 期待 | 実測 |
| --- | --- | --- |
| 全部 200 | 成功 | ✅ exit 0 |
| 実運用のメンテ中（`/livez` 200 / 他 503） | 成功 | ✅ exit 0 |
| 全部 503（`/livez` も落ちている = allowedPaths 事故） | 失敗 | ✅ exit 1 |
| 200 だが本文が `status != ok` | 失敗 | ✅ exit 1 |
| 500 | 失敗 | ✅ exit 1 |

## 補足

uptime check とアラートポリシー（`infra/monitoring/` のスクリプト）は本 PR に含みません。本番 GCP への適用操作を伴い、レビューの性質が違うためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMvxwbmw2ZcKxnNriwGokw