### PR TITLE
skill(evidence-video): 即席エビデンス撮影スキルを追加

### DIFF
--- a/.claude/skills/evidence-video/SKILL.md
+++ b/.claude/skills/evidence-video/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: evidence-video
+description: >-
+  web アプリの操作動画・スクリーンショットを CI を経由せず数分でチャットへ届ける即席エビデンス撮影。
+  ローカルで expo の web ビルドを立ち上げ、Supabase 認証・backend API・Google Maps をモックした
+  Playwright で画面フローを操作しながら録画する。「動画で見せて」「エビデンスください」「この画面
+  どうなってるかスクショで確認したい」「デザイン修正を目視確認して」のように、UI の実際の見た目や
+  挙動を人に見せる・自分で確かめる必要があるとき必ず使う。実 API・実データが必要な正式エビデンス
+  （CI の e2e 動画 Artifact）とは別物で、こちらはモック前提の高速版。
+---
+
+# 即席エビデンス撮影（web）
+
+ローカルビルド + Playwright 録画で、UI フローの動画 / スクショを数分で作る手順。
+CI を待てないとき・チャットへ直接届けたいとき・デザイン修正を自分の目で確かめたいときに使う。
+
+**認証・API・地図はすべてモック**なので、映るのは「画面と遷移」であって実データではない。
+実 API での正式エビデンスが要るときは e2e-web-test.yml（Playwright は失敗時に動画を残す）や
+e2e-mobile の Detox video artifact を使うこと。
+
+## 全体像
+
+```
+1. scripts/build-and-serve.sh   … ダミー .env 生成 → SPA モードで expo export → :8788 で配信
+2. scripts/record.mjs           … モック入り Playwright でフローを操作しながら録画（webm）
+3. SendUserFile                 … webm をチャットへ送る（キャプションに「何が映っているか」を書く）
+4. scripts/build-and-serve.sh stop … 片付け（サーバ停止・dist-local / .env 削除）
+```
+
+所要はビルド約 2 分 + 録画約 1 分。録画スクリプトは **e2e-web/ ディレクトリから**
+`env -u PLAYWRIGHT_BROWSERS_PATH node <script>` で実行する（後述の理由を参照）。
+
+## 手順
+
+### 1. ビルドと配信
+
+```bash
+bash .claude/skills/evidence-video/scripts/build-and-serve.sh start
+# → http://localhost:8788 で配信される。終わったら必ず:
+bash .claude/skills/evidence-video/scripts/build-and-serve.sh stop
+```
+
+このスクリプトがやっていること（なぜそうするかまで理解しておくこと）:
+
+- **ダミー値の `.env` を app-expo/ に生成する。** Env.ts の必須項目（SUPABASE_URL 等）を
+  埋めないとバンドルが組めない。値はどうせモックに差し替わるので localhost のダミーでよい。
+  **`.env` は絶対にコミットしない**（スクリプトが終了時に消す）
+- **app.config.ts の `web.output` を一時的に `"static"` → `"single"`（SPA）へ切り替える。**
+  static のままだと export 中の静的レンダリング（Node 側）で `Constants.expoConfig.extra` が
+  空になり「supabaseUrl is required.」で落ちる（CI は実環境変数で通るがローカルのダミーでは
+  再現不能）。SPA なら静的レンダリングが走らないので回避できる。
+  **切り替えは trap で必ず元へ戻す**（コミットへの混入事故防止）
+- **SPA フォールバック付きの静的サーバで配信する。** `python -m http.server` は
+  `/ja-JP/search` のような深い URL で 404 になるため、無ければ index.html を返す
+  自前サーバ（serve-spa.mjs）を使う
+
+### 2. 録画
+
+```bash
+env -u PLAYWRIGHT_BROWSERS_PATH node .claude/skills/evidence-video/scripts/record.mjs
+```
+
+- `@playwright/test` は e2e-web の node_modules から `createRequire` で借りている
+  （スクリプト冒頭）。e2e-web で `pnpm install` 済みであることが前提
+- **`PLAYWRIGHT_BROWSERS_PATH` を外す**のは、サンドボックスの既定値（/opt/pw-browsers）の
+  Chromium がリポジトリの Playwright バージョンと合わないことがあるため。合わないときは
+  `env -u PLAYWRIGHT_BROWSERS_PATH npx playwright install chromium-headless-shell` で
+  既定キャッシュへ入れる
+- record.mjs は**そのまま使うテンプレートではなく、撮りたいフローに合わせて書き換える**。
+  モック部分（`installMocks` / `MAPS_STUB`）は共通なので触らず、後半の操作シナリオだけ
+  変える。スクショだけ欲しいときは `recordVideo` を外して `page.screenshot()` にする
+
+### 3. チャットへ送る
+
+`SendUserFile` で webm を送る。キャプションには「どの commit のビルドか」「何の検証が
+映っているか（画面順）」を書く。見る側はキャプションだけで判断するので手を抜かない。
+
+### 4. 片付け
+
+`build-and-serve.sh stop` を必ず実行する。git status がクリーンであることを確認して終わる
+（app.config.ts の差分が残っていたら revert 漏れなので `git checkout -- app-expo/app.config.ts`）。
+
+## モックの中身と、その理由（scripts/record.mjs 冒頭に実装がある）
+
+| 対象 | モック | なぜ必要か |
+| --- | --- | --- |
+| Supabase 認証 | `/auth/v1/**` へ偽 JWT 入りセッション JSON を返す | 認証が確立しないと auth-error-fallback で画面が丸ごと出ない |
+| backend API | `{"data": []}` を返す | 500/接続失敗の連打とリトライを避ける。画面の器だけ映ればよい |
+| Google Maps | `window.google.maps` の最小スタブ + `window.initMap()` 呼び出し | `@react-google-maps/api` の LoadScript は **`initMap` コールバックが呼ばれるまで children の代わりに "Loading..." を出し続ける**。スタブが initMap を呼ばないとアプリ全体が Loading で止まる |
+| その他外部 | すべて `{"data": []}` で握りつぶす | サンドボックスは外部到達不可のため。ただし **JS として実行されるリソースに JSON を返すと SyntaxError で壊れる**ので、script 系 URL には contentType を合わせること |
+
+## ハマりどころ（実際に踏んだものだけ）
+
+- **SPA モードでは "/" からの初期タブが狂うことがある。** `/ja-JP/search` など
+  目的のルートへ**直接** goto する
+- **オンボーディングの表示状態**は localStorage `search_tutorial_seen_v1` で制御する。
+  未読状態を撮るならシード無し（既定）、既読状態は `"true"` を addInitScript で仕込む
+- **位置情報・通知の許可画面は、ヘッドレスでは映らない。** headless Chromium は要求へ
+  ダイアログ無しで即答拒否し、アプリ側はそれを「回答済み」として画面ごとスキップする設計
+  （OnboardingPermissionScreen の INSTANT_SETTLE_GRACE_MS）。撮りたいときは
+  `navigator.geolocation.getCurrentPosition = () => {}`（永遠に応答しない）を
+  addInitScript して「プロンプトが出たまま」を再現する。許可済みは context の
+  `permissions: ["geolocation"]` + `geolocation: {...}` で作る
+- **アニメーションは実時間で待つ。** オンボーディングの課題→解決は表示から約 1.5 秒 +
+  アニメ 0.3 秒。`waitForTimeout(2600)` 程度置いてから次へ進むと動画に全部映る
+- **iPhone 相当は viewport 390×844**（SE は 375×667）。これは「見た目が iPhone サイズ」な
+  だけで iOS 実機ではない。エビデンスとして提示するとき、プラットフォームを偽らないこと
+- ffmpeg はサンドボックスに無い。**webm のまま送る**（チャットで再生できる）
+
+## してはいけないこと
+
+- `.env`（ダミーでも）・`dist-local/`・app.config.ts の output 変更をコミットに混ぜる
+- このモック環境で撮った動画を「実 API での動作確認」として提示する
+- サーバの停止に `pkill -f` を使う（自分ごと死ぬ。CLAUDE.md のプロセス停止規則に従い
+  PID を取ってから kill する — build-and-serve.sh stop がやっている）

--- a/.claude/skills/evidence-video/scripts/build-and-serve.sh
+++ b/.claude/skills/evidence-video/scripts/build-and-serve.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# 即席エビデンス撮影用: web ビルドの生成と配信（SKILL.md の手順 1 / 4）
+#
+#   start … ダミー .env 生成 → SPA モードで expo export → :8788 で配信
+#   stop  … サーバ停止・dist-local / .env 削除・app.config.ts の復元確認
+#
+# app.config.ts の output 切り替えは trap で必ず戻す（コミット混入事故の防止）。
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+APP_DIR="$REPO_ROOT/app-expo"
+SERVE_JS="$(cd "$(dirname "$0")" && pwd)/serve-spa.mjs"
+PORT=8788
+
+restore_config() {
+	# SPA へ切り替えたまま死んでもリポジトリを汚さない
+	sed -i 's/\t\toutput: "single",/\t\toutput: "static",/' "$APP_DIR/app.config.ts" || true
+}
+
+stop_server() {
+	# ⚠️ pkill -f は自分ごと殺すので使わない（CLAUDE.md のプロセス停止規則）
+	local pid
+	pid=$(ps -eo pid,cmd | grep "[s]erve-spa.mjs" | awk '{print $1}' | head -1)
+	[ -n "${pid:-}" ] && kill "$pid" && echo "server (pid $pid) stopped" || echo "server not running"
+}
+
+case "${1:-start}" in
+start)
+	# Env.ts の必須項目を埋めるだけのダミー値。モックに差し替わるので値自体に意味は無い
+	cat > "$APP_DIR/.env" << 'EOF'
+EXPO_PUBLIC_NODE_ENV=development
+EXPO_PUBLIC_COMMIT_ID=localdev
+EXPO_PUBLIC_APP_STORE_URL=https://example.com/appstore
+EXPO_PUBLIC_PLAY_STORE_URL=https://example.com/playstore
+EXPO_PUBLIC_BACKEND_BASE_URL=http://localhost:9999
+EXPO_PUBLIC_GOOGLE_MAPS_WEB_API_KEY=dummy-maps-key
+EXPO_PUBLIC_SUPABASE_URL=http://localhost:9998
+EXPO_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key
+EXPO_PUBLIC_DB_SCHEMA=public
+EXPO_PUBLIC_CDN_PUBLIC_HOST=localhost
+EXPO_PUBLIC_GCS_STATIC_MASTER_DIR_PATH=static
+EXPO_PUBLIC_ADMOB_ANDROID_INTERSTITIAL_UNIT_ID=dummy
+EXPO_PUBLIC_ADMOB_IOS_INTERSTITIAL_UNIT_ID=dummy
+EXPO_PUBLIC_ADMOB_ANDROID_BANNER_UNIT_ID=dummy
+EXPO_PUBLIC_ADMOB_IOS_BANNER_UNIT_ID=dummy
+EXPO_PUBLIC_WEB_BASE_URL=http://localhost:8788
+EXPO_PUBLIC_FACEBOOK_APP_ID=0
+EXPO_PUBLIC_FACEBOOK_CLIENT_TOKEN=0
+EOF
+
+	# static のままだと SSR パスで supabaseUrl is required になる（SKILL.md 参照）
+	trap restore_config EXIT
+	sed -i 's/\t\toutput: "static",/\t\toutput: "single",/' "$APP_DIR/app.config.ts"
+
+	echo "building (about 2 min)..."
+	(cd "$APP_DIR" && npx expo export --platform web --output-dir dist-local > /tmp/evidence-video-build.log 2>&1) \
+		|| { echo "BUILD FAILED — see /tmp/evidence-video-build.log"; exit 1; }
+
+	restore_config
+	trap - EXIT
+	rm -f "$APP_DIR/.env"
+
+	stop_server > /dev/null 2>&1 || true
+	EVIDENCE_DIST="$APP_DIR/dist-local" nohup node "$SERVE_JS" > /tmp/evidence-video-serve.log 2>&1 &
+	sleep 1
+	code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$PORT/ja-JP/search")
+	echo "serving dist-local on http://localhost:$PORT (probe: $code)"
+	;;
+stop)
+	stop_server
+	restore_config
+	rm -rf "$APP_DIR/dist-local"
+	rm -f "$APP_DIR/.env"
+	echo "cleaned. git status:"
+	git -C "$REPO_ROOT" status --short | head -5
+	;;
+*)
+	echo "usage: build-and-serve.sh [start|stop]"; exit 1 ;;
+esac

--- a/.claude/skills/evidence-video/scripts/record.mjs
+++ b/.claude/skills/evidence-video/scripts/record.mjs
@@ -1,0 +1,107 @@
+/*
+即席エビデンス撮影の録画テンプレート（SKILL.md の手順 2）。
+
+実行方法（どのディレクトリからでもよい）:
+    env -u PLAYWRIGHT_BROWSERS_PATH node .claude/skills/evidence-video/scripts/record.mjs
+
+前半（モック）は共通部品なので触らない。後半の「シナリオ」だけを撮りたいフローへ書き換える。
+スクショだけ欲しいときは recordVideo を外して page.screenshot() を使う。
+出力先はセッションの scratchpad など、リポジトリの外に置くこと。
+*/
+import { rename, mkdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+
+// このスクリプトは node_modules を持たない場所に居るため、ESM の import では
+// @playwright/test を解決できない。e2e-web を基点にした require で借りる
+const require = createRequire(new URL("../../../../e2e-web/package.json", import.meta.url));
+const { chromium } = require("@playwright/test");
+
+const BASE = "http://localhost:8788";
+// 出力先。セッションの scratchpad へ書き換えて使う（リポジトリ内へは置かない）
+const OUT = process.env.EVIDENCE_OUT ?? "/tmp/evidence-video";
+
+// ── ここからモック（共通部品。触らない） ─────────────────────────────
+// Supabase 認証: 偽 JWT 入りセッション。確立しないと auth-error-fallback で画面が出ない
+const b64 = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
+const JWT = `${b64({ alg: "HS256", typ: "JWT" })}.${b64({
+	sub: "00000000-0000-4000-8000-000000000001",
+	aud: "authenticated",
+	role: "authenticated",
+	exp: 4102444800,
+	is_anonymous: true,
+})}.sig`;
+const USER = {
+	id: "00000000-0000-4000-8000-000000000001",
+	aud: "authenticated",
+	role: "authenticated",
+	email: "",
+	is_anonymous: true,
+	app_metadata: {},
+	user_metadata: {},
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+const SESSION = {
+	access_token: JWT,
+	token_type: "bearer",
+	expires_in: 3600,
+	expires_at: 4102444800,
+	refresh_token: "fake-refresh-token",
+	user: USER,
+};
+// Google Maps: LoadScript は window.initMap が呼ばれるまで "Loading..." を出し続けるため、
+// スタブの最後で必ず initMap を呼ぶ（呼ばないとアプリ全体が Loading で固まる）
+const MAPS_STUB = `window.google=window.google||{};window.google.maps={version:"3.58",importLibrary:async()=>({}),event:{addListener:()=>({remove:()=>{}})},places:{AutocompleteService:function(){this.getPlacePredictions=(r,cb)=>cb&&cb([],"ZERO_RESULTS");},PlacesServiceStatus:{OK:"OK"}},Map:function(){},Marker:function(){},LatLng:function(){},LatLngBounds:function(){},Geocoder:function(){},MapTypeId:{ROADMAP:"roadmap"}};window.initMap&&window.initMap();`;
+
+async function installMocks(page) {
+	await page.route("**", async (route) => {
+		const url = route.request().url();
+		if (url.startsWith(BASE)) return route.continue();
+		// script として実行される URL へ JSON を返すと SyntaxError で壊れるので contentType を合わせる
+		if (url.includes("maps.googleapis.com"))
+			return route.fulfill({ status: 200, contentType: "text/javascript", body: MAPS_STUB });
+		if (url.includes("/auth/v1/user"))
+			return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(USER) });
+		if (url.includes("/auth/v1/"))
+			return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(SESSION) });
+		// backend / CDN / その他外部はすべて空で握りつぶす（サンドボックスは外部到達不可）
+		return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ data: [] }) });
+	});
+}
+// ── モックここまで ───────────────────────────────────────────────
+
+await mkdir(OUT, { recursive: true });
+const browser = await chromium.launch();
+
+/**
+ * 1 本の動画を撮る。contextOptions で権限や viewport を変えられる。
+ * 例) 位置情報許可済み: { permissions: ["geolocation"], geolocation: { latitude: 35.68, longitude: 139.76 } }
+ */
+async function record(name, contextOptions, scenario) {
+	const context = await browser.newContext({
+		locale: "ja-JP",
+		viewport: { width: 390, height: 844 }, // iPhone 相当（SE は 375x667）
+		recordVideo: { dir: OUT, size: { width: 390, height: 844 } },
+		...contextOptions,
+	});
+	const page = await context.newPage();
+	await installMocks(page);
+	await scenario(page);
+	const video = page.video();
+	await context.close(); // close で動画が確定する
+	await rename(await video.path(), `${OUT}/${name}.webm`);
+	console.log("saved:", `${OUT}/${name}.webm`);
+}
+
+// ── シナリオ（ここを撮りたいフローへ書き換える） ─────────────────────
+// 例: オンボーディング初回導線。SPA モードは "/" からの初期タブが狂うことがあるので
+//     目的のルートへ直接 goto する。アニメーションは実時間ぶん waitForTimeout で待つ
+await record("example-onboarding", {}, async (page) => {
+	await page.goto(BASE + "/ja-JP/search");
+	await page.getByTestId("onboarding-screen").waitFor({ timeout: 30000 });
+	await page.waitForTimeout(2600); // 課題 → 解決アニメーション（約 1.5s + 0.3s）
+	await page.getByTestId("onboarding-next").click();
+	await page.waitForTimeout(2600);
+});
+
+await browser.close();

--- a/.claude/skills/evidence-video/scripts/serve-spa.mjs
+++ b/.claude/skills/evidence-video/scripts/serve-spa.mjs
@@ -1,0 +1,36 @@
+// SPA フォールバック付き静的サーバ。`python -m http.server` だと /ja-JP/search のような
+// 深い URL が 404 になるため、無いパスは index.html へ落とす（expo の single 出力用）
+import http from "node:http";
+import { readFile } from "node:fs/promises";
+import { join, extname } from "node:path";
+
+const ROOT = process.env.EVIDENCE_DIST ?? new URL("../../../../app-expo/dist-local", import.meta.url).pathname;
+const TYPES = {
+	".html": "text/html",
+	".js": "text/javascript",
+	".css": "text/css",
+	".json": "application/json",
+	".png": "image/png",
+	".webp": "image/webp",
+	".ico": "image/x-icon",
+	".svg": "image/svg+xml",
+	".ttf": "font/ttf",
+	".woff2": "font/woff2",
+};
+
+http
+	.createServer(async (req, res) => {
+		const path = decodeURIComponent(new URL(req.url, "http://x").pathname);
+		for (const candidate of [path, "/index.html"]) {
+			try {
+				const body = await readFile(join(ROOT, candidate));
+				res.writeHead(200, { "content-type": TYPES[extname(candidate)] ?? "application/octet-stream" });
+				return res.end(body);
+			} catch {
+				// 次の候補（index.html フォールバック）へ
+			}
+		}
+		res.writeHead(404);
+		res.end("not found");
+	})
+	.listen(8788, () => console.log(`serving ${ROOT} on 8788`));


### PR DESCRIPTION
## 概要

CI を経由せず数分で web UI の操作動画・スクショをチャットへ届けるための Claude Code スキル。#1486 オンボーディング検収の動画エビデンス提出で確立した手順・モック一式を `.claude/skills/evidence-video/` として永続化する。

- `scripts/build-and-serve.sh` — ダミー .env 生成 → app.config.ts を一時的に SPA 出力へ切り替えて `expo export`（static だと SSR パスが `supabaseUrl is required` で落ちるため）→ SPA フォールバック付きサーバで :8788 配信。output の切り替えは trap で必ず復元。`stop` でサーバ停止・`dist-local` / `.env` 削除まで行う
- `scripts/record.mjs` — Supabase 認証（偽 JWT セッション）・backend API・Google Maps（`initMap` を呼ぶ LoadScript 対応スタブ）をモックした Playwright 録画テンプレート。`@playwright/test` は e2e-web の node_modules から `createRequire` で解決
- `SKILL.md` — ハマりどころ（SPA の初期タブずれ・ヘッドレスの権限即答拒否・既読フラグのシード等）と禁止事項（ダミー .env / output 変更のコミット混入、モック動画を実 API 検証と偽らない）

アプリ本体のコード変更なし。start → 録画 → stop の全工程を実行して動作確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tj2QxpKP2MgtbycYndt68U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tj2QxpKP2MgtbycYndt68U)_