### PR TITLE
perf(e2e-mobile): APK キャッシュと test_filter の AND 化で実機エビデンス撮影を高速化

### DIFF
--- a/.claude/skills/evidence-video/SKILL.md
+++ b/.claude/skills/evidence-video/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   (A) 即席 = ローカルで expo の web ビルドを立ち上げ、認証・API・Maps をモックした Playwright で
   録画（数分。Android 相当 / iOS 相当 = WebKit のデバイスプリセット付き）。
   (B) 実機 = e2e-mobile CI を record_videos 入力付きで dispatch し、Android エミュレータ /
-  iOS シミュレータの本物の Detox 動画を Artifact から回収（約 30 分〜）。
+  iOS シミュレータの本物の Detox 動画を Artifact から回収（ビルドキャッシュ命中時
+  Android 約 6 分 / iOS 約 15 分）。
   「動画で見せて」「エビデンスください」「スクショで確認したい」「iOS/Android での見た目を確かめたい」
   「デザイン修正を目視確認して」のように、UI の見た目や挙動を人に見せる・自分で確かめる必要が
   あるとき必ず使う。
@@ -17,7 +18,7 @@ description: >-
 
 | | A. 即席（このファイルの主題） | B. 実機（Detox / CI） |
 | --- | --- | --- |
-| 所要 | 数分 | 約 30 分〜（iOS は更に長い） |
+| 所要 | 数分 | APK/app キャッシュ命中時: Android 約 6 分 / iOS 約 15 分。ミス時 +11〜16 分 |
 | 実体 | ローカル web ビルド + Playwright | Android エミュレータ / iOS シミュレータ + Detox |
 | データ | 認証・API・Maps は**モック** | 実 dev 環境（実 API） |
 | 映るもの | UI・デザイン・画面遷移 | 上に加えて OS 許可ダイアログ・ATT 等ネイティブ面 |
@@ -32,8 +33,12 @@ description: >-
 
 1. `e2e-mobile-test.yml` を workflow_dispatch で起動する。入力:
    - `record_videos: true`（.detoxrc.js の video plugin が "all" になり全テストの動画が残る）
-   - `test_filter` に撮りたいフローの spec 名を入れると短縮できる（例: `onboarding`）。
-     platform で android / ios を絞れる
+   - `test_filter` に撮りたいフローの spec 名（例: `onboarding`）。**scope は既定の
+     `tier1-2` のまま**にする。filter は scope と AND で効くため、tier1(smoke) に
+     smoke 外の spec 名を渡すと 0 件になる。platform で android / ios を絞れる
+   - ビルドはバイナリ単位でキャッシュされる（app-expo / shared / lockfile が前回
+     ビルド時と同一なら Gradle 11 分 / xcodebuild 16 分がスキップされる）。
+     main で一度撮った後の再撮影・テストコードだけの修正は毎回キャッシュに乗る
 2. 完了後、Artifact `detox-report-android` / `detox-report-ios` をダウンロードすると
    `artifacts/` 配下にテストごとの `test.mp4` が入っている。チャットへは必要な分だけ
    `SendUserFile` で転送する
@@ -42,6 +47,14 @@ description: >-
 
 Android / iOS どちらも `test.mp4` が出る（#1484 の run 32589219056 で両 OS の
 mp4 を確認）。スクショ（--take-screenshots all）は録画の有無によらず常時収集される。
+
+⚠️ **CI の実機動画に紙吹雪など「モーション削減で消える演出」は映らない。**
+CI エミュレータはテスト安定化のため `disable-animations: true` で走り、Android は
+これをモーション削減としてアプリへ通知する。アプリ側（ConfettiBurst 等）が
+reduced motion を正しく尊重して描画を抑制するので、映らないのが正しい挙動。
+アニメを有効にすると無限ループ演出（紙吹雪・スピナー）が Detox の同期機構を
+永久ビジーにして全テストがハングするため、CI では有効化しない。
+演出そのもののエビデンスは A（即席 web 動画）か手元の実機で撮ること。
 
 ⚠️ **`DETOX_RECORD_VIDEOS` という env 名は Detox 自身が CLI オプションとして
 解釈する**（collectCliConfig が argv と同格に読み、defaultsDeep で .detoxrc.js より

--- a/.github/workflows/e2e-mobile-test.yml
+++ b/.github/workflows/e2e-mobile-test.yml
@@ -29,7 +29,7 @@ on:
           - catalog
           - catalog-with-review-flow
       test_filter:
-        description: "実行する spec を絞る jest の --testPathPattern（例: logout|saved-topic）。修正 1 件の検証ループを全 suite 実行（iOS で 90 分超）から数分へ縮めるための入力。空なら全件。⚠️ マージ前の最終確認は必ず空（全件）で回すこと"
+        description: "実行する spec をパス部分一致で絞る（例: logout|saved-topic。| か空白区切りで OR）。scope の範囲内で AND で効く（jest.config.js が DETOX_TEST_FILTER から除外パターンを組む）。修正 1 件の検証ループやエビデンス撮影を数分へ縮めるための入力。空なら全件。⚠️ マージ前の最終確認は必ず空（全件）で回すこと"
         type: string
         required: false
         default: ""
@@ -151,8 +151,35 @@ jobs:
           COMMIT_ID: ${{ github.sha }}
         run: printf '\nEXPO_PUBLIC_COMMIT_ID=%s\n' "$COMMIT_ID" >> .env
 
+      # 🔑 アプリバイナリ(APK)のキャッシュキーを算出する（iOS ジョブの同名ステップと同一思想）。
+      # Gradle ビルドは毎 run 約 11 分かかる（run 32607545105 で実測）が、release APK は
+      # アプリ側の入力が同じなら同一。エビデンス動画の再撮影やテストコードだけの修正で
+      # 11 分を払わないためにバイナリ単位でキャッシュする。
+      # COMMIT_ID を除く理由・stale COMMIT_ID の代償は iOS 側のコメントを参照
+      - name: 🔑 Compute app binary cache key
+        id: appkey
+        shell: bash
+        run: |
+          grep -v '^EXPO_PUBLIC_COMMIT_ID=' app-expo/.env > app-expo/.env.cachekey
+          echo "app_tree=$(git rev-parse HEAD:app-expo)" >> "$GITHUB_OUTPUT"
+          echo "shared_tree=$(git rev-parse HEAD:shared)" >> "$GITHUB_OUTPUT"
+
+      # ⚠️ restore-keys は付けない（iOS 側と同じ理由: 前方一致で stale バイナリを掴まない）
+      - name: 📥 Cache Detox app binary (Android)
+        id: appcache
+        uses: actions/cache@v4
+        with:
+          path: app-expo/android/app/build/outputs/apk
+          key: android-detox-apk-${{ runner.os }}-${{ steps.appkey.outputs.app_tree }}-${{ steps.appkey.outputs.shared_tree }}-${{ hashFiles('pnpm-lock.yaml', 'app-expo/.env.cachekey') }}
+
+      - name: ♻️ Report app binary cache hit
+        if: steps.appcache.outputs.cache-hit == 'true'
+        run: |
+          echo "::warning::APK キャッシュがヒットしたため Gradle ビルドをスキップします。バイナリ内の EXPO_PUBLIC_COMMIT_ID はビルド元コミットのままです（E2E は COMMIT_ID を検証しない）"
+
       # Gradle (AGP 8.x) は JDK 17 を要求する
       - name: ☕ Setup JDK 17
+        if: steps.appcache.outputs.cache-hit != 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -160,11 +187,13 @@ jobs:
 
       # Gradle の依存・ビルドキャッシュを共有し、2 回目以降のビルドを高速化する
       - name: 🐘 Setup Gradle
+        if: steps.appcache.outputs.cache-hit != 'true'
         uses: gradle/actions/setup-gradle@v4
 
       # CNG: android/ ディレクトリを生成する。E2E_DETOX=1 で @config-plugins/detox が
       # androidTest 設定（DetoxTest.java・build.gradle・Network Security Config）を注入する
       - name: 🧬 Expo prebuild (Android)
+        if: steps.appcache.outputs.cache-hit != 'true'
         working-directory: app-expo
         env:
           E2E_DETOX: "1"
@@ -172,6 +201,7 @@ jobs:
 
       # release APK + androidTest APK をビルドする（エミュレータ用に x86_64 のみ。.detoxrc.js 参照）
       - name: 🏗️ Detox build (Android release)
+        if: steps.appcache.outputs.cache-hit != 'true'
         # #1030 【設計】A' 案のセッション注入フックは **バンドル時** に metro.config.js の resolver で
         # 有効/無効が決まる。ここで立てないと noop 実装が焼き込まれ、launchArgs が黙って無視される
         # （= 認証済みテストが匿名のまま走り、テストは緑なのに検証内容だけが嘘になる）
@@ -196,6 +226,7 @@ jobs:
       # #1076 焼き込みは失敗しても例外もログも出ない (@expo/env が黙って捨てる) ため、
       # 成果物を直接検査して落とす。assert-no-e2e-hook と同じ sentinel ゲートの考え方。
       - name: 🔍 Assert commit id is baked into the APK
+        if: steps.appcache.outputs.cache-hit != 'true'
         env:
           COMMIT_ID: ${{ github.sha }}
         run: |

--- a/e2e-mobile/jest.config.js
+++ b/e2e-mobile/jest.config.js
@@ -44,6 +44,23 @@ if (!isMutationEnabled) testPathIgnorePatterns.push("<rootDir>/tests/mutation/")
 if (!isProbeEnabled) testPathIgnorePatterns.push("<rootDir>/tests/probe/");
 if (!isCatalogEnabled) testPathIgnorePatterns.push("<rootDir>/tests/catalog/");
 
+// 🔬 spec の絞り込み（workflow_dispatch の test_filter → DETOX_RECORD 系と同じく env で届く）。
+//
+// ⚠️ jest の位置引数や --testPathPattern で渡してはいけない。それらは jest 内部で
+// **すべて 1 つの OR リストへ合流する**ため、tier スクリプトが持つ
+// `--testPathPattern 'tests/smoke/'` と併用すると「(smoke) OR (filter)」になり、
+// 絞ったつもりで全 smoke が実行されていた（run 32605810775 で実測: iOS のテストが 14.9 分）。
+// testPathIgnorePatterns は選択とは独立に AND で効くため、
+// 「filter のどの語も含まないパスを除外する」否定先読みで (tier) AND (filter) を表現する。
+const testFilter = (process.env.DETOX_TEST_FILTER || "").trim();
+if (testFilter) {
+	const words = testFilter
+		.split(/[|\s]+/)
+		.filter(Boolean)
+		.map((word) => word.replace(/[.*+?^${}()[\]\\]/g, "\\$&"));
+	if (words.length > 0) testPathIgnorePatterns.push(`^(?!.*(?:${words.join("|")}))`);
+}
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
 	rootDir: ".",

--- a/e2e-mobile/screens/OnboardingScreen.ts
+++ b/e2e-mobile/screens/OnboardingScreen.ts
@@ -119,6 +119,30 @@ export class OnboardingScreen {
 	}
 
 	/**
+	 * Welcome の「はじめる」を、**画面を抜けるまでタップし直しながら**押し切る。
+	 *
+	 * Welcome は紙吹雪が無限ループする（確定仕様）うえ、record_videos 有効時は
+	 * 画面録画の負荷も乗る。この状態の iOS シミュレータでは 1 回のタップが
+	 * 取りこぼされることがあり、「押したのに Welcome のまま」で後続の遷移待ちが
+	 * タイムアウトした（録画有効の run 32609985951 / 32615946840 で計 4 連続、
+	 * 録画無効の run 32605810775 では成功、という相関の実測）。
+	 * タップは冪等（markOnboardingSeen + 遷移）なので、着地確認とセットで繰り返す。
+	 *
+	 * @param exitedMatcher 遷移先で見えるはずの要素（例: 検索ヘッダのタイトル）
+	 */
+	async pressStartUntilExited(exitedMatcher: Detox.NativeMatcher, timeout = 60_000): Promise<void> {
+		await waitUntil(
+			async () => {
+				if (await visibleNow(this.startButton, 1_000)) {
+					await tapWhenPresent(this.startButton);
+				}
+				return visibleNow(exitedMatcher, 3_000);
+			},
+			{ description: "「はじめる」でアプリ本体へ戻ること", timeout },
+		);
+	}
+
+	/**
 	 * 「次へ」を **待機を挟まずに** `times` 回連打する（#1084 P3 と同じ狙い）。
 	 *
 	 * `pressNext()` の連続呼び出しでは連打にならない（Detox の同期機構が

--- a/e2e-mobile/scripts/run-detox-ci.sh
+++ b/e2e-mobile/scripts/run-detox-ci.sh
@@ -30,43 +30,29 @@ readonly WORK_DIR="${REPO_ROOT}/e2e-mobile/.detox-ci-logs"
 rm -rf "${WORK_DIR}"
 mkdir -p "${WORK_DIR}"
 
-# 🔬 spec の絞り込み（workflow_dispatch の test_filter）。
-# 修正 1 件の検証のために全 suite（iOS で 90 分超）を回すのは無駄なので、
-# 対象 spec 名を jest へ渡せるようにする。空なら従来どおり全件。
+# 🔬 spec の絞り込み（workflow_dispatch の test_filter → DETOX_TEST_FILTER）。
+# 修正 1 件の検証やエビデンス撮影のために全 suite（iOS で 90 分超）を回すのは無駄なので、
+# 対象 spec 名で絞れるようにする。空なら従来どおり全件。
 #
-# ⚠️ `--testPathPattern 'a|b'` の形にしないこと。detox は受け取った引数を
-# **シェル文字列として** jest コマンドに組み立て直すため、`|` が裸のパイプとして
-# 解釈され `logout` 等がコマンドとして実行された（run 31624910689 で実測:
-# `/bin/sh: line 0: logout: not login shell`）。
-# jest は位置引数を複数の testPathPattern（OR）として解釈するので、
-# `|` や空白で区切った単語を **1 語ずつ位置引数で**渡す。
-#
-# ⚠️ pnpm は最初の `--` を自分で消費するため、detox へ `--`（jest への区切り）を
-# 届けるには二重に書く（pnpm run script -- -- word1 word2）
-EXTRA_ARGS=()
+# ⚠️ ここで jest へ引数（位置引数や --testPathPattern）として渡してはいけない。
+# かつては位置引数で渡していたが、jest は位置引数と --testPathPattern を
+# **1 つの OR リストへ合流させる**ため、tier スクリプトの `--testPathPattern 'tests/smoke/'`
+# と併用すると「(tier) OR (filter)」になり絞れていなかった（run 32605810775 で実測）。
+# 現在は jest.config.js が DETOX_TEST_FILTER（env はシェル再組み立てを経ないので
+# `|` も安全）を読んで除外パターンで AND を組む。ここでは早期の入力検証だけを行う
 if [[ -n "${DETOX_TEST_FILTER:-}" ]]; then
-  IFS='| ' read -r -a FILTER_WORDS <<< "${DETOX_TEST_FILTER}"
-  SAFE_WORDS=()
-  for word in "${FILTER_WORDS[@]}"; do
-    [[ -z "${word}" ]] && continue
-    # detox がシェル経由で再組み立てするため、シェルに安全な文字だけを許す
-    if [[ ! "${word}" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-      echo "::error::test_filter に使えない文字が含まれています: ${word}（英数字と . _ / - のみ、区切りは | か空白）"
-      exit 1
-    fi
-    SAFE_WORDS+=("${word}")
-  done
-  if [[ ${#SAFE_WORDS[@]} -gt 0 ]]; then
-    EXTRA_ARGS=(-- -- "${SAFE_WORDS[@]}")
-    echo "▶ spec を絞り込みます: ${SAFE_WORDS[*]}"
+  if [[ ! "${DETOX_TEST_FILTER}" =~ ^[A-Za-z0-9._/|[:space:]-]+$ ]]; then
+    echo "::error::test_filter に使えない文字が含まれています: ${DETOX_TEST_FILTER}（英数字と . _ / - のみ、区切りは | か空白）"
+    exit 1
   fi
+  echo "▶ spec を絞り込みます (jest.config.js が AND で適用): ${DETOX_TEST_FILTER}"
 fi
 
 echo "▶ pnpm --filter e2e-mobile run ${SCRIPT_NAME}"
 
 # tee でジョブログと収集用ファイルの両方へ出す。冒頭の `set -o pipefail` により
 # tee ではなく pnpm 側の終了コードが $? に残る（`set -e` は付けない。後始末を必ず走らせるため）
-pnpm --filter e2e-mobile run "${SCRIPT_NAME}" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} 2>&1 | tee "${WORK_DIR}/detox-run.log"
+pnpm --filter e2e-mobile run "${SCRIPT_NAME}" 2>&1 | tee "${WORK_DIR}/detox-run.log"
 readonly EXIT_CODE=$?
 
 # ⚠️ 収集物のコピーは **後始末より先に**行う。後続がハングしても実行ログだけは必ず Artifact に残す

--- a/e2e-mobile/tests/search/onboarding.test.ts
+++ b/e2e-mobile/tests/search/onboarding.test.ts
@@ -1,4 +1,4 @@
-import { LAUNCH_TIMEOUT, describeJapaneseLocale, launchAppWithSession } from "../../fixtures/e2e";
+import { LAUNCH_TIMEOUT, describeJapaneseLocale, device, launchAppWithSession } from "../../fixtures/e2e";
 import { LoginScreen } from "../../screens/LoginScreen";
 import { OnboardingScreen } from "../../screens/OnboardingScreen";
 import { SearchScreen } from "../../screens/SearchScreen";
@@ -108,10 +108,23 @@ describeJapaneseLocale("オンボーディング（初回起動）", () => {
 		await login.expectOpened();
 		await login.skip();
 		await onboarding.waitForWelcome();
-		await onboarding.pressStart();
 
-		// #1486 §7 「はじめる」でアプリ本体（検索画面）へ戻る
-		await search.expectLoaded();
+		// ⚠️ Welcome の紙吹雪は **無限ループ**（最終検収で確定した仕様）のため、アプリは
+		// 二度と idle にならない。Detox の同期機構に任せたままタップすると
+		// 「Run loop awake / work items pending」のまま操作が不安定になり、
+		// 「はじめる」後の遷移待ちがフレークする（iOS run 32609985951 で 2 回連続失敗、
+		// 同一コードの run 32605810775 では成功、というフレーク実測）。
+		// 無限アニメーション画面の定石どおり、同期を切ってタップし、
+		// 着地（検索画面）をポーリングで確認してから同期を戻す
+		await device.disableSynchronization();
+		try {
+			await onboarding.pressStart();
+
+			// #1486 §7 「はじめる」でアプリ本体（検索画面）へ戻る
+			await search.expectLoaded();
+		} finally {
+			await device.enableSynchronization();
+		}
 
 		// ── #1027: 既読フラグが AsyncStorage へ永続化されている ──────────
 		// 【重要】ここで `tutorialSeen: true`（既定）にしてはいけない。

--- a/e2e-mobile/tests/search/onboarding.test.ts
+++ b/e2e-mobile/tests/search/onboarding.test.ts
@@ -1,4 +1,4 @@
-import { LAUNCH_TIMEOUT, describeJapaneseLocale, device, launchAppWithSession } from "../../fixtures/e2e";
+import { LAUNCH_TIMEOUT, describeJapaneseLocale, launchAppWithSession } from "../../fixtures/e2e";
 import { LoginScreen } from "../../screens/LoginScreen";
 import { OnboardingScreen } from "../../screens/OnboardingScreen";
 import { SearchScreen } from "../../screens/SearchScreen";
@@ -109,22 +109,12 @@ describeJapaneseLocale("オンボーディング（初回起動）", () => {
 		await login.skip();
 		await onboarding.waitForWelcome();
 
-		// ⚠️ Welcome の紙吹雪は **無限ループ**（最終検収で確定した仕様）のため、アプリは
-		// 二度と idle にならない。Detox の同期機構に任せたままタップすると
-		// 「Run loop awake / work items pending」のまま操作が不安定になり、
-		// 「はじめる」後の遷移待ちがフレークする（iOS run 32609985951 で 2 回連続失敗、
-		// 同一コードの run 32605810775 では成功、というフレーク実測）。
-		// 無限アニメーション画面の定石どおり、同期を切ってタップし、
-		// 着地（検索画面）をポーリングで確認してから同期を戻す
-		await device.disableSynchronization();
-		try {
-			await onboarding.pressStart();
-
-			// #1486 §7 「はじめる」でアプリ本体（検索画面）へ戻る
-			await search.expectLoaded();
-		} finally {
-			await device.enableSynchronization();
-		}
+		// #1486 §7 「はじめる」でアプリ本体（検索画面）へ戻る。
+		// ⚠️ 単発の pressStart + expectLoaded にしないこと。Welcome は紙吹雪が
+		// 無限ループし（確定仕様）、録画有効時はタップが取りこぼされることがある
+		//（詳細は pressStartUntilExited のコメント）。着地するまでタップし直す
+		await onboarding.pressStartUntilExited(search.headerTitle);
+		await search.expectLoaded();
 
 		// ── #1027: 既読フラグが AsyncStorage へ永続化されている ──────────
 		// 【重要】ここで `tutorialSeen: true`（既定）にしてはいけない。


### PR DESCRIPTION
## 概要

実機エビデンス動画（`record_videos`）の所要時間を実測分析し、2 つのボトルネックを解消する。

実測（run 32607545105 / 32605810775）: Android 16.7 分 = **Gradle 10.8** + テスト 3.9 / iOS 35.5 分 = **xcodebuild 15.8** + **テスト 14.9**。

**1. Android APK キャッシュ**（iOS の app バイナリキャッシュと同一思想）
- `app-expo` / `shared` の tree hash + lockfile + .env（COMMIT_ID 除外）をキーに `outputs/apk` をキャッシュ。ヒット時は JDK/Gradle セットアップ・prebuild・Gradle ビルド・焼き込み検査をスキップ（約 11 分削減）。restore-keys なし（stale バイナリ防止、iOS 側と同じ）

**2. test_filter の AND 化**（実は絞れていなかった）
- jest は位置引数と `--testPathPattern` を 1 つの **OR** リストへ合流させるため、tier スクリプトの `--testPathPattern 'tests/smoke/'` と併用すると「(tier) OR (filter)」= 全 smoke 実行になっていた（iOS テスト 14.9 分の主因）
- `jest.config.js` が `DETOX_TEST_FILTER` から否定先読みの除外パターンを組み、(tier) **AND** (filter) を表現する方式へ。env 渡しなので detox のシェル再組み立てを経ず、`|` も安全（旧位置引数方式の制約も解消）
- `--listTests` で検証済み: smoke AND onboarding = 0 件 / 全域 AND onboarding = 1 件 / `logout|saved-topic` = 2 件

**期待値**: キャッシュ命中 + filter で Android 約 6 分 / iOS 約 15 分（本 PR のブランチで実測検証中、結果をコメントで追記）。

SKILL.md には所要時間の実態・「scope は tier1-2 のまま filter を使う」指針・CI 動画に紙吹雪が映らない理由（`disable-animations` → reduced motion をアプリが正しく尊重。アニメ有効化は無限ループ演出が Detox 同期を永久ビジーにするため不可）を追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tj2QxpKP2MgtbycYndt68U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tj2QxpKP2MgtbycYndt68U)_