### PR TITLE
#1383 docs: dish-feature-correctionスキルとrunbookをproduction反映の実績に更新

### DIFF
--- a/.claude/skills/dish-feature-correction/APPLY.md
+++ b/.claude/skills/dish-feature-correction/APPLY.md
@@ -52,10 +52,8 @@ input_file_path / input_file_content: --input-jsonl 等でファイル入力が�
 
 ## 3. dev sync まで
 
-`step: sync-dev`（内部で `9_2_sync_dish_category_features.py --schema dev`）を
-dry-run → 本実行の順で行う。`--schema public`（本番）はこの workflow からは
-実行できない。本番反映は `manual/README.md` の「production 反映手順」を参照し、
-別途 `db-migrate.yml` に準じた承認フローを用意してから行う。
+`script_path: .../9_2_sync_dish_category_features.py`, `args: --schema dev` を
+dry-run → 本実行の順で行う。
 
 ## 4. recommendation regression
 
@@ -87,3 +85,17 @@ BigQuery/DB への直接アクセスしか無い環境では、少なくとも
 - BigQuery / PostgreSQL dev への反映が完了したか（run_id、workflow run のリンク）
 - recommendation regression をどこまで確認できたか（できなかった場合はその理由も明記）
 - production 反映がまだの場合、それも明記する（「完了した」と書かない）
+
+## 6. production 反映
+
+dev で問題ないことを確認し、5節の記録が済んだら、`args` に
+`--schema public --dry-run --yes` → `--schema public --yes` の順で実行する。
+`--yes` を付けないと `validate_schema` の対話確認（y/N）で `input()` が
+`EOFError` になり失敗する（GitHub Actionsに標準入力が無いため）。`--yes` は
+この対話確認をスキップするだけで、他の安全策（GCSバックアップ、dry-runでの
+件数確認）は変わらない。詳細は `manual/README.md` の「production 反映手順」を参照。
+
+recommendation regression（4節）を省略したまま production へ進める判断は、
+このスキル自身では下さない。Issueのオーナー等、判断できる人間の明示的な指示が
+あった場合のみ、5節の記録に「regression未実施のまま production へ進めた」ことを
+明記した上で進める。

--- a/.claude/skills/dish-feature-correction/SKILL.md
+++ b/.claude/skills/dish-feature-correction/SKILL.md
@@ -27,7 +27,8 @@ Issue #1383（`dining_pace:quick` で焼き鳥が過大評価されていた件�
 | APPLY.md | manual/ scripts・GitHub Actions の使い方、検証、rollback | 判断基準そのもの |
 
 補正が必要な行の実データ書き込みは、このリポジトリの他の DB 変更と同様
-GitHub Actions（`.github/workflows/manual-feature-correction.yml`）から行う。
+GitHub Actions（`.github/workflows/db-script-run.yml`、`scripts/` 配下の任意の
+Python スクリプトを `script_path` + `args` で実行できる汎用ランナー）から行う。
 ローカル/対話セッションから直接 BigQuery Python client や `DATABASE_URL` を叩く運用は
 想定していない（資格情報を対話セッションに置かないため）。
 
@@ -64,6 +65,17 @@ Issue に調査結果・判断根拠・before/after を記録する（次回の�
   **scripts側の詳細な運用ルール（phase=manualの優先順位、rollback、production反映）は
   `manual/README.md` が正なので、そちらを読むこと。APPLY.md はそこに無い
   「スキルとしての判断ポイント」だけを補う。**
+- `9_1〜9_4` の sync scripts は `--schema public`（本番）実行時に対話確認（y/N）を
+  要求するが、`db-script-run.yml`（GitHub Actions、非対話環境）では `input()` が
+  即 `EOFError` になり実行できない。`--yes` を明示的に渡した場合のみ確認をスキップする
+  （#1383 で追加。デフォルトの対話確認は変更していない）。production 反映は
+  `args: --schema public --yes` を指定する。
+- `9_2_sync_dish_category_features.py`（および他の `9_X` sync scripts）は反映前に
+  必ず GCS（`gs://nanitabeyo-private/system/PostgreSQL/csv_export/`）へバックアップを
+  取る安全設計になっている。manual correction 専用の書き込みSAには、BigQueryの権限
+  （`roles/bigquery.jobUser` + 対象datasetの `dataEditor`）だけでなく、この GCS
+  パスへの書き込み権限（`roles/storage.objectCreator` 等）も必要（#1458 で判明・対応済み）。
+  新しい書き込みSAを作る場合はこの2種類の権限を両方付与すること。
 - feature score を変えても最終表示は同じ比率で動かない
   （`rel_score × market_salience補正 × dine_out_orderability補正 = final_score`、
   `× jitter = order_score`、2〜6枚目はさらに diversity penalty がかかる）。

--- a/scripts/20251213T0000_wikidata_food_graph/581_relevance_scoring/manual/README.md
+++ b/scripts/20251213T0000_wikidata_food_graph/581_relevance_scoring/manual/README.md
@@ -191,11 +191,19 @@ rubric 修正（例: `866_dining_pace/dining_pace_prompt.md` の更新）とセ�
 ## GitHub Actions（`db-script-run.yml`）
 
 `DATABASE_URL` や GCP サービスアカウント資格情報をローカル/対話セッションに置かない運用のため、
-insert / merge / 9_2 sync dev は `.github/workflows/db-script-run.yml` の
+insert / merge / 9_2 sync（dev・public とも）は `.github/workflows/db-script-run.yml` の
 workflow_dispatch から実行する。このworkflowは特定のスクリプト専用ではなく、
-`scripts/` 配下の Python スクリプトを `script_path` + `args` で指定して実行する汎用ランナー
-（`secrets.GCP_SA_KEY` / `secrets.POSTGRES_DATABASE_URL` を使う点は
-`db-migrate.yml` / `pg-table-export.yml` 等の既存workflowと同じ）。
+`scripts/` 配下の Python スクリプトを `script_path` + `args` で指定して実行する汎用ランナー。
+
+BigQuery 認証は、4本のworkflowで共用されている静的キー `secrets.GCP_SA_KEY` ではなく、
+`error-triage.yml` と同じ WIF（`google-github-actions/auth`）方式で、このworkflow専用の
+`feature-correction-writer@food-scroll.iam.gserviceaccount.com`（`secrets.GCP_WIF_PROVIDER` +
+`secrets.GCP_FEATURE_CORRECTION_SERVICE_ACCOUNT`）を使う（#1458）。このSAには
+`roles/bigquery.jobUser`（プロジェクト）と `wikidata_food_graph` データセットのみへの
+`roles/bigquery.dataEditor` に加えて、`9_X` sync scripts が反映前に必ず行う GCS バックアップ
+（`gs://nanitabeyo-private/system/PostgreSQL/csv_export/`）のための
+`roles/storage.objectCreator`（同バケットの当該prefixへの条件付き付与）も必要。
+PostgreSQL 側は `secrets.POSTGRES_DATABASE_URL`（`db-migrate.yml` 等と共通）を使う。
 
 ```text
 script_path: scripts/20251213T0000_wikidata_food_graph/581_relevance_scoring/manual/1_insert_feature_scores.py
@@ -208,13 +216,16 @@ input_file_content: |
 
 `2_merge_feature_scores.py` を実行する場合は `input_file_path` / `input_file_content` は不要で、
 `args` に `--run-id <id> --dry-run`（確認後 `--apply`）を渡すだけでよい。
-`9_2_sync_dish_category_features.py` を実行する場合は
-`script_path: scripts/20251213T0000_wikidata_food_graph/9_2_sync_dish_category_features.py`、
-`args: --schema dev --dry-run`（確認後 `--schema dev`）を渡す。
-`--schema public`（本番）を指定すること自体はこのworkflowでは止めていないが、
-`validate_schema(require_confirmation=True)` が対話入力を要求するため、
-CI上では標準入力が無く失敗する。本番反映は別途 `db-migrate.yml` 相当の承認フローを
-用意し、非対話で完了できるようにしてから行うこと。
+`9_1〜9_4` の sync scripts を実行する場合は
+`script_path: scripts/20251213T0000_wikidata_food_graph/9_2_sync_dish_category_features.py`
+（他の`9_X`も同様）、`args: --schema dev --dry-run`（確認後 `--schema dev`）を渡す。
+
+`--schema public`（本番）は `validate_schema(require_confirmation=True)` により既定で
+対話確認（y/N）を要求するが、GitHub Actions には標準入力が無いため `input()` が即
+`EOFError` になり実行できない。明示的に `--yes` を渡した場合のみこの確認をスキップする
+（例: `args: --schema public --dry-run --yes` → `args: --schema public --yes`）。
+`--yes` を付けなければ従来どおり対話確認が必須のままなので、誤って `public` を
+指定しただけでは実行されない。
 
 まず `args` に `--dry-run` を付けて実行して出力（Job Summary / ログ）を確認し、
 問題なければ `--dry-run` を外して（`2_merge_feature_scores.py` は `--apply` に差し替えて）
@@ -258,12 +269,18 @@ python3 scripts/20251213T0000_wikidata_food_graph/9_2_sync_dish_category_feature
 
 1. dev で `9. API / recommendation の accuracy regression` を通し、問題がないことを確認する
 2. Issue に before/after・判断根拠を記録する（このrunbookの受入条件）
-3. `9_2_sync_dish_category_features.py --schema public` を実行する
-   （このリポジトリでは `public` = 本番。実行は対話確認 `y` の入力を要求される。
-   `manual-feature-correction.yml` の `step: sync-dev` は public を意図的にサポートしない。
-   本番反映は `db-migrate.yml` に準じた承認フロー・別途の workflow を用意してから行うこと。
-   BigQuery `dish_category_features_catalog` 自体は dev/public で分かれていない
-   （catalog は共通の採用版）ため、BigQuery側のMERGEは dev/prod 反映より前に完了している）
+3. `db-script-run.yml` で `script_path: .../9_2_sync_dish_category_features.py`、
+   `args: --schema public --dry-run --yes` を実行し、件数が期待どおりか確認する
+4. 問題なければ同じ `script_path` で `args: --schema public --yes` を実行する
+   （`--yes` を付けないと対話確認で `EOFError` になり失敗する。GCSバックアップ→
+   全削除→全INSERTという安全策自体は dev と同じ）
+   （このリポジトリでは `public` = 本番。BigQuery `dish_category_features_catalog`
+   自体は dev/public で分かれていない（catalog は共通の採用版）ため、
+   BigQuery側のMERGEは dev/prod 反映より前に完了している）
+
+recommendation regression（手順1）を省略したまま production へ進めるのは、
+Issueのオーナー等、判断できる人間の明示的な指示がある場合に限る。その場合も
+「regression未実施のまま反映した」ことを Issue に明記すること。
 
 ## recommendationへの影響確認
 


### PR DESCRIPTION
## Summary

このセッションでdining_pace:quickの実データ反映をdev→productionまで完了させた際に判明した以下を、`.claude/skills/dish-feature-correction/`と`manual/README.md`へ反映する。

- workflow名の更新: `manual-feature-correction.yml`（廃止済み） → `db-script-run.yml`（汎用ランナー）
- **誤った記述の修正**: 「production(`--schema public`)はこのworkflowから非対話実行できない」は誤り。`9_2_sync_dish_category_features.py`（および`9_1`/`9_3`/`9_4`）に追加した`--yes`フラグ（PR #1466）により、`db-script-run.yml`からproductionまで実行できることを実際に確認済み
- 書き込み専用SA(`feature-correction-writer`)には、BigQuery権限だけでなくGCSバケット(`nanitabeyo-private/system/PostgreSQL/csv_export/`)への`storage.objectCreator`も必要（#1458で判明・対応済み）だったことを明記
- recommendation regressionを省略してproductionへ進める場合の扱いを明文化（人間の明示的指示がある場合のみ、未実施である旨をIssueに記録する）

## Test plan

- [x] 3ファイルとも既存の記述と矛盾しないよう`git diff`で確認
- ドキュメントのみの変更のため、動作確認は不要

---
_Generated by [Claude Code](https://claude.ai/code/session_01T78V5RZDWRj4tRzSzc8Rwg)_