### PR TITLE
#1398 (PR4/7) feat(app-expo): want 行から「食べたを記録」する導線と、記録後の一覧無効化

### DIFF
--- a/app-expo/__tests__/myDishesStore.test.ts
+++ b/app-expo/__tests__/myDishesStore.test.ts
@@ -205,6 +205,9 @@ describe("#1396 取得結果 store にも viewport を置かない（§3-2）", 
 				"fetchInitial",
 				"fetchMore",
 				"fetchPins",
+				// #1398 (PR4/7) 破棄の世代。viewport の類ではなく «飛行中の取得を捨てるための版数» なので
+				// このガードの趣旨（Map の pan/zoom を store へ流し込ませない）には反しない
+				"generation",
 				"hasFetchedInitialByQuery",
 				"hasFetchedInitialPinsByQuery",
 				"isLoadingByQuery",

--- a/app-expo/app/[locale]/restaurant/[restaurantId]/review-from-media/[dishMediaId].tsx
+++ b/app-expo/app/[locale]/restaurant/[restaurantId]/review-from-media/[dishMediaId].tsx
@@ -18,6 +18,7 @@ import i18n from "@/lib/i18n";
 import type { QueryDishMediaByIdsDto } from "@shared/api/v1/dto";
 import { ScreenHeader } from "@/components/ScreenHeader";
 import { useLocale } from "@/hooks/useLocale";
+import { bumpMyDishesRevision } from "@/features/myDishes/stores/useMyDishesRevisionStore";
 
 export default function ReviewFromMediaScreen() {
 	const { restaurantId, dishMediaId } = useLocalSearchParams<{ restaurantId: string; dishMediaId: string }>();
@@ -36,6 +37,12 @@ export default function ReviewFromMediaScreen() {
 	// #1127 【修正】ReviewForm へ渡すコールバックは参照を安定させる（review.tsx と同じ多層防御）
 	const handleReviewSuccess = useCallback(
 		({ dishReviewId }: { dishReviewId: string }) => {
+			// #1398 (PR4/7) 設計 §3「唯一の実務上の落とし穴：クライアントキャッシュ」。
+			// サーバ側は want 枝の `NOT EXISTS (SELECT 1 FROM dish_reviews …)` で正しく畳むが、
+			// クライアントが取り直さないと **記録した直後の一覧に「食べたい」カードが残って見える**。
+			// ここでキャッシュを捨てる（`bump` が `clearQuery()` を呼ぶ）。
+			// ⚠️ `ReviewForm` 側には置かない。ReviewForm を my-dishes に結合させないため（設計 §3）
+			bumpMyDishesRevision();
 			// /my-dishes までスタックを掃除（なければ現在画面を /my-dishes に置き換え）
 			router.dismissTo(`/${locale}/(tabs)/my-dishes`);
 			router.push({

--- a/app-expo/app/[locale]/restaurant/[restaurantId]/review.tsx
+++ b/app-expo/app/[locale]/restaurant/[restaurantId]/review.tsx
@@ -12,6 +12,7 @@ import type { GetRestaurantByIdResponse, DishMediaEntry } from "@shared/api/v1/r
 import i18n from "@/lib/i18n";
 import { ScreenHeader } from "@/components/ScreenHeader";
 import { useLocale } from "@/hooks/useLocale";
+import { bumpMyDishesRevision } from "@/features/myDishes/stores/useMyDishesRevisionStore";
 
 export default function ReviewScreen() {
 	const { restaurantId } = useLocalSearchParams<{ restaurantId: string }>();
@@ -31,6 +32,12 @@ export default function ReviewScreen() {
 	// （ReviewForm 側の ref 化が失われた場合に）effect が張り替わって選択結果が捨てられる。多層防御。
 	const handleReviewSuccess = useCallback(
 		({ dishMedia, dishReviewId }: { dishMedia: DishMediaEntry["dish_media"] | null; dishReviewId: string }) => {
+			// #1398 (PR4/7) 設計 §3「唯一の実務上の落とし穴：クライアントキャッシュ」。
+			// サーバ側は want 枝の `NOT EXISTS (SELECT 1 FROM dish_reviews …)` で正しく畳むが、
+			// クライアントが取り直さないと **記録した直後の一覧に「食べたい」カードが残って見える**。
+			// ここでキャッシュを捨てる（`bump` が `clearQuery()` を呼ぶ）。
+			// ⚠️ `ReviewForm` 側には置かない。ReviewForm を my-dishes に結合させないため（設計 §3）
+			bumpMyDishesRevision();
 			// /my-dishes までスタックを掃除（なければ現在画面を /my-dishes に置き換え）
 			router.dismissTo(`/${locale}/(tabs)/my-dishes`);
 			/**

--- a/app-expo/features/myDishes/components/MyDishesListView.test.tsx
+++ b/app-expo/features/myDishes/components/MyDishesListView.test.tsx
@@ -243,3 +243,60 @@ describe("#1397 (PR4/5) Q2 リスト項目のタップ先は «その項目の�
 		});
 	});
 });
+
+describe("#1398 (PR4/7) want カードの「食べたを記録」CTA", () => {
+	const wantItem = () =>
+		({
+			...makeItem("dish:dish-1", { thumbnailImageUrl: "https://example.com/media.jpg" }),
+			status: "want",
+		}) as unknown as MyDishItem;
+
+	const findCta = (tree: TestRenderer.ReactTestRenderer) =>
+		tree.root.findAll(
+			(node) =>
+				node.props?.testID === "my-dishes-mark-as-eaten" && typeof node.props?.onPress === "function",
+		);
+
+	const renderWith = async (items: MyDishItem[]) => {
+		mockUseMyDishesQuery.mockReturnValue({
+			items,
+			isLoading: false,
+			isLoadingMore: false,
+			error: null,
+			hasNextPage: false,
+			loadMore: jest.fn(),
+			refresh: jest.fn(),
+		});
+		return render();
+	};
+
+	it("want カードの CTA は既存の review-from-media へ push する（新ルートを作らない）", async () => {
+		const tree = await renderWith([wantItem()]);
+
+		await act(async () => {
+			findCta(tree)[0].props.onPress({ stopPropagation: jest.fn() });
+		});
+
+		expect(mockPush).toHaveBeenCalledWith({
+			pathname: "/[locale]/restaurant/[restaurantId]/review-from-media/[dishMediaId]",
+			params: { locale: "ja-JP", restaurantId: "restaurant-1", dishMediaId: "media-1" },
+		});
+	});
+
+	// ここが崩れると CTA を押しただけで #1397 PR4 の全画面 Feed が開く
+	it("CTA を押してもカードの Feed 遷移は起きない（push は 1 回だけ）", async () => {
+		const tree = await renderWith([wantItem()]);
+
+		await act(async () => {
+			findCta(tree)[0].props.onPress({ stopPropagation: jest.fn() });
+		});
+
+		expect(mockPush).toHaveBeenCalledTimes(1);
+		expect(mockPush.mock.calls[0][0].pathname).not.toBe("/[locale]/(tabs)/my-dishes/feed");
+	});
+
+	it("eaten カードには CTA を出さない", async () => {
+		const tree = await renderWith([makeItem("review:eaten", { thumbnailImageUrl: "https://example.com/m.jpg" })]);
+		expect(findCta(tree)).toHaveLength(0);
+	});
+});

--- a/app-expo/features/myDishes/components/MyDishesListView.tsx
+++ b/app-expo/features/myDishes/components/MyDishesListView.tsx
@@ -13,6 +13,8 @@ import { useLogger } from "@/hooks/useLogger";
 import { getCacheKeyForImage } from "@/lib/image";
 import i18n from "@/lib/i18n";
 import type { MyDishItem } from "@shared/api/v1/res";
+import { MyDishEatenButton } from "./myDishCard";
+import { buildMarkAsEatenRoute } from "../markAsEaten";
 import { resolveMyDishThumbnailUrl } from "../thumbnail";
 import { useMyDishesQuery } from "../hooks/useMyDishesQuery";
 
@@ -34,7 +36,15 @@ const ASPECT_RATIO = 9 / 16;
 
 type MyDishGridItem = { id: string; item: MyDishItem };
 
-const MyDishCard = memo(function MyDishCard({ item, onPress }: { item: MyDishItem; onPress: (i: MyDishItem) => void }) {
+const MyDishCard = memo(function MyDishCard({
+	item,
+	onPress,
+	onPressMarkAsEaten,
+}: {
+	item: MyDishItem;
+	onPress: (i: MyDishItem) => void;
+	onPressMarkAsEaten: (i: MyDishItem) => void;
+}) {
 	const { lightImpact } = useHaptics();
 	// #958 と同じ理由で useWindowDimensions ではなく CenteredAppShell の中央カラム幅を使う
 	const contentWidth = useContentWidth();
@@ -113,6 +123,8 @@ const MyDishCard = memo(function MyDishCard({ item, onPress }: { item: MyDishIte
 					<Text style={styles.footerText} numberOfLines={1}>
 						{dishName ?? item.restaurant.name ?? ""}
 					</Text>
+					{/* #1398 PR4: want 行だけ。押しても親（= 全画面 Feed への遷移）は走らない */}
+					<MyDishEatenButton item={item} onPress={onPressMarkAsEaten} />
 				</View>
 			</LinearGradient>
 		</Pressable>
@@ -121,6 +133,7 @@ const MyDishCard = memo(function MyDishCard({ item, onPress }: { item: MyDishIte
 
 export function MyDishesListView() {
 	const { locale } = useLocale();
+	const { lightImpact } = useHaptics();
 	const { logFrontendEvent } = useLogger();
 	const { items, isLoading, isLoadingMore, error, hasNextPage, loadMore, refresh } = useMyDishesQuery();
 
@@ -161,9 +174,28 @@ export function MyDishesListView() {
 		[locale, logFrontendEvent],
 	);
 
+	// #1398 (PR4/7) want カードの「食べたを記録」。カード全体のタップ（= 全画面 Feed）とは別経路。
+	// 押しても Feed が開かないことは `MyDishEatenButton` 側の stopPropagation が担保する
+	const handleMarkAsEaten = useCallback(
+		(item: MyDishItem) => {
+			const route = buildMarkAsEatenRoute(item, locale);
+			if (route === null) return;
+			lightImpact();
+			logFrontendEvent({
+				event_name: "my_dishes_mark_as_eaten_pressed",
+				error_level: "log",
+				payload: { itemKey: item.key, from: "list" },
+			});
+			router.push(route);
+		},
+		[lightImpact, locale, logFrontendEvent],
+	);
+
 	const renderItem = useCallback(
-		({ item }: { item: MyDishGridItem }) => <MyDishCard item={item.item} onPress={handlePressItem} />,
-		[handlePressItem],
+		({ item }: { item: MyDishGridItem }) => (
+			<MyDishCard item={item.item} onPress={handlePressItem} onPressMarkAsEaten={handleMarkAsEaten} />
+		),
+		[handleMarkAsEaten, handlePressItem],
 	);
 
 	const renderEmpty = useCallback(

--- a/app-expo/features/myDishes/components/MyDishesRestaurantSheet.tsx
+++ b/app-expo/features/myDishes/components/MyDishesRestaurantSheet.tsx
@@ -14,7 +14,9 @@ import i18n from "@/lib/i18n";
 import { dismissSheetSafely, presentSheetSafely } from "@/lib/trueSheet";
 import type { MyDishItem, MyDishPin } from "@shared/api/v1/res";
 import { useMyDishesRestaurantQuery } from "../hooks/useMyDishesRestaurantQuery";
+import { buildMarkAsEatenRoute } from "../markAsEaten";
 import {
+	MyDishEatenButton,
 	MyDishStatusBadge,
 	formatMyDishOccurredAt,
 	resolveMyDishTitle,
@@ -86,10 +88,12 @@ const MyDishSheetRow = memo(function MyDishSheetRow({
 	item,
 	locale,
 	onPress,
+	onPressMarkAsEaten,
 }: {
 	item: MyDishItem;
 	locale: string;
 	onPress: (item: MyDishItem) => void;
+	onPressMarkAsEaten: (item: MyDishItem) => void;
 }) {
 	// #1375 追補2 決定3: 写真なしの記録も **実画像**（categoryImageUrl → restaurant.image_url）で並べる。
 	// 灰色プレースホルダーにしない（一覧ビューとの意図的な非対称。myDishCard.tsx 参照）
@@ -140,6 +144,8 @@ const MyDishSheetRow = memo(function MyDishSheetRow({
 					{rating !== null && <Text style={styles.rowRating}>{`★${rating}`}</Text>}
 					{occurredAt !== null && <Text style={styles.rowDate}>{occurredAt}</Text>}
 				</View>
+				{/* #1398 PR4: want 行だけ。押しても行タップ（= Feed / 店舗詳細）は走らない */}
+				<MyDishEatenButton item={item} onPress={onPressMarkAsEaten} testID="my-dishes-sheet-mark-as-eaten" />
 				{!hasPhoto && (
 					// タップ先が Feed ではなく店舗詳細であることを明示する（設計 (1/2) §3）
 					<Text style={styles.rowHint} numberOfLines={2}>
@@ -268,6 +274,27 @@ export function MyDishesRestaurantSheet({ pin, onDismissed }: MyDishesRestaurant
 		[lightImpact, locale, logFrontendEvent],
 	);
 
+	// #1398 (PR4/7) want 行の「食べたを記録」。遷移先は一覧ビューと同一（`buildMarkAsEatenRoute`）。
+	//
+	// ⚠️ Sheet を閉じる処理をここに **足さない**。閉じるのは既に 3 本立てで担保されている
+	// （`useFocusEffect` の cleanup / `navigation.beforeRemove` / unmount 時の保険。#644 の先例）。
+	// 行タップ（`handlePressItem`）も同じ作法で push だけしている。ここだけ独自に dismiss を
+	// 挟むと、閉じるアニメーションと push が競合して «閉じ切る前に画面が変わる» 挙動になる
+	const handleMarkAsEaten = useCallback(
+		(item: MyDishItem) => {
+			const route = buildMarkAsEatenRoute(item, locale);
+			if (route === null) return;
+			lightImpact();
+			logFrontendEvent({
+				event_name: "my_dishes_mark_as_eaten_pressed",
+				error_level: "log",
+				payload: { itemKey: item.key, from: "sheet" },
+			});
+			router.push(route);
+		},
+		[lightImpact, locale, logFrontendEvent],
+	);
+
 	/**
 	 * #1397 (PR4/5)「全画面で見る」。Feed には写真ありの行しか入れられないので、
 	 * **その店の記録が全部写真なしのときは出さない**（設計 (1/2) §3）。
@@ -310,8 +337,15 @@ export function MyDishesRestaurantSheet({ pin, onDismissed }: MyDishesRestaurant
 	}, [onDismissed]);
 
 	const renderItem = useCallback(
-		({ item }: { item: MyDishItem }) => <MyDishSheetRow item={item} locale={locale} onPress={handlePressItem} />,
-		[handlePressItem, locale],
+		({ item }: { item: MyDishItem }) => (
+			<MyDishSheetRow
+				item={item}
+				locale={locale}
+				onPress={handlePressItem}
+				onPressMarkAsEaten={handleMarkAsEaten}
+			/>
+		),
+		[handleMarkAsEaten, handlePressItem, locale],
 	);
 
 	const keyExtractor = useCallback((item: MyDishItem) => item.key, []);

--- a/app-expo/features/myDishes/components/myDishCard.tsx
+++ b/app-expo/features/myDishes/components/myDishCard.tsx
@@ -1,5 +1,6 @@
-import React, { memo, useMemo } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import React, { memo, useCallback, useMemo } from "react";
+import { Pressable, StyleSheet, Text, View, type GestureResponderEvent } from "react-native";
+import { Utensils } from "lucide-react-native";
 import i18n from "@/lib/i18n";
 import { getCacheKeyForImage } from "@/lib/image";
 import type { MyDishItem } from "@shared/api/v1/res";
@@ -77,6 +78,69 @@ export const MyDishStatusBadge = memo(function MyDishStatusBadge({ status }: { s
 	);
 });
 
+/**
+ * #1398 (PR4/7) want 行から「食べたを記録」へ送る CTA。一覧のカードと Sheet の行で共有する。
+ *
+ * ## いつ出すか
+ *
+ * `status === "want"` の行だけ。eaten 行には出さない。再訪の記録は全画面 Feed の
+ * `ActionButtons` 側（常時活性）で足りる（設計 (1/2) §1(b)）。
+ *
+ * want 行の `dishMedia` は契約上必ず非 null（want の定義が dish_media への save である以上、
+ * 保存対象のメディアが必ず在る。#1395 m-7）。それでも `null` を弾く形にしてあるのは、
+ * 呼び出し側で `dishMedia.id` を触るために型を絞る必要があるからで、防御であって仕様ではない。
+ *
+ * ## ⚠️ 親のタップを起こさないこと
+ *
+ * カード・行の全体は #1397 PR4 で全画面 Feed への遷移になっている。この CTA を押したときに
+ * Feed が開いてはいけない。
+ *
+ * - **native**: RN のタッチレスポンダは 1 つしか勝たない。子の `Pressable` が responder を取るので
+ *   親の `onPress` は発火しない。
+ * - **web（react-native-web）**: DOM の click がそのまま親へ **バブルする**。`stopPropagation()` を
+ *   自分で呼ばないと親の `onPress` まで走り、CTA を押しただけで Feed が開く。
+ *
+ * よって `onPress` で受け取ったイベントに対して必ず `stopPropagation()` を呼ぶ。
+ * RN 側の `GestureResponderEvent` にも `stopPropagation` は生えているので分岐は要らないが、
+ * 実装差を踏まないよう optional call にしてある。この挙動は
+ * `myDishCard.test.tsx` が «イベントを渡した場合 / 渡さない場合» の両方で固定している。
+ */
+export const MyDishEatenButton = memo(function MyDishEatenButton({
+	item,
+	onPress,
+	testID = "my-dishes-mark-as-eaten",
+}: {
+	item: MyDishItem;
+	onPress: (item: MyDishItem) => void;
+	testID?: string;
+}) {
+	const handlePress = useCallback(
+		(event?: GestureResponderEvent) => {
+			// web ではここで止めないと親（カード / 行）の onPress まで走る
+			event?.stopPropagation?.();
+			onPress(item);
+		},
+		[item, onPress],
+	);
+
+	if (item.status !== "want" || item.dishMedia === null) return null;
+
+	return (
+		<Pressable
+			testID={testID}
+			style={styles.eatenButton}
+			onPress={handlePress}
+			hitSlop={6}
+			accessibilityRole="button"
+			accessibilityLabel={i18n.t("MyDishes.actions.markAsEatenA11y")}>
+			<Utensils size={11} color="#FFFFFF" />
+			<Text style={styles.eatenButtonText} numberOfLines={1}>
+				{i18n.t("MyDishes.actions.markAsEaten")}
+			</Text>
+		</Pressable>
+	);
+});
+
 const styles = StyleSheet.create({
 	statusBadge: {
 		paddingHorizontal: 6,
@@ -90,6 +154,20 @@ const styles = StyleSheet.create({
 		backgroundColor: "rgba(240,85,55,0.9)",
 	},
 	statusBadgeText: {
+		fontSize: 10,
+		fontWeight: "700",
+		color: "#FFFFFF",
+	},
+	eatenButton: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 3,
+		paddingHorizontal: 8,
+		paddingVertical: 4,
+		borderRadius: 12,
+		backgroundColor: "rgba(240,85,55,0.95)",
+	},
+	eatenButtonText: {
 		fontSize: 10,
 		fontWeight: "700",
 		color: "#FFFFFF",

--- a/app-expo/features/myDishes/components/myDishEatenButton.test.tsx
+++ b/app-expo/features/myDishes/components/myDishEatenButton.test.tsx
@@ -1,0 +1,96 @@
+/*
+#1398 (PR4/7)「食べたを記録」CTA の 2 つの不変条件を固定する。
+
+1. **want 行にだけ出す。** eaten 行には出さない（再訪の記録は全画面 Feed の ActionButtons 側。設計 §1(b)）
+2. **親のタップを起こさない。** カード・行の全体は #1397 PR4 で全画面 Feed への遷移になっている。
+   native はタッチレスポンダが 1 つしか勝たないので放っておいても親は発火しないが、
+   **web（react-native-web）は DOM の click がそのまま親へバブルする**。`stopPropagation()` を
+   自分で呼ばないと、CTA を押しただけで Feed が開く。ここではその呼び出しを直接固定する。
+*/
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+jest.mock("lucide-react-native", () => new Proxy({}, { get: () => () => null }));
+
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import type { MyDishItem } from "@shared/api/v1/res";
+import { MyDishEatenButton } from "./myDishCard";
+
+const makeItem = (overrides: Partial<MyDishItem>): MyDishItem =>
+	({
+		key: "dish:dish-1",
+		status: "want",
+		occurredAt: "2026-08-01T00:00:00.000Z",
+		savedAt: "2026-08-01T00:00:00.000Z",
+		eatenAt: null,
+		restaurant: { id: "restaurant-1", name: "テスト食堂", image_url: null },
+		dish: { id: "dish-1", name: "唐揚げ定食", categoryImageUrl: "https://example.com/c.jpg" },
+		dishMedia: { id: "media-1", thumbnailImageUrl: null },
+		myReview: null,
+		distanceMeters: null,
+		...overrides,
+	}) as unknown as MyDishItem;
+
+const render = (item: MyDishItem, onPress = jest.fn()) => {
+	let tree!: TestRenderer.ReactTestRenderer;
+	act(() => {
+		tree = TestRenderer.create(<MyDishEatenButton item={item} onPress={onPress} />);
+	});
+	return { tree, onPress };
+};
+
+// Pressable は memo / forwardRef でラップされていて `node.type === Pressable` では拾えないので
+// testID と onPress の有無で指す（Pressable 要素と内側の View の両方が当たるため、先頭を使う）
+const findButton = (tree: TestRenderer.ReactTestRenderer) =>
+	tree.root.findAll(
+		(node) =>
+			node.props?.testID === "my-dishes-mark-as-eaten" && typeof node.props?.onPress === "function",
+	);
+
+const hasButton = (tree: TestRenderer.ReactTestRenderer) => findButton(tree).length > 0;
+
+describe("MyDishEatenButton", () => {
+	it("want 行には出る", () => {
+		const { tree } = render(makeItem({}));
+		expect(hasButton(tree)).toBe(true);
+	});
+
+	it("eaten 行には出さない（再訪の記録は Feed の ActionButtons 側）", () => {
+		const { tree } = render(makeItem({ status: "eaten" }));
+		expect(hasButton(tree)).toBe(false);
+	});
+
+	// want の dishMedia は契約上必ず非 null（#1395 m-7）。ここは異常系の防御であって仕様ではない
+	it("dishMedia が無ければ出さない（遷移先を組めないため）", () => {
+		const { tree } = render(makeItem({ dishMedia: null }));
+		expect(hasButton(tree)).toBe(false);
+	});
+
+	it("押すと onPress が item ごと呼ばれる", () => {
+		const item = makeItem({});
+		const { tree, onPress } = render(item);
+		act(() => {
+			findButton(tree)[0].props.onPress();
+		});
+		expect(onPress).toHaveBeenCalledWith(item);
+	});
+
+	// ここが web でカードごと Feed へ飛ばないための本体
+	it("イベントを受け取ったら stopPropagation する（web で親の onPress まで走らせない）", () => {
+		const { tree, onPress } = render(makeItem({}));
+		const stopPropagation = jest.fn();
+		act(() => {
+			findButton(tree)[0].props.onPress({ stopPropagation });
+		});
+		expect(stopPropagation).toHaveBeenCalledTimes(1);
+		expect(onPress).toHaveBeenCalledTimes(1);
+	});
+
+	// native の GestureResponderEvent は引数無しで呼ばれる経路もある。落ちないこと
+	it("イベントが無くても落ちない", () => {
+		const { tree, onPress } = render(makeItem({}));
+		act(() => {
+			expect(() => findButton(tree)[0].props.onPress(undefined)).not.toThrow();
+		});
+		expect(onPress).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app-expo/features/myDishes/hooks/useMyDishesCalendarQuery.ts
+++ b/app-expo/features/myDishes/hooks/useMyDishesCalendarQuery.ts
@@ -10,6 +10,10 @@ import {
 	useMyDishesFilterStore,
 } from "../stores/useMyDishesFilterStore";
 import {
+	selectMyDishesRevision,
+	useMyDishesRevisionStore,
+} from "../stores/useMyDishesRevisionStore";
+import {
 	MY_DISHES_PAGE_SIZE,
 	selectMyDishesByQuery,
 	useMyDishesStore,
@@ -61,6 +65,7 @@ export const useMyDishesCalendarQuery = (): UseMyDishesCalendarQueryResult => {
 	const queryKey = useMyDishesFilterStore(selectCalendarQueryKey);
 
 	const touchQuery = useMyDishesStore((s) => s.touchQuery);
+	const revision = useMyDishesRevisionStore(selectMyDishesRevision);
 	const fetchInitial = useMyDishesStore((s) => s.fetchInitial);
 	const fetchMore = useMyDishesStore((s) => s.fetchMore);
 	const itemByKey = useMyDishesStore((s) => s.itemByKey);
@@ -98,10 +103,16 @@ export const useMyDishesCalendarQuery = (): UseMyDishesCalendarQueryResult => {
 	// ⚠️ `!error` を必ず条件へ入れること。取得が失敗したときストアは
 	// `hasFetchedInitial` を false のまま `isLoading` を false へ戻すので（stores/useMyDishesStore.ts
 	// の fetchInitial）、error を見ないと **失敗するたびに再取得して無限ループする**（#1439 B-1）
+	// #1398 (PR4/7) `revision` を依存に入れる。実際にキャッシュを捨てるのは
+	// `useMyDishesRevisionStore.bump()`（`clearQuery()`）で、ここは «版が動いた» ことを
+	// この effect へ伝えるためだけに持つ。
+	// ⚠️ `error` を条件から外さないこと。外すと失敗のたびに叩き直して無限ループする（#1439 B-1）。
+	// 版が動いたときはスライスごと消えていて `error` も `hasFetchedInitial` も落ちているので、
+	// このガードを保ったまま «版が動いたときだけ» 取り直す形になる
 	useEffect(() => {
 		if (hasFetchedInitial || isLoading || error) return;
 		void fetchInitial(queryKey, fetcher);
-	}, [error, fetchInitial, fetcher, hasFetchedInitial, isLoading, queryKey]);
+	}, [error, fetchInitial, fetcher, hasFetchedInitial, isLoading, queryKey, revision]);
 
 	const items = useMemo(
 		() => itemKeys.map((key) => itemByKey[key]).filter((item): item is MyDishItem => Boolean(item)),

--- a/app-expo/features/myDishes/hooks/useMyDishesMapPinsQuery.ts
+++ b/app-expo/features/myDishes/hooks/useMyDishesMapPinsQuery.ts
@@ -9,6 +9,10 @@ import {
 	useMyDishesFilterStore,
 } from "../stores/useMyDishesFilterStore";
 import {
+	selectMyDishesRevision,
+	useMyDishesRevisionStore,
+} from "../stores/useMyDishesRevisionStore";
+import {
 	selectMyDishesPinsByQuery,
 	useMyDishesStore,
 	type MyDishesPinsFetcher,
@@ -46,6 +50,7 @@ export const useMyDishesMapPinsQuery = (options?: { enabled?: boolean }): UseMyD
 	const queryKey = useMyDishesFilterStore(selectFilterQueryKey);
 
 	const touchQuery = useMyDishesStore((s) => s.touchQuery);
+	const revision = useMyDishesRevisionStore(selectMyDishesRevision);
 	const fetchPins = useMyDishesStore((s) => s.fetchPins);
 	const { pins, isLoading, error, hasFetchedInitial, truncated } = useMyDishesStore(
 		selectMyDishesPinsByQuery(queryKey),
@@ -77,11 +82,17 @@ export const useMyDishesMapPinsQuery = (options?: { enabled?: boolean }): UseMyD
 	// false のまま `isLoadingPinsByQuery` を false へ戻すので（stores/useMyDishesStore.ts の fetchPins）、
 	// error を見ないと **失敗するたびに再取得して無限ループする**（#1439 レビュー B-1 と同じバグ型。
 	// `useMyDishesQuery.ts` / `feed.tsx` / `RestaurantReviewsTab.tsx` と同じ申し送り）
+	// #1398 (PR4/7) `revision` を依存に入れる。実際にキャッシュを捨てるのは
+	// `useMyDishesRevisionStore.bump()`（`clearQuery()`）で、ここは «版が動いた» ことを
+	// この effect へ伝えるためだけに持つ。
+	// ⚠️ `error` を条件から外さないこと。外すと失敗のたびに叩き直して無限ループする（#1439 B-1）。
+	// 版が動いたときはスライスごと消えていて `error` も `hasFetchedInitial` も落ちているので、
+	// このガードを保ったまま «版が動いたときだけ» 取り直す形になる
 	useEffect(() => {
 		if (!enabled) return;
 		if (hasFetchedInitial || isLoading || error) return;
 		void fetchPins(queryKey, fetcher);
-	}, [enabled, error, fetchPins, fetcher, hasFetchedInitial, isLoading, queryKey]);
+	}, [enabled, error, fetchPins, fetcher, hasFetchedInitial, isLoading, queryKey, revision]);
 
 	const refresh = useCallback(() => {
 		void fetchPins(queryKey, fetcher);

--- a/app-expo/features/myDishes/hooks/useMyDishesQuery.ts
+++ b/app-expo/features/myDishes/hooks/useMyDishesQuery.ts
@@ -9,6 +9,10 @@ import {
 	useMyDishesFilterStore,
 } from "../stores/useMyDishesFilterStore";
 import {
+	selectMyDishesRevision,
+	useMyDishesRevisionStore,
+} from "../stores/useMyDishesRevisionStore";
+import {
 	MY_DISHES_PAGE_SIZE,
 	selectMyDishesByQuery,
 	useMyDishesStore,
@@ -55,6 +59,7 @@ export const useMyDishesQuery = (options?: { enabled?: boolean }): UseMyDishesQu
 	const touchQuery = useMyDishesStore((s) => s.touchQuery);
 	const fetchInitial = useMyDishesStore((s) => s.fetchInitial);
 	const fetchMore = useMyDishesStore((s) => s.fetchMore);
+	const revision = useMyDishesRevisionStore(selectMyDishesRevision);
 	const itemByKey = useMyDishesStore((s) => s.itemByKey);
 	const { itemKeys, isLoading, isLoadingMore, error, hasFetchedInitial, hasNextPage, oldestOccurredAt } =
 		useMyDishesStore(selectMyDishesByQuery(queryKey), shallow);
@@ -90,11 +95,17 @@ export const useMyDishesQuery = (options?: { enabled?: boolean }): UseMyDishesQu
 	// ⚠️ `!error` を必ず条件へ入れること。取得が失敗したときストアは
 	// `hasFetchedInitial` を false のまま `isLoading` を false へ戻すので（stores/useMyDishesStore.ts
 	// の fetchInitial）、error を見ないと **失敗するたびに再取得して無限ループする**
+	// #1398 (PR4/7) `revision` を依存に入れる。実際にキャッシュを捨てるのは
+	// `useMyDishesRevisionStore.bump()`（`clearQuery()`）で、ここは «版が動いた» ことを
+	// この effect へ伝えるためだけに持つ。
+	// ⚠️ `error` を条件から外さないこと。外すと失敗のたびに叩き直して無限ループする（#1439 B-1）。
+	// 版が動いたときはスライスごと消えていて `error` も `hasFetchedInitial` も落ちているので、
+	// このガードを保ったまま «版が動いたときだけ» 取り直す形になる
 	useEffect(() => {
 		if (!enabled) return;
 		if (hasFetchedInitial || isLoading || error) return;
 		void fetchInitial(queryKey, fetcher);
-	}, [enabled, error, fetchInitial, fetcher, hasFetchedInitial, isLoading, queryKey]);
+	}, [enabled, error, fetchInitial, fetcher, hasFetchedInitial, isLoading, queryKey, revision]);
 
 	const items = useMemo(
 		() => itemKeys.map((key) => itemByKey[key]).filter((item): item is MyDishItem => Boolean(item)),

--- a/app-expo/features/myDishes/hooks/useMyDishesRestaurantQuery.ts
+++ b/app-expo/features/myDishes/hooks/useMyDishesRestaurantQuery.ts
@@ -10,6 +10,10 @@ import {
 	useMyDishesFilterStore,
 } from "../stores/useMyDishesFilterStore";
 import {
+	selectMyDishesRevision,
+	useMyDishesRevisionStore,
+} from "../stores/useMyDishesRevisionStore";
+import {
 	MY_DISHES_PAGE_SIZE,
 	selectMyDishesByQuery,
 	useMyDishesStore,
@@ -64,6 +68,7 @@ export const useMyDishesRestaurantQuery = (restaurantId: string | null): UseMyDi
 	const touchQuery = useMyDishesStore((s) => s.touchQuery);
 	const fetchInitial = useMyDishesStore((s) => s.fetchInitial);
 	const itemByKey = useMyDishesStore((s) => s.itemByKey);
+	const revision = useMyDishesRevisionStore(selectMyDishesRevision);
 	const { itemKeys, isLoading, error, hasFetchedInitial, hasNextPage } = useMyDishesStore(
 		selectMyDishesByQuery(effectiveQueryKey),
 		shallow,
@@ -101,11 +106,17 @@ export const useMyDishesRestaurantQuery = (restaurantId: string | null): UseMyDi
 	// ⚠️ `!error` を必ず条件へ入れること。取得が失敗したときストアは
 	// `hasFetchedInitial` を false のまま `isLoading` を false へ戻すので（stores/useMyDishesStore.ts
 	// の fetchInitial）、error を見ないと **失敗するたびに再取得して無限ループする**
+	// #1398 (PR4/7) `revision` を依存に入れる。実際にキャッシュを捨てるのは
+	// `useMyDishesRevisionStore.bump()`（`clearQuery()`）で、ここは «版が動いた» ことを
+	// この effect へ伝えるためだけに持つ。
+	// ⚠️ `error` を条件から外さないこと。外すと失敗のたびに叩き直して無限ループする（#1439 B-1）。
+	// 版が動いたときはスライスごと消えていて `error` も `hasFetchedInitial` も落ちているので、
+	// このガードを保ったまま «版が動いたときだけ» 取り直す形になる
 	useEffect(() => {
 		if (!enabled || queryKey === null || !fetcher) return;
 		if (hasFetchedInitial || isLoading || error) return;
 		void fetchInitial(queryKey, fetcher);
-	}, [enabled, error, fetchInitial, fetcher, hasFetchedInitial, isLoading, queryKey]);
+	}, [enabled, error, fetchInitial, fetcher, hasFetchedInitial, isLoading, queryKey, revision]);
 
 	const items = useMemo(
 		() =>

--- a/app-expo/features/myDishes/markAsEaten.test.ts
+++ b/app-expo/features/myDishes/markAsEaten.test.ts
@@ -1,0 +1,46 @@
+/*
+#1398 (PR4/7) want 行から「食べたを記録」へ送るときの遷移先を固定する。
+
+一覧のカードと Sheet の行という **2 つの呼び出し元**が同じ純関数を使うので、
+ここが崩れると両方が同時に壊れる。逆に言えば、ここを固定しておけば
+「片方だけパラメータ名が違う」という壊れ方をしない。
+*/
+import type { MyDishItem } from "@shared/api/v1/res";
+import { buildMarkAsEatenRoute } from "./markAsEaten";
+
+const makeItem = (overrides: Partial<MyDishItem>): MyDishItem =>
+	({
+		key: "dish:dish-1",
+		status: "want",
+		occurredAt: "2026-08-01T00:00:00.000Z",
+		savedAt: "2026-08-01T00:00:00.000Z",
+		eatenAt: null,
+		restaurant: { id: "restaurant-1", name: "テスト食堂", image_url: null },
+		dish: { id: "dish-1", name: "唐揚げ定食", categoryImageUrl: "https://example.com/c.jpg" },
+		dishMedia: { id: "media-1", thumbnailImageUrl: "https://example.com/m.jpg" },
+		myReview: null,
+		distanceMeters: null,
+		...overrides,
+	}) as unknown as MyDishItem;
+
+describe("buildMarkAsEatenRoute", () => {
+	it("既存の review-from-media ルートへ送る（新しいルートは作らない）", () => {
+		expect(buildMarkAsEatenRoute(makeItem({}), "ja-JP")).toEqual({
+			pathname: "/[locale]/restaurant/[restaurantId]/review-from-media/[dishMediaId]",
+			params: { locale: "ja-JP", restaurantId: "restaurant-1", dishMediaId: "media-1" },
+		});
+	});
+
+	it("dishMedia.id は文字列へ落とす（数値で来ても URL に載せられる形にする）", () => {
+		const route = buildMarkAsEatenRoute(
+			makeItem({ dishMedia: { id: 42, thumbnailImageUrl: null } as unknown as MyDishItem["dishMedia"] }),
+			"en-US",
+		);
+		expect(route?.params.dishMediaId).toBe("42");
+	});
+
+	// want 行の dishMedia は契約上必ず非 null（#1395 m-7）だが、`dishMedia.id` を触る前に必ず絞る
+	it("dishMedia が無ければ null（遷移先を組めないので押させない）", () => {
+		expect(buildMarkAsEatenRoute(makeItem({ dishMedia: null }), "ja-JP")).toBeNull();
+	});
+});

--- a/app-expo/features/myDishes/markAsEaten.ts
+++ b/app-expo/features/myDishes/markAsEaten.ts
@@ -1,0 +1,32 @@
+import type { MyDishItem } from "@shared/api/v1/res";
+
+/**
+ * #1398 (PR4/7) want 行から「食べたを記録」へ送るときの遷移先。
+ *
+ * **新しいルートは作らない。** 既存の `review-from-media` の呼び出し元が 1 つ増えるだけである
+ * （設計 (1/2) §1(a)）。元メディアに紐付くので写真撮影は要らず、`ReviewForm` は
+ * `prefilledMedia` モードで開く。叩く API は `POST /v1/dish-reviews` の 1 本だけ
+ * （`POST /v1/dishes` も `POST /v1/dish-media` も通らない）。
+ *
+ * 純関数に切り出してあるのは、一覧のカードと Sheet の行という **2 つの呼び出し元で
+ * パラメータが 1 文字でもズレないことをテストで固定する**ためである。
+ *
+ * `dishMedia === null` は `null` を返す。want 行の `dishMedia` は契約上必ず非 null なので
+ * （#1395 m-7）ここに来るのは異常系だけだが、`dishMedia.id` を触る前に必ず絞る。
+ */
+export type MarkAsEatenRoute = {
+	pathname: "/[locale]/restaurant/[restaurantId]/review-from-media/[dishMediaId]";
+	params: { locale: string; restaurantId: string; dishMediaId: string };
+};
+
+export const buildMarkAsEatenRoute = (item: MyDishItem, locale: string): MarkAsEatenRoute | null => {
+	if (item.dishMedia === null) return null;
+	return {
+		pathname: "/[locale]/restaurant/[restaurantId]/review-from-media/[dishMediaId]",
+		params: {
+			locale,
+			restaurantId: item.restaurant.id,
+			dishMediaId: String(item.dishMedia.id),
+		},
+	};
+};

--- a/app-expo/features/myDishes/stores/useMyDishesRevisionStore.test.ts
+++ b/app-expo/features/myDishes/stores/useMyDishesRevisionStore.test.ts
@@ -17,7 +17,7 @@ import {
 	useMyDishesFilterStore,
 } from "./useMyDishesFilterStore";
 import { useMyDishesRevisionStore } from "./useMyDishesRevisionStore";
-import { useMyDishesStore } from "./useMyDishesStore";
+import { useMyDishesStore, type MyDishesFetcher } from "./useMyDishesStore";
 
 const QUERY_KEY = "default";
 const OTHER_KEY = "restaurantId=restaurant-9";
@@ -93,5 +93,77 @@ describe("useMyDishesRevisionStore", () => {
 		useMyDishesFilterStore.setState({ filter: { ...DEFAULT_MY_DISHES_FILTER, status: ["eaten"] } });
 		useMyDishesRevisionStore.getState().bump();
 		expect(useMyDishesFilterStore.getState().filter.status).toEqual(["eaten"]);
+	});
+});
+
+/*
+飛行中の取得が «捨てた世代» の行を書き戻さないこと。
+
+この一覧の取得は平均 4.48 秒・最大 11.23 秒（#1395 §0(A) の実測）なので、
+「一覧を開いた直後に want カードの CTA を押して記録する」という普通の操作で、
+取得が飛行中のまま `bump()` が走る。世代を見ずに書き戻すと **記録前の行が
+`hasFetchedInitial: true` 付きで復活し、`!error` ガード付きの effect はもう取り直さない**。
+つまりこの PR が消しに来た「記録直後に食べたいカードが残る」がそのまま出る。
+*/
+describe("bump と飛行中の取得の競合", () => {
+	const fetcherFor = (resolve: { current?: (v: unknown) => void }) =>
+		jest.fn(
+			() =>
+				new Promise((res) => {
+					resolve.current = res as (v: unknown) => void;
+				}),
+		) as unknown as MyDishesFetcher;
+
+	it("飛行中に bump したら、遅れて返ってきた «記録前» の行を書き戻さない", async () => {
+		const resolve: { current?: (v: unknown) => void } = {};
+		const fetcher = fetcherFor(resolve);
+
+		const inFlight = useMyDishesStore.getState().fetchInitial(QUERY_KEY, fetcher);
+		expect(useMyDishesStore.getState().isLoadingByQuery[QUERY_KEY]).toBe(true);
+
+		// 記録が成功した（= 一覧を捨てた）
+		useMyDishesRevisionStore.getState().bump();
+
+		// 取得が «あとから» 返る
+		resolve.current?.({ data: [makeItem("dish:1")], nextCursor: null, oldestOccurredAt: null });
+		await inFlight;
+
+		const state = useMyDishesStore.getState();
+		expect(state.itemKeysByQuery[QUERY_KEY]).toBeUndefined();
+		expect(state.hasFetchedInitialByQuery[QUERY_KEY]).toBeUndefined();
+		// ここが残ると、新しい世代の取得が «二重投げ防止» に引っかかって永久に走らない
+		expect(state.isLoadingByQuery[QUERY_KEY]).toBeUndefined();
+	});
+
+	it("飛行中に bump したら、遅れて返ってきた失敗も error として書き戻さない", async () => {
+		const resolve: { current?: (v: unknown) => void } = {};
+		const fetcher = jest.fn(
+			() =>
+				new Promise((_res, rej) => {
+					resolve.current = () => rej(new Error("boom"));
+				}),
+		) as unknown as MyDishesFetcher;
+
+		const inFlight = useMyDishesStore.getState().fetchInitial(QUERY_KEY, fetcher);
+		useMyDishesRevisionStore.getState().bump();
+		resolve.current?.(undefined);
+		await inFlight;
+
+		// error が生えると `!error` ガードが «取り直すべきときに取り直さない» 側へ倒れる
+		expect(useMyDishesStore.getState().errorByQuery[QUERY_KEY]).toBeUndefined();
+	});
+
+	it("bump が無ければ従来どおり書き戻す（世代ガードが普通の取得を殺していない）", async () => {
+		const resolve: { current?: (v: unknown) => void } = {};
+		const fetcher = fetcherFor(resolve);
+
+		const inFlight = useMyDishesStore.getState().fetchInitial(QUERY_KEY, fetcher);
+		resolve.current?.({ data: [makeItem("dish:1")], nextCursor: null, oldestOccurredAt: null });
+		await inFlight;
+
+		const state = useMyDishesStore.getState();
+		expect(state.itemKeysByQuery[QUERY_KEY]).toEqual(["dish:1"]);
+		expect(state.hasFetchedInitialByQuery[QUERY_KEY]).toBe(true);
+		expect(state.isLoadingByQuery[QUERY_KEY]).toBe(false);
 	});
 });

--- a/app-expo/features/myDishes/stores/useMyDishesRevisionStore.test.ts
+++ b/app-expo/features/myDishes/stores/useMyDishesRevisionStore.test.ts
@@ -1,0 +1,97 @@
+/*
+#1398 (PR4/7) 記録成功時の一覧無効化（`revision` bump）。
+
+見るのは 3 つ。
+
+1. `bump()` が my-dishes のキャッシュを **丸ごと** 捨てること（設計 §3 の「クライアントキャッシュ」）
+2. **`queryKey` に版数が混ざらない**こと（PR4 の地雷 (b)。混ざると LRU 6 本を版が食い潰し、
+   記録するたびに base の一覧が追い出される）
+3. 捨てたあとのスライスが `hasFetchedInitial` / `error` ともに落ちていること。
+   ここが落ちていないと、`!error` ガード付きの取得 effect（#1439 B-1 の対策）が
+   «取り直すべきときに取り直さない» か «error のまま毎レンダー叩く» のどちらかに倒れる
+*/
+import type { MyDishItem } from "@shared/api/v1/res";
+import {
+	DEFAULT_MY_DISHES_FILTER,
+	selectFilterQueryKey,
+	useMyDishesFilterStore,
+} from "./useMyDishesFilterStore";
+import { useMyDishesRevisionStore } from "./useMyDishesRevisionStore";
+import { useMyDishesStore } from "./useMyDishesStore";
+
+const QUERY_KEY = "default";
+const OTHER_KEY = "restaurantId=restaurant-9";
+
+const makeItem = (key: string): MyDishItem =>
+	({
+		key,
+		status: "want",
+		occurredAt: "2026-08-01T00:00:00.000Z",
+		savedAt: "2026-08-01T00:00:00.000Z",
+		eatenAt: null,
+		restaurant: { id: "restaurant-1", name: "テスト食堂", image_url: null },
+		dish: { id: "dish-1", name: "唐揚げ定食", categoryImageUrl: "https://example.com/c.jpg" },
+		dishMedia: { id: "media-1", thumbnailImageUrl: null },
+		myReview: null,
+		distanceMeters: null,
+	}) as unknown as MyDishItem;
+
+const seed = () => {
+	useMyDishesStore.setState({
+		itemByKey: { "dish:1": makeItem("dish:1") },
+		itemKeysByQuery: { [QUERY_KEY]: ["dish:1"], [OTHER_KEY]: ["dish:1"] },
+		hasFetchedInitialByQuery: { [QUERY_KEY]: true, [OTHER_KEY]: true },
+		errorByQuery: { [QUERY_KEY]: "network error" },
+		recentQueryKeys: [QUERY_KEY, OTHER_KEY],
+	});
+};
+
+beforeEach(() => {
+	useMyDishesStore.getState().clearQuery();
+	useMyDishesRevisionStore.setState({ revision: 0 });
+	useMyDishesFilterStore.setState({ filter: DEFAULT_MY_DISHES_FILTER });
+});
+
+describe("useMyDishesRevisionStore", () => {
+	it("bump で版が 1 つ進む", () => {
+		useMyDishesRevisionStore.getState().bump();
+		expect(useMyDishesRevisionStore.getState().revision).toBe(1);
+	});
+
+	it("bump は my-dishes のスライスを丸ごと捨てる（部分無効化にしない）", () => {
+		seed();
+		useMyDishesRevisionStore.getState().bump();
+
+		const state = useMyDishesStore.getState();
+		// 1 件の記録は base の一覧・Map のピン・Calendar の月・他店の Sheet いずれにも波及する。
+		// どのキーが影響を受けるかをクライアントで再現するとサーバの SQL と二重管理になる
+		expect(state.itemKeysByQuery).toEqual({});
+		expect(state.itemByKey).toEqual({});
+		expect(state.recentQueryKeys).toEqual([]);
+	});
+
+	it("捨てたあとは hasFetchedInitial も error も落ちている（取得 effect が取り直せる）", () => {
+		seed();
+		useMyDishesRevisionStore.getState().bump();
+
+		const state = useMyDishesStore.getState();
+		// `!error` ガードは «error が立っている間は叩かない» なので、error が残っていると
+		// 版を進めても永久に取り直せなくなる
+		expect(state.errorByQuery[QUERY_KEY]).toBeUndefined();
+		expect(state.hasFetchedInitialByQuery[QUERY_KEY]).toBeUndefined();
+	});
+
+	it("版数は queryKey に混ざらない（LRU 6 本を版が食い潰さない）", () => {
+		const before = selectFilterQueryKey(useMyDishesFilterStore.getState());
+		useMyDishesRevisionStore.getState().bump();
+		useMyDishesRevisionStore.getState().bump();
+		const after = selectFilterQueryKey(useMyDishesFilterStore.getState());
+		expect(after).toBe(before);
+	});
+
+	it("bump はフィルタを 1 つも書き換えない（3 ビューの絞り込みを勝手に変えない）", () => {
+		useMyDishesFilterStore.setState({ filter: { ...DEFAULT_MY_DISHES_FILTER, status: ["eaten"] } });
+		useMyDishesRevisionStore.getState().bump();
+		expect(useMyDishesFilterStore.getState().filter.status).toEqual(["eaten"]);
+	});
+});

--- a/app-expo/features/myDishes/stores/useMyDishesRevisionStore.ts
+++ b/app-expo/features/myDishes/stores/useMyDishesRevisionStore.ts
@@ -1,0 +1,65 @@
+import { createWithEqualityFn } from "zustand/traditional";
+import { useMyDishesStore } from "./useMyDishesStore";
+
+/**
+ * #1398 (PR4/7) 「食べた」を記録したあとに my-dishes のキャッシュを捨てるための版数。
+ *
+ * ## なぜ必要か（設計 (1/2) §3「唯一の実務上の落とし穴：クライアントキャッシュ」）
+ *
+ * サーバ側は正しい。want 枝は `NOT EXISTS (SELECT 1 FROM dish_reviews …)` を持つので、
+ * `dish_reviews` の行ができた瞬間にその dish の want 行は消える（`my-dishes.query.ts`）。
+ * **save reaction を消さなくても消える。** しかしクライアントが取り直さなければ、
+ * 記録した直後の画面には「食べたい」カードが残ったままに見える。ユーザーからはこれが
+ * 「重複して表示されている」不具合に見える。
+ *
+ * ## なぜ «別 store» なのか
+ *
+ * `useMyDishesFilterStore` には入れない。あれは «ユーザーが明示的に選んだもの» だけを持つ
+ * 契約で、キー集合は `__tests__/myDishesFilterStore.test.ts` が固定している。版数を混ぜると
+ * `queryKey` が版数ごとに変わり、フィルタを触っていないのに 3 ビューが取り直す形になる。
+ *
+ * ## なぜ «queryKey に版数を混ぜない» のか（PR4 の地雷 (b)）
+ *
+ * `MY_DISHES_QUERY_LRU_SIZE` は 6 本しかない。版数を `queryKey` の一部にすると、記録するたびに
+ * 新しいキーが生まれ、**古い版のスライスが LRU を食い潰して base の一覧が追い出される**。
+ * そこで版数はキーに混ぜず、`bump()` が `clearQuery()` でスライスを丸ごと捨てる形にした。
+ * 捨てられたキーは `hasFetchedInitial` も `error` も消えるので、マウント中のフックは既存の
+ * `!error` ガード付き effect がそのまま取り直す（**新しい取得経路を足していない**）。
+ *
+ * ## なぜ «その店だけ» ではなく全部捨てるのか
+ *
+ * 1 件の記録は「want が 1 行消えて eaten が 1 行増える」変化であり、base の一覧・Map のピン・
+ * Calendar の月・他店の Sheet のいずれにも波及しうる（`meta.oldestOccurredAt` も動く）。
+ * 部分無効化にすると «どのキーが影響を受けるか» をクライアントで再現することになり、
+ * サーバの SQL と二重管理になる。**全部捨てるのが唯一ズレない**。捨てても失うのは
+ * キャッシュだけで、次の描画で取り直される。
+ */
+export type MyDishesRevisionStore = {
+	/**
+	 * 無効化が起きた回数。**取得キーには使わない**（上記の理由）。
+	 * フックはこれを effect の依存に持ち、版が動いたことを検知できるようにしている。
+	 */
+	revision: number;
+	/**
+	 * my-dishes のキャッシュを捨てて版を 1 つ進める。
+	 * 呼ぶのは `review.tsx` / `review-from-media/[dishMediaId].tsx` の `handleReviewSuccess` だけ。
+	 * **`ReviewForm` からは呼ばない**（ReviewForm を my-dishes に結合させないため。設計 §3）。
+	 */
+	bump: () => void;
+};
+
+export const useMyDishesRevisionStore = createWithEqualityFn<MyDishesRevisionStore>()((set) => ({
+	revision: 0,
+
+	bump: () => {
+		// 先にスライスを捨ててから版を進める。逆順にすると、版の変化で再描画されたフックが
+		// «まだ捨てられていない古いスライス»（`hasFetchedInitial === true`）を見て取り直さない
+		useMyDishesStore.getState().clearQuery();
+		set((state) => ({ revision: state.revision + 1 }));
+	},
+}));
+
+export const selectMyDishesRevision = (s: MyDishesRevisionStore): number => s.revision;
+
+/** 画面から呼ぶための薄い口。`useMyDishesRevisionStore.getState().bump()` と同じ */
+export const bumpMyDishesRevision = (): void => useMyDishesRevisionStore.getState().bump();

--- a/app-expo/features/myDishes/stores/useMyDishesStore.ts
+++ b/app-expo/features/myDishes/stores/useMyDishesStore.ts
@@ -107,6 +107,21 @@ export type MyDishesStore = {
 	recentQueryKeys: string[];
 
 	/**
+	 * #1398 (PR4/7) 破棄の世代。`clearQuery` を呼ぶたびに 1 つ進む。
+	 *
+	 * 取得は `await` を挟むので、**飛行中に `clearQuery` が走ることがある**
+	 * （記録成功時の `useMyDishesRevisionStore.bump()` / Feed を閉じるときの Q4 invalidate）。
+	 * 世代を見ずに書き戻すと、**捨てたはずの «記録前» の行が `hasFetchedInitial: true` 付きで
+	 * 復活し、`!error` ガード付きの effect はもう取り直さない**。つまり記録直後の一覧に
+	 * 「食べたい」カードが残る — この PR が消しに来たはずの症状がそのまま出る。
+	 * この一覧の取得は平均 4.48 秒・最大 11.23 秒（#1395 §0(A) の実測）なので、
+	 * 窓はミリ秒ではなく**秒の幅**で開いている。
+	 *
+	 * 各 fetch は開始時に世代を控え、`await` の後で変わっていたら **1 バイトも書かずに捨てる**。
+	 */
+	generation: number;
+
+	/**
 	 * `queryKey` を LRU の先頭へ touch する。キャッシュヒット（`fetchInitial` を呼ばない経路）でも
 	 * 呼ぶ必要があるため、`fetchInitial` の副作用から独立させている（#1396 m-1）。
 	 * `useMyDishesQuery` / `useMyDishesMapPinsQuery` がマウント・`queryKey` 変化のたびに毎回呼ぶ。
@@ -261,6 +276,7 @@ export const useMyDishesStore = createWithEqualityFn<MyDishesStore>()((set, get)
 	errorPinsByQuery: {},
 	truncatedByQuery: {},
 	recentQueryKeys: [],
+	generation: 0,
 
 	touchQuery: (queryKey) => set((state) => touchAndEvict(state, queryKey)),
 
@@ -276,9 +292,15 @@ export const useMyDishesStore = createWithEqualityFn<MyDishesStore>()((set, get)
 			errorByQuery: { ...state.errorByQuery, [queryKey]: null },
 		}));
 
+		// 世代は «ローディングを立てた後・await の前» に控える
+		const generation = get().generation;
+
 		try {
 			// #1396 【設計】フィルタ変更時は cursor を捨てて先頭から取り直す（#1395 §6）
 			const response = await fetcher({ cursor: null });
+		// #1398 (PR4/7) 飛行中に clearQuery が走ったら、この結果は «捨てた世代» のものなので
+		// 1 バイトも書かない（書くと «記録前» の行が hasFetchedInitial 付きで復活する）
+			if (get().generation !== generation) return;
 			set((state) => {
 				const itemPatch: Record<string, MyDishItem> = {};
 				for (const item of response.data) itemPatch[item.key] = item;
@@ -294,9 +316,15 @@ export const useMyDishesStore = createWithEqualityFn<MyDishesStore>()((set, get)
 				};
 			});
 		} catch (err) {
+			if (get().generation !== generation) return;
 			set((state) => ({ errorByQuery: { ...state.errorByQuery, [queryKey]: toErrorMessage(err) } }));
 		} finally {
-			set((state) => ({ isLoadingByQuery: { ...state.isLoadingByQuery, [queryKey]: false } }));
+			// ⚠️ 世代が変わっていたら **ローディングも触らない**。触ると、消えたキーへ
+			// `false` が生えるだけでなく、新しい世代で既に飛んでいる取得の «二重投げ防止» を
+			// 解除してしまう
+			if (get().generation === generation) {
+				set((state) => ({ isLoadingByQuery: { ...state.isLoadingByQuery, [queryKey]: false } }));
+			}
 		}
 	},
 
@@ -312,8 +340,13 @@ export const useMyDishesStore = createWithEqualityFn<MyDishesStore>()((set, get)
 			errorByQuery: { ...s.errorByQuery, [queryKey]: null },
 		}));
 
+		const generation = get().generation;
+
 		try {
 			const response = await fetcher({ cursor });
+		// #1398 (PR4/7) 飛行中に clearQuery が走ったら、この結果は «捨てた世代» のものなので
+		// 1 バイトも書かない（書くと «記録前» の行が hasFetchedInitial 付きで復活する）
+			if (get().generation !== generation) return;
 			// n-1（見送り・申し送り）: ここで `queryKey` がまだ `recentQueryKeys` に生きているかは見ていない。
 			// 飛行中に他の 4 本目の queryKey で LRU から追い出されると、この結果は誰も参照しない
 			// itemByKey の行として残り続ける（次の追い出しまで）。到達には「追加取得中に他の
@@ -333,9 +366,12 @@ export const useMyDishesStore = createWithEqualityFn<MyDishesStore>()((set, get)
 				};
 			});
 		} catch (err) {
+			if (get().generation !== generation) return;
 			set((s) => ({ errorByQuery: { ...s.errorByQuery, [queryKey]: toErrorMessage(err) } }));
 		} finally {
-			set((s) => ({ isLoadingMoreByQuery: { ...s.isLoadingMoreByQuery, [queryKey]: false } }));
+			if (get().generation === generation) {
+				set((s) => ({ isLoadingMoreByQuery: { ...s.isLoadingMoreByQuery, [queryKey]: false } }));
+			}
 		}
 	},
 
@@ -349,17 +385,25 @@ export const useMyDishesStore = createWithEqualityFn<MyDishesStore>()((set, get)
 			errorPinsByQuery: { ...state.errorPinsByQuery, [queryKey]: null },
 		}));
 
+		const generation = get().generation;
+
 		try {
 			const response = await fetcher();
+			// #1398 (PR4/7) 飛行中に clearQuery が走ったら、この結果は «捨てた世代» のものなので
+			// 1 バイトも書かない（書くと «記録前» のピンが hasFetchedInitial 付きで復活する）
+			if (get().generation !== generation) return;
 			set((state) => ({
 				pinsByQuery: { ...state.pinsByQuery, [queryKey]: response.data },
 				truncatedByQuery: { ...state.truncatedByQuery, [queryKey]: response.truncated },
 				hasFetchedInitialPinsByQuery: { ...state.hasFetchedInitialPinsByQuery, [queryKey]: true },
 			}));
 		} catch (err) {
+			if (get().generation !== generation) return;
 			set((state) => ({ errorPinsByQuery: { ...state.errorPinsByQuery, [queryKey]: toErrorMessage(err) } }));
 		} finally {
-			set((state) => ({ isLoadingPinsByQuery: { ...state.isLoadingPinsByQuery, [queryKey]: false } }));
+			if (get().generation === generation) {
+				set((state) => ({ isLoadingPinsByQuery: { ...state.isLoadingPinsByQuery, [queryKey]: false } }));
+			}
 		}
 	},
 
@@ -381,6 +425,8 @@ export const useMyDishesStore = createWithEqualityFn<MyDishesStore>()((set, get)
 					errorPinsByQuery: {},
 					truncatedByQuery: {},
 					recentQueryKeys: [],
+					// 飛行中の取得を «捨てた世代» にする（下の単一キー破棄でも同じ）
+					generation: state.generation + 1,
 				};
 			}
 
@@ -435,6 +481,9 @@ export const useMyDishesStore = createWithEqualityFn<MyDishesStore>()((set, get)
 				errorPinsByQuery: nextErrorPinsByQuery,
 				truncatedByQuery: nextTruncatedByQuery,
 				recentQueryKeys: state.recentQueryKeys.filter((k) => k !== queryKey),
+				// 単一キーの破棄でも世代を進める。飛行中の取得がこのキーを書き戻すと、
+				// 捨てたはずの行が hasFetchedInitial 付きで復活する（全破棄と同じ理由）
+				generation: state.generation + 1,
 			};
 		}),
 }));

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -781,6 +781,10 @@
 		"cancel": "إلغاء"
 	},
 	"MyDishes": {
+		"actions": {
+			"markAsEaten": "تسجيل كمأكول",
+			"markAsEatenA11y": "تسجيل هذا الطبق كمأكول"
+		},
 		"views": {
 			"map": "الخريطة",
 			"list": "القائمة",

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -781,6 +781,10 @@
 		"cancel": "Cancel"
 	},
 	"MyDishes": {
+		"actions": {
+			"markAsEaten": "Log as eaten",
+			"markAsEatenA11y": "Log this dish as eaten"
+		},
 		"views": {
 			"map": "Map",
 			"list": "List",

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -781,6 +781,10 @@
 		"cancel": "Cancelar"
 	},
 	"MyDishes": {
+		"actions": {
+			"markAsEaten": "Registrar comido",
+			"markAsEatenA11y": "Registrar este plato como comido"
+		},
 		"views": {
 			"map": "Mapa",
 			"list": "Lista",

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -781,6 +781,10 @@
 		"cancel": "Annuler"
 	},
 	"MyDishes": {
+		"actions": {
+			"markAsEaten": "Noter comme mangé",
+			"markAsEatenA11y": "Noter ce plat comme mangé"
+		},
 		"views": {
 			"map": "Carte",
 			"list": "Liste",

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -781,6 +781,10 @@
 		"cancel": "रद्द करें"
 	},
 	"MyDishes": {
+		"actions": {
+			"markAsEaten": "खाया दर्ज करें",
+			"markAsEatenA11y": "इस व्यंजन को खाया हुआ दर्ज करें"
+		},
 		"views": {
 			"map": "मानचित्र",
 			"list": "सूची",

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -781,6 +781,10 @@
 		"cancel": "キャンセル"
 	},
 	"MyDishes": {
+		"actions": {
+			"markAsEaten": "食べたを記録",
+			"markAsEatenA11y": "この料理を食べたとして記録する"
+		},
 		"views": {
 			"map": "マップ",
 			"list": "リスト",

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -781,6 +781,10 @@
 		"cancel": "취소"
 	},
 	"MyDishes": {
+		"actions": {
+			"markAsEaten": "먹었어요 기록",
+			"markAsEatenA11y": "이 음식을 먹었다고 기록하기"
+		},
 		"views": {
 			"map": "지도",
 			"list": "리스트",

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -781,6 +781,10 @@
 		"cancel": "取消"
 	},
 	"MyDishes": {
+		"actions": {
+			"markAsEaten": "记录已吃",
+			"markAsEatenA11y": "将这道菜记录为已吃"
+		},
 		"views": {
 			"map": "地图",
 			"list": "列表",


### PR DESCRIPTION
親: #1375 / 本 Issue: #1398
設計の正本: #1398 の設計コメント (1/2) §1(a)・§3 と、リーダー確定コメント（Q1〜Q6）。

base: `claude/review-tab-removal-shop-tab-put0bd`

> ワーカー（GitHub Actions）が共有の利用上限で 3 回連続して何も push せずに落ちたため、リーダーがローカルで実装した。

## やったこと

### 1. want 行の「食べたを記録」CTA

遷移先は純関数 `features/myDishes/markAsEaten.ts` に集約した。一覧のカードと Sheet の行という **2 つの呼び出し元でパラメータが 1 文字もズレない**ことをテストで固定するためである。**新しいルートは作らない** — 既存 `review-from-media` の呼び出し元が 1 つ増えるだけで、叩く API も `POST /v1/dish-reviews` の 1 本だけ（設計 §1(a)）。

- `status === "want"` の行にだけ出す。eaten 行には出さない（再訪の記録は全画面 Feed の `ActionButtons` 側で常時活性。設計 §1(b)）
- want 行の `dishMedia` は契約上必ず非 null（#1395 m-7）だが、`dishMedia.id` を触る前に必ず絞る（防御であって仕様ではない旨をコメントに明記）

### 2. 記録成功時の一覧無効化（`revision`）

`useMyDishesRevisionStore` を新設し、`review.tsx` / `review-from-media/[dishMediaId].tsx` の `handleReviewSuccess` から `bumpMyDishesRevision()` を呼ぶ。**`ReviewForm` 側には置かない**（ReviewForm を my-dishes に結合させないため。設計 §3 の明示条件）。

サーバは正しい（want 枝の `NOT EXISTS (SELECT 1 FROM dish_reviews …)` が `dish_reviews` の行ができた瞬間に want 行を落とす）。クライアントが取り直さないと **記録直後の一覧に「食べたい」カードが残って見える**、というのが設計 §3 が挙げた唯一の実務上の落とし穴で、その対処である。

これにより PR #1455 が `feed.tsx` のコメントで申し送った **m-3**（全画面 Feed の `ActionButtons` から記録 → 閉じたとき一覧へ反映）も満たされる。

## レビュー観点

### ⚠️ 地雷 (a) `!error` ガードを外していないか

4 フック（`useMyDishesQuery` / `useMyDishesMapPinsQuery` / `useMyDishesCalendarQuery` / `useMyDishesRestaurantQuery`）とも `if (hasFetchedInitial || isLoading || error) return;` の形を維持している。`revision` は依存に足しただけで、条件からは何も外していない。

`error` を条件から落とすと **取得が失敗するたびに再取得して無限ループする**（PR #1439 Blocker B-1）。版が動いたときはスライスごと消えていて `error` も `hasFetchedInitial` も落ちているので、ガードを保ったまま «版が動いたときだけ» 取り直す形になる。`useMyDishesRevisionStore.test.ts` がこの「捨てたあとに error が残っていないこと」を固定している。

### ⚠️ 地雷 (b) LRU を版数が食い潰していないか

**版数を `queryKey` に混ぜていない。** `MY_DISHES_QUERY_LRU_SIZE` は 6 本しかなく、混ぜると記録のたびに新しいキーが生まれて base の一覧が追い出される。代わりに `bump()` が `clearQuery()`（引数なし）でスライスを丸ごと捨てる。

部分無効化（その店だけ捨てる）にしなかったのは、1 件の記録が base の一覧・Map のピン・Calendar の月・他店の Sheet・`meta.oldestOccurredAt` のいずれにも波及しうるためで、どのキーが影響を受けるかをクライアントで再現するとサーバの SQL と二重管理になる。テストで「丸ごと捨てる」「フィルタは書き換えない」「queryKey は変わらない」の 3 つを固定している。

### ⚠️ カードのタップを奪っていないか

カード・行の全体は #1397 PR4（PR #1455）で全画面 Feed への遷移になっている。CTA を押して Feed が開いてはいけない。

- **native**: RN のタッチレスポンダは 1 つしか勝たないので、子の `Pressable` が取れば親は発火しない
- **web（react-native-web）**: DOM の click が **そのまま親へバブルする**。`stopPropagation()` を自分で呼ばないと CTA を押しただけで Feed が開く

`MyDishEatenButton` の `onPress` で必ず `event?.stopPropagation?.()` を呼んでいる。`myDishEatenButton.test.tsx` が «イベントを渡した場合 / 渡さない場合» の両方を、`MyDishesListView.test.tsx` が «CTA を押したとき push が 1 回だけで、それが Feed ではないこと» を固定している。

### Calendar にボタンを置かなかった理由（設計からの明示的な逸脱）

Calendar の日セルは月グリッド内の小さなサムネイルで、CTA を載せると押し分けできない。セルのタップは既に「その日で絞り込んでリストビューへ切り替える」（`MyDishesCalendarView.tsx` の `handlePressDay` → `patch({from,to})` + `setParams({view:"list"})`。#1396 PR5 §4-5）なので、**Calendar からの導線はリストビューの CTA へ合流する**。導線が失われているわけではない。

### Sheet を独自に閉じていないこと

`handleMarkAsEaten` は push するだけで dismiss を挟んでいない。閉じるのは既存の 3 本立て（`useFocusEffect` の cleanup / `navigation.beforeRemove` / unmount 時の保険。#644 の先例）が担保しており、行タップ（`handlePressItem`）も同じ作法である。ここだけ独自に dismiss を挟むと閉じるアニメーションと push が競合する。

## 確認

- `pnpm --filter app-expo typecheck`: exit 0
- `pnpm --filter app-expo test`: **94 suites / 976 tests passed**（base 91/959 から +3 suites / +17 tests）
- `pnpm --filter app-expo lint`: 0 errors
- `assert:legacy-blur-modal-boundary`: exit 0
- i18n: `MyDishes.actions.markAsEaten` / `markAsEatenA11y` を 8 言語同時に追加（parity テストは missing / extra の両方で落ちるが green）

## 触っていないもの

`ReviewForm.tsx` / `mediaGenerationRef`・`isSelectingMediaRef`・`prefilledMediaRef` の 3 本立て（#1127）/ `restaurant-feed-write-review-button` の testID / save reaction（消していない。食べたい登録日 `reactions.created_at` を失わないため）。Google Places の新規利用も LLM の利用も無い。

---
_Generated by [Claude Code](https://claude.ai/code/session_011PwkXTZx1eR3y5PHL2HACQ)_