### PR TITLE
ci(claude-worker): 読み取りワーカーの成果物を「読める」ようにし、出さなければ落とす

### DIFF
--- a/.claude/skills/parallel-development/CORE.md
+++ b/.claude/skills/parallel-development/CORE.md
@@ -561,7 +561,23 @@ mcp__github__actions_list  method=list_workflow_jobs  resource_id=<run_id>
 mcp__github__get_job_logs  job_id=<書き込みワーカーのjob_id>  return_content=true  tail_lines=120
   → `claude-summary: subtype=... turns=... permission_denials=...` の行
   → `claude-denial: N tool=... parameters=[...]` の行（拒否されたツール名）
+  → `claude-result-begin:` 〜 `claude-result-end:` に挟まれた **ワーカーの最後の出力**
 ```
+
+### observe run の成果物は job のログから回収する
+
+**observe run の成果物は commit ではなく «最後に書かれたテキスト» である**（設計、レビュー、
+採用した手段とその根拠など）。この workflow は `show_full_output: false` /
+`display_report: false` で動いているので、**ワーカーが Issue へ書き残すのを忘れると、
+その run の成果はまるごと失われる**。以前は回収する手段が無かった。
+
+いまは `summarize-claude-output.sh` が最終アシスタントメッセージを stdout へ出しているので、
+`get_job_logs` で `claude-result-begin:` 〜 `claude-result-end:` を読めば回収できる
+（20000 文字で切られる。それより長い成果物は、プロンプト側で Issue コメントへ書かせること）。
+
+write run でも同じ口を使う。**「どちらの手段を採ったか」のような判断の根拠は diff に現れない**
+ので、判断を伴うタスクではプロンプトで「根拠を最後の出力に含めること」と明示し、
+ここから読むこと。
 
 判定表:
 

--- a/.github/scripts/summarize-claude-output.sh
+++ b/.github/scripts/summarize-claude-output.sh
@@ -72,6 +72,7 @@ echo "claude-summary: subtype=$SUBTYPE is_error=$IS_ERROR turns=$NUM_TURNS cost=
 MAX_RESULT_CHARS=20000
 RESULT_TEXT=$(jq -r '[.[] | select(.type == "result")] | last | (.result // "")' "$TMP_EVENTS")
 
+RESULT_CHARS=0
 if [[ -n "$RESULT_TEXT" ]]; then
   RESULT_CHARS=${#RESULT_TEXT}
   echo "claude-result-begin: chars=$RESULT_CHARS truncated_to=$MAX_RESULT_CHARS"
@@ -95,6 +96,9 @@ if [[ -n "${GITHUB_ENV:-}" ]]; then
     echo "CLAUDE_IS_ERROR=$IS_ERROR"
     echo "CLAUDE_NUM_TURNS=$NUM_TURNS"
     echo "CLAUDE_DENIALS=$DENIALS"
+    # observe run の「成果物を出したか」検証（write の commit 検証に相当）が読む。
+    # 0 なら «最後まで走ったのに何も書かずに終わった» ということ
+    echo "CLAUDE_RESULT_CHARS=${RESULT_CHARS:-0}"
   } >> "$GITHUB_ENV"
 fi
 

--- a/.github/scripts/summarize-claude-output.sh
+++ b/.github/scripts/summarize-claude-output.sh
@@ -51,6 +51,43 @@ DENIALS=$(jq -r '[.[] | select(.type == "result")] | last | (.permission_denials
 # 機密情報は増えない。
 echo "claude-summary: subtype=$SUBTYPE is_error=$IS_ERROR turns=$NUM_TURNS cost=$COST permission_denials=$DENIALS"
 
+# ⚠️ **ワーカーの «最後の出力» を job のログへ出す。**
+#
+# observe run の成果物は commit ではなく «最後に書かれたテキスト» そのものである
+# （設計、レビュー、A/B の適合判定など）。ところがこの workflow は
+# `show_full_output: false` / `display_report: false` で動いており、集計値以外は
+# どこにも出ていなかった。そのため **ワーカーが Issue へ書き残すのを忘れた瞬間に、
+# その run の成果はまるごと失われ、リーダーには回収する手段が無かった**。
+# write run でも同じで、「どちらの手段を採ったか」のような判断の根拠は
+# diff には現れないため、ここを通さないとリーダーへ届かない。
+#
+# Step Summary ではなく **stdout** へ出すのは、Step Summary が GitHub の API から
+# 読めないためである（上の claude-summary と同じ理由）。
+#
+# 安全性について:
+#   - 出しているのは «最終アシスタントメッセージ» だけで、tool_use / tool_result の
+#     本文（Bash のコマンドや読み取ったファイルの中身）は含まない。
+#   - Actions は登録済み secrets をログ上でマスクする。
+#   - それでも無制限に出すとログが読めなくなるので 20000 文字で切る。
+MAX_RESULT_CHARS=20000
+RESULT_TEXT=$(jq -r '[.[] | select(.type == "result")] | last | (.result // "")' "$TMP_EVENTS")
+
+if [[ -n "$RESULT_TEXT" ]]; then
+  RESULT_CHARS=${#RESULT_TEXT}
+  echo "claude-result-begin: chars=$RESULT_CHARS truncated_to=$MAX_RESULT_CHARS"
+  printf '%s\n' "${RESULT_TEXT:0:$MAX_RESULT_CHARS}"
+  if (( RESULT_CHARS > MAX_RESULT_CHARS )); then
+    echo "…（$((RESULT_CHARS - MAX_RESULT_CHARS)) 文字を省略しました）"
+  fi
+  echo "claude-result-end:"
+else
+  # ここが出るのは «最後まで走ったのに何も書かずに終わった» とき。
+  # observe run ではそれ自体が失敗なので、リーダーが気付けるようにしておく。
+  echo "claude-result-begin: chars=0 truncated_to=$MAX_RESULT_CHARS"
+  echo "（最終アシスタントメッセージが空でした）"
+  echo "claude-result-end:"
+fi
+
 # 後続ステップ（commit検証）が失敗メッセージへ埋め込めるようにする
 if [[ -n "${GITHUB_ENV:-}" ]]; then
   {

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -244,6 +244,27 @@ jobs:
           CLAUDE_EXECUTION_OUTPUT: ${{ steps.claude.outputs.execution_file }}
         run: bash .claude-worker-trusted/.github/scripts/summarize-claude-output.sh
 
+      # 読み取りワーカーの «成果物を出したか» 検証。書き込みワーカーの
+      # 「commit・pushされたことを検証」に相当するものが、こちらには無かった。
+      #
+      # 2026-08-20、#1400 の設計runが **19分走って `success` のままコメントを1つも投稿せずに終了**した。
+      # observeの成果物は commit ではなく «最後に書かれたテキスト» なので、
+      # 何も書かずに終わっても誰も気付けず、リーダーは «成功した» と受け取ってしまう。
+      # 実際にはその19分ぶんのトークンが丸ごと無駄になっていた。
+      #
+      # ここでは «最終アシスタントメッセージが空» だけを失敗とする。Issue へ投稿したかどうかまでは
+      # 見ない（投稿の要否はプロンプト次第で、ここで一律に強制すると調査だけを頼んだrunまで赤くなる）。
+      # 空でなければ中身は job ログの `claude-result-begin:` 〜 `claude-result-end:` から回収できる。
+      - name: 成果物が出力されたことを検証
+        if: always()
+        shell: bash
+        run: |
+          if [[ "${CLAUDE_RESULT_CHARS:-0}" -eq 0 ]]; then
+            echo "::error::読み取りワーカーが成果物を1文字も出力せずに終了しました。observeの成果物は commit ではなく «最後に書かれたテキスト» なので、これは成功ではありません。 [subtype=${CLAUDE_SUBTYPE:-unknown} is_error=${CLAUDE_IS_ERROR:-unknown} turns=${CLAUDE_NUM_TURNS:-unknown} permission_denials=${CLAUDE_DENIALS:-unknown}] 拒否されたツール名はjobログの 'claude-denial:' 行を見ること。"
+            exit 1
+          fi
+          echo "成果物を確認しました（${CLAUDE_RESULT_CHARS} 文字）。本文は job ログの 'claude-result-begin:' 〜 'claude-result-end:' にあります。"
+
       - name: テストエビデンスを保存
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## 直したい事故

**observe run の成果物は commit ではなく «最後に書かれたテキスト» そのもの**（設計・レビュー・採用した手段とその根拠）である。ここに穴が 2 つ空いていた。

1. **読めない** — `claude-worker.yml` は `show_full_output: false` / `display_report: false` で動いており、集計値（`claude-summary:`）以外はどこにも出ていなかった。ワーカーが Issue へ書き残すのを忘れた瞬間に、その run の成果はまるごと失われ、リーダーには回収する手段が無かった
2. **出さなくても緑になる** — 書き込みワーカーには「commit・pushされたことを検証」があるが、読み取りワーカーには相当するものが無い。**何も書かずに終わっても `success` になる**

2026-08-20、#1400 の設計 run が **19 分走って `success` のままコメントを 1 つも投稿せずに終了**した。リーダーはこれを「成功した」と受け取り、その 19 分ぶんのトークンが丸ごと無駄になっている。この PR は 2 つとも塞ぐ。

## 1. 読めるようにする（`summarize-claude-output.sh`）

最終アシスタントメッセージ（`result` イベントの `.result`）を `claude-result-begin:` 〜 `claude-result-end:` で囲って **stdout** へ出す。

Step Summary ではなく stdout なのは、Step Summary が GitHub の API から読めず、リーダーの手が届くのが job のログだけだからである（既存の `claude-summary:` とまったく同じ理由で、その経緯はスクリプト内のコメントに残っている）。

スクリプトは observe / write の両ジョブから同じものが呼ばれているので、**write run にも同時に効く**。「A と B のどちらの手段を採ったか」のような判断の根拠は diff に現れないため、ここを通さないとリーダーへ届かない。

### 安全性

- 出すのは**最終アシスタントメッセージだけ**で、`tool_use` / `tool_result` の本文（Bash のコマンドや読み取ったファイルの中身）は含まない
- Actions は登録済み secrets をログ上でマスクする
- 無制限に出すとログが読めなくなるので **20000 文字で切る**（超過分は文字数だけ表示）

## 2. 出さなければ落とす（`claude-worker.yml` の observe ジョブ）

スクリプトが最終メッセージの文字数を `CLAUDE_RESULT_CHARS` として `GITHUB_ENV` へ出し、observe ジョブに新設した「成果物が出力されたことを検証」ステップが **0 なら job を失敗させる**。エラー行には既存の commit 検証と同じ診断値（`subtype` / `is_error` / `turns` / `permission_denials`）を埋め込むので、そのまま切り分けへ進める。

**«Issue へ投稿したか» までは見ない。** 投稿の要否はプロンプト次第で、ここで一律に強制すると調査だけを頼んだ run まで赤くなる。空でなければ中身は job ログから回収できるので、検証は「1 文字も書かずに終わっていないか」に留める。

write ジョブは触っていない（あちらは既存の commit 検証がこの役割を果たしている）。

## 検証

実行結果 JSON のフィクスチャ 2 通りでスクリプトを実際に走らせて確認した。

| ケース | stdout | `GITHUB_ENV` |
| --- | --- | --- |
| `result` あり | `claude-result-begin: chars=106 truncated_to=20000` → 本文 → `claude-result-end:` | `CLAUDE_RESULT_CHARS=106` |
| `result` 無し（`error_max_turns`） | `chars=0` と「最終アシスタントメッセージが空でした」 | `CLAUDE_RESULT_CHARS=0` |

`result` 無しのケースでは既存の `::warning::max_turns` も従来どおり出る。`bash -n` の構文検査と、workflow の YAML パースも通している。

## あわせて

`parallel-development` スキルの診断手順に、**この口から observe run の成果物を回収する**節を追記した。判断を伴うタスクではプロンプト側で「根拠を最後の出力に含めること」と明示し、ここから読む、という運用を書いてある。