### PR TITLE
#1324 feat: 本番トラフィックの切替をスモークでゲートする

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -190,7 +190,11 @@ jobs:
       # -------------------------------------------
 
       # ---------- 検証を通した候補を 100% へ昇格 ----------
-      - name: 🚦 Promote candidate
+      # 【設計】昇格と tag 剥がしはステップを分ける。1 つに束ねると、tag 剥がしが
+      # 落ちただけで「昇格していない」と読める失敗になり、障害対応で本番の状態を
+      # 逆に伝えてしまう。ステップが別なら outcome も別に判定できる。
+      - id: promote
+        name: 🚦 Promote candidate
         env:
           REVISION: ${{ steps.candidate.outputs.revision }}
         run: |
@@ -202,17 +206,34 @@ jobs:
           gcloud run services update-traffic "${SERVICE_NAME}" \
             --region "${REGION}" --to-revisions "${REVISION}=100"
 
-          # tag を残すとそのリビジョンがピン留めされ、古い世代が GC されずに溜まる。
-          # 昇格が成功した後にだけ剥がす。1 コマンドに束ねないのは、
-          # 昇格そのものの失敗と tag 剥がしの失敗を切り分けるため。
+          echo "✅ Deployed: ${{ steps.deploy.outputs.url }}（revision: ${REVISION}）"
+
+      # 【設計】tag 剥がしの失敗で job を落とさない（continue-on-error）。
+      # この時点で昇格は済んでおり、本番は新リビジョンが正常に捌いている。
+      # 残った tag が指すのも「今動いているリビジョン」なので実害は小さく、
+      # 次のデプロイで tag は新しい候補へ移る。ここで job を赤くすると
+      # 「デプロイ失敗」と読めてしまい、実態と食い違う。
+      - id: cleanup_tag
+        name: 🧹 Remove candidate tag
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          # tag を残し続けるとそのリビジョンがピン留めされ、古い世代が GC されない。
           gcloud run services update-traffic "${SERVICE_NAME}" \
             --region "${REGION}" --remove-tags "${CANDIDATE_TAG}"
 
-          echo "✅ Deployed: ${{ steps.deploy.outputs.url }}（revision: ${REVISION}）"
+      - name: ⚠️ Warn on leftover tag
+        if: steps.cleanup_tag.outcome == 'failure'
+        run: |
+          echo "::warning::昇格は成功したが tag '${CANDIDATE_TAG}' を剥がせなかった。\
+          本番は revision ${{ steps.candidate.outputs.revision }} が捌いている。\
+          tag は次のデプロイで新しい候補へ移るが、気になる場合は手動で剥がすこと。"
 
-      # スモークが落ちたときに、調査先を最後に出しておく。
+      # スモークが落ちたとき（= 昇格していないとき）だけ、調査先を出す。
+      # 条件に promote の outcome を入れているのは、昇格後の失敗でこの
+      # メッセージが出ると本番の状態を誤って伝えることになるため。
       - name: 🧭 Candidate left for investigation
-        if: failure() && steps.candidate.outputs.url != ''
+        if: failure() && steps.promote.outcome != 'success' && steps.candidate.outputs.url != ''
         run: |
           echo "⚠️ 昇格していない。本番は旧リビジョンのまま。"
           echo "   candidate revision: ${{ steps.candidate.outputs.revision }}"

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -30,6 +30,9 @@ jobs:
       REGION: ${{ vars.CLOUD_RUN_REGION }} # 例）asia-northeast1
       SERVICE_NAME: api-${{ github.event.inputs.target }}
       IMAGE: ${{ vars.ARTIFACT_REPO_URI }}/api:${{ github.sha }}
+      # #1323 スモークを通す前の候補リビジョンに付ける traffic tag。
+      # 昇格時に剥がす（残すと古いリビジョンがピン留めされ GC されない）。
+      CANDIDATE_TAG: candidate
 
     steps:
       - uses: actions/checkout@v4
@@ -81,37 +84,62 @@ jobs:
             --project="${{ secrets.GCP_PROJECT_ID }}" \
             --default-buckets-behavior=REGIONAL_USER_OWNED_BUCKET
       # -------------------------------------------
-      # ---------- Cloud Run へデプロイ & トラフィック切替 ----------
+      # ---------- Cloud Run へデプロイ（トラフィックは切り替えない） ----------
+      # #1323 【設計】トラフィック切替の *前* にスモークを挟むため、ここでは
+      # `--no-traffic --tag` でリビジョンを作るだけにする。旧リビジョンが本番を
+      # 捌き続けるので、スモークが落ちても利用者影響はゼロで済む。
+      # `revision_traffic` は使わない。切替は検証を通した後に自分で行う。
       - id: deploy
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.REGION }}
           image: ${{ env.IMAGE }}
-          revision_traffic: "LATEST=100" # 成功後ただちに全トラフィック移行
+          no_traffic: true
+          tag: ${{ env.CANDIDATE_TAG }}
           env_vars: |
             API_COMMIT_ID=${{ github.sha }}
             API_NODE_ENV=${{ github.event.inputs.target }}
 
-      - name: Show Service URL
+      # 候補リビジョンの URL と名前を引く。
+      # action の `outputs.url` は **service の URL**（= 切替前なので旧リビジョンを指す）
+      # であって tag 付き URL ではない。検証対象を取り違えないよう traffic から引き直す。
+      - id: candidate
+        name: 🔍 Resolve candidate revision
         run: |
-          echo "✅ Deployed: ${{ steps.deploy.outputs.url }}"
+          set -euo pipefail
 
-      # ---------- デプロイ直後のスモークテスト ----------
-      # デプロイした ref に対して、実際に HTTP が返ることを確認する。
+          traffic=$(gcloud run services describe "${SERVICE_NAME}" \
+                      --region "${REGION}" --format=json)
+
+          url=$(echo "$traffic" | jq -r --arg t "${CANDIDATE_TAG}" \
+                  '.status.traffic[]? | select(.tag == $t) | .url' | head -1)
+          revision=$(echo "$traffic" | jq -r --arg t "${CANDIDATE_TAG}" \
+                  '.status.traffic[]? | select(.tag == $t) | .revisionName' | head -1)
+
+          if [ -z "$url" ] || [ "$url" = "null" ] ||
+             [ -z "$revision" ] || [ "$revision" = "null" ]; then
+            echo "❌ tag '${CANDIDATE_TAG}' の付いたリビジョンが見つからない"
+            echo "$traffic" | jq '.status.traffic'
+            exit 1
+          fi
+
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+          echo "revision=${revision}" >> "$GITHUB_OUTPUT"
+          echo "🔍 candidate: ${revision} → ${url}"
+
+      # ---------- 候補リビジョンへのスモークテスト（切替のゲート） ----------
+      # 【設計】これは「ゲート」である。ここが落ちると次の昇格ステップへ進まず、
+      # 本番のトラフィックは旧リビジョンに留まる。壊れたリビジョンが本番を
+      # 捌くことは無い。落ちた候補は tag が付いたまま残るので、そのまま URL を
+      # 叩いて原因を追える（次回デプロイで tag は新しい候補へ移る）。
       #
-      # 【設計】これは「通知」であって「ゲート」ではない。上の deploy は
-      # revision_traffic: LATEST=100 なので、ここへ来た時点で全トラフィックは
-      # 既に新リビジョンへ移っている。ここが落ちても本番は差し戻らない。
-      # ゲートにするなら no_traffic + tag でデプロイ → ここでタグ付き URL を
-      # 叩く → 通ってから update-traffic、という順序に変える必要がある。
-      #
-      # 【設計】叩けるのは認証不要な 2 本だけ。/v1/** は AuthAnonGuard が
+      # 【設計】叩けるのは認証不要な 3 本だけ。/v1/** は AuthAnonGuard が
       # 付くのでトークン無しでは検証できない。それでも「コンテナが起動して
       # Nest のルーティングとグローバル Interceptor まで通る」ことは確認できる。
       - name: 🔥 Smoke test
         env:
-          BASE_URL: ${{ steps.deploy.outputs.url }}
+          BASE_URL: ${{ steps.candidate.outputs.url }}
         run: |
           set -euo pipefail
 
@@ -159,4 +187,34 @@ jobs:
           probe /livez  '.data.status == "ok"'
           probe /health '.data.status == "ok"' allow-maintenance
           probe /       ''                     allow-maintenance
+      # -------------------------------------------
+
+      # ---------- 検証を通した候補を 100% へ昇格 ----------
+      - name: 🚦 Promote candidate
+        env:
+          REVISION: ${{ steps.candidate.outputs.revision }}
+        run: |
+          set -euo pipefail
+
+          # --to-latest ではなく、実際にスモークを通したリビジョンを名指しする。
+          # concurrency でデプロイは直列化されているが、"最新" と "検証したもの" は
+          # 概念として別なので、ここで取り違える余地を残さない。
+          gcloud run services update-traffic "${SERVICE_NAME}" \
+            --region "${REGION}" --to-revisions "${REVISION}=100"
+
+          # tag を残すとそのリビジョンがピン留めされ、古い世代が GC されずに溜まる。
+          # 昇格が成功した後にだけ剥がす。1 コマンドに束ねないのは、
+          # 昇格そのものの失敗と tag 剥がしの失敗を切り分けるため。
+          gcloud run services update-traffic "${SERVICE_NAME}" \
+            --region "${REGION}" --remove-tags "${CANDIDATE_TAG}"
+
+          echo "✅ Deployed: ${{ steps.deploy.outputs.url }}（revision: ${REVISION}）"
+
+      # スモークが落ちたときに、調査先を最後に出しておく。
+      - name: 🧭 Candidate left for investigation
+        if: failure() && steps.candidate.outputs.url != ''
+        run: |
+          echo "⚠️ 昇格していない。本番は旧リビジョンのまま。"
+          echo "   candidate revision: ${{ steps.candidate.outputs.revision }}"
+          echo "   candidate url     : ${{ steps.candidate.outputs.url }}"
       # -------------------------------------------


### PR DESCRIPTION
Closes #1324

## 概要

#1323 で入れたスモークは「通知」であって「ゲート」ではありませんでした。deploy ステップが `revision_traffic: LATEST=100` のため、スモークが走る時点で全トラフィックは既に新リビジョンへ移っており、**壊れたリビジョンが本番を捌くこと自体は防げていません**でした。

deploy → 検証 → 昇格 の順序に変えます。

## なぜ今か

#1323 の時点でゲート化しなかったのは、スモークが一度も実サービスに対して走っておらず、判定に使う `.data.status == "ok"` が**コードを読んで書いた推測**だったためです。最初からゲートにすると、推測が外れた場合に全デプロイが止まります。

2026-08-14 の本番デプロイ（[run 31802546113](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/31802546113)）で実測が取れました。

```
BASE_URL: https://api-production-mmmhow6noq-an.a.run.app
✅ /livez → 200
✅ /health → 200
✅ / → 200
```

assertion 込みで通っているので、保留理由は解消しています。

## 変更内容

| 順 | ステップ | 内容 |
| --- | --- | --- |
| 1 | deploy | `no_traffic: true` + `tag: candidate`。リビジョンだけ作り、本番は旧リビジョンのまま |
| 2 | 🔍 Resolve candidate revision | `gcloud run services describe` から tag 付き URL とリビジョン名を引く |
| 3 | 🔥 Smoke test | その URL に対して実行（probe の中身は #1323 から変更なし） |
| 4 | 🚦 Promote candidate | `--to-revisions <検証したリビジョン>=100` で昇格し、tag を剥がす |
| 5 | 🧭 Candidate left for investigation | `if: failure()` で調査先の URL を出す |

3 が落ちれば 4 に進まないので、**本番のトラフィックは旧リビジョンに留まります。**

## 実装上の注意（コメントとして workflow にも残しています）

- **`outputs.url` は service の URL であって tag 付き URL ではない。** 切替前はこれが旧リビジョンを指すので、そのまま使うと「まだ検証していないもの」ではなく「今動いているもの」を叩いてしまい、ゲートが常に通る。traffic から引き直しています
- 昇格は `--to-latest` ではなく**スモークを通したリビジョンを名指し**。`concurrency` で直列化されてはいますが、「最新」と「検証したもの」は概念として別です
- **tag を剥がし忘れるとそのリビジョンがピン留めされ、古い世代が GC されずに溜まります。** 昇格成功後に剥がします。昇格と tag 剥がしを 1 コマンドに束ねていないのは、どちらが失敗したか切り分けるためです
- 失敗時は tag を残します。落ちた候補の URL をそのまま叩いて調査できるようにするためで、次回デプロイで tag は新しい候補へ移ります

## 検証

`deploy-cloudrun@v2` の仕様は推測せず、実物を取得して確認しました。

- `action.yml`: `no_traffic` / `tag` が入力として存在すること、`outputs` が `url`（"The URL of the Cloud Run service"）のみであることを確認
- `src/main.ts`: `--tag` と `--no-traffic` がいずれも deploy コマンドへ渡されること（`update-traffic` は `revision_traffic` / `tag_traffic` 用の別経路であること）を確認

bash 部分の実測:

| 対象 | シナリオ | 結果 |
| --- | --- | --- |
| candidate 解決の jq | `describe --format=json` のフィクスチャから url / revisionName を抽出 | ✅ 期待値一致 |
| candidate 解決の jq | tag が付いていない（異常系） | ✅ 空を検出し exit 1 の分岐へ |
| probe | 全部 200 | ✅ exit 0 |
| probe | 実運用のメンテ中（`/livez` 200 / 他 503） | ✅ exit 0 |
| probe | 全部 503（`/livez` も落ちている） | ✅ exit 1 |
| probe | 200 だが `status != ok` | ✅ exit 1 |
| probe | 500 | ✅ exit 1 |

- YAML パース: 成功（15 steps、`if: failure()` の付与位置も確認）
- api のコード変更なし（workflow のみ）

## 残作業

このゲートは**次のデプロイで初めて実走**します。マージ後に production へデプロイして、候補解決・スモーク・昇格・tag 剥がしが通ることを確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMvxwbmw2ZcKxnNriwGokw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMvxwbmw2ZcKxnNriwGokw)_