### PR TITLE
skill(evidence-video): 実機 Detox 動画の常設経路と Android/iOS 相当プリセットを追加

### DIFF
--- a/.claude/skills/evidence-video/SKILL.md
+++ b/.claude/skills/evidence-video/SKILL.md
@@ -40,14 +40,16 @@ description: >-
 3. CI の GitHub Actions を消費するだけで **EAS のビルド枠は消費しない**
    （CLAUDE.md の EAS Build 規則とは無関係に自由に実行してよい）
 
-⚠️ **動画が実際に出るのは現状 iOS のみ**（run 32589219056 で mp4 を確認）。
-Android は video: "all" でも mp4 が生成されない（headless エミュレータ +
-adb screenrecord の制約。ハードコード時代の run でも同様で、この入力の配管の
-問題ではない — run 32603604105 で `DETOX_RECORD_VIDEOS=1` が Detox まで
-届いていることをログで確認済み）。Android の動きのエビデンスが要るときは
-A の `android` プリセット（Pixel 7 相当）か、スクショ（--take-screenshots all が
-常時有効）で代替する。Android 側を直す場合は Detox の screenrecord 失敗を
-掘るところから（テスト時間が伸びる副作用も考慮すること）。
+Android / iOS どちらも `test.mp4` が出る（#1484 の run 32589219056 で両 OS の
+mp4 を確認）。スクショ（--take-screenshots all）は録画の有無によらず常時収集される。
+
+⚠️ **`DETOX_RECORD_VIDEOS` という env 名は Detox 自身が CLI オプションとして
+解釈する**（collectCliConfig が argv と同格に読み、defaultsDeep で .detoxrc.js より
+優先される）。record_videos 入力はこの仕組みを使って `all` を渡している。
+値を none|failing|all 以外（"1" 等）にすると、エラーにならず .detoxrc.js の
+video 設定を黙って上書きして動画が出なくなる（run 32603604105 / 32605810775 で
+実測）。.detoxrc.js 側を process.env の三項演算で切り替える実装も同じ理由で
+機能しないので、やらないこと。
 
 以下は A（即席）の手順。**認証・API・地図はすべてモック**なので、映るのは
 「画面と遷移」であって実データではないことを常にキャプションで明示する。

--- a/.claude/skills/evidence-video/SKILL.md
+++ b/.claude/skills/evidence-video/SKILL.md
@@ -32,13 +32,22 @@ description: >-
 
 1. `e2e-mobile-test.yml` を workflow_dispatch で起動する。入力:
    - `record_videos: true`（.detoxrc.js の video plugin が "all" になり全テストの動画が残る）
-   - `test_filter` に撮りたいフローの spec 名を入れると数分〜十数分に短縮できる
-     （例: `onboarding`）。platform で android / ios を絞れる
+   - `test_filter` に撮りたいフローの spec 名を入れると短縮できる（例: `onboarding`）。
+     platform で android / ios を絞れる
 2. 完了後、Artifact `detox-report-android` / `detox-report-ios` をダウンロードすると
-   `artifacts/` 配下にテストごとの動画が入っている。チャットへは必要な分だけ
+   `artifacts/` 配下にテストごとの `test.mp4` が入っている。チャットへは必要な分だけ
    `SendUserFile` で転送する
 3. CI の GitHub Actions を消費するだけで **EAS のビルド枠は消費しない**
    （CLAUDE.md の EAS Build 規則とは無関係に自由に実行してよい）
+
+⚠️ **動画が実際に出るのは現状 iOS のみ**（run 32589219056 で mp4 を確認）。
+Android は video: "all" でも mp4 が生成されない（headless エミュレータ +
+adb screenrecord の制約。ハードコード時代の run でも同様で、この入力の配管の
+問題ではない — run 32603604105 で `DETOX_RECORD_VIDEOS=1` が Detox まで
+届いていることをログで確認済み）。Android の動きのエビデンスが要るときは
+A の `android` プリセット（Pixel 7 相当）か、スクショ（--take-screenshots all が
+常時有効）で代替する。Android 側を直す場合は Detox の screenrecord 失敗を
+掘るところから（テスト時間が伸びる副作用も考慮すること）。
 
 以下は A（即席）の手順。**認証・API・地図はすべてモック**なので、映るのは
 「画面と遷移」であって実データではないことを常にキャプションで明示する。

--- a/.claude/skills/evidence-video/SKILL.md
+++ b/.claude/skills/evidence-video/SKILL.md
@@ -1,22 +1,47 @@
 ---
 name: evidence-video
 description: >-
-  web アプリの操作動画・スクリーンショットを CI を経由せず数分でチャットへ届ける即席エビデンス撮影。
-  ローカルで expo の web ビルドを立ち上げ、Supabase 認証・backend API・Google Maps をモックした
-  Playwright で画面フローを操作しながら録画する。「動画で見せて」「エビデンスください」「この画面
-  どうなってるかスクショで確認したい」「デザイン修正を目視確認して」のように、UI の実際の見た目や
-  挙動を人に見せる・自分で確かめる必要があるとき必ず使う。実 API・実データが必要な正式エビデンス
-  （CI の e2e 動画 Artifact）とは別物で、こちらはモック前提の高速版。
+  アプリの操作動画・スクリーンショットをチャットへ届けるエビデンス撮影。2 経路ある:
+  (A) 即席 = ローカルで expo の web ビルドを立ち上げ、認証・API・Maps をモックした Playwright で
+  録画（数分。Android 相当 / iOS 相当 = WebKit のデバイスプリセット付き）。
+  (B) 実機 = e2e-mobile CI を record_videos 入力付きで dispatch し、Android エミュレータ /
+  iOS シミュレータの本物の Detox 動画を Artifact から回収（約 30 分〜）。
+  「動画で見せて」「エビデンスください」「スクショで確認したい」「iOS/Android での見た目を確かめたい」
+  「デザイン修正を目視確認して」のように、UI の見た目や挙動を人に見せる・自分で確かめる必要が
+  あるとき必ず使う。
 ---
 
-# 即席エビデンス撮影（web）
+# エビデンス撮影
 
-ローカルビルド + Playwright 録画で、UI フローの動画 / スクショを数分で作る手順。
-CI を待てないとき・チャットへ直接届けたいとき・デザイン修正を自分の目で確かめたいときに使う。
+2 経路ある。目的で選ぶ:
 
-**認証・API・地図はすべてモック**なので、映るのは「画面と遷移」であって実データではない。
-実 API での正式エビデンスが要るときは e2e-web-test.yml（Playwright は失敗時に動画を残す）や
-e2e-mobile の Detox video artifact を使うこと。
+| | A. 即席（このファイルの主題） | B. 実機（Detox / CI） |
+| --- | --- | --- |
+| 所要 | 数分 | 約 30 分〜（iOS は更に長い） |
+| 実体 | ローカル web ビルド + Playwright | Android エミュレータ / iOS シミュレータ + Detox |
+| データ | 認証・API・Maps は**モック** | 実 dev 環境（実 API） |
+| 映るもの | UI・デザイン・画面遷移 | 上に加えて OS 許可ダイアログ・ATT 等ネイティブ面 |
+| デバイス | Chromium(素/Pixel 7 相当) + WebKit(iPhone 14 相当) | 本物の Android / iOS |
+
+**A で足りるか**の判断基準: アプリは React Native で web も native も同じ JS が描画される。
+デザイン・文言・レイアウト・フローの確認なら A でほぼ等価。OS ダイアログ・プッシュ通知・
+共有インテント・ネイティブ遷移の滑らかさが論点なら B。**A の動画を「実機で確認した」と
+提示してはいけない**（プリセットは «相当» であって実機ではない）。
+
+## B. 実機動画（Detox / CI）の手順
+
+1. `e2e-mobile-test.yml` を workflow_dispatch で起動する。入力:
+   - `record_videos: true`（.detoxrc.js の video plugin が "all" になり全テストの動画が残る）
+   - `test_filter` に撮りたいフローの spec 名を入れると数分〜十数分に短縮できる
+     （例: `onboarding`）。platform で android / ios を絞れる
+2. 完了後、Artifact `detox-report-android` / `detox-report-ios` をダウンロードすると
+   `artifacts/` 配下にテストごとの動画が入っている。チャットへは必要な分だけ
+   `SendUserFile` で転送する
+3. CI の GitHub Actions を消費するだけで **EAS のビルド枠は消費しない**
+   （CLAUDE.md の EAS Build 規則とは無関係に自由に実行してよい）
+
+以下は A（即席）の手順。**認証・API・地図はすべてモック**なので、映るのは
+「画面と遷移」であって実データではないことを常にキャプションで明示する。
 
 ## 全体像
 
@@ -103,8 +128,13 @@ env -u PLAYWRIGHT_BROWSERS_PATH node .claude/skills/evidence-video/scripts/recor
   `permissions: ["geolocation"]` + `geolocation: {...}` で作る
 - **アニメーションは実時間で待つ。** オンボーディングの課題→解決は表示から約 1.5 秒 +
   アニメ 0.3 秒。`waitForTimeout(2600)` 程度置いてから次へ進むと動画に全部映る
-- **iPhone 相当は viewport 390×844**（SE は 375×667）。これは「見た目が iPhone サイズ」な
-  だけで iOS 実機ではない。エビデンスとして提示するとき、プラットフォームを偽らないこと
+- **デバイスは record.mjs の PRESETS で選ぶ**: `default`（素の iPhone サイズ Chromium・最速）/
+  `android`（Pixel 7 相当）/ `ios`（iPhone 14 + WebKit）。後者 2 つは e2e-web CI の
+  mobile-chrome / mobile-safari と同じ descriptor。`ios` は WebKit バイナリと OS ライブラリが
+  要るため、初回に e2e-web で次の 2 つを実行する（数分。2 回目以降は不要）:
+  `env -u PLAYWRIGHT_BROWSERS_PATH ./node_modules/.bin/playwright install webkit` と
+  `env -u PLAYWRIGHT_BROWSERS_PATH ./node_modules/.bin/playwright install-deps webkit`。
+  いずれも実機ではないので、エビデンスとして提示するときプラットフォームを偽らないこと
 - ffmpeg はサンドボックスに無い。**webm のまま送る**（チャットで再生できる）
 
 ## してはいけないこと

--- a/.claude/skills/evidence-video/scripts/record.mjs
+++ b/.claude/skills/evidence-video/scripts/record.mjs
@@ -14,7 +14,29 @@ import { createRequire } from "node:module";
 // このスクリプトは node_modules を持たない場所に居るため、ESM の import では
 // @playwright/test を解決できない。e2e-web を基点にした require で借りる
 const require = createRequire(new URL("../../../../e2e-web/package.json", import.meta.url));
-const { chromium } = require("@playwright/test");
+const { chromium, webkit, devices } = require("@playwright/test");
+
+/**
+ * デバイスプリセット。e2e-web/playwright.config.ts の mobile-chrome / mobile-safari と
+ * 同じ device descriptor を使う（CI のテスト環境と見た目を揃えるため）。
+ *
+ * ⚠️ これは «相当» であって実機ではない。同じ React Native の JS が描画されるので
+ * UI・デザイン・フローのエビデンスとしてはほぼ等価だが、OS の許可ダイアログ・ATT・
+ * プッシュ通知・共有インテント等のネイティブ面は映らない。それらは e2e-mobile CI の
+ * record_videos 入力（本物の Detox 動画）で撮ること。SKILL.md 参照。
+ *
+ * ios プリセットは WebKit エンジンを使うため、初回は
+ *   env -u PLAYWRIGHT_BROWSERS_PATH npx playwright install webkit
+ * （e2e-web で実行）が必要になることがある。
+ */
+const PRESETS = {
+	// 素の iPhone サイズ Chromium（最速。エンジン差が論点でないときの既定）
+	default: { engine: chromium, options: { viewport: { width: 390, height: 844 } } },
+	// Android 相当（Pixel 7 の UA / viewport / タッチ。CI の mobile-chrome と同一）
+	android: { engine: chromium, options: { ...devices["Pixel 7"] } },
+	// iOS 相当（iPhone 14 + WebKit = Safari のレンダリングエンジン。CI の mobile-safari と同一）
+	ios: { engine: webkit, options: { ...devices["iPhone 14"] } },
+};
 
 const BASE = "http://localhost:8788";
 // 出力先。セッションの scratchpad へ書き換えて使う（リポジトリ内へは置かない）
@@ -71,17 +93,27 @@ async function installMocks(page) {
 // ── モックここまで ───────────────────────────────────────────────
 
 await mkdir(OUT, { recursive: true });
-const browser = await chromium.launch();
+const launched = new Map(); // エンジンごとに 1 度だけ起動して使い回す
 
 /**
- * 1 本の動画を撮る。contextOptions で権限や viewport を変えられる。
- * 例) 位置情報許可済み: { permissions: ["geolocation"], geolocation: { latitude: 35.68, longitude: 139.76 } }
+ * 1 本の動画を撮る。
+ *
+ * @param name    出力ファイル名（.webm が付く）
+ * @param preset  PRESETS のキー（"default" / "android" / "ios"）
+ * @param contextOptions 追加の context オプション。
+ *   例) 位置情報許可済み: { permissions: ["geolocation"], geolocation: { latitude: 35.68, longitude: 139.76 } }
+ * @param scenario page を受け取って操作する async 関数
  */
-async function record(name, contextOptions, scenario) {
+async function record(name, preset, contextOptions, scenario) {
+	const { engine, options } = PRESETS[preset];
+	if (!launched.has(engine)) launched.set(engine, await engine.launch());
+	const browser = launched.get(engine);
+
+	const viewport = options.viewport;
 	const context = await browser.newContext({
 		locale: "ja-JP",
-		viewport: { width: 390, height: 844 }, // iPhone 相当（SE は 375x667）
-		recordVideo: { dir: OUT, size: { width: 390, height: 844 } },
+		...options,
+		recordVideo: { dir: OUT, size: viewport },
 		...contextOptions,
 	});
 	const page = await context.newPage();
@@ -95,8 +127,9 @@ async function record(name, contextOptions, scenario) {
 
 // ── シナリオ（ここを撮りたいフローへ書き換える） ─────────────────────
 // 例: オンボーディング初回導線。SPA モードは "/" からの初期タブが狂うことがあるので
-//     目的のルートへ直接 goto する。アニメーションは実時間ぶん waitForTimeout で待つ
-await record("example-onboarding", {}, async (page) => {
+//     目的のルートへ直接 goto する。アニメーションは実時間ぶん waitForTimeout で待つ。
+//     プラットフォーム比較が要るときは同じシナリオを "android" / "ios" でも record する
+await record("example-onboarding", "default", {}, async (page) => {
 	await page.goto(BASE + "/ja-JP/search");
 	await page.getByTestId("onboarding-screen").waitFor({ timeout: 30000 });
 	await page.waitForTimeout(2600); // 課題 → 解決アニメーション（約 1.5s + 0.3s）
@@ -104,4 +137,4 @@ await record("example-onboarding", {}, async (page) => {
 	await page.waitForTimeout(2600);
 });
 
-await browser.close();
+for (const browser of launched.values()) await browser.close();

--- a/.github/workflows/e2e-mobile-test.yml
+++ b/.github/workflows/e2e-mobile-test.yml
@@ -34,7 +34,7 @@ on:
         required: false
         default: ""
       record_videos:
-        description: "エビデンス用に全テストの実機動画を録画して Artifact へ残す（.detoxrc.js の video plugin を all にする）。test_filter と併用すると狙ったフローだけ短時間で撮れる。⚠️ mp4 が出るのは現状 iOS のみ（Android は headless エミュレータの制約で生成されない。スクショは常時収集される）"
+        description: "エビデンス用に全テストの実機動画（test.mp4）を録画して Artifact へ残す（DETOX_RECORD_VIDEOS=all 相当）。Android / iOS 両対応。test_filter と併用すると狙ったフローだけ短時間で撮れる"
         type: boolean
         required: false
         default: false
@@ -267,9 +267,11 @@ jobs:
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
           DETOX_TEST_FILTER: ${{ inputs.test_filter }}
-          # record_videos 入力が true のときだけ .detoxrc.js の video plugin を all にする
-          # （schedule 実行では inputs が空 = 従来どおり録画しない）
-          DETOX_RECORD_VIDEOS: ${{ inputs.record_videos && '1' || '' }}
+          # record_videos 入力が true のとき Detox の env→CLI マッピングで --record-videos all
+          # に相当する指定になる（schedule 実行では inputs が空 = 'none' で従来どおり）。
+          # ⚠️ 値は none|failing|all 以外を渡さないこと。不正値でも Detox はエラーにせず
+          # .detoxrc.js の video 設定を黙って上書きして動画が出なくなる（run 32605810775 で実測）
+          DETOX_RECORD_VIDEOS: ${{ inputs.record_videos && 'all' || 'none' }}
 
       # 📋 UI カタログ（scope=catalog*）: 画面定義と突き合わせて一覧を生成する
       - name: 📋 Generate UI catalog document (Android)
@@ -497,9 +499,11 @@ jobs:
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
           DETOX_TEST_FILTER: ${{ inputs.test_filter }}
-          # record_videos 入力が true のときだけ .detoxrc.js の video plugin を all にする
-          # （schedule 実行では inputs が空 = 従来どおり録画しない）
-          DETOX_RECORD_VIDEOS: ${{ inputs.record_videos && '1' || '' }}
+          # record_videos 入力が true のとき Detox の env→CLI マッピングで --record-videos all
+          # に相当する指定になる（schedule 実行では inputs が空 = 'none' で従来どおり）。
+          # ⚠️ 値は none|failing|all 以外を渡さないこと。不正値でも Detox はエラーにせず
+          # .detoxrc.js の video 設定を黙って上書きして動画が出なくなる（run 32605810775 で実測）
+          DETOX_RECORD_VIDEOS: ${{ inputs.record_videos && 'all' || 'none' }}
 
       # 📋 UI カタログ（scope=catalog*）: 画面定義と突き合わせて一覧を生成する
       - name: 📋 Generate UI catalog document (iOS)

--- a/.github/workflows/e2e-mobile-test.yml
+++ b/.github/workflows/e2e-mobile-test.yml
@@ -33,6 +33,11 @@ on:
         type: string
         required: false
         default: ""
+      record_videos:
+        description: "エビデンス用に全テストの実機動画を録画して Artifact へ残す（.detoxrc.js の video plugin を all にする）。test_filter と併用すると狙ったフローだけ短時間で撮れる"
+        type: boolean
+        required: false
+        default: false
   schedule:
     # #1029 【設計】毎日 JST 4:00（UTC 19:00）。e2e-web(JST 3:00 / timeout 30分) と時間帯を分け、
     # テストユーザーと Supabase の匿名サインイン枠を取り合わないようにする
@@ -262,6 +267,9 @@ jobs:
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
           DETOX_TEST_FILTER: ${{ inputs.test_filter }}
+          # record_videos 入力が true のときだけ .detoxrc.js の video plugin を all にする
+          # （schedule 実行では inputs が空 = 従来どおり録画しない）
+          DETOX_RECORD_VIDEOS: ${{ inputs.record_videos && '1' || '' }}
 
       # 📋 UI カタログ（scope=catalog*）: 画面定義と突き合わせて一覧を生成する
       - name: 📋 Generate UI catalog document (Android)
@@ -489,6 +497,9 @@ jobs:
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
           DETOX_TEST_FILTER: ${{ inputs.test_filter }}
+          # record_videos 入力が true のときだけ .detoxrc.js の video plugin を all にする
+          # （schedule 実行では inputs が空 = 従来どおり録画しない）
+          DETOX_RECORD_VIDEOS: ${{ inputs.record_videos && '1' || '' }}
 
       # 📋 UI カタログ（scope=catalog*）: 画面定義と突き合わせて一覧を生成する
       - name: 📋 Generate UI catalog document (iOS)

--- a/.github/workflows/e2e-mobile-test.yml
+++ b/.github/workflows/e2e-mobile-test.yml
@@ -34,7 +34,7 @@ on:
         required: false
         default: ""
       record_videos:
-        description: "エビデンス用に全テストの実機動画を録画して Artifact へ残す（.detoxrc.js の video plugin を all にする）。test_filter と併用すると狙ったフローだけ短時間で撮れる"
+        description: "エビデンス用に全テストの実機動画を録画して Artifact へ残す（.detoxrc.js の video plugin を all にする）。test_filter と併用すると狙ったフローだけ短時間で撮れる。⚠️ mp4 が出るのは現状 iOS のみ（Android は headless エミュレータの制約で生成されない。スクショは常時収集される）"
         type: boolean
         required: false
         default: false

--- a/e2e-mobile/.detoxrc.js
+++ b/e2e-mobile/.detoxrc.js
@@ -52,12 +52,15 @@ module.exports = {
 		plugins: {
 			log: "none",
 			screenshot: "failing",
-			// #1484 エビデンス動画の収集用。workflow_dispatch の record_videos 入力が
-			// DETOX_RECORD_VIDEOS=1 を渡したときだけ全テストの動画を artifacts/ へ残す
-			//（Upload Detox artifacts ステップが always() で拾う）。
-			// 上の #1030 の注意のとおり video に launchArgs のトークンは写らないため、
-			// 動画の常設化はセキュリティ上の後退にならない。既定は従来どおり "none"
-			video: process.env.DETOX_RECORD_VIDEOS === "1" ? "all" : "none",
+			// #1484 エビデンス動画は workflow_dispatch の record_videos 入力で撮る。
+			// 入力は DETOX_RECORD_VIDEOS=all を渡し、Detox 自身の env→CLI マッピング
+			//（collectCliConfig が argv と同格に DETOX_RECORD_VIDEOS を読む）で有効化される。
+			// ⚠️ ここを process.env の三項演算にしてはいけない。CLI 設定は defaultsDeep で
+			// この config より優先されるため、"1" のような不正値の env が来た時点で
+			// この行の値は黙って上書きされ、動画が出ない（run 32603604105 / 32605810775 で実測）。
+			// env の値は必ず none|failing|all のいずれかにすること。
+			// #1030 の注意のとおり video に launchArgs のトークンは写らない。既定は "none"
+			video: "none",
 			instruments: "none",
 		},
 	},

--- a/e2e-mobile/.detoxrc.js
+++ b/e2e-mobile/.detoxrc.js
@@ -52,7 +52,12 @@ module.exports = {
 		plugins: {
 			log: "none",
 			screenshot: "failing",
-			video: "none",
+			// #1484 エビデンス動画の収集用。workflow_dispatch の record_videos 入力が
+			// DETOX_RECORD_VIDEOS=1 を渡したときだけ全テストの動画を artifacts/ へ残す
+			//（Upload Detox artifacts ステップが always() で拾う）。
+			// 上の #1030 の注意のとおり video に launchArgs のトークンは写らないため、
+			// 動画の常設化はセキュリティ上の後退にならない。既定は従来どおり "none"
+			video: process.env.DETOX_RECORD_VIDEOS === "1" ? "all" : "none",
 			instruments: "none",
 		},
 	},


### PR DESCRIPTION
## 概要

エビデンス撮影（PR #1496 のスキル）を「即席（web）」と「実機（Detox / CI）」の 2 経路へ拡張する。

**A. 即席（ローカル + Playwright）**
- `record.mjs` にデバイスプリセット追加: `default`（素の iPhone サイズ Chromium）/ `android`（Pixel 7 相当）/ `ios`（iPhone 14 + **WebKit** = Safari のレンダリングエンジン）。後者 2 つは e2e-web CI の mobile-chrome / mobile-safari と同一 descriptor
- 3 プリセットとも録画動作をローカルで確認済み（WebKit は `playwright install webkit` + `install-deps webkit` が初回必要。SKILL.md に記載）

**B. 実機（Detox / CI）**
- `e2e-mobile-test.yml` に `record_videos` 入力を追加。true のとき `.detoxrc.js` の video plugin が `"all"` になり、Android エミュレータ / iOS シミュレータの**本物の動画**が既存の `detox-report-*` Artifact に入る（#1484 で一時ブランチにより実証済みの設定の入力化）
- schedule 実行では inputs が空のため従来どおり録画しない。video に launchArgs のトークンは写らない（#1030 の注意書きどおり）ためセキュリティ上の後退なし
- `SKILL.md` に A/B の使い分け表（モック/実機で映るものの違い、「相当」を実機と偽らない原則）と B の手順を追記

## テスト

- 即席側: 3 プリセットの録画を実行し webm 生成を確認
- 実機側: 本 PR のブランチで `record_videos: true` + `test_filter: onboarding` の短縮 dispatch を実行し、Artifact に動画が入ることを検証中（結果はコメントで追記）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tj2QxpKP2MgtbycYndt68U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tj2QxpKP2MgtbycYndt68U)_