### PR TITLE
#1451 test(app-expo): 店舗選択の «upsert してから push» を 4 経路とも固定し、孤児 i18n キーを消す

### DIFF
--- a/app-expo/__tests__/selectRestaurantRoute.test.tsx
+++ b/app-expo/__tests__/selectRestaurantRoute.test.tsx
@@ -1,0 +1,264 @@
+/*
+#1451 【設計】店舗選択 → 店詳細 «ルート» の結び目を固定する。
+
+## なぜ必要か
+遷移先（`app/[locale]/(tabs)/review/restaurant/[restaurantId].tsx`）は `useRestaurantStore` の
+キャッシュ優先で描く。この画面は `POST v1/restaurants` /
+`GET v1/users/me/saved-restaurants` の応答として **店の実体をすでに持っている**ので、
+push より先にストアへ入れておけば遷移先は API を引かずに即描ける。
+逆順にすると、遷移先のマウント時点ではストアが空なので `GET v1/restaurants/:id` を
+1 本余計に叩き、その間ローディングが出る。**順序を入れ替えると赤くなる**ようにしてある。
+
+## この検査が無かった経緯（同じ轍を踏まないために）
+同じ不変条件は `__tests__/mapRestaurantRoute.test.tsx` が持っていたが、**あれは地図タブ側
+だけを見ていた**。その地図タブは `_layout.tsx` で `href: null` ＝ 本番から到達不能で、
+#1419 で丸ごと削除した。**到達可能なこの画面は、最初から 1 度も守られていなかった。**
+
+「到達不能な側にだけ検査が付いている」は #1411 / #1418 と同じ形の見落としである
+（`docs/ux/blur-modal-teardown.md` の «#1419 マップタブを丸ごと削除した» を参照）。
+
+## 4 経路すべてを見る
+`upsert → push` は 1 箇所ではなく **4 箇所**にある。1 つだけ直しても他が壊れうるので全部固定する。
+
+| 経路 | ハンドラ |
+| --- | --- |
+| 地図の POI 押下（＝ Place から店を作る） | `createAndOpenRestaurant` |
+| 保存した店のマーカー押下（アクティブなものをもう一度） | `handleSavedRestaurantMarkerPress` |
+| 保存した店のカード押下 | `handleSavedRestaurantCardPress` |
+| 保存した店の「写真・動画を投稿」 | `handleSavedRestaurantReviewPress` |
+
+## 方針
+`router.push` と `useRestaurantStore.upsert` の «呼び出し順» を 1 本の列で観測する。
+周辺（地図・位置情報・シート・画像）はすべてスタブへ落とす。
+
+`app/` 配下に置いたテストは expo-router がルートとして拾ってしまうため、ここに置いている。
+*/
+import React, { act } from "react";
+import TestRenderer from "react-test-renderer";
+
+/** push と upsert の «呼び出し順» を 1 本の列で観測する（この 2 つの順序が検証対象） */
+const callOrder: string[] = [];
+const mockPush = jest.fn((_href: unknown) => {
+	callOrder.push("push");
+});
+const mockUpsert = jest.fn((_entry: unknown) => {
+	callOrder.push("upsert");
+});
+
+// ⚠️ スタブ本体をファクトリの «外» に置かないこと。import 文はこのファイルの const 宣言より前へ
+// 巻き上げられるため、ファクトリが走る時点では外の変数がまだ undefined になる
+// （loginEntryPoints.test.tsx と同じ注意）
+jest.mock("expo-router", () => {
+	const stub = {
+		push: (href: unknown) => mockPush(href),
+		replace: () => {},
+		back: () => {},
+		canGoBack: () => true,
+	};
+	return {
+		router: stub,
+		useRouter: () => stub,
+		useLocalSearchParams: () => ({}),
+		useGlobalSearchParams: () => ({}),
+		useFocusEffect: () => {},
+		useNavigation: () => ({ addListener: () => () => {} }),
+	};
+});
+
+jest.mock("@/features/review/stores/useRestaurantStore", () => ({
+	useRestaurantStore: { getState: () => ({ upsert: (entry: unknown) => mockUpsert(entry), getById: () => undefined }) },
+}));
+
+jest.mock("@/hooks/useLocale", () => ({ useLocale: () => ({ locale: "ja-JP", isJapanese: false }) }));
+jest.mock("@/hooks/useHaptics", () => ({
+	useHaptics: () => ({ lightImpact: jest.fn(), mediumImpact: jest.fn() }),
+}));
+jest.mock("@/hooks/useLogger", () => ({ useLogger: () => ({ logFrontendEvent: jest.fn() }) }));
+jest.mock("@/contexts/SnackbarProvider", () => ({ useSnackbar: () => ({ showSnackbar: jest.fn() }) }));
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+
+const mockCallBackend = jest.fn();
+jest.mock("@/hooks/useAPICall", () => ({
+	useAPICall: () => ({ callBackend: mockCallBackend }),
+	ApiError: class ApiError extends Error {},
+}));
+jest.mock("@/hooks/useLocationSearch", () => ({
+	useLocationSearch: () => ({
+		getLocationDetails: jest.fn(),
+		// マウント時 effect が現在地の周辺検索まで走り、保存した店のマーカーが描かれるところまで進む
+		getCurrentLocation: () => Promise.resolve({ location: { latitude: 35, longitude: 139 } }),
+	}),
+}));
+jest.mock("@/components/MapView", () => {
+	const ReactActual = jest.requireActual("react");
+	const { View: RNView } = jest.requireActual("react-native");
+	return {
+		__esModule: true,
+		// POI 押下（onPoiClick）をテストから起動できるよう、ハンドラを testID 付きで露出する
+		default: ReactActual.forwardRef(
+			(
+				{ children, onPoiClick }: { children?: React.ReactNode; onPoiClick?: (event: unknown) => void },
+				_ref: unknown,
+			) => ReactActual.createElement(RNView, { testID: "map-view", onPress: onPoiClick }, children),
+		),
+	};
+});
+jest.mock("react-native-maps", () => ({ __esModule: true, default: () => null }));
+jest.mock("@/features/mapMarkers", () => {
+	const ReactActual = jest.requireActual("react");
+	const { View: RNView } = jest.requireActual("react-native");
+	return {
+		// マーカーは「押せる何か」としてだけ必要。押下ハンドラを testID 付きで露出する
+		AvatarBubbleMarker: ({ onPress }: { onPress?: () => void }) =>
+			ReactActual.createElement(RNView, { testID: "map-marker", onPress }),
+	};
+});
+// シートの中身は要らない。カード押下 / 投稿ボタン押下の 2 経路だけを押せる形で露出する
+jest.mock("@/features/review/components/SavedRestaurantsSheet", () => {
+	const ReactActual = jest.requireActual("react");
+	const { View: RNView } = jest.requireActual("react-native");
+	return {
+		SavedRestaurantsSheet: ReactActual.forwardRef(
+			(
+				{
+					savedRestaurants,
+					onRestaurantCardPress,
+					onRestaurantReviewPress,
+				}: {
+					savedRestaurants: { restaurant: { id: string } }[];
+					onRestaurantCardPress?: (r: { restaurant: { id: string } }) => void;
+					onRestaurantReviewPress?: (r: { restaurant: { id: string } }) => void;
+				},
+				ref: { current?: unknown },
+			) => {
+				ReactActual.useImperativeHandle(ref, () => ({ present: () => {}, dismiss: () => {} }));
+				const first = savedRestaurants?.[0];
+				return ReactActual.createElement(
+					RNView,
+					null,
+					ReactActual.createElement(RNView, {
+						key: "card",
+						testID: "saved-restaurant-card",
+						onPress: () => first && onRestaurantCardPress?.(first),
+					}),
+					ReactActual.createElement(RNView, {
+						key: "review",
+						testID: "saved-restaurant-review",
+						onPress: () => first && onRestaurantReviewPress?.(first),
+					}),
+				);
+			},
+		),
+	};
+});
+jest.mock("@/components/LocationAutocomplete", () => ({ LocationAutocomplete: () => null }));
+jest.mock("@/components/PrimaryButton", () => ({ PrimaryButton: () => null }));
+jest.mock("@/components/LoadingIndicator", () => ({ LoadingIndicator: () => null }));
+jest.mock("@/components/ScreenHeader", () => ({ ScreenHeader: () => null }));
+jest.mock("lucide-react-native", () => new Proxy({}, { get: () => () => null }));
+
+import SelectRestaurantScreen from "../app/[locale]/(tabs)/review/selectRestaurant";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const RESTAURANT_ID = "restaurant-42";
+const SAVED = {
+	restaurant: { id: RESTAURANT_ID, name: "テスト食堂", latitude: 35, longitude: 139, imageUrls: undefined },
+	meta: { averageRating: 4.2, reviewCount: 12, totalCents: 0, maxEndDate: null },
+};
+/** POI 押下で作られる店（`POST v1/restaurants` の応答） */
+const CREATED = { restaurant: SAVED.restaurant, meta: SAVED.meta };
+
+const mountedTrees: TestRenderer.ReactTestRenderer[] = [];
+const render = async (element: React.ReactElement) => {
+	let tree!: TestRenderer.ReactTestRenderer;
+	await act(async () => {
+		tree = TestRenderer.create(element);
+	});
+	mountedTrees.push(tree);
+	return tree;
+};
+
+afterEach(async () => {
+	await act(async () => {
+		mountedTrees.splice(0).forEach((tree) => tree.unmount());
+	});
+});
+
+/** 指定 testID の要素を押す（引数はハンドラへそのまま渡す） */
+const press = async (tree: TestRenderer.ReactTestRenderer, testID: string, arg?: unknown): Promise<void> => {
+	const target = tree.root.find((node) => node.props?.testID === testID);
+	await act(async () => {
+		await target.props.onPress(arg);
+	});
+};
+
+beforeEach(() => {
+	callOrder.length = 0;
+	mockCallBackend.mockReset();
+	// 保存した店の検索（GET）は { data } を、店の作成（POST v1/restaurants）は単体を返す
+	mockCallBackend.mockImplementation((path: string) =>
+		Promise.resolve(path === "v1/restaurants" ? CREATED : { data: [SAVED] }),
+	);
+});
+
+describe("#1451 店舗選択から店詳細へ push する 4 経路", () => {
+	/*
+	⚠️ アサーションは «push されたこと» ではなく **`["upsert", "push"]` という列**に置くこと。
+	push だけを見ていると、順序を入れ替えても緑のままになる（それが今まさに無防備だった形）。
+	*/
+	it("地図の POI 押下: 店を作ってから upsert → push の順で遷移する", async () => {
+		const tree = await render(<SelectRestaurantScreen />);
+
+		await press(tree, "map-view", {
+			nativeEvent: { placeId: "place-1", name: "テスト食堂", coordinate: { latitude: 35, longitude: 139 } },
+		});
+
+		expect(mockCallBackend).toHaveBeenCalledWith("v1/restaurants", expect.objectContaining({ method: "POST" }));
+		expect(callOrder).toEqual(["upsert", "push"]);
+		expect(mockPush).toHaveBeenCalledWith({
+			pathname: "/[locale]/(tabs)/review/restaurant/[restaurantId]",
+			params: { locale: "ja-JP", restaurantId: RESTAURANT_ID },
+		});
+	});
+
+	it("保存した店のカード押下: upsert → push の順で遷移する", async () => {
+		const tree = await render(<SelectRestaurantScreen />);
+
+		await press(tree, "saved-restaurant-card");
+
+		expect(callOrder).toEqual(["upsert", "push"]);
+		expect(mockPush).toHaveBeenCalledWith({
+			pathname: "/[locale]/(tabs)/review/restaurant/[restaurantId]",
+			params: { locale: "ja-JP", restaurantId: RESTAURANT_ID },
+		});
+	});
+
+	it("保存した店の「写真・動画を投稿」: upsert → push の順で投稿フォームへ進む", async () => {
+		const tree = await render(<SelectRestaurantScreen />);
+
+		await press(tree, "saved-restaurant-review");
+
+		expect(callOrder).toEqual(["upsert", "push"]);
+		expect(mockPush).toHaveBeenCalledWith(
+			expect.objectContaining({
+				pathname: "/[locale]/(tabs)/review/restaurant/[restaurantId]/review",
+			}),
+		);
+	});
+
+	/*
+	マーカーは «2 度押し» が仕様である。1 度目はアクティブにするだけで遷移しない
+	（シートのスクロールを同期させるため）。ここを 1 度目で遷移させると、
+	地図を触っただけで画面が飛ぶ。
+	*/
+	it("保存した店のマーカー押下: 1 度目は遷移せず、2 度目に upsert → push する", async () => {
+		const tree = await render(<SelectRestaurantScreen />);
+
+		await press(tree, "map-marker");
+		expect(callOrder).toEqual([]);
+
+		await press(tree, "map-marker");
+		expect(callOrder).toEqual(["upsert", "push"]);
+	});
+});

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -362,10 +362,6 @@
 			"million": "M",
 			"thousand": "K"
 		},
-		"menuOptions": {
-			"viewCreatorProfile": "انتقل إلى ملف المُنشئ",
-			"reservation": "حجز"
-		},
 		"actions": {
 			"share": "مشاركة",
 			"seeMore": "عرض المزيد",
@@ -513,7 +509,6 @@
 		"buttons": {
 			"postReview": "نشر مراجعة",
 			"postPhotoVideoReview": "نشر صورة/فيديو",
-			"placeBid": "تقديم عرض",
 			"bid": "عرض",
 			"searchNearby": "ابحث في هذه المنطقة",
 			"openInGoogle": "فتح في Google"
@@ -541,13 +536,11 @@
 		"labels": {
 			"endDate": "تاريخ الانتهاء:",
 			"paymentProcessing": "معالجة الدفع...",
-			"currentBidAmount": "مبلغ العرض الحالي",
 			"restaurant": "مطعم",
 			"dishCategory": "فئة الطبق"
 		},
 		"tabs": {
-			"reviews": "المراجعات",
-			"bids": "العروض"
+			"reviews": "المراجعات"
 		},
 		"emptyState": {
 			"noBidsForStatus": "لا توجد عروض للحالة المحددة"
@@ -671,9 +664,7 @@
 	"auth": {
 		"login_title": "تسجيل الدخول",
 		"create_title": "إنشاء حساب",
-		"field_phone": "الهاتف",
 		"field_name": "الاسم",
-		"hint_sms": "سنرسل لك رمز لمرة واحدة عبر الرسائل النصية لتسجيل الدخول.",
 		"btn_login": "تسجيل الدخول",
 		"btn_create": "إنشاء حساب",
 		"divider_or": "أو تسجيل الدخول باستخدام",
@@ -682,13 +673,8 @@
 		"provider_facebook": "Facebook",
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
-		"otp_title": "أدخل الرمز",
-		"otp_resending": "جارٍ إعادة إرسال الرمز...",
-		"otp_send_again": "إعادة إرسال الرمز",
-		"otp_enter_all_digits": "يرجى إدخال الأرقام الستة كاملة",
 		"login_success": "تم تسجيل الدخول بنجاح!",
 		"error_required": "هذا الحقل مطلوب",
-		"error_invalid_phone": "رقم الهاتف غير صحيح",
 		"tos_link_text": "شروط الخدمة",
 		"existing_account_checkbox": "هل لديك حساب بالفعل؟",
 		"conflict_dialog_title": "تم العثور على حساب موجود",

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -362,10 +362,6 @@
 			"million": "M",
 			"thousand": "K"
 		},
-		"menuOptions": {
-			"viewCreatorProfile": "Go to creator profile",
-			"reservation": "Reservation"
-		},
 		"actions": {
 			"share": "Share",
 			"seeMore": "see more",
@@ -512,7 +508,6 @@
 		"buttons": {
 			"postReview": "Post Review",
 			"postPhotoVideoReview": "Post Photo/Video",
-			"placeBid": "Place Bid",
 			"bid": "Bid",
 			"searchNearby": "Search in this area",
 			"openInGoogle": "Open in Google"
@@ -540,13 +535,11 @@
 		"labels": {
 			"endDate": "End date:",
 			"paymentProcessing": "Processing payment...",
-			"currentBidAmount": "Current bid amount",
 			"restaurant": "Restaurant",
 			"dishCategory": "Dish category"
 		},
 		"tabs": {
-			"reviews": "Reviews",
-			"bids": "Bids"
+			"reviews": "Reviews"
 		},
 		"emptyState": {
 			"noBidsForStatus": "No bids for the selected status"
@@ -671,9 +664,7 @@
 	"auth": {
 		"login_title": "Log In",
 		"create_title": "Create Account",
-		"field_phone": "Phone",
 		"field_name": "Name",
-		"hint_sms": "We will send you a one-time code via SMS to log in.",
 		"btn_login": "Login",
 		"btn_create": "Create an Account",
 		"divider_or": "Or Sign in with",
@@ -682,13 +673,8 @@
 		"provider_facebook": "Facebook",
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
-		"otp_title": "Enter Code",
-		"otp_resending": "Resending code...",
-		"otp_send_again": "Resend Code",
-		"otp_enter_all_digits": "Please enter all 6 digits",
 		"login_success": "Successfully logged in!",
 		"error_required": "This field is required",
-		"error_invalid_phone": "Invalid phone number",
 		"tos_link_text": "Terms of Service",
 		"existing_account_checkbox": "Do you already have an account?",
 		"conflict_dialog_title": "Existing Account Found",

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -362,10 +362,6 @@
 			"million": "M",
 			"thousand": "K"
 		},
-		"menuOptions": {
-			"viewCreatorProfile": "Ver perfil del creador",
-			"reservation": "Reserva"
-		},
 		"actions": {
 			"share": "Compartir",
 			"seeMore": "ver más",
@@ -513,7 +509,6 @@
 		"buttons": {
 			"postReview": "Publicar Reseña",
 			"postPhotoVideoReview": "Publicar Foto/Video",
-			"placeBid": "Hacer Oferta",
 			"bid": "Ofertar",
 			"searchNearby": "Buscar en esta área",
 			"openInGoogle": "Abrir en Google"
@@ -541,13 +536,11 @@
 		"labels": {
 			"endDate": "Fecha de fin:",
 			"paymentProcessing": "Procesando pago...",
-			"currentBidAmount": "Monto de oferta actual",
 			"restaurant": "Restaurante",
 			"dishCategory": "Categoría del plato"
 		},
 		"tabs": {
-			"reviews": "Reseñas",
-			"bids": "Ofertas"
+			"reviews": "Reseñas"
 		},
 		"emptyState": {
 			"noBidsForStatus": "No hay ofertas para el estado seleccionado"
@@ -671,9 +664,7 @@
 	"auth": {
 		"login_title": "Iniciar Sesión",
 		"create_title": "Crear Cuenta",
-		"field_phone": "Teléfono",
 		"field_name": "Nombre",
-		"hint_sms": "Te enviaremos un código único por SMS para iniciar sesión.",
 		"btn_login": "Iniciar Sesión",
 		"btn_create": "Crear una Cuenta",
 		"divider_or": "O Inicia sesión con",
@@ -682,13 +673,8 @@
 		"provider_facebook": "Facebook",
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
-		"otp_title": "Introducir Código",
-		"otp_resending": "Reenviando el código...",
-		"otp_send_again": "Reenviar Código",
-		"otp_enter_all_digits": "Por favor ingresa los 6 dígitos",
 		"login_success": "¡Inicio de sesión exitoso!",
 		"error_required": "Este campo es obligatorio",
-		"error_invalid_phone": "Número de teléfono inválido",
 		"tos_link_text": "Términos de Servicio",
 		"existing_account_checkbox": "¿Ya tienes una cuenta?",
 		"conflict_dialog_title": "Cuenta Existente Encontrada",

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -362,10 +362,6 @@
 			"million": "M",
 			"thousand": "K"
 		},
-		"menuOptions": {
-			"viewCreatorProfile": "Voir le profil du créateur",
-			"reservation": "Réservation"
-		},
 		"actions": {
 			"share": "Partager",
 			"seeMore": "voir plus",
@@ -513,7 +509,6 @@
 		"buttons": {
 			"postReview": "Publier un avis",
 			"postPhotoVideoReview": "Publier une Photo/Vidéo",
-			"placeBid": "Placer une enchère",
 			"bid": "Enchérir",
 			"searchNearby": "Rechercher dans cette zone",
 			"openInGoogle": "Ouvrir dans Google"
@@ -541,13 +536,11 @@
 		"labels": {
 			"endDate": "Date de fin:",
 			"paymentProcessing": "Traitement du paiement...",
-			"currentBidAmount": "Montant de l'enchère actuelle",
 			"restaurant": "Restaurant",
 			"dishCategory": "Catégorie de plat"
 		},
 		"tabs": {
-			"reviews": "Avis",
-			"bids": "Enchères"
+			"reviews": "Avis"
 		},
 		"emptyState": {
 			"noBidsForStatus": "Aucune enchère pour l'état sélectionné"
@@ -671,9 +664,7 @@
 	"auth": {
 		"login_title": "Se connecter",
 		"create_title": "Créer un compte",
-		"field_phone": "Téléphone",
 		"field_name": "Nom",
-		"hint_sms": "Nous vous enverrons un code unique par SMS pour vous connecter.",
 		"btn_login": "Se connecter",
 		"btn_create": "Créer un compte",
 		"divider_or": "Ou se connecter avec",
@@ -682,13 +673,8 @@
 		"provider_facebook": "Facebook",
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
-		"otp_title": "Entrer le code",
-		"otp_resending": "Renvoi du code...",
-		"otp_send_again": "Renvoyer le code",
-		"otp_enter_all_digits": "Veuillez saisir les 6 chiffres",
 		"login_success": "Connexion réussie !",
 		"error_required": "Ce champ est obligatoire",
-		"error_invalid_phone": "Numéro de téléphone invalide",
 		"tos_link_text": "Conditions de Service",
 		"existing_account_checkbox": "Avez-vous déjà un compte?",
 		"conflict_dialog_title": "Compte Existant Trouvé",

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -362,10 +362,6 @@
 			"million": "M",
 			"thousand": "K"
 		},
-		"menuOptions": {
-			"viewCreatorProfile": "निर्माता की प्रोफ़ाइल पर जाएँ",
-			"reservation": "आरक्षण"
-		},
 		"actions": {
 			"share": "साझा करें",
 			"seeMore": "और देखें",
@@ -512,7 +508,6 @@
 		"buttons": {
 			"postReview": "समीक्षा पोस्ट करें",
 			"postPhotoVideoReview": "फोटो/वीडियो पोस्ट करें",
-			"placeBid": "बोली लगाएं",
 			"bid": "बोली",
 			"searchNearby": "इस क्षेत्र में खोजें",
 			"openInGoogle": "Google में खोलें"
@@ -540,13 +535,11 @@
 		"labels": {
 			"endDate": "समाप्ति तिथि:",
 			"paymentProcessing": "भुगतान प्रसंस्करण...",
-			"currentBidAmount": "वर्तमान बोली राशि",
 			"restaurant": "रेस्टोरेंट",
 			"dishCategory": "व्यंजन श्रेणी"
 		},
 		"tabs": {
-			"reviews": "समीक्षाएँ",
-			"bids": "बोली"
+			"reviews": "समीक्षाएँ"
 		},
 		"emptyState": {
 			"noBidsForStatus": "चयनित स्थिति के लिए कोई बोली नहीं"
@@ -671,9 +664,7 @@
 	"auth": {
 		"login_title": "लॉग इन करें",
 		"create_title": "खाता बनाएं",
-		"field_phone": "फोन",
 		"field_name": "नाम",
-		"hint_sms": "हम आपको लॉग इन करने के लिए SMS के माध्यम से एक वन-टाइम कोड भेजेंगे।",
 		"btn_login": "लॉग इन करें",
 		"btn_create": "खाता बनाएं",
 		"divider_or": "या इसके साथ साइन इन करें",
@@ -682,13 +673,8 @@
 		"provider_facebook": "Facebook",
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
-		"otp_title": "कोड दर्ज करें",
-		"otp_resending": "कोड दोबारा भेजा जा रहा है...",
-		"otp_send_again": "कोड पुनः भेजें",
-		"otp_enter_all_digits": "कृपया सभी 6 अंक दर्ज करें",
 		"login_success": "सफलतापूर्वक लॉग इन हो गया!",
 		"error_required": "यह फ़ील्ड आवश्यक है",
-		"error_invalid_phone": "अमान्य फोन नंबर",
 		"tos_link_text": "सेवा की शर्तें",
 		"existing_account_checkbox": "क्या आपके पास पहले से खाता है?",
 		"conflict_dialog_title": "मौजूदा खाता मिला",

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -362,10 +362,6 @@
 			"million": "M",
 			"thousand": "K"
 		},
-		"menuOptions": {
-			"viewCreatorProfile": "投稿者プロフィールへ",
-			"reservation": "予約"
-		},
 		"actions": {
 			"share": "シェア",
 			"seeMore": "もっと見る",
@@ -513,7 +509,6 @@
 		"buttons": {
 			"postReview": "レビュー投稿",
 			"postPhotoVideoReview": "写真・動画を投稿する",
-			"placeBid": "入札する",
 			"bid": "入札",
 			"searchNearby": "このエリアで探す",
 			"openInGoogle": "Google で開く"
@@ -541,13 +536,11 @@
 		"labels": {
 			"endDate": "終了日:",
 			"paymentProcessing": "決済処理中...",
-			"currentBidAmount": "現在の入札額",
 			"restaurant": "お店",
 			"dishCategory": "料理カテゴリ"
 		},
 		"tabs": {
-			"reviews": "レビュー",
-			"bids": "入札"
+			"reviews": "レビュー"
 		},
 		"emptyState": {
 			"noBidsForStatus": "選択したステータスの入札がありません"
@@ -671,9 +664,7 @@
 	"auth": {
 		"login_title": "ログイン",
 		"create_title": "アカウント作成",
-		"field_phone": "電話番号",
 		"field_name": "名前",
-		"hint_sms": "SMSでワンタイムコードを送信します。",
 		"btn_login": "ログイン",
 		"btn_create": "アカウントを作成",
 		"divider_or": "または次でサインイン",
@@ -682,13 +673,8 @@
 		"provider_facebook": "Facebook",
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
-		"otp_title": "コードを入力",
-		"otp_resending": "コードを再送信中...",
-		"otp_send_again": "コードを再送",
-		"otp_enter_all_digits": "6桁すべてを入力してください",
 		"login_success": "ログインに成功しました！",
 		"error_required": "必須項目です",
-		"error_invalid_phone": "電話番号が正しくありません",
 		"tos_link_text": "利用規約",
 		"existing_account_checkbox": "既にアカウントをお持ちですか？",
 		"conflict_dialog_title": "既存アカウントが見つかりました",

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -362,10 +362,6 @@
 			"million": "M",
 			"thousand": "K"
 		},
-		"menuOptions": {
-			"viewCreatorProfile": "작성자 프로필로 이동",
-			"reservation": "예약"
-		},
 		"actions": {
 			"share": "공유하기",
 			"seeMore": "더 보기",
@@ -513,7 +509,6 @@
 		"buttons": {
 			"postReview": "리뷰 게시",
 			"postPhotoVideoReview": "사진/동영상 게시",
-			"placeBid": "입찰하기",
 			"bid": "입찰",
 			"searchNearby": "이 지역에서 검색",
 			"openInGoogle": "Google에서 열기"
@@ -541,13 +536,11 @@
 		"labels": {
 			"endDate": "종료일:",
 			"paymentProcessing": "결제 처리 중...",
-			"currentBidAmount": "현재 입찰 금액",
 			"restaurant": "레스토랑",
 			"dishCategory": "요리 카테고리"
 		},
 		"tabs": {
-			"reviews": "리뷰",
-			"bids": "입찰"
+			"reviews": "리뷰"
 		},
 		"emptyState": {
 			"noBidsForStatus": "선택한 상태의 입찰이 없습니다"
@@ -671,9 +664,7 @@
 	"auth": {
 		"login_title": "로그인",
 		"create_title": "계정 생성",
-		"field_phone": "전화번호",
 		"field_name": "이름",
-		"hint_sms": "로그인을 위해 SMS로 일회용 코드를 보내드립니다.",
 		"btn_login": "로그인",
 		"btn_create": "계정 생성",
 		"divider_or": "또는 다음으로 로그인",
@@ -682,13 +673,8 @@
 		"provider_facebook": "Facebook",
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
-		"otp_title": "코드 입력",
-		"otp_resending": "인증 코드를 다시 전송 중...",
-		"otp_send_again": "코드 재전송",
-		"otp_enter_all_digits": "6자리 모두 입력해 주세요",
 		"login_success": "성공적으로 로그인되었습니다!",
 		"error_required": "필수 입력 항목입니다",
-		"error_invalid_phone": "유효하지 않은 전화번호입니다",
 		"tos_link_text": "서비스 약관",
 		"existing_account_checkbox": "이미 계정이 있으신가요?",
 		"conflict_dialog_title": "기존 계정을 찾았습니다",

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -362,10 +362,6 @@
 			"million": "M",
 			"thousand": "K"
 		},
-		"menuOptions": {
-			"viewCreatorProfile": "查看创作者资料",
-			"reservation": "预订"
-		},
 		"actions": {
 			"share": "分享",
 			"seeMore": "查看更多",
@@ -512,7 +508,6 @@
 		"buttons": {
 			"postReview": "发布评论",
 			"postPhotoVideoReview": "发布照片/视频",
-			"placeBid": "出价",
 			"bid": "出价",
 			"searchNearby": "在此区域搜索",
 			"openInGoogle": "在 Google 中打开"
@@ -540,13 +535,11 @@
 		"labels": {
 			"endDate": "结束日期:",
 			"paymentProcessing": "付款处理中...",
-			"currentBidAmount": "当前出价金额",
 			"restaurant": "餐厅",
 			"dishCategory": "菜品类别"
 		},
 		"tabs": {
-			"reviews": "评论",
-			"bids": "出价"
+			"reviews": "评论"
 		},
 		"emptyState": {
 			"noBidsForStatus": "所选状态没有出价"
@@ -671,9 +664,7 @@
 	"auth": {
 		"login_title": "登录",
 		"create_title": "创建账户",
-		"field_phone": "电话",
 		"field_name": "姓名",
-		"hint_sms": "我们将通过短信向您发送一次性验证码以进行登录。",
 		"btn_login": "登录",
 		"btn_create": "创建账户",
 		"divider_or": "或使用以下方式登录",
@@ -682,13 +673,8 @@
 		"provider_facebook": "Facebook",
 		"provider_twitter": "Twitter",
 		"provider_apple": "Apple",
-		"otp_title": "输入验证码",
-		"otp_resending": "正在重新发送验证码...",
-		"otp_send_again": "重新发送验证码",
-		"otp_enter_all_digits": "请输入全部6位数字",
 		"login_success": "登录成功！",
 		"error_required": "此字段为必填项",
-		"error_invalid_phone": "无效的电话号码",
 		"tos_link_text": "服务条款",
 		"existing_account_checkbox": "您已经有账户了吗？",
 		"conflict_dialog_title": "找到现有账户",

--- a/docs/ux/blur-modal-teardown.md
+++ b/docs/ux/blur-modal-teardown.md
@@ -497,7 +497,35 @@ map タブは **`href: null`** でタブバーに出ない。地図側の店詳�
 「写真・動画を投稿」の意匠も #1386 以前のレビュー側（カード内・淡色アウトライン）へ戻した。
 #1386 は入札ボタンと横並びにするためカード下のアクション行へ出していた。
 
-> ⚠️ **`app/[locale]/(tabs)/review/selectRestaurant.tsx` の «ストアへ upsert してから push する»
-> 順序は、いまどのテストにも守られていない。** 旧 `__tests__/mapRestaurantRoute.test.tsx` は
-> 同じ不変条件を **地図側だけ**で見ていたため、マップタブと一緒に消えた。
-> あちらは 3 箇所（Place 作成 / マーカー押下 / カード押下）で同じ順序を踏んでいる。
+`app/[locale]/(tabs)/review/selectRestaurant.tsx` の «ストアへ upsert してから push する»
+順序は、旧 `__tests__/mapRestaurantRoute.test.tsx` が **地図側だけ**で見ていたため、
+マップタブと一緒に消えた。**到達可能なあちらは、最初から 1 度も守られていなかった。**
+
+> 「到達不能な側にだけ検査が付いている」は #1411 / #1418 とまったく同じ形の見落としである。
+> 検査を書くときは «その画面が本番から到達できるか» を先に確かめること。
+
+#1451 で `__tests__/selectRestaurantRoute.test.tsx` を新設し、**4 経路すべて**
+（Place 作成 / マーカー押下 / カード押下 / 投稿ボタン）を `["upsert", "push"]` という
+**呼び出し順の列**で固定した。変異テストで 5 種類すべてが赤くなることを実測してある。
+
+⚠️ アサーションを «push されたこと» に置かないこと。それだと順序を入れ替えても緑のままになる
+（それが今まさに無防備だった形）。
+
+### 孤児化した i18n キーの片付け（#1451）
+
+撤去で参照が 0 件になったキーを 8 ロケールから消した（521 キーへ）。
+**コード参照が実際に 0 件であることを 1 件ずつ実測してから**消している。
+
+| 消したキー | 出どころ |
+| --- | --- |
+| `DishMediaContent.menuOptions.*` | #1357 到達不能だった料理カードのメニュー |
+| `auth.field_phone` / `hint_sms` / `otp_*` / `error_invalid_phone` | #1359 削除した電話番号 / SMS ログイン |
+| `Map.buttons.placeBid` / `Map.tabs.bids` / `Map.labels.currentBidAmount` | #1411 落とした入札の «導線» 3 つ |
+
+**残したもの**: `Map.buttons.openInGoogle`（`DishMediaMap` がまだ使う）、
+`Review.everybodyPostsTitle`（#1418 で復活）、入札 *そのもの* の文言
+（`RestaurantBidsTab` / `BidForm` がコードとして残っており決済実装時に使う）。
+
+> ⚠️ 「`i18n.t("<key>")` の grep が 0 件」だけで消さないこと。この repo には
+> `i18n.t(option.label)` のような **動的参照**が検索画面に多数ある。
+> 実際、機械的に数えると «直接参照が無いキー» は 197 件出るが、そのほとんどは生きている。


### PR DESCRIPTION
Closes #1451

BlurModal 撤去の後片付け 2 件。

---

# 1. 店舗選択の «upsert してから push» を固定する

`app/[locale]/(tabs)/review/selectRestaurant.tsx` には
「ストアへ upsert してから店詳細へ push する」経路が **4 箇所**ある。
順序を入れ替えると、遷移先はストアが空の状態でマウントされ `GET /v1/restaurants/:id` を
1 本余計に叩き、その間ローディングが出る。

## なぜ無防備だったか

同じ不変条件は `__tests__/mapRestaurantRoute.test.tsx` が持っていたが、
**あれは地図タブ側だけを見ていた**。その地図タブは `href: null` ＝ 本番から到達不能で、
#1419 で丸ごと削除した。**到達可能なこの画面は、最初から 1 度も守られていなかった。**

「到達不能な側にだけ検査が付いている」は #1411 / #1418 とまったく同じ形の見落としである。

## 変異テストで «本当に落ちるか» を確認した

| 変異 | 結果 |
| --- | --- |
| 保存した店の 3 経路で push を upsert より前に出す | 3 failed |
| POI 押下（Place 作成）で push を upsert より前に出す | 1 failed |
| マーカーの «2 度押し» を 1 度目で遷移させる | 1 failed |

⚠️ アサーションは **`["upsert", "push"]` という列**に置いてある。
«push されたこと» を見るだけだと、順序を入れ替えても緑のままになる
（それが今まさに無防備だった形）。この理由もテストにコメントで残した。

マーカーの «2 度押し» は仕様である（1 度目はアクティブにするだけ）。
1 度目で遷移させると地図を触っただけで画面が飛ぶので、そこも固定した。

---

# 2. 孤児化した i18n キーを 8 ロケールから削除（533 → 521）

**コード参照が 0 件であることを 1 件ずつ実測**してから消した。

| 消したキー | 出どころ |
| --- | --- |
| `DishMediaContent.menuOptions.*`（2 件） | #1357 到達不能だった料理カードのメニュー |
| `auth.field_phone` / `hint_sms` / `otp_title` / `otp_resending` / `otp_send_again` / `otp_enter_all_digits` / `error_invalid_phone` | #1359 オーナー判断で削除した電話番号 / SMS ログイン |
| `Map.buttons.placeBid` / `Map.tabs.bids` / `Map.labels.currentBidAmount` | #1411 店舗詳細から落とした入札の **導線** 3 つ |

## 残したもの（消していない）

- **`Map.buttons.openInGoogle`** — 店舗詳細からは落としたが `DishMediaMap` がまだ使っている
- **`Review.everybodyPostsTitle`** — #1418 でタブ文言として復活した
- **入札そのものの文言**（`Map.inputs.bidAmount` / `Map.labels.paymentProcessing` /
  `Map.empty.bidHistory` など）— `RestaurantBidsTab` と `BidForm` がコードとして残っており、
  決済実装時にそのまま使う。消したのは «導線» の 3 つだけ

## ⚠️ 一括削除しなかった理由

`i18n.t("<key>")` の grep で機械的に数えると «直接参照が無いキー» は **197 件**出る。
しかしこの repo の検索画面には `i18n.t(option.label)` / `i18n.t(timeSlotsById[id]?.label)` の
ような **動的参照**が多数あり、そのほとんどは生きている。
実測で 0 件を確認できた 11 キーだけに絞った。8 ロケールのキー集合が一致することも検算済み。

---

## 検証

- `pnpm typecheck`（app-expo）: green
- `pnpm test`（app-expo）: **704 passed / 71 suites**（新規 4 件を含む）
- `pnpm lint`（app-expo）: 0 errors
- 8 ロケールのキー集合が完全一致（521 キー）

---
_Generated by [Claude Code](https://claude.ai/code/session_019GVn2NvCTnuD5s5PRvb3JJ)_