### PR TITLE
fix(api): CORS_ORIGIN のワイルドカード指定を実際に効かせる

### DIFF
--- a/.github/workflows/firebase-hosting-deploy.yml
+++ b/.github/workflows/firebase-hosting-deploy.yml
@@ -93,6 +93,9 @@ jobs:
       # preview チャンネルの URL には hash が入り、既定 7 日で失効する。作り直すと
       # hash が変わるので、WEB_BASE_URL も API の CORS_ORIGIN も固定できなかった。
       # 専用サイトの live チャンネルなら https://nanitabeyo-dev.web.app で不変になる。
+      # なお CORS_ORIGIN 側だけは `https://nanitabeyo-dev--preview-*.web.app` の
+      # ワイルドカード指定に対応済み（api/src/core/config/cors-origin.ts）。
+      # WEB_BASE_URL は依然として 1 つの固定 URL しか持てないため、上の判断は変わらない。
       #
       # ## ⚠️ preview を development と同じ扱いにしないこと
       # target は 3 つある。`production 以外はすべて else` にすると、**preview を流した

--- a/api/src/core/config/cors-origin.spec.ts
+++ b/api/src/core/config/cors-origin.spec.ts
@@ -1,0 +1,110 @@
+import { parseCorsOrigins } from './cors-origin';
+
+/**
+ * `cors` パッケージ（NestJS の `enableCors` が内部で使う）の `isOriginAllowed`
+ * と同じ判定をここに写して検証する。実装は下記のとおり
+ * 「文字列は完全一致・RegExp は test」のみで、glob 展開は行わない。
+ * この前提が崩れると本番の CORS 判定も変わるため、テスト側でも明示しておく。
+ */
+function isOriginAllowed(
+  origin: string,
+  allowed: (string | RegExp)[],
+): boolean {
+  return allowed.some((a) =>
+    typeof a === 'string' ? origin === a : a.test(origin),
+  );
+}
+
+describe('parseCorsOrigins', () => {
+  it('カンマ区切りを分割し、前後の空白と空要素を落とす', () => {
+    expect(
+      parseCorsOrigins(' http://localhost:8081 , https://example.web.app ,, '),
+    ).toEqual(['http://localhost:8081', 'https://example.web.app']);
+  });
+
+  it('`*` を含まない項目は文字列のまま（完全一致）', () => {
+    const allowed = parseCorsOrigins('https://nanitabeyo-dev.web.app');
+
+    expect(allowed).toEqual(['https://nanitabeyo-dev.web.app']);
+    expect(isOriginAllowed('https://nanitabeyo-dev.web.app', allowed)).toBe(
+      true,
+    );
+    expect(
+      isOriginAllowed('https://nanitabeyo-dev.web.app.evil.com', allowed),
+    ).toBe(false);
+  });
+
+  it('`*` を含む項目は RegExp になり、preview チャンネルの URL に一致する', () => {
+    const allowed = parseCorsOrigins(
+      'https://nanitabeyo-dev--preview-*.web.app',
+    );
+
+    expect(allowed[0]).toBeInstanceOf(RegExp);
+    expect(
+      isOriginAllowed(
+        'https://nanitabeyo-dev--preview-3lfz8fnu.web.app',
+        allowed,
+      ),
+    ).toBe(true);
+  });
+
+  it('`*` はドットを跨がない（サフィックスを足した別ドメインを弾く）', () => {
+    const allowed = parseCorsOrigins(
+      'https://nanitabeyo-dev--preview-*.web.app',
+    );
+
+    // `*` を `.*` に展開してしまうと、以下がすべて通ってしまう
+    expect(
+      isOriginAllowed(
+        'https://nanitabeyo-dev--preview-x.web.app.evil.com',
+        allowed,
+      ),
+    ).toBe(false);
+    expect(
+      isOriginAllowed('https://nanitabeyo-dev--preview-x.evil.com', allowed),
+    ).toBe(false);
+    expect(
+      isOriginAllowed(
+        'https://evil.com/nanitabeyo-dev--preview-x.web.app',
+        allowed,
+      ),
+    ).toBe(false);
+  });
+
+  it('パターン内のドットはメタ文字ではなくリテラルとして扱う', () => {
+    const allowed = parseCorsOrigins('https://*.web.app');
+
+    expect(isOriginAllowed('https://foo.web.app', allowed)).toBe(true);
+    expect(isOriginAllowed('https://fooXweb.app', allowed)).toBe(false);
+  });
+
+  it('部分一致では通さない（前後にアンカーが付いている）', () => {
+    const allowed = parseCorsOrigins('https://*.web.app');
+
+    expect(isOriginAllowed('https://foo.web.app.evil.com', allowed)).toBe(
+      false,
+    );
+    expect(
+      isOriginAllowed('http://evil.com?https://foo.web.app', allowed),
+    ).toBe(false);
+  });
+
+  it('複数指定で、固定 Origin とワイルドカードを混在できる', () => {
+    const allowed = parseCorsOrigins(
+      'http://localhost:4173,http://localhost:8081,https://nanitabeyo-dev.web.app,https://nanitabeyo-dev--preview-*.web.app',
+    );
+
+    expect(allowed).toHaveLength(4);
+    expect(isOriginAllowed('http://localhost:8081', allowed)).toBe(true);
+    expect(isOriginAllowed('https://nanitabeyo-dev.web.app', allowed)).toBe(
+      true,
+    );
+    expect(
+      isOriginAllowed(
+        'https://nanitabeyo-dev--preview-abc123.web.app',
+        allowed,
+      ),
+    ).toBe(true);
+    expect(isOriginAllowed('https://nanitabeyo.web.app', allowed)).toBe(false);
+  });
+});

--- a/api/src/core/config/cors-origin.ts
+++ b/api/src/core/config/cors-origin.ts
@@ -1,0 +1,51 @@
+/**
+ * `CORS_ORIGIN` 環境変数（カンマ区切り）を、`cors` パッケージが理解できる
+ * 「文字列 or 正規表現」の配列へ変換する。
+ *
+ * ## なぜ変換が要るのか
+ * NestJS の `enableCors({ origin })` は内部で `cors` パッケージを使う。その
+ * `isOriginAllowed` は配列要素が **文字列なら `===` の完全一致**、
+ * **RegExp なら `.test()`** でしか判定しない。つまり
+ * `https://example--preview-*.web.app` と書いても `*` はワイルドカードとして
+ * 展開されず「アスタリスクという文字を含むホスト名」として比較されるため、
+ * Firebase Hosting の preview チャンネル（URL に毎回異なる hash が入る）は
+ * 永久に一致しない。preflight が落ち、web の API 呼び出しが全滅する。
+ *
+ * ## 展開のルール
+ * `*` は **1 ラベル内の DNS 文字（英数字とハイフン）** にのみ展開する。
+ * `.*` にしてはいけない。`https://example--preview-*.web.app` を `.*` で
+ * 組むと `https://example--preview-x.web.app.evil.com` のような
+ * 「サフィックスを付け足しただけの別ドメイン」まで許可してしまう。
+ *
+ * ## 注意
+ * 単独の `*`（全許可のつもりの値）は許可されない。展開結果が
+ * `/^[A-Za-z0-9-]*$/` となり、実在するどの Origin にも一致しない。
+ * これは変換前から同じ挙動（配列要素としての `'*'` は `cors` に全許可とは
+ * 解釈されない）であり、`credentials: true` と全許可は併用できないため、
+ * 許可したい Origin は必ず明示的に列挙すること。
+ */
+
+/** 正規表現のメタ文字を literal として扱えるようエスケープする。 */
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * カンマ区切りの Origin 定義を、`cors` に渡せる形へパースする。
+ *
+ * @param raw 例: `"http://localhost:8081,https://example--preview-*.web.app"`
+ * @returns `*` を含まない項目は文字列のまま、含む項目は RegExp に変換した配列
+ */
+export function parseCorsOrigins(raw: string): (string | RegExp)[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((origin) =>
+      origin.includes('*')
+        ? new RegExp(
+            `^${origin.split('*').map(escapeRegExp).join('[A-Za-z0-9-]*')}$`,
+          )
+        : origin,
+    );
+}

--- a/api/src/core/config/env.ts
+++ b/api/src/core/config/env.ts
@@ -1,5 +1,6 @@
 import * as dotenv from 'dotenv';
 import { z } from 'zod';
+import { parseCorsOrigins } from './cors-origin';
 
 // .env ファイルから環境変数を読み込む
 dotenv.config();
@@ -13,12 +14,9 @@ const envSchema = z.object({
   API_NODE_ENV: z.string(),
   // カンマ区切りで複数オリジンを許可する（例: "https://app.example.com,http://localhost:4173"）
   // 単一値もそのまま 1 要素の配列になるため後方互換
-  CORS_ORIGIN: z.string().transform((v) =>
-    v
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean),
-  ),
+  // `*` を含む項目は RegExp へ展開される（Firebase Hosting の preview チャンネルのように
+  // URL の一部が毎回変わる配信先を許可するため）。詳細は cors-origin.ts を参照。
+  CORS_ORIGIN: z.string().transform(parseCorsOrigins),
   DATABASE_URL: z.string(),
   DB_SCHEMA: z.string(),
   // #904 【設計】Prisma 7 driver adapterではPool設定をDATABASE_URLではなくpg.Poolへ渡す


### PR DESCRIPTION
## 何が起きていたか

Cloud Run の `CORS_ORIGIN` に

```
http://localhost:4173,http://localhost:8081,https://nanitabeyo-dev.web.app,https://nanitabeyo-dev--preview-*.web.app
```

を設定しているにもかかわらず、`https://nanitabeyo-dev--preview-3lfz8fnu.web.app/ja-Jp/search` からの API 呼び出しが CORS で全滅していた。

## 原因

`*` がワイルドカードとして展開されていなかった。

1. `api/src/core/config/env.ts` は `CORS_ORIGIN` をカンマで split するだけで `string[]` にする
2. `api/src/main.ts` はそれをそのまま `enableCors({ origin })` へ渡す
3. NestJS が内部で使う `cors@2.8.5` の `isOriginAllowed` は、配列要素が**文字列なら `===` の完全一致**、**RegExp なら `.test()`** でしか判定しない（glob 展開はしない）

つまり `https://nanitabeyo-dev--preview-*.web.app` は「アスタリスクという文字を含むホスト名」として比較され、実際の Origin とは永久に一致しなかった。

web 版は `fetchWithAuth` が全リクエストへ非 safelisted な `x-app-language` を付ける（`main.ts` のコメント参照）ため**すべての API 呼び出しが preflight を伴う**。したがって preview URL では画面が一部ではなく丸ごと動かなくなる。

## 変更内容

- `api/src/core/config/cors-origin.ts`（新規）: `*` を含む項目を `RegExp` へ展開する `parseCorsOrigins` を追加。`cors` は配列内の RegExp をそのまま `.test()` するため、`main.ts` 側は変更不要
- `api/src/core/config/env.ts`: `CORS_ORIGIN` の transform を `parseCorsOrigins` に差し替え
- `api/src/core/config/cors-origin.spec.ts`（新規）: `cors` の判定ロジックを写したうえでのユニットテスト 7 件
- `.github/workflows/firebase-hosting-deploy.yml`: 「preview の URL は固定できないので CORS_ORIGIN も固定できない」というコメントに、CORS 側は解決済みである旨を追記（`WEB_BASE_URL` は 1 つの固定 URL しか持てないため、development を専用サイトの live に出す判断そのものは変えていない）

### セキュリティ上の注意点

`*` の展開先は `.*` ではなく **`[A-Za-z0-9-]*`（1 DNS ラベル内の文字）** に限定し、前後を `^$` でアンカーしている。`.*` にすると以下がすべて許可されてしまうため。

- `https://nanitabeyo-dev--preview-x.web.app.evil.com`（サフィックスを足した別ドメイン）
- `https://nanitabeyo-dev--preview-x.evil.com`

この 3 ケースを弾くことをテストで固定した。

なお単独の `*`（全許可のつもりの値）は今回も許可されない（展開結果がどの Origin にも一致しない）。`credentials: true` と `Access-Control-Allow-Origin: *` は併用できないため、許可したい Origin は明示的に列挙する必要がある — これは変更前と同じ挙動。

## 検証

- `npx jest src/core/config/cors-origin.spec.ts` → 7 件すべて green
- `npx jest`（api 全体）→ 変更前 10 suites failed / 3 tests failed、変更後も同じ（失敗はいずれも `api/.env` の secrets 不足による既存のもの。pr-check.yml も同じ理由で api のテストを載せていない）。成功テストは 365 → 372（+7 = 今回追加分）
- `npx tsc --noEmit -p api/tsconfig.json` → クリーン
- 対象ファイルの eslint / prettier → クリーン

## デプロイ

反映には `api-deploy.yml` を `development` で実行する必要がある（Cloud Run 上の `CORS_ORIGIN` の値は変更不要。`deploy-cloudrun` の `env_vars` は merge なので既存値は保持される）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AopBpzX9whfoxRTbFFpueL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AopBpzX9whfoxRTbFFpueL)_