### PR TITLE
#1374 fix(app-expo): OAuth の redirectTo で next を二重エンコードしない

### DIFF
--- a/app-expo/contexts/AuthProvider.tsx
+++ b/app-expo/contexts/AuthProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useRef, useCallback, useMemo } from "react";
 import { supabase, consumeAuthRetryAfterHeader } from "@/lib/supabase";
+import { readOAuthResultQuery } from "@/lib/oauthResultUrl";
 // #1030 【設計】E2E(Detox) 専用のセッション注入フック。
 // 通常ビルドでは metro.config.js が noop 実装（lib/e2e/injectTestSession.noop.ts）へ解決し直すため、
 // 本番バンドルにはこの実装コードも react-native-launch-arguments も一切含まれない。
@@ -806,7 +807,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
 		const parsed = Linking.parse(result.url);
 		const parsedLocale = (parsed.hostname ?? "ja-JP") as string;
-		const qp = Object.fromEntries(Object.entries(parsed.queryParams ?? {}).map(([k, v]) => [k, String(v)])); // queryParams は string | number | boolean | null などが来るので文字列化
+		// #1374 クエリは «デコード 1 回» で読む（lib/oauthResultUrl.ts の JSDoc 参照）。
+		// Linking.parse の queryParams は 2 回デコードなので、redirectTo を 1 回エンコードへ直した
+		// 今は過剰になる。読めなかったときだけ従来の経路へ倒す
+		const qp =
+			readOAuthResultQuery(result.url) ??
+			Object.fromEntries(Object.entries(parsed.queryParams ?? {}).map(([k, v]) => [k, String(v)]));
 		const href: Href = {
 			pathname: "/[locale]/auth/callback",
 			params: { locale: parsedLocale, ...qp },
@@ -824,12 +830,18 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 		if (!url) return { status: "no_result" };
 
 		const parsed = Linking.parse(url);
-		const code = parsed.queryParams?.code as string | undefined;
-		const intent = parsed.queryParams?.intent as string | undefined;
-		const provider = parsed.queryParams?.provider as Provider | undefined;
-		const error = parsed.queryParams?.error as string | undefined;
-		const error_code = parsed.queryParams?.error_code as string | undefined;
-		const error_description = parsed.queryParams?.error_description as string | undefined;
+		// #1374 同上。ここが 2 回デコードのままだと、next に裸の `%` が入っただけで
+		// URIError が起き、Linking.parse の catch がそれを飲んで **code まで消える**
+		const queryParams =
+			readOAuthResultQuery(url) ??
+			(parsed.queryParams as Record<string, string | undefined> | undefined) ??
+			{};
+		const code = queryParams.code as string | undefined;
+		const intent = queryParams.intent as string | undefined;
+		const provider = queryParams.provider as Provider | undefined;
+		const error = queryParams.error as string | undefined;
+		const error_code = queryParams.error_code as string | undefined;
+		const error_description = queryParams.error_description as string | undefined;
 
 		// エラーがある場合は、そのまま例外として throw する
 		// callback.tsx 側で処理するため、ここでは自動フォールバックしない

--- a/app-expo/contexts/AuthProvider.tsx
+++ b/app-expo/contexts/AuthProvider.tsx
@@ -130,10 +130,36 @@ const AUTH_RESOLVE_WAIT_MS = 8_000;
  * 通してから遷移する（URL は外から書き換えられるため、最終的な砦は受け取り側にある）。
  * この関数は運ぶだけで、Supabase 呼び出しの意味は変えない。
  *
- * @param query `intent=signin` のような、この経路を識別する既存のクエリ
+ * #1374 【バグ】ここで «クエリを文字列に組み立てない» こと。
+ *
+ * 以前は `?intent=signin&next=${encodeURIComponent(next)}` まで含めた 1 本の文字列を作り、
+ * それを `makeRedirectUri({ path })` に渡していた。`makeRedirectUri` は中で
+ * `Linking.createURL(path, …)` を呼び、`createURL` は **path 部分だけに `encodeURI()` を掛ける**
+ *（expo-linking の build/createURL.js:113）。そのため `%2F` が `%252F` へ二重エンコードされる。
+ *
+ * 二重になると、デコード回数が経路によって食い違う。
+ *   経路A: WebBrowser.openAuthSessionAsync 成功 → Linking.parse → searchParams + decodeURIComponent の 2 回
+ *          → たまたま元に戻り、動く
+ *   経路B: OS のディープリンクで callback へ直接着地（アプリがコールドスタートし
+ *          Linking.getInitialURL() から拾う経路）→ expo-router は searchParams の 1 回だけ
+ *          → `"%2Fja-JP%2F…"` のままで先頭が `/` にならず、resolveNextPath が null を返して
+ *            next が黙って捨てられる
+ *
+ * `createURL` は `queryParams` を **`encodeURI` の後に** `URLSearchParams` で 1 回だけ
+ * エンコードして連結する（同ファイル :113-114）。だからクエリは «構造のまま» 渡す。
+ *
+ * @param params `{ intent: "signin" }` のような、この経路を識別する既存のクエリ
  */
-const buildAuthCallbackPath = (locale: string, query: string, next?: string): string =>
-	`${locale}/auth/callback?${query}${next ? `&next=${encodeURIComponent(next)}` : ""}`;
+const buildAuthCallbackPath = (locale: string): string => `${locale}/auth/callback`;
+
+const buildAuthCallbackQueryParams = (
+	params: Record<string, string>,
+	next?: string,
+): Record<string, string> => (next ? { ...params, next } : { ...params });
+
+/** web の redirectTo。`encodeURI` を通らないので、ここは自分で 1 回だけエンコードする */
+const buildWebAuthCallbackUrl = (locale: string, params: Record<string, string>): string =>
+	`${window.location.origin}/${buildAuthCallbackPath(locale)}?${new URLSearchParams(params).toString()}`;
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
@@ -667,11 +693,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 			...queryParams, // 呼び出し側で上書きしたければこちらが優先
 		};
 
-		const callbackPath = buildAuthCallbackPath(locale, "intent=signin", next);
+		const callbackQueryParams = buildAuthCallbackQueryParams({ intent: "signin" }, next);
 		const redirectTo =
 			Platform.OS === "web"
-				? `${window.location.origin}/${callbackPath}`
-				: AuthSession.makeRedirectUri({ scheme: "nanitabeyo", path: callbackPath });
+				? buildWebAuthCallbackUrl(locale, callbackQueryParams)
+				: AuthSession.makeRedirectUri({
+						scheme: "nanitabeyo",
+						path: buildAuthCallbackPath(locale),
+						queryParams: callbackQueryParams,
+					});
 		const { data, error } = await supabase.auth.signInWithOAuth({
 			provider,
 			options: {
@@ -736,11 +766,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 		};
 
 		// linkIdentity の場合は、 匿名アップグレード由来のリダイレクトであることを示すために `?intent=link` を付与
-		const callbackPath = buildAuthCallbackPath(locale, `intent=link&provider=${provider}`, next);
+		const callbackQueryParams = buildAuthCallbackQueryParams({ intent: "link", provider }, next);
 		const redirectTo =
 			Platform.OS === "web"
-				? `${window.location.origin}/${callbackPath}`
-				: AuthSession.makeRedirectUri({ scheme: "nanitabeyo", path: callbackPath });
+				? buildWebAuthCallbackUrl(locale, callbackQueryParams)
+				: AuthSession.makeRedirectUri({
+						scheme: "nanitabeyo",
+						path: buildAuthCallbackPath(locale),
+						queryParams: callbackQueryParams,
+					});
 		const { data, error } = await supabase.auth.linkIdentity({
 			provider,
 			options: {

--- a/app-expo/contexts/authProviderOAuthNext.test.tsx
+++ b/app-expo/contexts/authProviderOAuthNext.test.tsx
@@ -32,6 +32,7 @@ jest.mock("@/lib/supabase", () => ({
 			refreshSession: jest.fn(),
 			signInWithOAuth: jest.fn(),
 			linkIdentity: jest.fn(),
+			exchangeCodeForSession: jest.fn(),
 		},
 	},
 	consumeAuthRetryAfterHeader: jest.fn(() => null),
@@ -86,6 +87,7 @@ const auth = supabase.auth as unknown as {
 	onAuthStateChange: jest.Mock;
 	signInWithOAuth: jest.Mock;
 	linkIdentity: jest.Mock;
+	exchangeCodeForSession: jest.Mock;
 };
 const makeRedirectUri = AuthSession.makeRedirectUri as unknown as jest.Mock;
 
@@ -493,5 +495,65 @@ describe("#1374 ブラウザ復帰（経路A）が callback へ渡す params", (
 		});
 
 		expect(mockRouterReplace.mock.calls.at(-1)?.[0].params.next).toBe(next);
+	});
+});
+
+/*
+#1374 `handleOAuthResultUrl` 側も «デコード 1 回» で読む（PR #1393 の再レビュー N1）。
+
+openOAuthBrowserSession だけ直しても、callback 画面が実際に認証を成立させるのはこちらである。
+Linking.parse（2 回デコード）のままだと、next に裸の `%` が入った瞬間に URIError が
+forEach を止め、**code が queryParams に入らない**。エラーにもならず no_result になるので、
+ユーザーには «ログインが黙って失敗した» としか見えない。
+*/
+describe("#1374 handleOAuthResultUrl のクエリ読み取り", () => {
+	let authValue: ReturnType<typeof useAuth>;
+	const Probe = () => {
+		authValue = useAuth();
+		return null;
+	};
+
+	beforeEach(async () => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		auth.getSession.mockResolvedValue({ data: { session: null }, error: null });
+		auth.setSession.mockResolvedValue({ data: { session: null }, error: null });
+		auth.signInAnonymously.mockResolvedValue({
+			data: { session: { access_token: "a", refresh_token: "r", user: { id: "anon-1" } } },
+			error: null,
+		});
+		auth.onAuthStateChange.mockImplementation(() => ({ data: { subscription: { unsubscribe: jest.fn() } } }));
+		auth.exchangeCodeForSession.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
+		await act(async () => {
+			TestRenderer.create(
+				<AuthProvider>
+					<Probe />
+				</AuthProvider>,
+			);
+		});
+	});
+
+	// ⚠️ 本命。2 回デコードへ戻すと code が消えて no_result になる
+	it("next に裸の % が入っていても code を取り出して認証を成立させる", async () => {
+		const url =
+			"nanitabeyo://ja-JP/auth/callback?intent=signin&next=%2Fja-JP%2Fx%3Fq%3D50%25&code=AUTHCODE";
+
+		let result!: Awaited<ReturnType<typeof authValue.handleOAuthResultUrl>>;
+		await act(async () => {
+			result = await authValue.handleOAuthResultUrl(url);
+		});
+
+		expect(auth.exchangeCodeForSession).toHaveBeenCalledWith("AUTHCODE");
+		expect(result.status).toBe("authenticated");
+	});
+
+	// error 系のクエリが従来どおり読めること（読み取りを差し替えたので対で見る）
+	it("error クエリは従来どおり例外として投げる", async () => {
+		const url = "nanitabeyo://ja-JP/auth/callback?intent=signin&error=access_denied&error_code=403";
+
+		await expect(
+			act(async () => {
+				await authValue.handleOAuthResultUrl(url);
+			}),
+		).rejects.toThrow();
 	});
 });

--- a/app-expo/contexts/authProviderOAuthNext.test.tsx
+++ b/app-expo/contexts/authProviderOAuthNext.test.tsx
@@ -6,10 +6,17 @@
 // 実際の OAuth を通さないと踏めない経路なので、redirectTo の «組み立て» だけをここで観測する。
 //
 // ⚠️ 検証（`resolveNextPath`）はここではなく呼び出し側と受け取り側で行う。この層は運ぶだけ。
+//
+// #1374 【バグ】運び方も観測対象である。以前は `?intent=…&next=${encodeURIComponent(next)}` まで
+// 含めた 1 本の文字列を `makeRedirectUri({ path })` に渡していたが、`createURL` が path へ
+// `encodeURI()` を掛けるため `%2F` が `%252F` になっていた。二重になるとデコード回数が経路で
+// 食い違い、OS のディープリンクで callback へ着地する経路（アプリのコールドスタート）だけ
+// `next` が捨てられる。そこで下の describe は «makeRedirectUri が実際に作る URL» まで見る。
 import React from "react";
 import { act } from "react";
 import TestRenderer from "react-test-renderer";
 import * as AuthSession from "expo-auth-session";
+import { Platform } from "react-native";
 import { supabase } from "@/lib/supabase";
 import { AuthProvider, useAuth } from "./AuthProvider";
 
@@ -42,6 +49,8 @@ jest.mock("expo-router", () => {
 });
 jest.mock("@/lib/logoutRedirect", () => ({ requestLogoutRedirect: jest.fn() }));
 jest.mock("expo-linking", () => ({ parse: jest.fn() }));
+// ⚠️ 既定の戻り値は使い捨ての文字列だが、#1374 の describe では
+// «expo-linking の createURL と同じ規約» を実装した版に差し替える（下の buildLikeCreateURL）
 jest.mock("expo-auth-session", () => ({ makeRedirectUri: jest.fn(() => "nanitabeyo://redirect") }));
 jest.mock("expo-web-browser", () => ({ openAuthSessionAsync: jest.fn() }));
 jest.mock("@/stores/useDishMediaEntriesStore", () => ({
@@ -100,15 +109,18 @@ describe("#1370 OAuth の redirectTo が next を運ぶ", () => {
 		await mountProvider();
 	});
 
-	/** native では redirectTo は makeRedirectUri({ path }) から組まれる（Platform.OS !== "web"） */
+	/** native では redirectTo は makeRedirectUri({ path, queryParams }) から組まれる（Platform.OS !== "web"） */
 	const redirectPath = (): string => makeRedirectUri.mock.calls[0][0].path;
+	/** #1374 クエリは «構造のまま» 渡す。文字列に組み立てない */
+	const redirectQueryParams = (): Record<string, string> => makeRedirectUri.mock.calls[0][0].queryParams;
 
 	it("signInWithOAuth: next を intent と同じクエリに載せる", async () => {
 		await act(async () => {
 			await authValue.signInWithOAuth("google", { next: "/ja-JP/(tabs)/review" });
 		});
 
-		expect(redirectPath()).toBe("ja-JP/auth/callback?intent=signin&next=%2Fja-JP%2F(tabs)%2Freview");
+		expect(redirectPath()).toBe("ja-JP/auth/callback");
+		expect(redirectQueryParams()).toEqual({ intent: "signin", next: "/ja-JP/(tabs)/review" });
 	});
 
 	it("linkIdentity: 既存の intent=link&provider に続けて next を載せる", async () => {
@@ -116,7 +128,8 @@ describe("#1370 OAuth の redirectTo が next を運ぶ", () => {
 			await authValue.linkIdentity("google", { next: "/ja-JP/(tabs)/review" });
 		});
 
-		expect(redirectPath()).toBe("ja-JP/auth/callback?intent=link&provider=google&next=%2Fja-JP%2F(tabs)%2Freview");
+		expect(redirectPath()).toBe("ja-JP/auth/callback");
+		expect(redirectQueryParams()).toEqual({ intent: "link", provider: "google", next: "/ja-JP/(tabs)/review" });
 	});
 
 	// next はあくまで optional。指定しない既存の呼び出しの URL を変えていないこと
@@ -125,16 +138,18 @@ describe("#1370 OAuth の redirectTo が next を運ぶ", () => {
 			await authValue.signInWithOAuth("google");
 		});
 
-		expect(redirectPath()).toBe("ja-JP/auth/callback?intent=signin");
+		expect(redirectPath()).toBe("ja-JP/auth/callback");
+		expect(redirectQueryParams()).toEqual({ intent: "signin" });
 	});
 
-	// `?`/`&`/`#` を含むパスがそのまま連結されると、callback 側で別のパラメータとして読まれる
-	it("next はエンコードして載せる（クエリ付きの行き先が壊れない）", async () => {
+	// `?`/`&`/`#` を含むパスは «生のまま» 渡し、エンコードは createURL（URLSearchParams）に 1 回だけ任せる。
+	// 自分でも掛けると #1374 の二重エンコードに戻る
+	it("クエリ付きの行き先も生のまま渡す（エンコードは 1 箇所に任せる）", async () => {
 		await act(async () => {
 			await authValue.signInWithOAuth("google", { next: "/ja-JP/profile?tab=posts" });
 		});
 
-		expect(redirectPath()).toBe("ja-JP/auth/callback?intent=signin&next=%2Fja-JP%2Fprofile%3Ftab%3Dposts");
+		expect(redirectQueryParams()).toEqual({ intent: "signin", next: "/ja-JP/profile?tab=posts" });
 	});
 
 	// Supabase 呼び出しの «意味» は変えない（#1370 のスコープ外）。redirectTo 以外の引数が動いていないこと
@@ -149,5 +164,175 @@ describe("#1370 OAuth の redirectTo が next を運ぶ", () => {
 				options: expect.objectContaining({ queryParams: { prompt: "select_account" } }),
 			}),
 		);
+	});
+});
+
+/*
+#1374 【バグ】OAuth 復帰の 2 経路でデコード回数が食い違い、片方だけ `next` が落ちる。
+
+- 経路A: WebBrowser.openAuthSessionAsync が成功 → Linking.parse（searchParams）→ さらに
+  decodeURIComponent → 合計 2 回
+- 経路B: OS のディープリンクで callback へ直接着地（ブラウザ中にアプリが落とされ、
+  コールドスタートして Linking.getInitialURL() から拾う経路）→ expo-router の
+  `new URL(...).searchParams` で 1 回だけ
+
+redirectTo が二重エンコードされていると、A では «たまたま» 元に戻り、B では
+`"%2Fja-JP%2F…"` のままになる。先頭が `/` でないので resolveNextPath が null を返し、
+next が黙って捨てられてマイページへ倒れる（fail-closed なので穴ではないが、行き先は失われる）。
+
+⚠️ ここが赤くなったら、また経路 B だけが壊れている。ユニットでしか踏めない。
+*/
+describe("#1374 redirectTo が二重エンコードされない", () => {
+	let authValue: ReturnType<typeof useAuth>;
+
+	const Probe = () => {
+		authValue = useAuth();
+		return null;
+	};
+
+	/**
+	 * expo-linking の `createURL` と同じ規約で URL を組む。
+	 *
+	 * 本物（build/createURL.js:113-114）は
+	 *   `encodeURI(scheme + "://" + path)` に、`URLSearchParams(queryParams)` の結果を **後から** 足す。
+	 * つまり path だけが `encodeURI` を通り、クエリは 1 回だけエンコードされる。
+	 */
+	const buildLikeCreateURL = ({
+		path,
+		queryParams,
+	}: {
+		path: string;
+		queryParams?: Record<string, string>;
+	}): string => {
+		const query = new URLSearchParams(queryParams ?? {}).toString();
+		return `${encodeURI(`nanitabeyo:///${path}`)}${query ? `?${query}` : ""}`;
+	};
+
+	/** 経路B の読み取り。expo-router と同じく searchParams で «1 回だけ» デコードする */
+	const readNextLikeRouteB = (url: string): string | null =>
+		new URL(url.replace("nanitabeyo://", "https://deeplink")).searchParams.get("next");
+
+	beforeEach(async () => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		auth.getSession.mockResolvedValue({ data: { session: null }, error: null });
+		auth.setSession.mockResolvedValue({ data: { session: null }, error: null });
+		auth.signInAnonymously.mockResolvedValue({
+			data: { session: { access_token: "a", refresh_token: "r", user: { id: "anon-1" } } },
+			error: null,
+		});
+		auth.onAuthStateChange.mockImplementation(() => ({ data: { subscription: { unsubscribe: jest.fn() } } }));
+		auth.signInWithOAuth.mockResolvedValue({ data: { url: null }, error: null });
+		auth.linkIdentity.mockResolvedValue({ data: { url: null }, error: null });
+		// 本物の createURL と同じ規約で組み立てる
+		makeRedirectUri.mockImplementation(buildLikeCreateURL);
+		await act(async () => {
+			TestRenderer.create(
+				<AuthProvider>
+					<Probe />
+				</AuthProvider>,
+			);
+		});
+	});
+
+	it.each([
+		["/ja-JP/(tabs)/review", "スラッシュと括弧を含む通常の行き先"],
+		["/ja-JP/profile?tab=posts", "クエリ付きの行き先"],
+		["/ja-JP/review/restaurant/abc-123/review", "深い階層"],
+	])("経路B（1 回デコード）でも next が元のパスに戻る: %s", async (next) => {
+		await act(async () => {
+			await authValue.signInWithOAuth("google", { next });
+		});
+
+		const redirectTo = makeRedirectUri.mock.results[0].value as string;
+
+		// ⚠️ 二重エンコードされていると "%2Fja-JP%2F…" が返り、先頭が "/" にならない
+		expect(readNextLikeRouteB(redirectTo)).toBe(next);
+		expect(redirectTo).not.toContain("%25");
+	});
+
+	it("linkIdentity でも同じ", async () => {
+		await act(async () => {
+			await authValue.linkIdentity("google", { next: "/ja-JP/(tabs)/review" });
+		});
+
+		const redirectTo = makeRedirectUri.mock.results[0].value as string;
+
+		expect(readNextLikeRouteB(redirectTo)).toBe("/ja-JP/(tabs)/review");
+		expect(redirectTo).not.toContain("%25");
+	});
+
+	// 経路A（2 回デコード）を壊していないこと。ここが «たまたま動いていた» 側なので、
+	// 直したことで逆に壊れていないかを対で見る
+	it("経路A（Linking.parse 相当の 2 回デコード）でも壊れない", async () => {
+		await act(async () => {
+			await authValue.signInWithOAuth("google", { next: "/ja-JP/(tabs)/review" });
+		});
+
+		const redirectTo = makeRedirectUri.mock.results[0].value as string;
+		const once = readNextLikeRouteB(redirectTo);
+
+		// 経路A は decodeURIComponent をもう 1 回掛ける。エンコードが 1 回なら «もう変わらない»
+		expect(decodeURIComponent(once as string)).toBe("/ja-JP/(tabs)/review");
+	});
+});
+
+/*
+#1374 web 側の redirectTo。
+
+web は `makeRedirectUri` を通らず（`Platform.OS === "web"` の分岐）、`window.location.origin` に
+自分でクエリを足す。つまり `createURL` の `encodeURI` を通らないので、**ここは自分で 1 回だけ**
+エンコードする必要がある。native 側だけ直しても web を二重にしてしまえば、
+今度は web の全画面リダイレクト復帰（#1370 の完了条件）が落ちる。
+
+web の OAuth はページごと作り直されるため、`next` を運ぶ手段は URL 以外に無い。
+*/
+describe("#1374 web の redirectTo も 1 回だけエンコードする", () => {
+	let authValue: ReturnType<typeof useAuth>;
+	const ORIGINAL_OS = Platform.OS;
+
+	const Probe = () => {
+		authValue = useAuth();
+		return null;
+	};
+
+	beforeEach(async () => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		Object.defineProperty(Platform, "OS", { value: "web", configurable: true });
+		(globalThis as { window?: unknown }).window = { location: { origin: "https://app.nanitabeyo.net" } };
+
+		auth.getSession.mockResolvedValue({ data: { session: null }, error: null });
+		auth.setSession.mockResolvedValue({ data: { session: null }, error: null });
+		auth.signInAnonymously.mockResolvedValue({
+			data: { session: { access_token: "a", refresh_token: "r", user: { id: "anon-1" } } },
+			error: null,
+		});
+		auth.onAuthStateChange.mockImplementation(() => ({ data: { subscription: { unsubscribe: jest.fn() } } }));
+		auth.signInWithOAuth.mockResolvedValue({ data: { url: null }, error: null });
+		await act(async () => {
+			TestRenderer.create(
+				<AuthProvider>
+					<Probe />
+				</AuthProvider>,
+			);
+		});
+	});
+
+	afterEach(() => {
+		Object.defineProperty(Platform, "OS", { value: ORIGINAL_OS, configurable: true });
+	});
+
+	it("redirectTo は origin + callback パス + 1 回だけエンコードしたクエリ", async () => {
+		await act(async () => {
+			await authValue.signInWithOAuth("google", { next: "/ja-JP/(tabs)/review" });
+		});
+
+		const redirectTo = auth.signInWithOAuth.mock.calls[0][0].options.redirectTo as string;
+
+		// ⚠️ 二重にすると "%25" が現れる
+		expect(redirectTo).not.toContain("%25");
+		expect(new URL(redirectTo).searchParams.get("next")).toBe("/ja-JP/(tabs)/review");
+		expect(new URL(redirectTo).pathname).toBe("/ja-JP/auth/callback");
+		// web では makeRedirectUri（native 用）を通らない
+		expect(makeRedirectUri).not.toHaveBeenCalled();
 	});
 });

--- a/app-expo/contexts/authProviderOAuthNext.test.tsx
+++ b/app-expo/contexts/authProviderOAuthNext.test.tsx
@@ -17,6 +17,8 @@ import { act } from "react";
 import TestRenderer from "react-test-renderer";
 import * as AuthSession from "expo-auth-session";
 import { Platform } from "react-native";
+import * as WebBrowser from "expo-web-browser";
+import { readOAuthResultQuery } from "@/lib/oauthResultUrl";
 import { supabase } from "@/lib/supabase";
 import { AuthProvider, useAuth } from "./AuthProvider";
 
@@ -43,12 +45,25 @@ jest.mock("@/hooks/useLogger", () => {
 	return { useLogger: () => ({ logFrontendEvent }) };
 });
 jest.mock("@/hooks/useLocale", () => ({ useLocale: () => ({ locale: "ja-JP" }) }));
-jest.mock("expo-router", () => {
-	const replace = jest.fn();
-	return { useRouter: () => ({ replace }) };
-});
+const mockRouterReplace = jest.fn();
+jest.mock("expo-router", () => ({ useRouter: () => ({ replace: mockRouterReplace }) }));
 jest.mock("@/lib/logoutRedirect", () => ({ requestLogoutRedirect: jest.fn() }));
-jest.mock("expo-linking", () => ({ parse: jest.fn() }));
+// #1374 ロケールの復元にだけ使う（クエリは readOAuthResultQuery が読む）。
+// 本物と同じく «ホスト部» を返し、queryParams は 2 回デコードする形にしておく
+jest.mock("expo-linking", () => ({
+	parse: jest.fn((url: string) => {
+		const parsed = new URL(url);
+		const queryParams: Record<string, string> = {};
+		try {
+			parsed.searchParams.forEach((value, key) => {
+				queryParams[key] = decodeURIComponent(value);
+			});
+		} catch {
+			// 本物（createURL.js:137-139）と同じく URIError を握り潰す
+		}
+		return { hostname: parsed.hostname, queryParams };
+	}),
+}));
 // ⚠️ 既定の戻り値は使い捨ての文字列だが、#1374 の describe では
 // «expo-linking の createURL と同じ規約» を実装した版に差し替える（下の buildLikeCreateURL）
 jest.mock("expo-auth-session", () => ({ makeRedirectUri: jest.fn(() => "nanitabeyo://redirect") }));
@@ -193,9 +208,14 @@ describe("#1374 redirectTo が二重エンコードされない", () => {
 	/**
 	 * expo-linking の `createURL` と同じ規約で URL を組む。
 	 *
-	 * 本物（build/createURL.js:113-114）は
-	 *   `encodeURI(scheme + "://" + path)` に、`URLSearchParams(queryParams)` の結果を **後から** 足す。
-	 * つまり path だけが `encodeURI` を通り、クエリは 1 回だけエンコードされる。
+	 * 本物（build/createURL.js:111-114、独自スキーム・非 Expo-hosted の場合）はこうである。
+	 *   hostUri = ensureLeadingSlash("", true)                    // → "/"
+	 *   encodeURI(`${scheme}:/${hostUri}${path}`)                 // → "nanitabeyo://ja-JP/auth/callback"
+	 *   + `?${new URLSearchParams(queryParams)}`                  // ← encodeURI の «後» に足す
+	 *
+	 * つまり **スラッシュは 2 本**で、`path` の先頭セグメント（ロケール）がホストになる。
+	 * `openOAuthBrowserSession` が `Linking.parse(url).hostname` からロケールを復元するのは
+	 * この形が前提なので、ここも本物と同じ形にしておく（PR #1393 のレビュー 4）。
 	 */
 	const buildLikeCreateURL = ({
 		path,
@@ -205,7 +225,20 @@ describe("#1374 redirectTo が二重エンコードされない", () => {
 		queryParams?: Record<string, string>;
 	}): string => {
 		const query = new URLSearchParams(queryParams ?? {}).toString();
-		return `${encodeURI(`nanitabeyo:///${path}`)}${query ? `?${query}` : ""}`;
+		return `${encodeURI(`nanitabeyo://${path}`)}${query ? `?${query}` : ""}`;
+	};
+
+	/** 経路A の読み取り。`Linking.parse` と同じく searchParams のうえに decodeURIComponent を重ねる */
+	const readNextLikeRouteALegacy = (url: string): string | undefined => {
+		const queryParams: Record<string, string> = {};
+		try {
+			new URL(url).searchParams.forEach((value, key) => {
+				queryParams[key] = decodeURIComponent(value);
+			});
+		} catch {
+			// Linking.parse は URIError を握り潰す（createURL.js:137-139）。ここも同じにする
+		}
+		return queryParams.next;
 	};
 
 	/** 経路B の読み取り。expo-router と同じく searchParams で «1 回だけ» デコードする */
@@ -250,6 +283,20 @@ describe("#1374 redirectTo が二重エンコードされない", () => {
 		expect(redirectTo).not.toContain("%25");
 	});
 
+	// レビュー 4: 従来この形をテストが一切カバーしていなかった。
+	// `openOAuthBrowserSession` はここからロケールを復元する
+	it("ロケールはホスト部に載る（Linking.parse の hostname から復元できる）", async () => {
+		await act(async () => {
+			await authValue.signInWithOAuth("google", { next: "/ja-JP/(tabs)/review" });
+		});
+
+		const redirectTo = makeRedirectUri.mock.results[0].value as string;
+
+		// 独自スキームは «special scheme» ではないので、ホスト部の大文字小文字は保たれる
+		expect(new URL(redirectTo).hostname).toBe("ja-JP");
+		expect(new URL(redirectTo).pathname).toBe("/auth/callback");
+	});
+
 	it("linkIdentity でも同じ", async () => {
 		await act(async () => {
 			await authValue.linkIdentity("google", { next: "/ja-JP/(tabs)/review" });
@@ -261,18 +308,54 @@ describe("#1374 redirectTo が二重エンコードされない", () => {
 		expect(redirectTo).not.toContain("%25");
 	});
 
-	// 経路A（2 回デコード）を壊していないこと。ここが «たまたま動いていた» 側なので、
-	// 直したことで逆に壊れていないかを対で見る
-	it("経路A（Linking.parse 相当の 2 回デコード）でも壊れない", async () => {
+	/*
+	経路A も «1 回デコード» で読むようになったことの確認（PR #1393 のレビュー 2）。
+
+	以前の経路A は `Linking.parse`（searchParams + decodeURIComponent = 2 回）だった。
+	redirectTo が二重エンコードだったので «たまたま» 釣り合っていたが、エンコードを 1 回へ
+	直した時点でこちらが過剰になる。`readOAuthResultQuery` で読む側も 1 回へ揃えた。
+
+	⚠️ 下の 3 ケース目が本命。裸の `%` は 2 回デコードで URIError を起こし、
+	`Linking.parse` の catch がそれを飲むため **code まで消えてログイン自体が失敗する**。
+	*/
+	it.each([
+		["/ja-JP/(tabs)/review", "%XX を含まない通常の行き先"],
+		["/ja-JP/search?q=%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%B3", "値に %XX を含む行き先"],
+		["/ja-JP/x?q=50%", "裸の % を含む行き先"],
+	])("経路A（1 回デコード）でも next が元のパスに戻る: %s", async (next) => {
 		await act(async () => {
-			await authValue.signInWithOAuth("google", { next: "/ja-JP/(tabs)/review" });
+			await authValue.signInWithOAuth("google", { next });
 		});
 
 		const redirectTo = makeRedirectUri.mock.results[0].value as string;
-		const once = readNextLikeRouteB(redirectTo);
 
-		// 経路A は decodeURIComponent をもう 1 回掛ける。エンコードが 1 回なら «もう変わらない»
-		expect(decodeURIComponent(once as string)).toBe("/ja-JP/(tabs)/review");
+		expect(readOAuthResultQuery(redirectTo)?.next).toBe(next);
+	});
+
+	// 旧い読み方（2 回デコード）だと «直っていない» ことを対で残す。
+	// これが緑になったら、揃えた意味が無くなっている
+	it("旧い 2 回デコードのままなら経路A は壊れる（対照）", async () => {
+		await act(async () => {
+			await authValue.signInWithOAuth("google", { next: "/ja-JP/x?q=50%" });
+		});
+
+		const redirectTo = makeRedirectUri.mock.results[0].value as string;
+
+		expect(readNextLikeRouteALegacy(redirectTo)).toBeUndefined();
+	});
+
+	// レビュー 2 の最重要点: 裸の % が入っても code は生き残る
+	it("next に裸の % が入っても code は落ちない", async () => {
+		await act(async () => {
+			await authValue.signInWithOAuth("google", { next: "/ja-JP/x?q=50%" });
+		});
+
+		const redirectTo = makeRedirectUri.mock.results[0].value as string;
+		// Supabase が付ける code を模して足す
+		const withCode = `${redirectTo}&code=AUTHCODE`;
+
+		expect(readOAuthResultQuery(withCode)?.code).toBe("AUTHCODE");
+		expect(readNextLikeRouteALegacy(withCode)).toBeUndefined();
 	});
 });
 
@@ -334,5 +417,81 @@ describe("#1374 web の redirectTo も 1 回だけエンコードする", () => 
 		expect(new URL(redirectTo).pathname).toBe("/ja-JP/auth/callback");
 		// web では makeRedirectUri（native 用）を通らない
 		expect(makeRedirectUri).not.toHaveBeenCalled();
+	});
+});
+
+/*
+#1374 経路A の «実際の入口» を通す（PR #1393 のレビュー 2 / N1 の取りこぼし）。
+
+`readOAuthResultQuery` 単体と «組み立てた URL» のテストだけでは、
+`openOAuthBrowserSession` が `Linking.parse(...).queryParams`（2 回デコード）へ戻されても
+気付けなかった。ここはブラウザからの戻り URL を実際に流し、
+**callback へ渡る params** を観測する。
+
+⚠️ これが赤くなったら、経路A が 2 回デコードへ逆戻りしている。裸の `%` を含む `next` で
+`code` が消え、ログインそのものが失敗する。
+*/
+describe("#1374 ブラウザ復帰（経路A）が callback へ渡す params", () => {
+	let authValue: ReturnType<typeof useAuth>;
+
+	const Probe = () => {
+		authValue = useAuth();
+		return null;
+	};
+
+	beforeEach(async () => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		auth.getSession.mockResolvedValue({ data: { session: null }, error: null });
+		auth.setSession.mockResolvedValue({ data: { session: null }, error: null });
+		auth.signInAnonymously.mockResolvedValue({
+			data: { session: { access_token: "a", refresh_token: "r", user: { id: "anon-1" } } },
+			error: null,
+		});
+		auth.onAuthStateChange.mockImplementation(() => ({ data: { subscription: { unsubscribe: jest.fn() } } }));
+		// ブラウザを開く経路へ入るため data.url を返す
+		auth.signInWithOAuth.mockResolvedValue({ data: { url: "https://provider.example/auth" }, error: null });
+		makeRedirectUri.mockReturnValue("nanitabeyo://ja-JP/auth/callback");
+		await act(async () => {
+			TestRenderer.create(
+				<AuthProvider>
+					<Probe />
+				</AuthProvider>,
+			);
+		});
+	});
+
+	/** ブラウザが返してくる URL（Supabase が code を付けた形） */
+	const returnUrlWith = (next: string): string =>
+		`nanitabeyo://ja-JP/auth/callback?intent=signin&next=${encodeURIComponent(next)}&code=AUTHCODE`;
+
+	it("裸の % を含む next でも code が callback へ届く", async () => {
+		(WebBrowser.openAuthSessionAsync as unknown as jest.Mock).mockResolvedValue({
+			type: "success",
+			url: returnUrlWith("/ja-JP/x?q=50%"),
+		});
+
+		await act(async () => {
+			await authValue.signInWithOAuth("google", { next: "/ja-JP/x?q=50%" });
+		});
+
+		const href = mockRouterReplace.mock.calls.at(-1)?.[0];
+		expect(href.params.code).toBe("AUTHCODE");
+		expect(href.params.next).toBe("/ja-JP/x?q=50%");
+		// ロケールはホスト部から復元する（Linking.parse の担当。ここは変えていない）
+		expect(href.params.locale).toBe("ja-JP");
+	});
+
+	it("値に %XX を含む next が化けない", async () => {
+		const next = "/ja-JP/search?q=%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%B3";
+		(WebBrowser.openAuthSessionAsync as unknown as jest.Mock).mockResolvedValue({
+			type: "success",
+			url: returnUrlWith(next),
+		});
+
+		await act(async () => {
+			await authValue.signInWithOAuth("google", { next });
+		});
+
+		expect(mockRouterReplace.mock.calls.at(-1)?.[0].params.next).toBe(next);
 	});
 });

--- a/app-expo/lib/oauthResultUrl.test.ts
+++ b/app-expo/lib/oauthResultUrl.test.ts
@@ -1,4 +1,4 @@
-import { carriesOAuthResult, describeOAuthUrl, pickOAuthResultUrl, type OAuthUrlCandidate } from "./oauthResultUrl";
+import { carriesOAuthResult, describeOAuthUrl, pickOAuthResultUrl, type OAuthUrlCandidate, readOAuthResultQuery } from "./oauthResultUrl";
 
 /** Android の development build を QR / `a` キーで起動したときに getInitialURL() が返す URL（#1062 の元凶） */
 const DEV_LAUNCHER_URL = "nanitabeyo://expo-development-client/?url=https%3A%2F%2Fabc.exp.direct";
@@ -124,5 +124,62 @@ describe("describeOAuthUrl", () => {
 			expect(serialized).not.toContain("tok123");
 			expect(serialized).not.toContain("ref456");
 		}
+	});
+});
+
+/*
+#1374 【バグ】認証結果 URL のクエリを «デコード 1 回» で読む。
+
+`Linking.parse` は searchParams（1 回）に decodeURIComponent をもう 1 回重ねる。
+redirectTo のエンコードを 1 回へ直した以上、読む側も 1 回に揃えないと経路 A だけ過剰にデコードする。
+
+⚠️ 一番重いのは「裸の `%`」で、2 回デコードだと URIError が Linking.parse の catch に飲まれ、
+**code まで queryParams から消えてログイン自体が失敗する**。ここはその再発を止める番人である。
+*/
+describe("#1374 readOAuthResultQuery", () => {
+	const CALLBACK = "nanitabeyo://ja-JP/auth/callback";
+
+	it("クエリを 1 回だけデコードする", () => {
+		const url = `${CALLBACK}?intent=signin&next=%2Fja-JP%2F(tabs)%2Freview&code=AUTHCODE`;
+
+		expect(readOAuthResultQuery(url)).toEqual({
+			intent: "signin",
+			next: "/ja-JP/(tabs)/review",
+			code: "AUTHCODE",
+		});
+	});
+
+	// 2 回デコードすると `%E3%83%A9…` がさらに «ラーメン» へ化ける
+	it("next の値に含まれる %XX は «そのまま» 残す", () => {
+		const url = `${CALLBACK}?next=%2Fja-JP%2Fsearch%3Fq%3D%25E3%2583%25A9%25E3%2583%25BC`;
+
+		expect(readOAuthResultQuery(url)?.next).toBe("/ja-JP/search?q=%E3%83%A9%E3%83%BC");
+	});
+
+	// ⚠️ ここが本命。2 回デコードだと URIError で code ごと落ちる
+	it("next に裸の % が入っていても code を落とさない", () => {
+		const url = `${CALLBACK}?intent=signin&next=%2Fja-JP%2Fx%3Fq%3D50%25&code=AUTHCODE`;
+
+		const params = readOAuthResultQuery(url);
+
+		expect(params?.code).toBe("AUTHCODE");
+		expect(params?.next).toBe("/ja-JP/x?q=50%");
+	});
+
+	it("linkIdentity の provider も従来どおり読める", () => {
+		const url = `${CALLBACK}?intent=link&provider=google&code=AUTHCODE`;
+
+		expect(readOAuthResultQuery(url)).toEqual({ intent: "link", provider: "google", code: "AUTHCODE" });
+	});
+
+	it("クエリが無ければ空", () => {
+		expect(readOAuthResultQuery(CALLBACK)).toEqual({});
+	});
+
+	// 呼び出し側は null のとき従来の Linking.parse へ倒す
+	it("URL として読めなければ null", () => {
+		expect(readOAuthResultQuery("not a url")).toBeNull();
+		expect(readOAuthResultQuery(null)).toBeNull();
+		expect(readOAuthResultQuery(undefined)).toBeNull();
 	});
 });

--- a/app-expo/lib/oauthResultUrl.ts
+++ b/app-expo/lib/oauthResultUrl.ts
@@ -79,3 +79,42 @@ export const describeOAuthUrl = (url: string | null | undefined): OAuthUrlShape 
 		error_code: query.get("error_code") ?? null,
 	};
 };
+
+/**
+ * 認証結果 URL の «クエリ» を、デコード 1 回で読む（#1374 / PR #1393 のレビュー 2）。
+ *
+ * ## なぜ `Linking.parse` を使わないのか
+ * `expo-linking` の `parse` は `new URL(...).searchParams`（1 回デコード）の結果へ、さらに
+ * `decodeURIComponent` を掛ける（build/createURL.js:129-132）。**合計 2 回**である。
+ * 一方 expo-router 側（OS のディープリンク着地＝経路 B）は `searchParams` の **1 回だけ**
+ *（build/fork/getStateFromPath-forks.js）。経路によって回数が違う。
+ *
+ * #1374 以前は redirectTo を二重エンコードしていたので、経路 A ではその 2 回と釣り合って
+ * «たまたま» 元に戻っていた。エンコードを 1 回に直した以上、読む側も 1 回に揃える必要がある。
+ * 揃えないと経路 A が過剰にデコードし、次の 2 つが起きる。
+ *
+ *   1. `next` に `%XX` を含む行き先（例 `?q=%E3%83%A9…`）が別の文字列になる
+ *   2. `next` に **裸の `%`** が含まれると `decodeURIComponent` が URIError を投げ、
+ *      `Linking.parse` の `catch {}` がそれを飲む。`forEach` の途中で止まるため
+ *      **`code` まで queryParams に入らず、ログイン自体が失敗する**
+ *
+ * ## ホスト部は触らない
+ * ロケールは `Linking.parse(url).hostname` から取り続ける。Expo Go の `exp://host/--/path` を
+ * `expo-linking` が正規化してくれるためで、`new URL` に置き換えると開発ビルドで
+ * ホスト（IP）をロケールとして拾ってしまう。ここで直したいのはクエリのデコード回数だけである。
+ *
+ * @returns 読めなければ null（呼び出し側は従来どおりのフォールバックへ倒す）
+ */
+export const readOAuthResultQuery = (url: string | null | undefined): Record<string, string> | null => {
+	if (!url) return null;
+	try {
+		const params: Record<string, string> = {};
+		new URL(url).searchParams.forEach((value, key) => {
+			params[key] = value;
+		});
+		return params;
+	} catch {
+		// スキームが URL として解釈できない等。呼び出し側のフォールバックに任せる
+		return null;
+	}
+};


### PR DESCRIPTION
対象 Issue: #1374（親 #1350 から分離）

## なぜ «見送り» ではなく直したか

オーナーから「ネイティブのディープリンクの話なら普通に操作していたら起こり得ないのでは」と確認がありました。**起こり得ます。** 手で作ったリンクを踏む必要はありません。

経路 B（OS のディープリンクで callback へ直接着地）は、**ブラウザで OAuth 中にアプリが落とされ、コールドスタートで戻ってきたとき**に通ります。Android の低メモリ端末では珍しくありません。

そのことは実装自身が示しています。`lib/oauthResultUrl.ts` の `pickOAuthResultUrl` が `router_params` と `initial_url` の**両方**を候補に取り、`app/[locale]/auth/callback.tsx` が `Linking.getInitialURL()` を必ず読むのは、まさにこの経路で結果が届くためです（#1062 で実機確認の記録あり）。経路 B が死んでいれば、あのモジュール自体が不要になります。

## 症状

OAuth からの復帰で、**経路 B だけ `next` が黙って捨てられ**、マイページへ倒れます。

fail-closed（外部へ抜けるのではなく `next` を捨てる）なので**セキュリティ上の穴ではありません**が、行き先は失われます。

## 原因

`buildAuthCallbackPath` が `?intent=signin&next=${encodeURIComponent(next)}` まで含めた 1 本の文字列を作り、それを `makeRedirectUri({ path })` に渡していました。`makeRedirectUri` は中で `Linking.createURL(path, …)` を呼び、`createURL` は **path 部分だけに `encodeURI()` を掛けます**。

`expo-linking@8` の `build/createURL.js:113-114`:

```js
// URLSearchParams.stringify already encodes query parameters, so we only need to encode the remaining part of the URL.
const encodedURI = encodeURI(`${resolvedScheme}:${isTripleSlashed ? '/' : ''}/${hostUri}${path}`);
return `${encodedURI}${queryString}`;
```

`%2F` が `%252F` になり、デコード回数が経路で食い違います。

| 経路 | デコード | 結果 |
| --- | --- | --- |
| **A** `openAuthSessionAsync` 成功 → `Linking.parse` | `searchParams` + `decodeURIComponent` の **2 回** | 元に戻り、**たまたま動く** |
| **B** OS のディープリンクで着地（コールドスタート） | expo-router の `searchParams` で **1 回** | `"%2Fja-JP%2F…"` のまま → 先頭が `/` でない → `resolveNextPath` が **null** |

実測:

```
$ node -e '...'
redirectTo が作る URL : nanitabeyo:///ja-JP/auth/callback?intent=signin&next=%252Fja-JP%252F(tabs)%252Freview
経路B（1回デコード）  : "%2Fja-JP%2F(tabs)%2Freview"  → 先頭が / でない → null
経路A（2回デコード）  : "/ja-JP/(tabs)/review"        → 通る
```

## 直し方

`createURL` は `queryParams` を **`encodeURI` の後に** `URLSearchParams` で 1 回だけエンコードして連結します。そこでクエリを «構造のまま» 渡す形へ寄せました。

- **native**: `makeRedirectUri({ path: "<locale>/auth/callback", queryParams: { intent, provider?, next? } })`
- **web**: `makeRedirectUri` を通らず `encodeURI` も掛からないので、`URLSearchParams` で**自分で 1 回だけ**エンコードする（`buildWebAuthCallbackUrl`）

`next` の検証（`resolveNextPath`）はこれまでどおり呼び出し側と受け取り側で行います。この層は運ぶだけです。

## 検証結果

| 対象 | 結果 |
| --- | --- |
| `pnpm --filter app-expo typecheck` | exit 0 |
| `pnpm --filter app-expo test` | **68 suites / 657 tests all pass** |
| `pnpm --filter e2e-web typecheck` / `e2e-mobile typecheck` | exit 0 |
| Playwright / Detox 実走 | していません |

テストは `makeRedirectUri` のスタブを **`createURL` と同じ規約**（`encodeURI(path)` + 後から `URLSearchParams`）で実装し、**経路 B の読み取り（`searchParams` 1 回）で元のパスに戻ること**を直接見ています。

### ミューテーション実測（毎回復元）

| # | 変異 | 結果 |
| --- | --- | --- |
| 1 | 旧実装へ戻す（`next` をパス文字列へ埋め込む） | ✕ 8 failed / 2 passed |
| 2 | `buildAuthCallbackQueryParams` が `next` を落とす | ✕ 8 failed / 2 passed |
| 3 | web 側で `next` を二重エンコードする | ✕ 1 failed |
| 4 | web が callback パスを間違える | ✕ 1 failed |

> ⚠️ **3 は最初「素通り」しました。** テストが native 分岐（`Platform.OS !== "web"`）しか見ておらず、web 経路のケースが 1 件も無かったためです。`Platform.OS` を `web` に差し替える describe を足したところ正しく赤くなりました。native だけ直して web を二重にすれば、今度は #1370 の完了条件（web の全画面リダイレクト復帰で `next` が効く）が落ちます。

## 実機で確認が要る項目

1. **経路 B の実走** — Android で OAuth 中にアプリを落とし（開発者オプションの「アクティビティを保持しない」等）、ブラウザから戻ったときに `next` の画面へ着地すること
2. **経路 A の退行が無いこと** — 通常の OAuth 復帰で従来どおり `next` が効くこと
3. **web の全画面リダイレクト復帰**（#1370 の完了条件）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GVn2NvCTnuD5s5PRvb3JJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019GVn2NvCTnuD5s5PRvb3JJ)_