### PR TITLE
fix(manual-correction): STRUCT配列クエリパラメータの不正な使い方を修正

### DIFF
--- a/scripts/20251213T0000_wikidata_food_graph/581_relevance_scoring/manual/_common.py
+++ b/scripts/20251213T0000_wikidata_food_graph/581_relevance_scoring/manual/_common.py
@@ -162,31 +162,32 @@ def fetch_existing_run_keys(client: bigquery.Client, run_id: str) -> set:
 def fetch_current_catalog_scores(
     client: bigquery.Client, keys: List[tuple]
 ) -> Dict[tuple, Dict[str, Any]]:
-    """(item_qid, feature_type, feature_key) をキーに、現行 catalog の score/run_id/source を返す。"""
+    """(item_qid, feature_type, feature_key) をキーに、現行 catalog の score/run_id/source を返す。
+
+    google-cloud-bigquery の ArrayQueryParameter は STRUCT 要素型を素の dict では
+    受け付けない（400 Invalid value for type: STRUCT<...> is not a valid value）ため、
+    item_qid だけを配列パラメータで絞り込み、(feature_type, feature_key) の一致は
+    Python側でフィルタする。manual correctionは少数件のバッチが前提のため、
+    この程度の絞り込み不足は問題にならない。
+    """
     if not keys:
         return {}
+    item_qids = sorted({qid for qid, _, _ in keys})
     query = f"""
         SELECT item_qid, feature_type, feature_key, score, source, run_id, updated_at
         FROM `{CATALOG_FEATURES_TABLE}`
-        WHERE (item_qid, feature_type, feature_key) IN (
-            SELECT AS STRUCT * FROM UNNEST(@keys)
-        )
+        WHERE item_qid IN UNNEST(@qids)
     """
-    struct_keys = [
-        {"item_qid": qid, "feature_type": ft, "feature_key": fk} for qid, ft, fk in keys
-    ]
     job_config = bigquery.QueryJobConfig(
-        query_parameters=[
-            bigquery.ArrayQueryParameter(
-                "keys",
-                "STRUCT<item_qid STRING, feature_type STRING, feature_key STRING>",
-                struct_keys,
-            )
-        ]
+        query_parameters=[bigquery.ArrayQueryParameter("qids", "STRING", item_qids)]
     )
+    wanted = set(keys)
     result: Dict[tuple, Dict[str, Any]] = {}
     for row in client.query(query, job_config=job_config).result():
-        result[(row.item_qid, row.feature_type, row.feature_key)] = {
+        key = (row.item_qid, row.feature_type, row.feature_key)
+        if key not in wanted:
+            continue
+        result[key] = {
             "score": row.score,
             "source": row.source,
             "run_id": row.run_id,


### PR DESCRIPTION
## Summary

#1383 の manual correction 基盤（PR #1456）を `db-script-run.yml` 経由で実際に実行したところ、`manual/1_insert_feature_scores.py --dry-run` の before/after preview 表示部分で以下のエラーが発生した。

```
google.api_core.exceptions.BadRequest: 400 POST https://bigquery.googleapis.com/bigquery/v2/projects/food-scroll/jobs?prettyPrint=false:
Invalid value for type: STRUCT<item_qid STRING, feature_type STRING, feature_key STRING> is not a valid value
```

実行ログ: https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/32403697164

## 原因

`_common.py` の `fetch_current_catalog_scores` が `bigquery.ArrayQueryParameter` に `STRUCT<...>` 要素型を指定し、値として素の `dict` のリストを渡していたが、google-cloud-bigquery の `ArrayQueryParameter` はSTRUCT要素型を素のdictでは受け付けない。

## 修正内容

`(item_qid, feature_type, feature_key)` のタプルでの絞り込みをやめ、`item_qid` のみを `STRING` 配列パラメータで絞り込み、`(feature_type, feature_key)` の一致はPython側でフィルタする方式に変更した。manual correctionは少数件のバッチが前提のため、この程度の絞り込み不足（対象item_qidに紐づく他featureも取得すること）は実用上問題にならない。

他の manual/ スクリプト（`2_merge_feature_scores.py`、`sql/merge_feature_scores_by_run_id.sql`）にはSTRUCT配列パラメータの使用箇所は無いことを確認済み。

## Test plan

- [x] `python3 -m py_compile` で構文確認
- [ ] マージ後、`db-script-run.yml` で `manual/1_insert_feature_scores.py --dry-run` を再実行し、before/after previewが正常に表示されることを確認する

---
_Generated by [Claude Code](https://claude.ai/code/session_01T78V5RZDWRj4tRzSzc8Rwg)_