### PR TITLE
fix(e2e-mobile): SearchScreen.ts に紛れ込んだ競合マーカー 1 行を消す

### DIFF
--- a/e2e-mobile/screens/SearchScreen.ts
+++ b/e2e-mobile/screens/SearchScreen.ts
@@ -363,7 +363,6 @@ export class SearchScreen {
 	}
 
 	/**
-<<<<<<< HEAD
 	 * 場所入力欄をタップしてフォーカスを与える（#528）。
 	 *
 	 * `typeLocation()` から入力操作だけを切り離したもの。`LocationAutocomplete` は


### PR DESCRIPTION
## 何を直すか

`e2e-mobile/screens/SearchScreen.ts:366` の JSDoc ブロックの内部に、競合マーカー `<<<<<<< HEAD` が **1 行だけ**残っていた。

```ts
	/**
<<<<<<< HEAD          ← これ
	 * 場所入力欄をタップしてフォーカスを与える（#528）。
```

## なぜ今まで気付かれなかったか

- **対になる `=======` / `>>>>>>>` が無い**ので、テキスト検索で「競合が残っている」と分かりにくい
- **コメントの内部**にあるため TypeScript の構文としては通り、typecheck も lint も素通りする

`#1375` の統合ブランチへ `main` を取り込む作業（PR #1453）中に発見した。**この取り込み由来ではなく、`main` に元から入っていた混入**である。

## 確認

リポジトリ全体を走査し、**マーカーはこの 1 行だけ**であることを確認した。

```
$ grep -rnE "^(<<<<<<< |=======$|>>>>>>> )" . --exclude-dir=.git
（削除後は 0 件）
```

削除は 1 行のみで、JSDoc の本文・`focusLocationInput()` の実装・前後のメソッドには手を触れていない。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PwkXTZx1eR3y5PHL2HACQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011PwkXTZx1eR3y5PHL2HACQ)_