### PR TITLE
#1324 fix: 昇格後に案内する URL が死んだ tag URL になっていた

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -116,6 +116,8 @@ jobs:
                   '.status.traffic[]? | select(.tag == $t) | .url' | head -1)
           revision=$(echo "$traffic" | jq -r --arg t "${CANDIDATE_TAG}" \
                   '.status.traffic[]? | select(.tag == $t) | .revisionName' | head -1)
+          # 昇格後に案内する恒常 URL。tag 付き URL は tag を剥がすと死ぬので使えない。
+          service_url=$(echo "$traffic" | jq -r '.status.url')
 
           if [ -z "$url" ] || [ "$url" = "null" ] ||
              [ -z "$revision" ] || [ "$revision" = "null" ]; then
@@ -126,6 +128,7 @@ jobs:
 
           echo "url=${url}" >> "$GITHUB_OUTPUT"
           echo "revision=${revision}" >> "$GITHUB_OUTPUT"
+          echo "service_url=${service_url}" >> "$GITHUB_OUTPUT"
           echo "🔍 candidate: ${revision} → ${url}"
 
       # ---------- 候補リビジョンへのスモークテスト（切替のゲート） ----------
@@ -206,7 +209,11 @@ jobs:
           gcloud run services update-traffic "${SERVICE_NAME}" \
             --region "${REGION}" --to-revisions "${REVISION}=100"
 
-          echo "✅ Deployed: ${{ steps.deploy.outputs.url }}（revision: ${REVISION}）"
+          # deploy の outputs.url は使わない。action.yml の説明は "The URL of the
+          # Cloud Run service" だが、`tag` を渡すと **tag 付き URL** が返ることを
+          # 2026-08-14 の本番デプロイ（run 31804486694）で実測した。次の
+          # ステップで tag を剥がすため、それを案内すると死んだ URL を渡すことになる。
+          echo "✅ Deployed: ${{ steps.candidate.outputs.service_url }}（revision: ${REVISION}）"
 
       # 【設計】tag 剥がしの失敗で job を落とさない（continue-on-error）。
       # この時点で昇格は済んでおり、本番は新リビジョンが正常に捌いている。


### PR DESCRIPTION
#1324 で入れたゲートを本番で実走させたところ（[run 31804486694](``https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/31804486694)）、ゲート自体は全ステップ通ったものの、成功メッセージが誤った`` URL を出していました。

## 事象

```
✅ Deployed: https://candidate---api-production-mmmhow6noq-an.a.run.app（revision: api-production-00075-wot）
```

案内しているのが **tag 付き URL** で、しかも**この直後のステップで tag を剥がすため、表示された URL は既に死んでいます**。

## 原因

`deploy-cloudrun@v2` の `outputs.url` は action.yml の説明では "The URL of the Cloud Run service" ですが、**`tag` を渡すと tag 付き URL が返ります**。上記 run のログで実測しました。#1324 のレビュー時点では action.yml の記述を根拠にしていたため、この差分に気付けませんでした。

なお、スモークの検証対象は `outputs.url` ではなく `gcloud run services describe` から引いているので、**検証そのものは正しい対象に対して行われています**（結果的には同じ URL でしたが、依存していません）。影響はこの表示メッセージだけです。

## 修正

候補解決ステップで `describe` の `.status.url`（service の恒常 URL）も出力し、昇格後のメッセージはそちらを使います。`outputs.url` を使わない理由と、実測した事実をコメントに残しました。

## 検証

- `.status.url` の抽出をフィクスチャで確認: `https://api-production-mmmhow6noq-an.a.run.app`（実際に gcloud が `URL:` として出力した値と一致）
- YAML パース: 成功（17 steps）
- マージ後、development へデプロイして表示を実確認します

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMvxwbmw2ZcKxnNriwGokw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMvxwbmw2ZcKxnNriwGokw)_