### PR TITLE
fix(error-triage): 位置情報の取得失敗を kind で畳んで起票を止める (#1196)

### DIFF
--- a/scripts/error-triage/constants.js
+++ b/scripts/error-triage/constants.js
@@ -219,7 +219,10 @@ const EXCLUSION_REASONS = Object.freeze([
 	"unauthenticated_race", // E2 Supabase access_token is missing
 	"client_network", // E3 frontend api_call_error かつ status=0
 	"transient_status", // E4 frontend の EXCLUDED_HTTP_STATUSES
-	"user_denied_permission", // E5 位置情報の権限拒否（S2: kind は denied/timeout/unavailable/unsupported の4値）
+	// E5 端末が現在地を返せない（kind = denied/timeout/unavailable）。
+	//    「権限拒否」だけではないので user_denied_permission から改名した。除外の対象は
+	//    current_location_* の event に閉じてある（sql-generator.js の E5 を参照）。
+	"device_location_failed",
 	"expected_client_error", // E6 backend の EXCLUDED_HTTP_STATUSES
 	"external_transient", // E7 外部API側の一時障害
 ]);

--- a/scripts/error-triage/sql-generator.js
+++ b/scripts/error-triage/sql-generator.js
@@ -98,11 +98,7 @@ const toRawStringLiteral = (pattern) => {
  * @returns {string}
  */
 const toStringLiteral = (value) =>
-	`'${String(value)
-		.replace(/\\/g, "\\\\")
-		.replace(/'/g, "\\'")
-		.replace(/\n/g, "\\n")
-		.replace(/\r/g, "\\r")}'`;
+	`'${String(value).replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/\n/g, "\\n").replace(/\r/g, "\\r")}'`;
 
 const indent = (level) => "  ".repeat(level);
 
@@ -190,10 +186,11 @@ const generateErrorTriageSql = () => {
 	const pathLocaleExpression = buildPathLocaleExpression({ innerExpr: "n.norm[OFFSET(1)]", baseLevel: 3 });
 	const pathLocaleExtract = toRawStringLiteral(PATH_LOCALE_EXTRACT.re2Pattern);
 	const slotComments = NORMALIZED_SLOTS.map(
-		(slot) => `${indent(4)}IFNULL(${slot.source}, '')${slot.offset === NORMALIZED_SLOTS.length - 1 ? "" : ","}`.padEnd(
-			44,
-			" ",
-		) + `-- OFFSET(${slot.offset}) ${slot.name}: ${slot.why}`,
+		(slot) =>
+			`${indent(4)}IFNULL(${slot.source}, '')${slot.offset === NORMALIZED_SLOTS.length - 1 ? "" : ","}`.padEnd(
+				44,
+				" ",
+			) + `-- OFFSET(${slot.offset}) ${slot.name}: ${slot.why}`,
 	).join("\n");
 
 	return `-- =============================================================================
@@ -433,12 +430,29 @@ ${pathLocaleExpression}
       WHEN n.surface = 'frontend'
        AND SAFE_CAST(n.feHttpStatus AS INT64) IN (${excludedStatusList()})
         THEN 'transient_status'
-      -- (E5) 位置情報の権限拒否。kind の値集合は denied/timeout/unavailable/unsupported の4値
-      --      （locationPermissionError.ts）。除外するのは denied だけ。
-      --      timeout / unavailable は端末側の障害なので残す（横断レビュー S2）。
-      --      unsupported（Web で Geolocation 非対応）はオーナー判断により SQL では除外せず残す。
-      WHEN n.surface = 'frontend' AND n.feKind = 'denied'
-        THEN 'user_denied_permission'
+      -- (E5) 端末が現在地を返せない。kind の値集合は denied/timeout/unavailable/unsupported の4値
+      --      （locationPermissionError.ts）。denied / timeout / unavailable を除外する。
+      --
+      --      当初は denied だけを除外していたが、それでは止まらなかった。fingerprint は
+      --      messagePattern を含むため、**同じ「位置情報が取れない」が OS ごとの文言で割れる**。
+      --      実測で event 名 2 種 × 文言 9 種 × 経路 3 種に分かれ、err/skip ラベル を付けても
+      --      文言違いで新しい Issue が立ち続けた（実際に 10 件立った / #1196）。
+      --      kind は既に 3 値へ正規化済みなので、そちらで畳むのが唯一の止め方である。
+      --
+      --      ⚠️ **kind の値だけで判定しないこと。** kind は payload の汎用キーで、
+      --      将来 位置情報と無関係な機能が kind: 'timeout' を積んだら、その不具合が
+      --      «理由も告げずに» 除外される。除外の取りこぼし（Issue が立つ）は見えるが、
+      --      過剰な除外（Issue が立たない）は見えない。見えるほうの失敗に倒すため
+      --      event 名で範囲を閉じる。
+      --      前方一致にしてあるのは、位置情報の event が現状 5 つあり
+      --      （current_location_{fetch_failed,failed,auto_fetch_failed,backend_failed_fallback,
+      --      expo_fallback_failed}）今後も増えうるため。この命名規約が唯一の前提。
+      --
+      --      unsupported（Web で Geolocation 非対応）はオーナー判断により除外せず残す。
+      WHEN n.surface = 'frontend'
+       AND STARTS_WITH(IFNULL(n.eventName, ''), 'current_location_')
+       AND n.feKind IN ('denied', 'timeout', 'unavailable')
+        THEN 'device_location_failed'
       -- (E6) 期待された 4xx。E4 と**同じ定数**を共有する（横断レビュー §6-4 / S3）。
       --      400 / 409 / 422 は残す: このリポジトリは logQueue.ts で既に
       --      「400/422 は契約が壊れている状態＝不具合」と定義済みで、この API の一次クライアントは

--- a/scripts/error-triage/sql-generator.test.js
+++ b/scripts/error-triage/sql-generator.test.js
@@ -425,10 +425,17 @@ describe("除外ルール: constants.js が唯一の正", () => {
 		}
 	});
 
-	test("E5 は denied だけを除外する（unsupported はオーナー判断で残す）", () => {
-		expect(generated).toContain("n.feKind = 'denied'");
+	test("E5 は denied / timeout / unavailable を除外する（unsupported はオーナー判断で残す）", () => {
+		expect(generated).toContain("n.feKind IN ('denied', 'timeout', 'unavailable')");
 		expect(code).not.toContain("'unsupported'");
 		expect(code).not.toContain("'permission_denied'");
+	});
+
+	test("E5 は current_location_* の event に閉じている", () => {
+		// ⚠️ kind の値だけで判定すると、位置情報と無関係な機能が将来 `kind: 'timeout'` を
+		// 積んだときに、その不具合が理由も告げずに除外される（＝ 見えない失敗）。
+		// event 名で閉じることで、取りこぼしても «Issue が立つ» 側へ倒す。
+		expect(generated).toContain("STARTS_WITH(IFNULL(n.eventName, ''), 'current_location_')");
 	});
 
 	test("除外行は WHERE で消さず理由付きで残している", () => {

--- a/scripts/error-triage/sql/error-triage.sql
+++ b/scripts/error-triage/sql/error-triage.sql
@@ -271,12 +271,29 @@ keyed AS (
       WHEN n.surface = 'frontend'
        AND SAFE_CAST(n.feHttpStatus AS INT64) IN (401, 403, 404, 408, 425, 426, 429)
         THEN 'transient_status'
-      -- (E5) 位置情報の権限拒否。kind の値集合は denied/timeout/unavailable/unsupported の4値
-      --      （locationPermissionError.ts）。除外するのは denied だけ。
-      --      timeout / unavailable は端末側の障害なので残す（横断レビュー S2）。
-      --      unsupported（Web で Geolocation 非対応）はオーナー判断により SQL では除外せず残す。
-      WHEN n.surface = 'frontend' AND n.feKind = 'denied'
-        THEN 'user_denied_permission'
+      -- (E5) 端末が現在地を返せない。kind の値集合は denied/timeout/unavailable/unsupported の4値
+      --      （locationPermissionError.ts）。denied / timeout / unavailable を除外する。
+      --
+      --      当初は denied だけを除外していたが、それでは止まらなかった。fingerprint は
+      --      messagePattern を含むため、**同じ「位置情報が取れない」が OS ごとの文言で割れる**。
+      --      実測で event 名 2 種 × 文言 9 種 × 経路 3 種に分かれ、err/skip ラベル を付けても
+      --      文言違いで新しい Issue が立ち続けた（実際に 10 件立った / #1196）。
+      --      kind は既に 3 値へ正規化済みなので、そちらで畳むのが唯一の止め方である。
+      --
+      --      ⚠️ **kind の値だけで判定しないこと。** kind は payload の汎用キーで、
+      --      将来 位置情報と無関係な機能が kind: 'timeout' を積んだら、その不具合が
+      --      «理由も告げずに» 除外される。除外の取りこぼし（Issue が立つ）は見えるが、
+      --      過剰な除外（Issue が立たない）は見えない。見えるほうの失敗に倒すため
+      --      event 名で範囲を閉じる。
+      --      前方一致にしてあるのは、位置情報の event が現状 5 つあり
+      --      （current_location_{fetch_failed,failed,auto_fetch_failed,backend_failed_fallback,
+      --      expo_fallback_failed}）今後も増えうるため。この命名規約が唯一の前提。
+      --
+      --      unsupported（Web で Geolocation 非対応）はオーナー判断により除外せず残す。
+      WHEN n.surface = 'frontend'
+       AND STARTS_WITH(IFNULL(n.eventName, ''), 'current_location_')
+       AND n.feKind IN ('denied', 'timeout', 'unavailable')
+        THEN 'device_location_failed'
       -- (E6) 期待された 4xx。E4 と**同じ定数**を共有する（横断レビュー §6-4 / S3）。
       --      400 / 409 / 422 は残す: このリポジトリは logQueue.ts で既に
       --      「400/422 は契約が壊れている状態＝不具合」と定義済みで、この API の一次クライアントは


### PR DESCRIPTION
提案していた E5 の拡張です。オーナー承認済み。

## なぜ `err/skip` では止まらなかったか

fingerprint は `messagePattern` を含むため、**同じ「位置情報が取れない」が OS ごとの文言で割れます**。実測で event 名 2 種 × 文言 9 種 × 経路 3 種に分かれ、`err/skip` を付けても文言違いで新しい Issue が立ち続けました（10 件）。`kind` は既に 4 値へ正規化済みなので、そちらで畳むのが唯一の止め方です。

## 変更

除外を `kind IN ('denied','timeout','unavailable')` へ広げたうえで、**対象を `current_location_*` の event に閉じました**。

提案時は kind の値だけで判定するつもりでしたが、実装時に閉じる側へ寄せています。`kind` は payload の汎用キーなので、値だけで見ると位置情報と無関係な機能が将来 `kind: 'timeout'` を積んだとき、**その不具合が理由も告げずに除外されます**。除外の取りこぼし（Issue が立つ）は見えますが、過剰な除外（Issue が立たない）は見えません。見えるほうの失敗へ倒しました。前方一致にしてあるのは、位置情報の event が現状 5 つあり今後も増えうるためです。

`unsupported` はオーナー判断どおり除外せず残しています。

## 実測での検証（本番 2026-08-08〜08-23 / `error_level = 'error'`）

| | 件数 |
|---|---|
| 新ルールで除外される | **1,122 件**（旧 937 + timeout 117 + unavailable 68） |
| **旧ルールで除外されていて新ルールで残るもの** | **0 件**（event 名で閉じても取りこぼしなし） |
| `kind` を持つ非位置情報 event | **0 件**（巻き込みなし） |

## 除外理由の識別子を改名

`user_denied_permission` → `device_location_failed`。「権限拒否」だけを指す名前のまま timeout / unavailable を畳むと、オーナーが読む run サマリの除外内訳が実態と食い違うためです。参照は `constants.js` / `sql-generator.js` / その test の 3 箇所のみで、永続化も run 跨ぎの突合もしていないことを確認しています。

## テスト

`scripts/error-triage` jest: **12 suites / 665 tests / 失敗 0**。E5 の不変条件は 2 本のテストで固定しています（kind 3 値であること / `current_location_` に閉じていること）。SQL は生成物なので `generate:sql` で再生成済みです。

## Migration

**ありません**（DB 変更なし）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoysKNnizjrnvz2dQGhjRr)_