### PR TITLE
#1383 9_1〜9_4 sync scripts に非対話実行用の --yes を追加

### DIFF
--- a/scripts/20251213T0000_wikidata_food_graph/9_1_sync_dish_categories.py
+++ b/scripts/20251213T0000_wikidata_food_graph/9_1_sync_dish_categories.py
@@ -308,7 +308,14 @@ def main():
         default='/tmp',
         help='Output directory for dry-run summary'
     )
-    
+    parser.add_argument(
+        '--yes',
+        action='store_true',
+        help='Skip the interactive (y/N) confirmation for --schema public. '
+             'Required for non-interactive environments (e.g. GitHub Actions), '
+             'where input() would otherwise raise EOFError. Has no effect for --schema dev.'
+    )
+
     args = parser.parse_args()
     
     # 環境変数チェック
@@ -327,8 +334,8 @@ def main():
     # PostgreSQL 接続初期化
     pg_conn = PostgreSQLConnection(database_url, args.schema)
     
-    # スキーマバリデーション
-    if not pg_conn.validate_schema(require_confirmation=True):
+    # スキーマバリデーション（--yes 指定時のみ public の対話確認をスキップする）
+    if not pg_conn.validate_schema(require_confirmation=not args.yes):
         sys.exit(1)
     
     # BigQuery Loader 初期化

--- a/scripts/20251213T0000_wikidata_food_graph/9_2_sync_dish_category_features.py
+++ b/scripts/20251213T0000_wikidata_food_graph/9_2_sync_dish_category_features.py
@@ -18,6 +18,10 @@ python3 9_2_sync_dish_category_features.py --schema dev
 # ドライラン
 python3 9_2_sync_dish_category_features.py --schema dev --dry-run
 
+# public（本番）は対話確認 (y/N) を要求する。GitHub Actions 等の非対話環境では
+# input() が即 EOFError になるため、明示的に --yes を渡した場合のみ確認をスキップする。
+python3 9_2_sync_dish_category_features.py --schema public --yes
+
 【環境変数】
 - DATABASE_URL: PostgreSQL 接続文字列（必須）
 """
@@ -168,7 +172,14 @@ def main():
         default='/tmp',
         help='Output directory for dry-run summary'
     )
-    
+    parser.add_argument(
+        '--yes',
+        action='store_true',
+        help='Skip the interactive (y/N) confirmation for --schema public. '
+             'Required for non-interactive environments (e.g. GitHub Actions), '
+             'where input() would otherwise raise EOFError. Has no effect for --schema dev.'
+    )
+
     args = parser.parse_args()
     
     # 環境変数チェック
@@ -187,8 +198,8 @@ def main():
     # PostgreSQL 接続初期化
     pg_conn = PostgreSQLConnection(database_url, args.schema)
     
-    # スキーマバリデーション
-    if not pg_conn.validate_schema(require_confirmation=True):
+    # スキーマバリデーション（--yes 指定時のみ public の対話確認をスキップする）
+    if not pg_conn.validate_schema(require_confirmation=not args.yes):
         sys.exit(1)
     
     # BigQuery Loader 初期化

--- a/scripts/20251213T0000_wikidata_food_graph/9_3_sync_dish_category_localized_text.py
+++ b/scripts/20251213T0000_wikidata_food_graph/9_3_sync_dish_category_localized_text.py
@@ -155,7 +155,14 @@ def main():
         default='/tmp',
         help='Output directory for dry-run summary'
     )
-    
+    parser.add_argument(
+        '--yes',
+        action='store_true',
+        help='Skip the interactive (y/N) confirmation for --schema public. '
+             'Required for non-interactive environments (e.g. GitHub Actions), '
+             'where input() would otherwise raise EOFError. Has no effect for --schema dev.'
+    )
+
     args = parser.parse_args()
     
     # 環境変数チェック
@@ -174,8 +181,8 @@ def main():
     # PostgreSQL 接続初期化
     pg_conn = PostgreSQLConnection(database_url, args.schema)
     
-    # スキーマバリデーション
-    if not pg_conn.validate_schema(require_confirmation=True):
+    # スキーマバリデーション（--yes 指定時のみ public の対話確認をスキップする）
+    if not pg_conn.validate_schema(require_confirmation=not args.yes):
         sys.exit(1)
     
     # BigQuery Loader 初期化

--- a/scripts/20251213T0000_wikidata_food_graph/9_4_sync_dish_category_variants.py
+++ b/scripts/20251213T0000_wikidata_food_graph/9_4_sync_dish_category_variants.py
@@ -163,7 +163,14 @@ def main():
         default='/tmp',
         help='Output directory for dry-run summary'
     )
-    
+    parser.add_argument(
+        '--yes',
+        action='store_true',
+        help='Skip the interactive (y/N) confirmation for --schema public. '
+             'Required for non-interactive environments (e.g. GitHub Actions), '
+             'where input() would otherwise raise EOFError. Has no effect for --schema dev.'
+    )
+
     args = parser.parse_args()
     
     # 環境変数チェック
@@ -182,8 +189,8 @@ def main():
     # PostgreSQL 接続初期化
     pg_conn = PostgreSQLConnection(database_url, args.schema)
     
-    # スキーマバリデーション
-    if not pg_conn.validate_schema(require_confirmation=True):
+    # スキーマバリデーション（--yes 指定時のみ public の対話確認をスキップする）
+    if not pg_conn.validate_schema(require_confirmation=not args.yes):
         sys.exit(1)
     
     # BigQuery Loader 初期化


### PR DESCRIPTION
## Summary

Issue #1383 の manual correction を production（`--schema public`）へ反映するために必要な変更。

- `9_1_sync_dish_categories.py` / `9_2_sync_dish_category_features.py` / `9_3_sync_dish_category_localized_text.py` / `9_4_sync_dish_category_variants.py` に `--yes` フラグを追加
- `--schema public` は既存どおり対話確認（y/N）を要求するが、GitHub Actions 等の非対話環境では `input()` が即 `EOFError` になり実行できない
- `--yes` を明示的に渡した場合のみ確認をスキップする。デフォルト動作（対話確認あり）は変更しない
- 4スクリプトとも同一の `validate_schema(require_confirmation=True)` パターンを持っていたため、一貫して同じ変更を適用した

## Test plan

- [x] 4ファイルとも `git diff` で差分を目視確認（同一パターンの機械的な追加のみ）
- [ ] `.github/workflows/db-script-run.yml` から `9_2_sync_dish_category_features.py --schema public --yes` を実行し、production反映を確認（このPRマージ後に実施）

---
_Generated by [Claude Code](https://claude.ai/code/session_01T78V5RZDWRj4tRzSzc8Rwg)_