### PR TITLE
fix(app-expo): main が red だったのを直す（#1392 と #1405 の相互作用）

### DIFF
--- a/app-expo/__tests__/profileEditRoute.test.tsx
+++ b/app-expo/__tests__/profileEditRoute.test.tsx
@@ -385,11 +385,15 @@ describe("#1387 プロフィール取得に失敗したときの編集画面", (
 	});
 
 	// 失敗表示は «行き止まり» にしないこと。再試行が通らない環境でも離脱はできる必要がある
+	// ⚠️ 戻るの testID は #1404 で画面ごと（${testID}-back）になった。
+	// 共通 id のままにすると «存在しない id を探して常に緑» になる
 	it("失敗表示のままでも戻れる", async () => {
 		arrangeFailed();
 		const tree = await render(<ProfileEditScreen />);
 
-		expect(tree.root.findAll((node) => node.props?.testID === "screen-header-back").length).toBeGreaterThan(0);
+		expect(
+			tree.root.findAll((node) => node.props?.testID === "profile-edit-screen-back").length,
+		).toBeGreaterThan(0);
 	});
 
 	/*


### PR DESCRIPTION
## 何が起きたか

`main`（`71bab19c`）で `pnpm --filter app-expo test` が **1 件落ちています**。

```
● #1387 プロフィール取得に失敗したときの編集画面 › 失敗表示のままでも戻れる
Tests: 1 failed, 678 passed, 679 total
```

#1392 が追加したこのテストは共通 id `screen-header-back` を参照していましたが、#1405 が戻るボタンの testID を画面ごと（`${testID}-back`）へ改名しました。**両方が別々のブランチで緑だったため、main へ入って初めて衝突しました。**

`profile-edit-screen-back` へ直しています。他に取り残しが無いことも確認済みです（`grep` で残存 0 件）。

## 検証

| 対象 | 結果 |
| --- | --- |
| `pnpm --filter app-expo test` | 69 suites / **679 tests all pass** |
| `pnpm --filter app-expo lint` | 0 errors |

> ⚠️ この形は «存在しない id を探して常に緑» にもなりえます（`findAll` は 0 件でも例外を投げない）。今回は `toBeGreaterThan(0)` で数えていたので赤くなり気付けました。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GVn2NvCTnuD5s5PRvb3JJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019GVn2NvCTnuD5s5PRvb3JJ)_