### PR TITLE
#1383 docs: recommendation regressionの省略容認を撤回

### DIFF
--- a/.claude/skills/dish-feature-correction/APPLY.md
+++ b/.claude/skills/dish-feature-correction/APPLY.md
@@ -95,7 +95,11 @@ dev で問題ないことを確認し、5節の記録が済んだら、`args` �
 この対話確認をスキップするだけで、他の安全策（GCSバックアップ、dry-runでの
 件数確認）は変わらない。詳細は `manual/README.md` の「production 反映手順」を参照。
 
-recommendation regression（4節）を省略したまま production へ進める判断は、
-このスキル自身では下さない。Issueのオーナー等、判断できる人間の明示的な指示が
-あった場合のみ、5節の記録に「regression未実施のまま production へ進めた」ことを
-明記した上で進める。
+recommendation regression（4節）は production 反映前に**必ず完了させる**。
+「エージェントがlive APIへアクセスできないから省略する」は許容しない。
+このスキル/エージェント自身がlive API regressionを実行できない環境では、
+Issueのオーナー等、人間に regression を実施してもらい、「誰が・何を確認し・
+問題なしと判断したか」を Issue に記録してもらってから production へ進める。
+確認の実行者が人間に変わるだけで、確認そのものを省略してよいことには
+ならない。5節の記録には、regression をエージェントが実行したか人間が実行したかを
+明記し、「未実施のまま進めた」という記録は残さない。

--- a/scripts/20251213T0000_wikidata_food_graph/581_relevance_scoring/manual/README.md
+++ b/scripts/20251213T0000_wikidata_food_graph/581_relevance_scoring/manual/README.md
@@ -278,9 +278,12 @@ python3 scripts/20251213T0000_wikidata_food_graph/9_2_sync_dish_category_feature
    自体は dev/public で分かれていない（catalog は共通の採用版）ため、
    BigQuery側のMERGEは dev/prod 反映より前に完了している）
 
-recommendation regression（手順1）を省略したまま production へ進めるのは、
-Issueのオーナー等、判断できる人間の明示的な指示がある場合に限る。その場合も
-「regression未実施のまま反映した」ことを Issue に明記すること。
+recommendation regression（手順1）は production 反映前に**必ず完了させる**。
+「実行エージェントがlive APIへアクセスできないから省略する」は許容しない。
+エージェント自身がlive API regressionを実行できない環境では、Issueのオーナー等の
+人間に regression を実施してもらい、「誰が・何を確認し・問題なしと判断したか」を
+Issue に記録してもらってから production へ進める。確認の実行者が人間に変わるだけで、
+確認そのものを省略してよいことにはならない。
 
 ## recommendationへの影響確認
 


### PR DESCRIPTION
## Summary

PR #1467 で追加した「人間の明示的指示があれば regression 未実施のまま production へ進めてよい」という記述は、regression要件を実質的に弱めてしまっていたため撤回する。

- regression は production 反映前に必ず完了させる、という原則を維持する
- エージェントがlive APIにアクセスできない環境では、人間が regression を実施し、その結果（誰が・何を確認し・問題なしと判断したか）をIssueに記録してもらった上で進める
- 「確認の実行者が人間に変わる」ことと「確認そのものを省略する」ことは別物、という区別を明記した

## Test plan

- ドキュメントのみの変更のため、動作確認は不要

---
_Generated by [Claude Code](https://claude.ai/code/session_01T78V5RZDWRj4tRzSzc8Rwg)_