### PR TITLE
ci(claude-worker): 書き込みワーカーが使えるツールを明示する

### DIFF
--- a/.claude/skills/parallel-development/CORE.md
+++ b/.claude/skills/parallel-development/CORE.md
@@ -592,6 +592,32 @@ mcp__github__get_job_logs  job_id=<書き込みワーカーのjob_id>  return_co
 実際は `permission_denials=7` で、成功した run のログには同じ警告が 1 行も無かった。
 **最初に `list_workflow_jobs` を見ていれば 1 本目で分かった。**
 
+### 実例: 「ファイルを書く手段が無い」ワーカーを 5 本走らせた（2026-08-20）
+
+書き込みワーカーが 5 本続けて **何も commit せずに正常終了**した。最終的に読めた診断は:
+
+```
+subtype=success is_error=false turns=76 permission_denials=22
+claude-denial: 10 tool=WebFetch parameters=[prompt, url]
+claude-denial: 12 tool=Write   parameters=[content, file_path]
+claude-denial: 13 tool=Edit    parameters=[file_path, new_string, old_string, replace_all]
+claude-denial: 17 tool=Bash    parameters=[command, dangerouslyDisableSandbox, description]
+（残りはほぼ Bash）
+```
+
+`Write` と `Edit` が拒否されている = **ファイルを書く手段が 1 つも無い状態で走らせていた**。
+Claude は作業できず、`subtype=success` のまま引き返すしかなかった。turn 切れ（150 に対して 76）でも
+利用上限でもない。
+
+対処: `claude-worker.yml` の書き込みワーカーへ `--permission-mode acceptEdits` と
+`--allowedTools` を明示した。**Action のバージョンはコミットで固定していても、Action が
+実行時に入れる Claude Code CLI は固定されていない。** CLI 側の既定（permission mode /
+sandbox）が変わると、ワーカーは黙って作業不能になる。**既定に頼らないこと。**
+
+教訓として一般化できるのは次の 1 点である。
+**「ワーカーが同じ形で 2 本続けて手ぶらで帰ってきたら、プロンプトを疑う前に権限を疑う。」**
+プロンプトを書き直して再実行しても、ツールが拒否されている限り何度でも同じ場所で止まる。
+
 ### 落ちた run はトークンをそのまま捨てる
 
 失敗した run も、Claude が動いた分のトークンは消費している。**盲目的な再実行は二重の浪費**である。

--- a/.claude/skills/parallel-development/CORE.md
+++ b/.claude/skills/parallel-development/CORE.md
@@ -609,10 +609,22 @@ claude-denial: 17 tool=Bash    parameters=[command, dangerouslyDisableSandbox, d
 Claude は作業できず、`subtype=success` のまま引き返すしかなかった。turn 切れ（150 に対して 76）でも
 利用上限でもない。
 
-対処: `claude-worker.yml` の書き込みワーカーへ `--permission-mode acceptEdits` と
+対処: `claude-worker.yml` の書き込みワーカーへ `--permission-mode bypassPermissions` と
 `--allowedTools` を明示した。**Action のバージョンはコミットで固定していても、Action が
 実行時に入れる Claude Code CLI は固定されていない。** CLI 側の既定（permission mode /
 sandbox）が変わると、ワーカーは黙って作業不能になる。**既定に頼らないこと。**
+
+`acceptEdits` では足りない。あれが自動承認するのは **ファイル編集だけ**で、`Bash` は確認を求める。
+非対話実行では確認する人が居ないので、確認 = 拒否である。さらに `dangerouslyDisableSandbox` の
+存在が示すとおり «サンドボックス外への昇格» という別の承認軸があり、`git push` も `pnpm install` も
+ネットワークが要るので必ずそこへ来る。`--allowedTools Bash` は «Bash というツール» を許すだけで、
+この昇格までは前もって承認できない。
+
+そして `--allowedTools Bash` を入れた時点で **任意の Bash を許している**のだから、
+`acceptEdits` と `bypassPermissions` の差は実質的にセキュリティの差ではなく信頼性の差でしかない。
+**非対話のワーカーでは、中途半端な権限モードを選ぶと «黙って何もせず帰ってくる» に倒れる。**
+影響範囲は「使い捨てランナー」「job の `permissions:`」「`CLAUDE_BRANCH` による作業ブランチ固定」の
+3 つで閉じているので、そちらで縛るのが正しい。
 
 教訓として一般化できるのは次の 1 点である。
 **「ワーカーが同じ形で 2 本続けて手ぶらで帰ってきたら、プロンプトを疑う前に権限を疑う。」**

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -346,6 +346,22 @@ jobs:
         # 実装ファイルとテストエビデンスを分離し、誤commitを防ぐ。
         run: mkdir -p /tmp/claude-artifacts
 
+      # ⚠️ 使えるツールを明示すること。既定に頼らない。
+      #
+      # 2026-08-20、書き込みワーカーが5本続けて «何もcommitせずに正常終了» した。
+      # 原因は Bash / Write / Edit / WebFetch が軒並み権限拒否されていたこと
+      # （1本で permission_denials=22。subtype=success・turns=76 で、上限でもturn切れでもない）。
+      # **ファイルを書く手段が1つも無い状態で走らせていた**ので、Claudeは作業できずに
+      # 引き返すしかなかった。
+      #
+      # Actionのバージョンはコミットで固定しているが、Actionが実行時に入れる
+      # Claude Code CLI は固定されていない。CLI側の既定（permission mode・sandbox）が
+      # 変わるとワーカーが黙って作業不能になる。ここを明示しておけば、CLIの既定が
+      # 何であっても書き込みワーカーは動く。
+      #
+      # `observe` 側は読み取り専用のままにする（あちらへは付けない）。ここで許可するのは
+      # 「runner上の作業ツリーを触る」ことだけで、GitHubへの権限は下の
+      # `additional_permissions` と job の `permissions:` が引き続き決める。
       - name: Claude Codeを実行
         id: claude
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
@@ -362,6 +378,8 @@ jobs:
           claude_args: |
             --model ${{ inputs.model }}
             --max-turns ${{ inputs.max_turns }}
+            --permission-mode acceptEdits
+            --allowedTools Bash,Edit,Write,Read,Glob,Grep,TodoWrite,WebFetch,WebSearch,Task
             ${{ inputs.extra_claude_args }}
           # 使用権限をWorkflow上にも列挙し、動的promptから権限を拡張させない。
           additional_permissions: |

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -359,6 +359,24 @@ jobs:
       # 変わるとワーカーが黙って作業不能になる。ここを明示しておけば、CLIの既定が
       # 何であっても書き込みワーカーは動く。
       #
+      # なぜ `acceptEdits` ではなく `bypassPermissions` なのか。
+      # 拒否 22 件のうち大半は `Bash` で、1 件は `dangerouslyDisableSandbox` 付きだった。
+      #   - `acceptEdits` が自動承認するのは **ファイル編集だけ**。`Bash` は確認を求めるので、
+      #     非対話実行（確認する人が居ない）では結局すべて拒否になる。
+      #   - `dangerouslyDisableSandbox` の存在は «サンドボックス外への昇格» という
+      #     別の承認軸があることを示す。`git push` も `pnpm install` もネットワークが要るので
+      #     必ずここへ来る。`--allowedTools Bash` は «Bash というツール» を許すだけで、
+      #     この昇格までは前もって承認できない。
+      # なお `--allowedTools Bash` を入れた時点で **任意の Bash を許している**ので、
+      # `acceptEdits` との差は実質的にセキュリティの差ではなく信頼性の差でしかない。
+      # `--allowedTools` は、CLI が `--permission-mode` の綴りを変えたときの保険として残す。
+      #
+      # 影響範囲は次の 3 つで閉じている。
+      #   1. 使い捨ての GitHub ホストランナー上でしか動かない
+      #   2. GitHub 側でできることは job の `permissions:` と `additional_permissions` が決める
+      #      （ここは 1 行も緩めていない。`contents: write` は元から付いている）
+      #   3. 触れるブランチは `CLAUDE_BRANCH` で作業ブランチに固定している
+      #
       # `observe` 側は読み取り専用のままにする（あちらへは付けない）。ここで許可するのは
       # 「runner上の作業ツリーを触る」ことだけで、GitHubへの権限は下の
       # `additional_permissions` と job の `permissions:` が引き続き決める。
@@ -378,7 +396,7 @@ jobs:
           claude_args: |
             --model ${{ inputs.model }}
             --max-turns ${{ inputs.max_turns }}
-            --permission-mode acceptEdits
+            --permission-mode bypassPermissions
             --allowedTools Bash,Edit,Write,Read,Glob,Grep,TodoWrite,WebFetch,WebSearch,Task
             ${{ inputs.extra_claude_args }}
           # 使用権限をWorkflow上にも列挙し、動的promptから権限を拡張させない。


### PR DESCRIPTION
#1460 の続き。診断がログへ出るようになったので、**5 本連続で「何も commit せずに正常終了」していた原因が確定しました。**

## 原因

```
subtype=success is_error=false turns=76 permission_denials=22
claude-denial: 10 tool=WebFetch parameters=[prompt, url]
claude-denial: 12 tool=Write   parameters=[content, file_path]
claude-denial: 13 tool=Edit    parameters=[file_path, new_string, old_string, replace_all]
claude-denial: 17 tool=Bash    parameters=[command, dangerouslyDisableSandbox, description]
（残りはほぼ Bash。合計 22 件）
```

**`Write` と `Edit` が拒否されている** — つまり **ファイルを書く手段が 1 つも無い状態で走らせていました**。Claude は作業できず、`subtype=success` のまま引き返すしかなかった。turn 切れ（上限 150 に対して 76）でも利用上限でもありません。

Action は SHA で固定していますが、**Action が実行時に入れる Claude Code CLI は固定されていません**。拒否された `Bash` の引数に `dangerouslyDisableSandbox` が現れていることから、CLI 側の permission mode / sandbox の既定が変わったと考えられます。既定に依存している限り、同じことがいつでも再発します。

## 変更

書き込みワーカーの `claude_args` へ明示:

```yaml
--permission-mode bypassPermissions
--allowedTools Bash,Edit,Write,Read,Glob,Grep,TodoWrite,WebFetch,WebSearch,Task
```

### なぜ `acceptEdits` ではなく `bypassPermissions` なのか

当初 `acceptEdits` で出していましたが、レビュー指摘を受けて見直しました。**`acceptEdits` では足りません。**

- `acceptEdits` が自動承認するのは **ファイル編集だけ**。`Bash` は確認を求めるので、**非対話実行（確認する人が居ない）では結局すべて拒否**になります。実際の拒否 22 件の大半が `Bash` でした
- `dangerouslyDisableSandbox` の存在は「**サンドボックス外への昇格**」という別の承認軸があることを示します。`git push` も `pnpm install` もネットワークが要るので必ずそこへ来ますが、`--allowedTools Bash` は「Bash というツール」を許すだけで、この昇格までは前もって承認できません

そして **`--allowedTools Bash` を入れた時点で任意の Bash を許している**ので、`acceptEdits` と `bypassPermissions` の差は実質的にセキュリティの差ではなく**信頼性の差**でしかありません。`--allowedTools` は CLI が `--permission-mode` の綴りを変えたときの保険として残しています。

### 影響範囲は 3 つで閉じています

1. 使い捨ての GitHub ホストランナー上でしか動かない
2. GitHub 側でできることは job の `permissions:` と `additional_permissions` が決める（**ここは 1 行も緩めていません**。`contents: write` は元から付いています）
3. 触れるブランチは `CLAUDE_BRANCH` で作業ブランチに固定

**`observe`（読み取りワーカー）は 1 行も触っていません。** 読み取り専用のままです。

## そのほか

- なぜ既定に頼らないのかを、ステップ直前のコメントとして残しました
- `parallel-development/CORE.md` へ実例と、一般化した教訓 **「ワーカーが同じ形で 2 本続けて手ぶらで帰ってきたら、プロンプトを疑う前に権限を疑う」** を追加

## 確認状況

- workflow の YAML パース: 成功
- **`extra_claude_args` へ同じフラグを渡した最小プローブ run を実行中**です（使い捨てブランチへファイルを 1 つ作って commit・push するだけ）。`--permission-mode bypassPermissions` が実際に効くことを、本番タスクを賭けずに確認してからマージするのが安全です
- プローブの結果はこの PR へ追記します