### PR TITLE
ci(firebase-hosting-deploy): previewチャンネルIDをブランチごとに一意化する

### DIFF
--- a/.github/workflows/firebase-hosting-deploy.yml
+++ b/.github/workflows/firebase-hosting-deploy.yml
@@ -108,6 +108,7 @@ jobs:
         env:
           DEPLOY_TARGET: ${{ github.event.inputs.target }}
           WEB_BASE_URL: ${{ vars.WEB_BASE_URL }}
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           case "$DEPLOY_TARGET" in
@@ -124,7 +125,21 @@ jobs:
             preview)
               # 使い捨ての確認用。live は踏まないので development の配信に影響しない。
               # URL は毎回変わるため、デプロイ後に出力から拾う（url はここでは決めない）
-              echo "channel=preview" >> "$GITHUB_OUTPUT"
+              #
+              # #1485 のレビューで発覚: チャンネルIDが固定文字列 "preview" だと、
+              # 複数ブランチが同時に preview を流したとき **同じURL・同じチャンネル**を
+              # 取り合い、後から流した方が先の内容を無条件に上書きしてしまう
+              # （実際に別ブランチの確認用デプロイに上書きされ、無関係な画面が出た）。
+              # ブランチ名から一意なチャンネルIDを作り、ブランチごとに専用URLへ分離する。
+              slug=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-+//; s/-+$//')
+              channel="pr-${slug}"
+              # Firebase のチャンネルIDは 63 文字以内。切り詰めで末尾がハイフンになる場合を除去する
+              channel=$(echo "${channel:0:63}" | sed -E 's/-+$//')
+              # ブランチ名が記号のみ等でslugが空になる場合の保険（コミットSHAで一意性を確保）
+              if [ -z "$slug" ]; then
+                channel="pr-${GITHUB_SHA:0:12}"
+              fi
+              echo "channel=$channel" >> "$GITHUB_OUTPUT"
               echo "only=nanitabeyo-dev" >> "$GITHUB_OUTPUT"
               ;;
             *)


### PR DESCRIPTION
## Summary
- `Firebase Hosting Deploy` ワークフロー（`.github/workflows/firebase-hosting-deploy.yml`）の `target: preview` が、チャンネルIDに固定文字列 `"preview"` を使っていたアンチパターンを修正しました。
- 固定チャンネルIDだと、別ブランチが同時に `preview` デプロイを流すと**同じURL・同じチャンネルを取り合い、後から流した方が先の内容を無条件に上書き**してしまいます。実際に PR #1485 の確認用に取得した preview URL が、直後に別Issue(#1486)の確認用デプロイで上書きされ、無関係な画面が表示される事故が発生しました。
- ブランチ名を正規化（小文字化・`[^a-z0-9-]` をハイフン化・連続ハイフン圧縮・前後ハイフン除去・63文字以内に切り詰め）して `pr-<ブランチ名>` 形式のチャンネルIDを生成するようにし、ブランチごとに専用のpreview URLへ分離しました。
- ブランチ名がすべて記号などでslugが空になる場合のフォールバック（コミットSHA先頭12文字）も入れています。
- `production` / `development` ターゲットの挙動（liveチャンネルへの配信）は変更していません。

## 動作確認
- ワークフローYAMLの構文検証（`yaml.safe_load`）
- チャンネルID生成ロジックを単体でシェル実行し、以下のケースで期待どおりの出力になることを確認
  - `claude/cooking-store-loading-change-3mlnmr` → `pr-claude-cooking-store-loading-change-3mlnmr`
  - `claude/onboarding-refresh-ej6t1a` → `pr-claude-onboarding-refresh-ej6t1a`
  - `feature/ABC_123-Some.Weird--Name!!` → `pr-feature-abc-123-some-weird-name`
  - `main` → `pr-main`
  - 100文字の英字ブランチ名 → 63文字以内に切り詰め
  - 記号のみのブランチ名 → コミットSHAベースのフォールバック

## Test plan
- [x] YAML構文検証
- [x] チャンネルID生成ロジックの単体シェル実行での確認
- [ ] マージ後、実際に `workflow_dispatch`（target: preview）を実行し、ブランチ名を含んだ一意なURLが払い出されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpBzYbwhXg7wUqiajwiHJw)_