### PR TITLE
#1366 fix(app-expo): lint の既存 48 errors を解消し、pr-check.yml で lint を強制する

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,14 +2,15 @@ name: PR Check
 
 # 🔎 pull_request で回る軽量ゲート（#1112）
 # - このリポジトリ初の pull_request トリガー。既存 12 本はすべて workflow_dispatch / schedule。
-# - 検査は 5 つ。いずれも secrets もネットワークも不要なので、fork からの PR でも実行できる。
+# - 検査は 6 つ。いずれも secrets もネットワークも不要なので、fork からの PR でも実行できる。
 #     1. 4-1: remoteConfigSchema のキー集合 ≡ DEFAULT_REMOTE_CONFIG のキー集合（#1116）
 #     2. error-triage の jest（#1196。外部I/Oゼロの純関数群 + SQL 生成物の一致検査。
 #        他のどの workflow からも実行されていない）
 #     3. app-expo の typecheck（どの workflow でも実行されていなかった）
 #     4. app-expo の jest（同上。2026-08-01 時点で 21 suites / 167 tests・全 green を実測済み）
-#     5. legacyBlurModal の import 境界（#1363。ESLint にも同じ境界があるが CI で lint を
-#        回していないため、依存ゼロの assert スクリプトで独立に守る）
+#     5. legacyBlurModal の import 境界（#1363。ESLint にも同じ境界があるが、あちらが見ていない
+#        features/blurModal の復活と Portal の許可リストもここで守る）
+#     6. app-expo の lint（#1366。既存 48 errors を解消したうえで新規に追加した）
 # - 4-2（実際の config.json との値の突き合わせ）は EAS の env が要るのでここでは SKIP される。
 #   SKIP した旨は必ずログへ出る。4-2 は引き続き nightly の e2e-web-test.yml が担当する。
 # - api は入れていない。pnpm --filter api test は api/.env（secrets）を要求し、
@@ -69,9 +70,10 @@ jobs:
 
       # #1363 legacyBlurModal（社内タスク画面専用の凍結コピー）が公開アプリから import されて
       # いないことを検査する。同じ境界は app-expo/.eslintrc.js の no-restricted-imports にも
-      # 書いてあるが、**このリポジトリは CI で lint を回していない**（回そうにも既存違反が
-      # 48 件あり、その解消は別課題）。lint に頼ると境界は「書いてあるが誰も評価しない」状態に
-      # なるため、依存ゼロの assert スクリプトを最後の砦として独立に走らせる。
+      # 書いてあり、#1366 で下の lint step が入ったことで **そちらも CI で評価される**ように
+      # なった。それでもこの step を残すのは、依存ゼロで速いことに加え、ESLint が見ていない
+      # 2 つ（撤去した features/blurModal の再出現、react-native-paper の Portal の許可リスト）を
+      # このスクリプトだけが検査しているためである。
       # 凍結の価値は利用者が社内タスク画面だけに閉じていることに全面的に依存している（#1350 §7）。
       - name: legacyBlurModal の import 境界を検査
         run: pnpm --filter app-expo assert:legacy-blur-modal-boundary
@@ -84,6 +86,20 @@ jobs:
       # ルール表は SQL の生成元でもあるので、CI で回っていないと PR1 の価値が保全されない。
       - name: error-triage のユニットテスト
         run: pnpm --filter error-triage test
+
+      # #1366 これまで lint はどの workflow でも実行されていなかった。載せられなかったのは
+      # 既存 48 errors（react-hooks/rules-of-hooks 45 / no-undef 3）で落ちていたためで、
+      # #1366 でその全件を解消したうえでここへ入れている。
+      #
+      # ⚠️ warning は素通りする（--max-warnings は付けていない）。2026-08-19 時点で 234 件あり、
+      #    ここで 0 を要求すると無関係な PR まで巻き添えで落ちる。error だけを強制する。
+      #    warning の削減は別途。逆に、**新しいルールを error で足すときはこの step が本当に
+      #    強制する**ので、追加時は全件解消してから入れること。
+      #
+      # shared/dist を要求しないので shared build より前に置ける（型情報を使う
+      # typed-linting は有効にしていない）。ローカル実測で約 23 秒。
+      - name: app-expo の lint
+        run: pnpm --filter app-expo lint
 
       # app-expo/tsconfig.dev.json は @shared/* を ../shared/dist/* へ向けているため、
       # typecheck の前に shared を build しておかないと解決できない。

--- a/app-expo/.eslintrc.js
+++ b/app-expo/.eslintrc.js
@@ -6,9 +6,10 @@
   1 箇所でも import された時点で、共有部品が全画面を人質に取る元の状態（#1350 §7）へ逆戻りする。
   レビューでの目視に頼らず機械的に落とす。warning は素通りするので必ず error にする。
 
-  ただしこの lint は CI で実行されていない（pr-check.yml に lint の step が無く、既存 48 errors で
-  落ちるため今すぐには載せられない）。そこでエディタ上で即座に効くのはこの ESLint ルール、CI の
-  最後の砦は scripts/assert-legacy-blur-modal-boundary.mjs、という役割分担にしている。
+  #1366 で既存 48 errors を解消し `pnpm --filter app-expo lint` を pr-check.yml へ載せたので、
+  このルールは **CI でも評価される**（それ以前は「書いてあるが誰も評価しない」状態だった）。
+  それでも scripts/assert-legacy-blur-modal-boundary.mjs は残してある。あちらは
+  features/blurModal の復活と Portal の import 許可リストも見ており、ここと範囲が重ならない。
   許可範囲を変えるときは両方を必ず揃えること。
 */
 const LEGACY_BLUR_MODAL_PATTERNS = [
@@ -42,6 +43,18 @@ module.exports = {
 	overrides: [
 		{
 			/*
+			  #1366 【設計】Jest のランタイム下でだけ評価されるファイル。`jest` / `describe` / `expect` は
+			  Jest が実行時に注入するグローバルであり、import して使うものではない。env を宣言しないと
+			  no-undef が「未定義の変数」として誤検出する（コードの誤りではなく globals 設定の漏れ）。
+
+			  型付きファイル（.ts / .tsx）では eslint-config-expo が no-undef を無効化しているため
+			  現に落ちていたのは jest.setup.js だけだが、同じ性質のファイルはまとめてここで宣言する。
+			*/
+			files: ["jest.setup.js", "**/*.test.ts", "**/*.test.tsx"],
+			env: { jest: true },
+		},
+		{
+			/*
 			  #1363 【設計】legacyBlurModal を import してよい唯一の範囲。
 			  ロケール階層は `[locale]` と直書きせず下のようにワイルドカードで書く。角括弧はグロブでは
 			  1 文字の文字クラスとして解釈され、literal な `[locale]` ディレクトリに一致しないため、
@@ -51,7 +64,8 @@ module.exports = {
 			  #1350 P6 で features/blurModal は撤去済み。したがって「逆向き（公開アプリから
 			  features/blurModal を使う）」という状態はもう存在せず、ここで制限する対象も無い。
 			  復活していないことは scripts/assert-legacy-blur-modal-boundary.mjs が CI で見ている
-			  （lint は CI で走っていないため。#1366）。
+			  （#1366 以降はこの lint も CI で走るが、features/blurModal の «再出現» はグロブでは
+			  見られないので、あちらの担当のまま）。
 			*/
 			files: ["app/**/contribution-tasks/**", "features/contributionTasks/**"],
 			rules: {

--- a/app-expo/components/ImageCardGrid.tsx
+++ b/app-expo/components/ImageCardGrid.tsx
@@ -52,7 +52,14 @@ export interface ImageCardGridProps<T extends ImageCardItem = ImageCardItem> {
 /*                              Card 内部実装                                 */
 /* -------------------------------------------------------------------------- */
 
-function _ImageCard<T extends ImageCardItem>({
+/*
+  #1366 【設計】名前を `_` で始めてはいけない。react-hooks/rules-of-hooks は「大文字で始まる関数」を
+  コンポーネントと見なすため、`_ImageCard` はコンポーネントとして認識されず、中のフック呼び出しが
+  «コンポーネントでもフックでもない関数からの呼び出し» として一律 error になる（＝ルールがこの
+  ファイルのフック順序を一切検査できない状態だった）。memo でラップした公開名と衝突させずに
+  大文字始まりにするため `Impl` 接尾辞にしている。
+*/
+function ImageCardImpl<T extends ImageCardItem>({
 	item,
 	columns = 3,
 	gap = 1,
@@ -135,7 +142,7 @@ function _ImageCard<T extends ImageCardItem>({
 /*                               Grid 本体                                    */
 /* -------------------------------------------------------------------------- */
 
-function _ImageCardGrid<T extends ImageCardItem>({
+function ImageCardGridImpl<T extends ImageCardItem>({
 	data,
 	columns = 3,
 	gap = 1,
@@ -150,9 +157,9 @@ function _ImageCardGrid<T extends ImageCardItem>({
 }: ImageCardGridProps<T>) {
 	const renderItem = useCallback(
 		(info: ListRenderItemInfo<T>) => (
-			<_ImageCard item={info.item} aspectRatio={aspectRatio} gap={gap} onPress={onPress} cardStyle={cardStyle}>
+			<ImageCardImpl item={info.item} aspectRatio={aspectRatio} gap={gap} onPress={onPress} cardStyle={cardStyle}>
 				{renderOverlay?.(info.item)}
-			</_ImageCard>
+			</ImageCardImpl>
 		),
 		[aspectRatio, gap, onPress, renderOverlay, cardStyle],
 	);
@@ -176,8 +183,8 @@ function _ImageCardGrid<T extends ImageCardItem>({
 	);
 }
 
-export const ImageCardGrid = memo(_ImageCardGrid) as typeof _ImageCardGrid;
-export const ImageCard = memo(_ImageCard) as typeof _ImageCard;
+export const ImageCardGrid = memo(ImageCardGridImpl) as typeof ImageCardGridImpl;
+export const ImageCard = memo(ImageCardImpl) as typeof ImageCardImpl;
 
 /* -------------------------------------------------------------------------- */
 /*                               スタイル定義                                 */

--- a/app-expo/components/deepLinking/OpenInAppBanner.tsx
+++ b/app-expo/components/deepLinking/OpenInAppBanner.tsx
@@ -52,15 +52,12 @@ export interface OpenInAppBannerProps {
  * - OIA relay はサーバ側で許可ホストを固定し open redirect を防ぐ
  * - JSで遷移をいじらない（ULはリンクタップが最強）
  */
-const OpenInAppBannerComponent: React.FC<OpenInAppBannerProps> = ({
+const OpenInAppBannerWeb: React.FC<OpenInAppBannerProps> = ({
 	path,
 	params,
 	universalBaseUrl = Env.WEB_BASE_URL /* 例: https://app.nanitabeyo.net を想定。違うなら差し替え */,
 	scheme = "nanitabeyo",
 }) => {
-	// ネイティブアプリでは不要（Web deep linking 導線専用）
-	if (Platform.OS !== "web") return null;
-
 	const { locale } = useLocale();
 
 	// SSR/Prerender 対策：window が無い環境では何もしない
@@ -342,6 +339,30 @@ const OpenInAppBannerComponent: React.FC<OpenInAppBannerProps> = ({
 			)}
 		</View>
 	);
+};
+
+/*
+  #1366 【修正】`Platform.OS !== "web"` の早期 return を、その後ろに続く 22 個のフックより
+  前に置いたままにしない。react-hooks/rules-of-hooks が «条件付きのフック呼び出し» として
+  一律 error にしていたのはこの形である。
+
+  `Platform.OS` はモジュール定数で同一プロセス内では変化しないため、この 1 件に限れば
+  観測できる不具合は無い。ただし «早期 return の後ろにフックがある» という形そのものが
+  壊れやすい。React 19 の実挙動を測った結果は SavedPostsTab.tsx のコメントに書いたとおりで、
+  早期 return の «前» にフックが 1 本でも入った瞬間に
+  「Rendered more hooks than during the previous render」で throw する。
+  ここは特に危ない: 下の内側コンポーネントは visibilitychange のリスナと setTimeout を
+  張っており、フック 0 本のレンダーへ切り替わる形になると **cleanup が呼ばれず両方残る**。
+
+  フックを無条件化して早期 return を後ろへ動かす直し方は採れない。内側は window / document /
+  navigator を触るので、ネイティブでも評価されるようになると壊れる。
+  そこで判定だけを持つ外側と、フックを持つ内側（OpenInAppBannerWeb）に分けてある。
+*/
+const OpenInAppBannerComponent: React.FC<OpenInAppBannerProps> = (props) => {
+	// ネイティブアプリでは不要（Web deep linking 導線専用）
+	if (Platform.OS !== "web") return null;
+
+	return <OpenInAppBannerWeb {...props} />;
 };
 
 export const OpenInAppBanner = memo(OpenInAppBannerComponent);

--- a/app-expo/features/map/components/ReviewForm.test.tsx
+++ b/app-expo/features/map/components/ReviewForm.test.tsx
@@ -87,10 +87,17 @@ jest.mock("@/hooks/useHaptics", () => {
 	const mediumImpact = jest.fn();
 	return { useHaptics: () => ({ lightImpact, mediumImpact }) };
 });
-jest.mock("@/hooks/useLogger", () => {
-	const logFrontendEvent = jest.fn();
-	return { useLogger: () => ({ logFrontendEvent }) };
-});
+/*
+  #1366 jest.fn をファクトリの内側に閉じ込めると、テストから取り出す手段が `useLogger()` を
+  呼ぶことしか無くなる。差し替え後の useLogger は «毎回同じ jest.fn を返すただの関数» であって
+  フックではないのだが、名前が use で始まるため rules-of-hooks は
+  «トップレベルでのフック呼び出し» として error にする（この 1 件がまさにそれだった）。
+  jest.fn をモジュールスコープへ出せば呼ぶ必要そのものが消える。
+  変数名の `mock` 接頭辞は必須。babel-plugin-jest-hoist が jest.mock の巻き上げ後も
+  参照を許すのはこの命名だけで、外すと «out-of-scope variables» で落ちる。
+*/
+const mockLogFrontendEvent = jest.fn();
+jest.mock("@/hooks/useLogger", () => ({ useLogger: () => ({ logFrontendEvent: mockLogFrontendEvent }) }));
 jest.mock("@/hooks/useAPICall", () => ({ useAPICall: () => ({ callBackend: jest.fn() }) }));
 jest.mock("@/hooks/useDishCategorySearch", () => ({
 	useDishCategorySearch: () => ({ createDishCategoryVariant: jest.fn() }),
@@ -113,7 +120,7 @@ import { useLogger } from "@/hooks/useLogger";
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 const selectMediaMock = selectMedia as jest.MockedFunction<typeof selectMedia>;
-const logFrontendEventMock = useLogger().logFrontendEvent as jest.MockedFunction<
+const logFrontendEventMock = mockLogFrontendEvent as jest.MockedFunction<
 	ReturnType<typeof useLogger>["logFrontendEvent"]
 >;
 

--- a/app-expo/features/profile/tabs/SavedPostsTab.test.tsx
+++ b/app-expo/features/profile/tabs/SavedPostsTab.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * #1366 `SavedPostsTab` の «非公開表示 / 自分のプロフィール» の出し分けを固定する。
+ *
+ * 元のコードは `if (!isOwnProfile) return <非公開>;` という早期 return の **後ろ**に
+ * 15 個のフックを並べていた（rules-of-hooks が 15 件 error にしていた形）。
+ * React 19 の実挙動を測った限り、この形«そのもの»が今すぐ throw するわけではない。
+ * 詳細は SavedPostsTab.tsx のコメントにあるが、要点は
+ * 「フック 0 本のレンダーとの往復では throw しない代わりに effect の cleanup が捨てられる」
+ * 「早期 return の前にフックが 1 本でも入った瞬間に throw する」の 2 つである。
+ *
+ * したがってこのテストが守るのは «クラッシュしないこと» ではなく、**直し方**である。
+ * lint を通すだけならフックを早期 return の前へ移せばよいが、それをやると
+ * 他人のプロフィールを開いただけで自分の保存投稿を fetch する（`useEffect` が走る）。
+ * 1 つ目のケースがその «誤った直し方» を落とす。
+ * 2・3 つ目は、出し分けを外側／内側に割った後もどちらの向きの切り替えでも
+ * 期待どおりに描画されることを押さえる。
+ */
+import React, { act } from "react";
+import TestRenderer from "react-test-renderer";
+
+const mockFetchInitialByKey = jest.fn();
+const mockFetchMoreByKey = jest.fn();
+/** 本体（内側）がマウントされたときだけ書き込まれる。null なら一度も描画されていない */
+const mockRenderedGrid: { props: { testID?: string } | null } = { props: null };
+
+jest.mock("@/components/collapsible-tabs/GridList", () => ({
+	GridList: (props: { testID?: string }) => {
+		mockRenderedGrid.props = props;
+		return null;
+	},
+}));
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+jest.mock("expo-router", () => ({ router: { push: jest.fn() } }));
+jest.mock("@/hooks/useLocale", () => ({ useLocale: () => ({ locale: "ja-JP", isJapanese: true }) }));
+jest.mock("@/hooks/useHaptics", () => ({ useHaptics: () => ({ lightImpact: jest.fn() }) }));
+jest.mock("@/hooks/useAPICall", () => ({ useAPICall: () => ({ callBackend: jest.fn() }) }));
+jest.mock("@/hooks/useLogger", () => ({ useLogger: () => ({ logFrontendEvent: jest.fn() }) }));
+
+// 保存投稿の «取得» が走ったかどうかが、内側のフックが実際に動いたかの目印になる。
+// そのため hasFetchedInitial は false（＝ useEffect が fetch を呼ぶ状態）にしてある。
+jest.mock("@/stores/useDishMediaEntriesStore", () => {
+	const storeState = {
+		fetchInitialByKey: (...args: unknown[]) => mockFetchInitialByKey(...args),
+		fetchMoreByKey: (...args: unknown[]) => mockFetchMoreByKey(...args),
+	};
+	const useDishMediaEntriesStore = (selector: (state: unknown) => unknown) => selector(storeState);
+	useDishMediaEntriesStore.getState = () => storeState;
+	return {
+		useDishMediaEntriesStore,
+		selectIdsByKey: () => () => ({
+			ids: [],
+			isLoading: false,
+			isLoadingMore: false,
+			error: null,
+			hasFetchedInitial: false,
+		}),
+		selectEntryByMediaId: () => () => undefined,
+	};
+});
+
+import { SavedPostsTab } from "./SavedPostsTab";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/** レンダー結果を JSON 化した文字列。i18n はキーをそのまま返すのでキーで検索できる */
+const renderedText = (renderer: TestRenderer.ReactTestRenderer) => JSON.stringify(renderer.toJSON());
+
+describe("SavedPostsTab", () => {
+	beforeEach(() => {
+		mockRenderedGrid.props = null;
+	});
+
+	it("他人のプロフィールでは非公開表示になり、保存投稿の取得も走らない", () => {
+		let renderer!: TestRenderer.ReactTestRenderer;
+		act(() => {
+			renderer = TestRenderer.create(<SavedPostsTab isOwnProfile={false} />);
+		});
+
+		expect(renderedText(renderer)).toContain("Profile.privateContent");
+		// 本体が一度も描画されておらず、内側のフックも動いていない
+		// ＝ 他人のプロフィールで自分の保存投稿を取りに行っていない
+		expect(mockRenderedGrid.props).toBeNull();
+		expect(mockFetchInitialByKey).not.toHaveBeenCalled();
+
+		act(() => renderer.unmount());
+	});
+
+	it("非公開表示から自分のプロフィールへ切り替えると本体がマウントされ、初回取得が走る", () => {
+		let renderer!: TestRenderer.ReactTestRenderer;
+		act(() => {
+			renderer = TestRenderer.create(<SavedPostsTab isOwnProfile={false} />);
+		});
+
+		act(() => {
+			renderer.update(<SavedPostsTab isOwnProfile />);
+		});
+
+		expect(mockRenderedGrid.props?.testID).toBe("save-post-tab-grid");
+		expect(renderedText(renderer)).not.toContain("Profile.privateContent");
+		// 切り替わった後は内側がマウントされ、初回取得が走る
+		expect(mockFetchInitialByKey).toHaveBeenCalledTimes(1);
+		expect(mockFetchInitialByKey.mock.calls[0][0]).toBe("profileSavedPosts");
+
+		act(() => renderer.unmount());
+	});
+
+	it("自分のプロフィールから非公開へ切り替えると非公開表示へ戻る", () => {
+		let renderer!: TestRenderer.ReactTestRenderer;
+		act(() => {
+			renderer = TestRenderer.create(<SavedPostsTab isOwnProfile />);
+		});
+		act(() => {
+			renderer.update(<SavedPostsTab isOwnProfile={false} />);
+		});
+
+		expect(renderedText(renderer)).toContain("Profile.privateContent");
+
+		act(() => renderer.unmount());
+	});
+});

--- a/app-expo/features/profile/tabs/SavedPostsTab.tsx
+++ b/app-expo/features/profile/tabs/SavedPostsTab.tsx
@@ -21,6 +21,29 @@ interface SavedPostsTabProps {
 
 export const profileSavedPostsEntriesKey = "profileSavedPosts";
 
+/**
+ * #1366 【修正】`isOwnProfile` による «早期 return» の後ろにフックを並べない。
+ *
+ * この形が何を招くかは react-test-renderer で React 19 の実挙動を測って確かめた。
+ *   - フック 0 本 → 15 本（非公開 → 自分）: 直前のレンダーが memoizedState を持たないので
+ *     React は mount 側のディスパッチャを使う。**throw しない**。
+ *   - フック 15 本 → 0 本（自分 → 非公開）: throw しないが、**effect の cleanup が呼ばれない**。
+ *     フックを 1 本も呼ばなかったレンダーは updateQueue ごと捨てられるため、購読やタイマーを
+ *     張っていたらそのまま残る。
+ *   - 早期 return の «前» にフックが 1 本でもある場合: 「Rendered more hooks than during the
+ *     previous render」で throw する。
+ *
+ * したがって現時点のこのファイルに観測できる不具合は無い（useEffect が cleanup を返しておらず、
+ * 呼び出し元の ProfileTabsLayout も `isOwnProfile` を定数 true にしているため）。危険なのは、
+ * この形のまま «早期 return の前にフックを 1 本足す» か «effect に cleanup を足す» だけで
+ * 上の 3 番目・2 番目へ落ちる点である。
+ *
+ * 直し方として、フックを無条件化して早期 return を後ろへ動かすのは **誤り**。
+ * `useEffect` が保存投稿を fetch するので、他人のプロフィールで自分の保存投稿を取りに行く。
+ * そこで «出し分ける外側» と «フックを持つ内側» に分け、非公開時は内側を **マウントしない**
+ * ことで、フックの本数がコンポーネントごとに一定になるようにしてある。
+ * この «誤った直し方» への退行は SavedPostsTab.test.tsx が検知する。
+ */
 export function SavedPostsTab({ isOwnProfile }: SavedPostsTabProps) {
 	if (!isOwnProfile) {
 		return (
@@ -32,6 +55,11 @@ export function SavedPostsTab({ isOwnProfile }: SavedPostsTabProps) {
 		);
 	}
 
+	return <OwnSavedPostsTab />;
+}
+
+/** 自分のプロフィールのときだけマウントされる本体。フックはすべてここに閉じている。 */
+function OwnSavedPostsTab() {
 	const { callBackend } = useAPICall();
 	const { lightImpact } = useHaptics();
 	const { logFrontendEvent } = useLogger();

--- a/app-expo/scripts/assert-legacy-blur-modal-boundary.mjs
+++ b/app-expo/scripts/assert-legacy-blur-modal-boundary.mjs
@@ -25,24 +25,26 @@ import { fileURLToPath } from "node:url";
  *   pnpm --filter app-expo assert:legacy-blur-modal-boundary
  *
  * ## なぜ必要か（ESLint の `no-restricted-imports` だけでは足りない理由）
- * 同じ境界は `.eslintrc.js` の `no-restricted-imports` でも張っているが、**その lint は CI で
- * 一度も実行されていない**。
- * - `.github/workflows/pr-check.yml` が回すのは remoteConfig キー検査 / error-triage jest /
- *   app-expo typecheck / app-expo jest の 4 つだけで、`pnpm --filter app-expo lint` は含まれない。
- *   他の workflow にも無い。
- * - そのうえ `pnpm --filter app-expo lint` は現状 **48 errors で落ちる**
- *   （`react-hooks/rules-of-hooks` 45 / `no-undef` 3。いずれも #1363 以前からの既存違反で、
- *   `no-restricted-imports` 由来は 0 件）。既存違反の解消は別 Issue なので、
- *   **lint 全体を今すぐ CI に載せることはできない**。
+ * このスクリプトを書いた時点（#1363）では `.eslintrc.js` の `no-restricted-imports` に同じ境界が
+ * ありながら、**その lint が CI で一度も実行されていなかった**（`pnpm --filter app-expo lint` は
+ * どの workflow にも無く、そのうえ既存 48 errors で落ちる状態だった）。
+ * #1366 で既存違反を解消し、`pnpm --filter app-expo lint` を pr-check.yml へ載せたので、
+ * この前提は変わっている。**lint も CI で評価される**。
  *
- * つまり lint に任せたままだと、公開アプリから `legacyBlurModal` を import しても CI では誰も
- * 気付かない。凍結の価値は「利用者が社内タスク画面だけに閉じていること」に全面的に依存しており、
+ * それでもこのスクリプトを残すのは、検査している範囲が ESLint と重ならないためである。
+ * - 2（`features/blurModal` が復活していないこと）と 3（`Portal` の import 許可リスト）は
+ *   `.eslintrc.js` に対応するルールが無く、ここにしか無い。
+ * - 1 は ESLint と重複するが、二重防御として残す。ESLint 側の許可範囲はグロブで書かれており
+ *   （`[locale]` の角括弧の件は `.eslintrc.js` のコメント参照）、書き方ひとつで許可範囲が
+ *   意図せず広がりうる。こちらは解決後の絶対パスで見るため、同じ間違いをしない。
+ *
+ * 凍結の価値は「利用者が社内タスク画面だけに閉じていること」に全面的に依存しており、
  * 1 箇所でも外から import された時点で、共有部品が全画面を人質に取る元の状態（#1350 §7）へ
- * 逆戻りする。この検査は**既存 48 errors とは独立に単体で走る**ので、今日から CI で強制できる。
+ * 逆戻りする。
  *
  * ## 役割分担
- * - **ESLint**: エディタ上で書いた瞬間に赤くする（速いが CI では評価されない）
- * - **このスクリプト**: CI の最後の砦。lint が回っていなくても機械的に落とす
+ * - **ESLint**: エディタ上で書いた瞬間に赤くする。#1366 以降は CI でも評価される
+ * - **このスクリプト**: CI の最後の砦。ESLint が見ていない 2・3 も含めて機械的に落とす
  *
  * ## 検出方法
  * import 指定子の文字列そのものではなく、**解決後の絶対パス**が凍結ディレクトリ配下かどうかで


### PR DESCRIPTION
Closes #1366

`pnpm --filter app-expo lint` はどの workflow でも実行されておらず、実行すると 48 errors で落ちる状態だった。全件を解消したうえで `pr-check.yml` へ lint step を追加し、以後 CI で強制する。

## 実測した 48 件の内訳

Issue の記載を鵜呑みにせず `pnpm install` 後に実走し、JSON フォーマッタで分類した。数・分類とも記載どおりだった。

| ファイル | 件数 | ルール |
| --- | ---: | --- |
| `components/deepLinking/OpenInAppBanner.tsx` | 22 | `react-hooks/rules-of-hooks` |
| `features/profile/tabs/SavedPostsTab.tsx` | 15 | `react-hooks/rules-of-hooks` |
| `components/ImageCardGrid.tsx` | 7 | `react-hooks/rules-of-hooks` |
| `features/map/components/ReviewForm.test.tsx` | 1 | `react-hooks/rules-of-hooks` |
| `jest.setup.js` | 3 | `no-undef` |

`eslint-disable` は **1 件も使っていない**。

## 分割について

（a）機械的なもの・（b）挙動を変えるもの・（c）CI への配線 に分ける選択肢があったが、単一 PR にした。差分が 7 ファイル + テスト 1 本と小さく、**同一コミットで lint が緑になったうえで配線が入る**ため「先に配線して既存違反で落ちる」という順序事故は起きない。CI の順序制約は満たしている。

---

## 1. `no-undef` 3 件 — 環境設定（globals）の不足だった

`jest.setup.js` の `jest` は Jest が実行時に注入するグローバルで、import して使うものではない。コードの誤りではなく env 宣言の漏れである。`.eslintrc.js` に override を追加した。

```js
files: ["jest.setup.js", "**/*.test.ts", "**/*.test.tsx"],
env: { jest: true },
```

`.ts` / `.tsx` では eslint-config-expo が `no-undef` を無効化しているため現に落ちていたのは `jest.setup.js` だけだが、同じ性質のファイルはまとめて宣言した。

## 2. `ImageCardGrid.tsx` 7 件 — ルールが機能していなかった

`_ImageCard` / `_ImageCardGrid` が `_` 始まりのため、rules-of-hooks が「コンポーネントでもフックでもない関数」と判定し、中のフック呼び出しを一律 error にしていた。**このファイルのフック順序はこれまで一度も検査されていなかった**ということでもある。

`Impl` 接尾辞へ改名（`memo` でラップした公開名との衝突を避けつつ大文字始まりにするため）。改名後にルールが実際に走るようになった結果、このファイルに他の違反は無いことも確認できた。挙動は変わらない。

## 3. 早期 return の後ろにフックがある 2 ファイル（37 件）

`OpenInAppBanner.tsx`（`Platform.OS !== "web"`）と `SavedPostsTab.tsx`（`!isOwnProfile`）が、早期 return の後ろにそれぞれ 22 個・15 個のフックを並べていた。

### React 19 の実挙動を先に測った

「早期 return の後ろのフック = 必ずクラッシュ」と決めつけずに `react-test-renderer` で実測したところ、**この形そのものは今すぐ落ちるわけではなかった**。

| 遷移 | 結果 |
| --- | --- |
| フック 0 本 → N 本 | **throw しない**。直前のレンダーが `memoizedState` を持たないので React は mount 側のディスパッチャを使う |
| フック N 本 → 0 本 | **throw しない**が、**effect の cleanup が呼ばれない**（フックを 1 本も呼ばなかったレンダーは `updateQueue` ごと捨てられる） |
| 早期 return の **前** にフックが 1 本でもある | `Rendered more hooks than during the previous render.` で **throw する** |

したがって現時点でこの 2 ファイルに観測できる不具合は無い。`SavedPostsTab` の `useEffect` は cleanup を返しておらず、呼び出し元 `ProfileTabsLayout` は `isOwnProfile` を定数 `true` にしている。`Platform.OS` はモジュール定数で変化しない。

**「既存のクラッシュを直した」とは書けない。** 直したのは、この形のまま「早期 return の前にフックを 1 本足す」か「effect に cleanup を足す」だけで上表の 3 行目・2 行目へ落ちる、という構造のほうである。測った内容は各ファイルのコメントに残した。

### 直し方

**フックを無条件化して早期 return を後ろへ動かす直し方は採っていない。** `SavedPostsTab` では `useEffect` が保存投稿を fetch するため、他人のプロフィールを開いただけで自分の保存投稿を取りに行く。`OpenInAppBanner` の内側は `window` / `document` / `navigator` を触るため、ネイティブでも評価されると壊れる。

どちらも「判定だけを持つ外側」と「フックを持つ内側」に分割し、条件を満たさないときは内側を**マウントしない**ようにした。これでフックの本数がコンポーネントごとに一定になる。

## 4. `ReviewForm.test.tsx` 1 件

`jest.fn` をモック工場の内側に閉じ込めていたため、テストから取り出す手段が `useLogger()` を呼ぶことしか無かった。差し替え後の `useLogger` は「毎回同じ jest.fn を返すただの関数」でフックではないが、名前が `use` で始まるためルールが反応する。`jest.fn` をモジュールスコープ（`mock` 接頭辞は babel-plugin-jest-hoist の要求）へ出し、呼び出しそのものを不要にした。

---

## テストとミューテーション検証

`SavedPostsTab.test.tsx` を追加した（3 ケース）。守るのは「クラッシュしないこと」ではなく **直し方** である。lint を通すだけならフックを早期 return の前へ移せばよいが、それをやると他人のプロフィールで fetch が走る。

コードを壊して赤くなることを 1 件ずつ確認した。

| # | ミューテーション | 結果 |
| --- | --- | --- |
| M1 | フックを早期 return の前へ移す（＝ lint だけ通る誤った直し方） | 🔴 2 件 fail（`fetchInitialByKey` が他人のプロフィールで呼ばれる） |
| M2 | 非公開分岐を落として常に本体を返す | 🔴 3 件 fail |
| M3 | `profileSavedPostsEntriesKey` を壊す | 🔴 1 件 fail |
| M4 | `GridList` の `testID` を `save-post-tab-grid-BROKEN` へ | 🟢 **検知できず** |
| M4b | 同 `other-grid` へ（M4 の修正後） | 🔴 1 件 fail |
| M5 | 非公開カードの文言を差し替える | 🔴 2 件 fail |
| M6 | 初回取得の `useEffect` を落とす | 🔴 1 件 fail |

**M4 で最初にテストの穴が出た。** `toContain("save-post-tab-grid")` という部分文字列一致だったため、末尾に付け足す変異を素通ししていた。`GridList` のモックで props を捕捉し `toBe` で厳密比較する形へ直してから M4b を再実行し、赤くなることを確認した。

あわせて以下も検証した。

- **`ReviewForm.test.tsx` のモック配線が生きていること** — `logFrontendEventMock` を別の `jest.fn` へ差し替えると 2 ケースが赤くなる。既存アサーションが今も同じ関数を見ていることの確認。
- **`.eslintrc.js` の override が効いていること** — override を外すと `jest.setup.js` の `no-undef` 3 件が戻る。
- **改名が修正の実体であること** — `_` 始まりへ戻すと rules-of-hooks 7 件が戻る。
- **CI ゲートが本物であること** — 早期 return の前にフックを 1 本足すと `pnpm --filter app-expo lint` が **exit 1**。復元すると exit 0。

## CI への配線

`pr-check.yml` に step を追加した。`shared/dist` を要求しないので shared build より前（error-triage の後）に置いてある。`shared/dist` を消した状態から CI と同じ順序で全 step を通し、緑を確認済み。ローカル実測で約 23 秒。

```yaml
- name: app-expo の lint
  run: pnpm --filter app-expo lint
```

**warning は素通りさせている**（`--max-warnings` は付けていない）。現時点で 234 件あり、ここで 0 を要求すると無関係な PR まで巻き添えで落ちる。error だけを強制する。この判断はコメントに書き、「新しいルールを error で足すときはこの step が本当に強制するので、追加時は全件解消してから入れること」も添えた。warning の削減は本 PR の担当範囲外。

### 前提が変わったコメントの追随

lint が CI に載ったことで記述が古くなる 3 箇所を直した。

- `app-expo/scripts/assert-legacy-blur-modal-boundary.mjs` — 「lint が CI で走っていないため専用スクリプトを書いた」という経緯を、現状に合わせて書き換えた。**スクリプト自体は残している。** ESLint と重ならない検査（撤去した `features/blurModal` の再出現、`react-native-paper` の `Portal` の import 許可リスト）はこのスクリプトにしか無く、境界 1 についても許可範囲の表現がグロブと絶対パスで異なるため二重防御の価値がある。
- `app-expo/.eslintrc.js` — 「この lint は CI で実行されていない」の記述を更新。
- `.github/workflows/pr-check.yml` — 検査 5 つ → 6 つ、および legacyBlurModal step の説明。

## 完了条件

| 条件 | 結果 |
| --- | --- |
| `pnpm --filter app-expo lint` が exit 0 | ✅ 0 errors / 234 warnings、exit 0 |
| `pr-check.yml` で lint が回っている | ✅ shared build 前に追加、順序どおり通ることを実測 |
| typecheck / test が退行していない | ✅ typecheck exit 0。jest 69 suites / 654 tests（基準 68 / 651 + 追加分 1 / 3） |
| `eslint-disable` に理由が書かれている | ✅ 使用箇所なし |

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETnSrHEXKU7j9FyMUND8ed)_