### PR TITLE
#843 fix: parquet load に enable_list_inference を指定する

### DIFF
--- a/scripts/20260808T0000_restaurant/pipeline_common.py
+++ b/scripts/20260808T0000_restaurant/pipeline_common.py
@@ -280,6 +280,11 @@ class BigQueryPipeline:
         parquet_options = bigquery.ParquetOptions()
         parquet_options.enable_list_inference = True
         job_config.parquet_options = parquet_options
+        # duckdb の COPY は全列を optional で書くため、スキーマ推定に任せると
+        # REQUIRED 列が "changed mode from REQUIRED to NULLABLE" で落ちる。
+        # 宛先テーブルのスキーマを明示して推定を使わせない（NULL が実際に
+        # 入っていればこの指定でも load 時に落ちる。それは落ちるべきである）。
+        job_config.schema = self.client.get_table(self.table(table_name)).schema
         with path.open("rb") as stream:
             job = self.client.load_table_from_file(
                 stream,

--- a/scripts/20260808T0000_restaurant/pipeline_common.py
+++ b/scripts/20260808T0000_restaurant/pipeline_common.py
@@ -274,6 +274,12 @@ class BigQueryPipeline:
             source_format=bigquery.SourceFormat.PARQUET,
             write_disposition=write_disposition,
         )
+        # これが無いと parquet の LIST 型が RECORD（list.element の入れ子）として
+        # 解釈され、ARRAY<STRING> 列への load が schema mismatch で落ちる
+        # （実際に categories 列で落ちた）。
+        parquet_options = bigquery.ParquetOptions()
+        parquet_options.enable_list_inference = True
+        job_config.parquet_options = parquet_options
         with path.open("rb") as stream:
             job = self.client.load_table_from_file(
                 stream,


### PR DESCRIPTION
## 概要

overture ロード（[run 32603844757](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/32603844757)）が次の 400 で失敗したのを修正します。

```
400 Provided Schema does not match Table food-scroll:restaurant_recommendation.restaurant_overture_raw.
Field categories has changed type from STRING to RECORD
```

BigQuery の parquet ロードは、`enable_list_inference` を指定しないと parquet の LIST 型を RECORD（`list.element` の入れ子）として解釈し、`ARRAY<STRING>` 列とのスキーマ不一致で落ちます。`pipeline_common.load_parquet` に `ParquetOptions.enable_list_inference = True` を追加しました。parquet ロードを使うのは 1_3（Overture）だけで、他のローダーは NDJSON のため影響ありません。

## 検証

このブランチ ref での overture 再実行（[run 32605829854](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/32605829854)）が実行待ち。green を確認してからマージします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCVVMHHhHRMMUCUtMj5d2A

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCVVMHHhHRMMUCUtMj5d2A)_