### PR TITLE
ci(claude-worker): 読み取りワーカーにも bypassPermissions を付ける

### DIFF
--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -211,12 +211,30 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ inputs.prompt }}
           base_branch: ${{ inputs.base_branch || github.event.repository.default_branch }}
+          # ⚠️ 読み取りワーカーにも bypassPermissions が要る。
+          #
+          # 2026-08-21、権利面の調査を頼んだ observe run が **permission_denials=29** で
+          # 終わった。`success` かつ最終メッセージも 9546 文字あったので一見成功に見えるが、
+          # WebFetch / WebSearch が拒否されており **外部を 1 ページも見ないまま「調査」していた**。
+          # 成果物の体裁は整うので、denials を見ないと気付けない種類の失敗である。
+          #
+          # 「observe は読み取り専用だから権限は要らない」は誤りだった。ここでの
+          # «読み取り専用» は **リポジトリへ書けないこと** を指しており、それを担保するのは
+          # 下の `additional_permissions: contents: read`（＋ push ステップが無いこと）であって、
+          # ツールの許可とは別の層である。調査タスクでは外部取得こそが仕事なので、
+          # ツールを塞ぐと仕事そのものが成立しない。
+          #
+          # write 側と同じ理由で `--allowedTools` は綴り変更に対する保険として残す
+          # （bypassPermissions が効いている限り、実際に効くのは permission-mode の方）。
           claude_args: |
             --model ${{ inputs.model }}
             --max-turns ${{ inputs.max_turns }}
+            --permission-mode bypassPermissions
+            --allowedTools Bash,Edit,Write,Read,Glob,Grep,TodoWrite,WebFetch,WebSearch,Task
             ${{ inputs.extra_claude_args }}
           # Claude GitHub Appトークンの既定値はcontents: writeのため、
           # observeでは明示的にreadへ下げ、コード変更を権限レベルで防ぐ。
+          # **コード変更を防いでいるのはこの行であって、ツールの許可ではない。**
           additional_permissions: |
             contents: read
             pull_requests: write


### PR DESCRIPTION
## 直したい事故

2026-08-21、権利面の調査を頼んだ observe run が **`permission_denials=29`** で終わりました。

`success` かつ最終メッセージも 9,546 文字あったので**一見成功に見えます**。しかし `WebFetch` / `WebSearch` が拒否されており、**外部を 1 ページも見ないまま「調査」していた**ことになります。成果物の体裁だけは整うので、`permission_denials` を見ないと気付けない種類の失敗です。

## 原因

#1461 で `--permission-mode bypassPermissions` / `--allowedTools` を **write ジョブにだけ**付けたとき、「observe は読み取り専用だから要らない」と判断しました。**これが誤りでした。**

ここでの «読み取り専用» は **リポジトリへ書けないこと** を指していて、それを担保しているのは

- `additional_permissions: contents: read`
- observe ジョブに push ステップが無いこと

の 2 つであって、**ツールの許可とは別の層**です。調査タスクでは外部取得こそが仕事なので、ツールを塞ぐと仕事そのものが成立しません。

## 変更

observe ジョブの `claude_args` に write と同じ 2 行を足しました。

```
--permission-mode bypassPermissions
--allowedTools Bash,Edit,Write,Read,Glob,Grep,TodoWrite,WebFetch,WebSearch,Task
```

あわせて **「コード変更を防いでいるのは `additional_permissions` であってツール許可ではない」** ことをコメントで明示しています。同じ誤解で次に誰かがツールを絞り直すのを防ぐためです。

## 権限は広がっていません

`additional_permissions` は `contents: read` のままです。observe ジョブは今までどおり**リポジトリへ push できません**。変わるのは「ワーカーが調べ物をできるかどうか」だけです。

## 検証

- YAML パース: OK
- write ジョブは 1 行も変更していません

この修正が入ったら、拒否されたまま終わった権利調査を回し直します。

---
_Generated by [Claude Code](https://claude.ai/code/session_011PwkXTZx1eR3y5PHL2HACQ)_