### PR TITLE
DB migration 運用を migration-first へ固定し、api デプロイを DB 非依存ビルドにする

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -61,8 +61,42 @@ jobs:
           echo 'DATABASE_URL=${{ secrets.PRISMA_DATABASE_URL }}'            >> ./api/.env
           echo "DB_SCHEMA=$DB_SCHEMA" >> ./api/.env
 
-      - name: Prisma db:pull
-        run: pnpm db:pull
+      # ==========================================================================
+      # 【設計】デプロイ時に生きた DB を introspect（db:pull）しない。
+      #
+      # かつてここで `pnpm db:pull` していたが、それは「ビルドの Prisma 型 =
+      # その瞬間の DB の姿」を意味する。2026-08 に、機能ブランチ（#1469）が dev へ
+      # migration を先行適用した結果、dev を introspect した型と噛み合うコードが
+      # そのブランチにしか無くなり、**main から api-development をデプロイできない**
+      # 事故が起きた。
+      #
+      # 以後、ビルドはブランチ自己完結にする: コミット済み api/prisma/schema.prisma
+      # （db-migrate.yml の regenerate_prisma が migration 適用時に introspect して
+      # commit している）のスキーマ名だけを適用先へ差し替え、`prisma generate` で
+      # Client を作り直す。DB へは一切接続しない。DB がコードより先に進んでいても、
+      # migration が後方互換（additive）である限りこのビルドは正しく動く
+      # （運用規則: infra/supabase/migrations/README.md）。
+      # ==========================================================================
+      - name: Prisma Client を生成（コミット済み schema から・DB 非接続）
+        run: |
+          set -euo pipefail
+          # prisma.config.ts が env("DATABASE_URL") を要求する（validate / generate は
+          # 接続しないが、config の評価に必要）。旧 db-pull.sh と同じく api/.env から export する
+          set -a; source ./api/.env; set +a
+          # コミット済み schema.prisma は dev スキーマ名で introspect されている。
+          # 適用先スキーマ名へ機械置換する（対象は schemas 配列と @@schema の 2 パターンのみ）。
+          sed -i \
+            -e "s/= \[\"dev\"\]/= [\"${DB_SCHEMA}\"]/" \
+            -e "s/@@schema(\"dev\")/@@schema(\"${DB_SCHEMA}\")/g" \
+            api/prisma/schema.prisma
+          # 置換漏れがあると別スキーマへ向いたまま本番へ出るので、ここで検算する
+          if [ "${DB_SCHEMA}" != "dev" ] && grep -q '"dev"' api/prisma/schema.prisma; then
+            echo "::error::schema.prisma に \"dev\" が残っています。置換パターンを見直してください。"
+            grep -n '"dev"' api/prisma/schema.prisma
+            exit 1
+          fi
+          pnpm -C api exec prisma validate --schema prisma/schema.prisma --config ../prisma.config.ts
+          pnpm -C api exec prisma generate --schema prisma/schema.prisma --config ../prisma.config.ts
 
       # ---------- Google Cloud へ OIDC でログイン ----------
       - name: Auth to Google Cloud (WIF)

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -27,6 +27,14 @@ name: DB Migrate
 # ## なぜ Actions でやるのか
 # migration は「誰かのローカルから流す」と、いつ・どのファイルまで当たったのかが
 # 記録に残りません。dispatch のログが残る形にしておくと、後から追えます。
+#
+# ## 実適用（dry_run=false）は main ブランチからのみ
+# 2026-08 に、機能ブランチ（#1469）から dev へ migration を先行適用した結果、
+# 「dev の schema と噛み合うコードがそのブランチにしか無く、api-development を
+# main からデプロイできない」状態が発生しました。以後、DB 変更は
+# «migration だけの小 PR を先に main へマージ → main からこの workflow で適用»
+# という migration-first 運用に固定します（infra/supabase/migrations/README.md）。
+# ブランチからは dry_run のみ許可します（適用対象と検査の事前確認用）。
 # ==============================================================================
 
 on:
@@ -88,6 +96,16 @@ jobs:
         run: |
           if [ -z "${DATABASE_URL}" ]; then
             echo "::error::secrets.POSTGRES_DATABASE_URL が未設定です。migration 対象 DB の接続文字列を登録してください。"
+            exit 1
+          fi
+
+      - name: 実適用は main ブランチからのみ許可
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "::error::実適用（dry_run=false）は main ブランチからのみ実行できます（現在: ${GITHUB_REF_NAME}）。"
+            echo "::error::migration を適用したい場合は、migration ファイルだけの小 PR を先に main へマージしてください（infra/supabase/migrations/README.md）。"
             exit 1
           fi
 

--- a/.github/workflows/migration-order-check.yml
+++ b/.github/workflows/migration-order-check.yml
@@ -1,0 +1,45 @@
+name: Migration Order Check
+
+# ==============================================================================
+# migration の「ファイル名順 = 適用順」を PR で守るゲート
+#
+# このリポジトリの migration は DB 側に台帳を持たず、apply-migration.sh が
+# from_file 以降をファイル名昇順で流す。よって、既存ファイルより辞書順で前に
+# 新ファイルが割り込むと適用順が壊れる（実際に 2026-08 に発生した。
+# 20260819T* が dev 先行適用のまま、main へ 20260823T0000 が先に入った）。
+#
+# ここでは PR が追加する *.sql が base の最後尾より後ろであることだけを検査する。
+# 依存ゼロの bash なので fork からの PR でも動く。
+# 運用の全体像: infra/supabase/migrations/README.md
+# ==============================================================================
+
+on:
+  pull_request:
+    paths:
+      - "infra/supabase/migrations/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  order-check:
+    name: migration ファイル名の順序を検査
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: リポジトリを取得
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: base を取得して順序を検査
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          bash scripts/assert-migration-filename-order.sh "$BASE_SHA"

--- a/infra/supabase/migrations/20260824T0000_alter_dish_reviews_created_dish_media_id_nullable.sql
+++ b/infra/supabase/migrations/20260824T0000_alter_dish_reviews_created_dish_media_id_nullable.sql
@@ -1,0 +1,49 @@
+-- NOTE: 旧 20260819T0000_alter_dish_reviews_created_dish_media_id_nullable.sql からのリネーム（#1469 ブランチが dev へ旧名で先行適用済み。SQL 本体は同一で、全体が冪等なので再適用は無害）。
+-- リネーム理由: main の 20260823T0000 より後ろに並べ、「ファイル名順 = 適用順」を守るため。
+-- ==============================================================================
+-- 20260819T0000_alter_dish_reviews_created_dish_media_id_nullable.sql
+-- #1395（親 #1375）
+-- ==============================================================================
+-- 【目的】
+--   「食べた」を写真なしで記録できるようにするため、
+--   dish_reviews.created_dish_media_id の NOT NULL 制約を外す。
+--
+-- 【背景】
+--   - 20250802T0304_create_dish_reviews.sql:12 のとおり、この列は
+--       created_dish_media_id UUID NOT NULL,
+--     で定義されており、**FK は存在しない**
+--     （「メディアに対するレビューではないため references は貼らない」という当時の判断）。
+--   - したがって NOT NULL 解除は FK の張り替えを伴わない単独の
+--     ALTER COLUMN ... DROP NOT NULL で済む。
+--   - 前例: 20250903T1030_drop_not_null_plus_code_from_restaurants.sql と同形。
+--
+-- 【コスト】
+--   NOT NULL の解除は pg_attribute のカタログ更新のみでテーブル書き換えを伴わない。
+--   dish_reviews は約 964MB（DB 使用容量の約 60%。20260718T0000 のヘッダ参照）だが、
+--   この ALTER は一瞬で終わる。ACCESS EXCLUSIVE ロックは取るため、
+--   長時間クエリが走っていない時間帯に適用すること。
+--
+-- 【デプロイ順序（不可逆点があるため厳守）】
+--   [1] 本マイグレーションを適用する（ここまでは既存コードのまま動く）
+--   [2] API / フロントの型追従をデプロイする
+--   [3] ここで初めて createdDishMediaId 省略の書き込みを許可する
+--   [3] を [1] より先に出すと 500 になる。逆順にしないこと。
+--
+-- 【ロールバック】
+--   ALTER TABLE dish_reviews ALTER COLUMN created_dish_media_id SET NOT NULL;
+--   ただし NULL 行が 1 件でも入ったら戻せない（実質片道）。
+--   上記 [3] を実行する前なら戻せる。
+--
+-- 【影響範囲（#1395 設計書 §1 で全列挙済み）】
+--   - 集計は全て dish_id 経由であり、created_dish_media_id を見ていないため
+--     店舗の reviewCount / averageRating は壊れない
+--     （restaurants.repository.ts / dish-media.repository.ts の avgByDish）。
+--   - 写真なしレビューも従来どおり公開レビューとして平均評価に載る。
+--     これは #1375 の「決定1: レビューは全ユーザー公開」で確定した意図した仕様。
+--   - BigQuery へ dish_reviews を同期するコードは本リポジトリに存在しない。
+-- ==============================================================================
+
+ALTER TABLE dish_reviews ALTER COLUMN created_dish_media_id DROP NOT NULL;
+
+COMMENT ON COLUMN dish_reviews.created_dish_media_id IS
+  'レビュー作成時に投稿したメディア。写真なしで「食べた」を記録できるため NULL 可（#1395）。メディアに対するレビューではないため FK は張らない（20250802T0304 の判断を踏襲）';

--- a/infra/supabase/migrations/20260824T0100_add_render_type_to_dish_media.sql
+++ b/infra/supabase/migrations/20260824T0100_add_render_type_to_dish_media.sql
@@ -1,0 +1,101 @@
+-- NOTE: 旧 20260819T0100_add_render_type_to_dish_media.sql からのリネーム（#1469 ブランチが dev へ旧名で先行適用済み。SQL 本体は同一で、全体が冪等なので再適用は無害）。
+-- リネーム理由: main の 20260823T0000 より後ろに並べ、「ファイル名順 = 適用順」を守るため。
+-- ==============================================================================
+-- 20260819T0100_add_render_type_to_dish_media.sql
+-- #1395（親 #1375 / #1273 §40 準拠）
+-- ==============================================================================
+-- 【目的】
+--   1) dish_media.render_type（'stored' / 'external_embed'）を追加する
+--   2) dish_media.media_path の NOT NULL を解除する（external_embed には実体が無い）
+--   3) 上記を破らないための CHECK 制約を張る
+--
+-- 【背景】
+--   - #1375 の設計の正本 §6:「動画本体は保存しない（公式埋め込みを使う）。
+--     サムネイル画像のみ自ストレージへ保存する」
+--   - よって external_embed の行には media_path に相当する実体が無い。
+--     一方 thumbnail_path は NOT NULL を維持する（nullable 化すると
+--     DishMediaEntry.thumbnailImageUrl: string が破壊的変更になり、
+--     リスト・Map・Calendar・検索フィードの全読み取り経路へ波及するため）。
+--   - サムネイルは **全 provider について取り込み時に自ストレージへ保存する**
+--     （統一キャッシュ方式。#1395 の仕様追補で確定）。よってサムネイルの置き場は
+--     thumbnail_path 一本であり、外部 CDN URL を持つ列は追加しない。
+--     1 つの概念の置き場を 2 列に分けると読み取り分岐が全経路へ波及するため。
+--     YouTube の 30 日ルールは「30 日 TTL で再取得するバッチ」で準拠する（#1399）。
+--
+-- 【media_path に canonical_url を入れる案を却下した理由】
+--   dish-media.assembler.ts の buildCdnUrlFromPath() が
+--   `https://${CDN_HOST}/${gcsPath}` を組み立てるため、media_path に
+--   'https://tiktok.com/...' を入れると
+--   'https://cdn.example/https://tiktok.com/...' という壊れた URL になる。
+--
+-- 【render_type='external_embed' の行が NOT NULL 列に入れる値（#1395 レビュー M-3）】
+--   dish_media.media_processing_status / thumbnail_processing_status は
+--   どちらも NOT NULL でデフォルトが無いため、取り込み側が必ず値を入れる必要がある。
+--   本 Issue で下記の規約に確定する（#1399 の前提と矛盾させないこと）:
+--     - media_processing_status     = 'idle'
+--       （自ストレージに実体が無く、リサイズもトランスコードも発生しないため。
+--         'idle' は MediaProcessingStatus の「まだ何もしていない」に対応する）
+--     - thumbnail_processing_status = 'processing'
+--       （サムネイルは取り込み後にリサイズを走らせる。#1399 がこの値を前提にしている）
+--   この規約は下記 COMMENT ON COLUMN にも記録する。
+--
+-- 【CHECK 制約の張り方】
+--   CHECK をインラインで書くと既存全行の検証中 ACCESS EXCLUSIVE を保持する。
+--   NOT VALID で即時に張ってから VALIDATE する（VALIDATE は弱いロックで済む）。
+--
+-- 【⚠️ ADD CONSTRAINT に IF NOT EXISTS は無い（#1395 レビュー m-2）】
+--   scripts/apply-migration.sh は from_file 以降の全ファイルを毎回順に流すため、
+--   このファイルは複数回実行されうる。ADD CONSTRAINT は 2 回目に
+--     ERROR: constraint "..." for relation "dish_media" already exists
+--   で ON_ERROR_STOP に引っかかり、**以降のマイグレーションが全部止まる**。
+--   よって ADD CONSTRAINT の直前に必ず DROP CONSTRAINT IF EXISTS を置く
+--   （20251224T0005_update_dish_category_variants_constraints.sql:36-40 の作法）。
+--
+-- 【ロールバック】
+--   ALTER TABLE dish_media DROP CONSTRAINT IF EXISTS dish_media_media_path_required_for_stored;
+--   ALTER TABLE dish_media DROP CONSTRAINT IF EXISTS dish_media_render_type_check;
+--   ALTER TABLE dish_media ALTER COLUMN media_path SET NOT NULL;   -- external_embed 行が入る前に限る
+--   ALTER TABLE dish_media DROP COLUMN IF EXISTS render_type;
+-- ==============================================================================
+
+-- ------------------------------------------------------------------
+-- 1) render_type
+--    PG11+ の非 volatile DEFAULT 付き ADD COLUMN はテーブル書き換えを伴わない
+-- ------------------------------------------------------------------
+ALTER TABLE dish_media
+  ADD COLUMN IF NOT EXISTS render_type text NOT NULL DEFAULT 'stored';
+
+COMMENT ON COLUMN dish_media.render_type IS
+  'メディアの実体をどこから描画するか。stored=自ストレージ（media_path 必須）／external_embed=SNS の公式埋め込み（media_path は NULL、表示は dish_media_external_embeddings.canonical_url から provider 別コンポーネントが行う）。#1273 §40 / #1395';
+
+ALTER TABLE dish_media
+  DROP CONSTRAINT IF EXISTS dish_media_render_type_check;
+ALTER TABLE dish_media
+  ADD CONSTRAINT dish_media_render_type_check
+  CHECK (render_type IN ('stored','external_embed')) NOT VALID;
+ALTER TABLE dish_media VALIDATE CONSTRAINT dish_media_render_type_check;
+
+-- ------------------------------------------------------------------
+-- 2) media_path の NOT NULL 解除 + stored のときだけ必須にする CHECK
+-- ------------------------------------------------------------------
+ALTER TABLE dish_media ALTER COLUMN media_path DROP NOT NULL;
+
+COMMENT ON COLUMN dish_media.media_path IS
+  '自ストレージ上のメディア実体パス。render_type=''stored'' のとき必須、''external_embed'' のときは NULL（動画本体は保存せず公式埋め込みを使うため）。#1395';
+
+ALTER TABLE dish_media
+  DROP CONSTRAINT IF EXISTS dish_media_media_path_required_for_stored;
+ALTER TABLE dish_media
+  ADD CONSTRAINT dish_media_media_path_required_for_stored
+  CHECK (render_type <> 'stored' OR media_path IS NOT NULL) NOT VALID;
+ALTER TABLE dish_media VALIDATE CONSTRAINT dish_media_media_path_required_for_stored;
+
+-- ------------------------------------------------------------------
+-- 3) 既存の NOT NULL 列に対する external_embed 時の規約を DB に記録する
+--    （#1395 レビュー M-3。列定義は変更しない）
+-- ------------------------------------------------------------------
+COMMENT ON COLUMN dish_media.media_processing_status IS
+  'メディア加工ステータス（idle / processing / completed / failed）。render_type=''external_embed'' の行は実体を持たず加工も発生しないため ''idle'' を入れる（#1395）';
+
+COMMENT ON COLUMN dish_media.thumbnail_processing_status IS
+  'サムネイル加工ステータス（idle / processing / completed / failed）。render_type=''external_embed'' の行は取り込み後にリサイズを走らせるため ''processing'' を入れる（#1395 / #1399 がこの値を前提にしている）';

--- a/infra/supabase/migrations/20260824T0200_create_dish_media_external_embeddings.sql
+++ b/infra/supabase/migrations/20260824T0200_create_dish_media_external_embeddings.sql
@@ -1,0 +1,262 @@
+-- NOTE: 旧 20260819T0200_create_dish_media_external_embeddings.sql からのリネーム（#1469 ブランチが dev へ旧名で先行適用済み。SQL 本体は同一で、全体が冪等なので再適用は無害）。
+-- リネーム理由: main の 20260823T0000 より後ろに並べ、「ファイル名順 = 適用順」を守るため。
+-- ==============================================================================
+-- 20260819T0200_create_dish_media_external_embeddings.sql
+-- #1395（親 #1375 / #1273 §14・§39 準拠）/ #1399（自然キーへ dish_id を追加・
+-- thumbnail_url を追加）
+--
+-- ⚠️ このテーブルは **まだ public（本番）へ適用していない**。
+--    public の最終適用は 20260807T0100 で、20260819T0000 以降は 1 本も当たっていない。
+--    したがって列の追加は「新しい migration を積む」のではなく **このファイルを直接直す**。
+--    理由は infra/supabase/migrations/README.md を読むこと。
+-- ==============================================================================
+-- 【目的】
+--   render_type='external_embed' の dish_media が指す「SNS 側の投稿」を保持する。
+--   dish_media と 1:1（dish_media_analysis_results と同じく PK = 参照先 ID）。
+--
+-- 【このテーブルの位置づけ（混同しやすいので明示する）】
+--   目的の違う制約が 2 つ同居している。片方でもう片方を説明しないこと。
+--
+--     1. dish_media_id が PRIMARY KEY 兼 FK
+--        → 「どの dish_media にぶら下がるか」。dish_media 1 行につき埋め込みは最大 1 行（1:1）。
+--          行を持つのは render_type='external_embed' の dish_media だけで、
+--          従来の 'stored' の行は 1 行も持たない。**dish_media 側は何も変わらない。**
+--
+--     2. UNIQUE (provider, external_content_id, dish_id)
+--        → 「同じ SNS 投稿を二重に取り込まない」ため。1 とは無関係の別目的。
+--
+--   dish_media に列を足さずテーブルを分けたのは、canonical_url / embed_status /
+--   last_verified_at が external_embed でしか使われず、dish_media へ足すと
+--   既存の大多数（stored）の行で全部 NULL になるためである。
+--
+-- 【設計上の判断】
+--   - oEmbed が返す HTML の列は置かない（#1375 設計の正本 §2 / #1273 §14）。
+--     HTML を永続的な SoT にすると provider 側の仕様変更に追随できなくなるため、
+--     canonical_url から provider 別コンポーネントが都度描画する。
+--   - embed_status / last_verified_at は #1273 §39 の「埋め込み死活監視」バッチが
+--     「古い順に再検証」するために使う。
+--   - thumbnail_url は **URL を持つだけで複製はしない**（列コメント参照）。
+--
+-- 【自然キーに dish_id を含める理由（#1399）】
+--   (provider, external_content_id) だけでは «同じ投稿を別のユーザーが別の料理として
+--   分類する» 取り込みが構造的に失敗する。dishes は (restaurant_id, category_id) で
+--   一意なので、同じ動画でも分類が違えば別 dish になり、それぞれに dish_media が要る。
+--   自然キーを (provider, external_content_id, dish_id) へ広げることで、
+--   «同じ投稿 × 別の料理» は通し、«同じ投稿 × 同じ料理» の二重取り込みは弾く。
+--
+--   dish_id は dish_media_id から一意に決まる冗長列なので、
+--   (dish_media_id, dish_id) → dish_media (id, dish_id) の複合 FK でズレを構造的に禁じる
+--   （参照先要件のため dish_media に UNIQUE (id, dish_id) を 1 本張る）。
+--   この複合 FK が単一列 FK を包含するので、dish_media_id 単独の FK は張らない。
+--
+-- 【provider の値域: DB は 4 種・アプリ仕様は 3 種（オーナー判断 2026-08-21）】
+--   ⚠️ **DB の CHECK と「アプリとして取り込む対象」は意図的にズラしてある。**
+--     - DB の CHECK … instagram / tiktok / youtube / **x** の 4 種を許可する。
+--       CHECK は「あり得ない値を弾くガードレール」であり、広めに取る方が
+--       将来の拡張と、restaurant_recommendation 系ブランチ（provider に x を含む）
+--       との整合の両方にとって都合がよい。
+--     - アプリの仕様 … 取り込み対象は **TikTok / YouTube Shorts / Instagram の 3 つ**。
+--       X は対象外（#1395 仕様追補）。これは shared/utils/snsUrl.ts の
+--       SnsProvider（3 種）が構造的に担保しており、X の URL は parseSnsUrl() が
+--       null を返すのでそもそもこのテーブルへ到達しない。
+--   つまり「DB で弾く」のではなく「アプリで受け付けない」形にしてある。
+--   仕様を変えるときに migration を伴わせないための線引きである。
+--
+-- 【ロールバック】
+--   DROP TABLE IF EXISTS dish_media_external_embeddings;
+--   DROP INDEX IF EXISTS uq_dish_media_id_dish_id;
+-- ==============================================================================
+
+-- 依存拡張（gen_random_uuid は使わないが、近隣ファイルと同じく明示しておく）
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ------------------------------------------------------------------
+-- 複合 FK の参照先要件
+--
+-- FOREIGN KEY (dish_media_id, dish_id) → dish_media (id, dish_id) を張るには、
+-- 参照先の列組に UNIQUE か PK が要る。id は既に PK なので (id, dish_id) は
+-- 常に一意だが、Postgres は「宣言された一意制約」しか参照先に採れない。
+-- **CREATE TABLE より前に置くこと**（下の複合 FK が参照する）。
+-- ------------------------------------------------------------------
+CREATE UNIQUE INDEX IF NOT EXISTS uq_dish_media_id_dish_id
+  ON dish_media (id, dish_id);
+COMMENT ON INDEX uq_dish_media_id_dish_id IS 'dish_media_external_embeddings の複合 FK (dish_media_id, dish_id) の参照先。#1399';
+
+CREATE TABLE IF NOT EXISTS dish_media_external_embeddings (
+  -- dish_media と 1:1。dish_media_analysis_results（20251025T0201）と同じく PK = 参照先 ID
+  dish_media_id       uuid NOT NULL,
+
+  -- dish_media.dish_id と必ず一致する冗長列。自然キーに含めるために持つ
+  dish_id             uuid NOT NULL,
+
+  provider            text NOT NULL,
+  external_content_id text NOT NULL,
+  canonical_url       text NOT NULL,
+  embed_status        text NOT NULL DEFAULT 'unknown',
+  last_verified_at    timestamptz(6) NULL,
+
+  -- #1399 provider 側のサムネイル URL。**自ストレージへ複製した実体ではない**。
+  -- 権利調査の結論により、サムネイルは複製せず参照する:
+  --   Instagram … 画像の persisting が利用規約で明示的に禁止
+  --   TikTok    … og:image は参照できるが、CDN の署名 URL は約 48h で失効する
+  --   YouTube   … i.ytimg.com は無署名・安定で直接参照できる
+  -- provider ごとに扱いが違うので「全部複製」も「全部直接参照」も成立しない。
+  -- ここは «参照先» を持つだけで、取れない provider では NULL になる
+  -- （表示は料理カテゴリ画像へ落ちる）。dish_media.thumbnail_path（自ストレージのパス）とは別物。
+  thumbnail_url       text NULL,
+
+  -- 監査
+  created_at          timestamptz(6) NOT NULL DEFAULT now(),
+  updated_at          timestamptz(6) NOT NULL DEFAULT now(),
+
+  CONSTRAINT dish_media_external_embeddings_pkey PRIMARY KEY (dish_media_id),
+
+  -- dish_id のズレを構造的に禁じる。単一列 FK はこれに包含されるので張らない
+  CONSTRAINT dmee_dish_media_dish_fk
+    FOREIGN KEY (dish_media_id, dish_id)
+    REFERENCES dish_media (id, dish_id)
+    ON DELETE CASCADE,
+
+  -- ⚠️ これらの CHECK / UNIQUE は CREATE TABLE IF NOT EXISTS のインライン制約なので、
+  --    既にテーブルがある環境には**反映されない**。ファイル末尾の
+  --    「既存テーブルを現行仕様へ揃え直す」ブロックが実体を保証する。
+  CONSTRAINT dmee_provider_check
+    CHECK (provider IN ('instagram','tiktok','youtube','x')),
+  CONSTRAINT dmee_embed_status_check
+    CHECK (embed_status IN ('unknown','available','unavailable')),
+  -- 同じ投稿 × 同じ料理の二重取り込みを弾く自然キー
+  CONSTRAINT dmee_provider_content_dish_uq UNIQUE (provider, external_content_id, dish_id),
+
+  -- PK が dish_media_id なので論理的には冗長。**Prisma のために張っている。**
+  -- 複合 FK (dish_media_id, dish_id) で 1:1 を表現するには «参照元側にも複合ユニークが
+  -- 宣言されていること» を Prisma が要求する（無いと 1:1 ではなく 1:N として
+  -- introspect され、API 側の型が配列になってしまう）。
+  CONSTRAINT dmee_media_dish_uq UNIQUE (dish_media_id, dish_id)
+);
+
+-- 埋め込み死活監視（#1273 §39）のバッチが「古い順に再検証」するための索引
+CREATE INDEX IF NOT EXISTS idx_dmee_status_verified
+  ON dish_media_external_embeddings (embed_status, last_verified_at);
+
+-- コメント（テーブル）
+COMMENT ON TABLE dish_media_external_embeddings IS 'SNS の公式埋め込みで描画する dish_media の外部投稿情報。dish_media と 1:1（render_type=''external_embed'' の行のみが持つ）。oEmbed が返す HTML は保持しない。#1395 / #1273';
+
+-- コメント（カラム）
+COMMENT ON COLUMN dish_media_external_embeddings.dish_media_id IS 'dish_media の主キーを参照（削除時 CASCADE）。この列が PK なので dish_media と 1:1';
+COMMENT ON COLUMN dish_media_external_embeddings.dish_id IS 'この埋め込みが紐づく料理（dish_media.dish_id と必ず一致する。複合 FK dmee_dish_media_dish_fk で保証）。自然キーに含めることで «同じ投稿 × 別の料理» の取り込みを許し、«同じ投稿 × 同じ料理» の二重取り込みは弾く。#1399';
+COMMENT ON COLUMN dish_media_external_embeddings.provider IS '埋め込み元 SNS。DB の CHECK は instagram / tiktok / youtube / x の 4 種を許可するが、**アプリの取り込み対象は 3 種**（X は #1395 仕様追補で対象外。shared/utils/snsUrl.ts が構造的に弾く）';
+COMMENT ON COLUMN dish_media_external_embeddings.external_content_id IS 'provider 側の投稿ID（動画IDなど）。(provider, external_content_id, dish_id) で一意（#1399 で dish_id を追加）。同じ投稿を別の料理として分類する取り込みは通し、同じ料理への二重取り込みは弾く';
+COMMENT ON COLUMN dish_media_external_embeddings.canonical_url IS 'provider 上の正規URL。埋め込み描画とリンク遷移の SoT';
+COMMENT ON COLUMN dish_media_external_embeddings.embed_status IS '埋め込みの死活（unknown=未検証 / available=表示可 / unavailable=削除・非公開等で表示不可）';
+COMMENT ON COLUMN dish_media_external_embeddings.last_verified_at IS '最後に死活検証した日時。NULL は未検証。idx_dmee_status_verified で古い順に再検証する';
+COMMENT ON COLUMN dish_media_external_embeddings.thumbnail_url IS 'provider 側のサムネイル URL（参照であって複製ではない）。取得できなければ NULL。複製の可否は provider ごとに異なる（Instagram は禁止 / TikTok の署名 URL は約48hで失効 / YouTube の i.ytimg.com は無署名で安定）ため、ここでは URL のみを保持する。#1399';
+COMMENT ON COLUMN dish_media_external_embeddings.created_at IS 'レコード作成日時';
+COMMENT ON COLUMN dish_media_external_embeddings.updated_at IS 'レコード更新日時（トリガで自動更新）';
+
+-- updated_at 自動更新トリガ（20251025T0201:49-62 の作法）
+-- DEFAULT now() は INSERT にしか効かないため、死活監視バッチの UPDATE では
+-- このトリガが無いと updated_at が古いまま残る
+CREATE OR REPLACE FUNCTION trg_set_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS set_updated_at_on_dmee ON dish_media_external_embeddings;
+CREATE TRIGGER set_updated_at_on_dmee
+BEFORE UPDATE ON dish_media_external_embeddings
+FOR EACH ROW
+EXECUTE FUNCTION trg_set_updated_at();
+
+-- RLS 有効化
+--
+-- ⚠️ ポリシーは意図的に 1 つも定義しない = 全てのクライアントロールからのアクセスを拒否する。
+--    このテーブルを読み書きするのは API サーバ（Prisma 接続ロール = テーブル所有者）と
+--    埋め込み死活監視バッチだけであり、どちらも RLS をバイパスする。
+--    dish_media_analysis_results（20251025T0201）も同じ扱いである。
+--    クライアント（supabase-js の anon / authenticated）から直接読む必要が出た場合に限り、
+--    そのとき必要な範囲のポリシーを追加すること。
+ALTER TABLE dish_media_external_embeddings ENABLE ROW LEVEL SECURITY;
+
+-- ==================================================================
+-- 既存テーブルを現行仕様へ揃え直す
+--
+-- ⚠️ **上の CREATE TABLE は IF NOT EXISTS なので、既にテーブルがある環境では
+--    丸ごとスキップされ、インライン制約の変更は一切反映されない。**
+--    scripts/apply-migration.sh は from_file 以降を毎回全部流すため、
+--    「テーブルが既にある環境」は普通に起こりうる。
+--    よって制約の実体はここで DROP → ADD で張り直す
+--    （ADD CONSTRAINT に IF NOT EXISTS は無いので DROP CONSTRAINT IF EXISTS を必ず前に置く）。
+--    NOT VALID で即時に張ってから VALIDATE する（VALIDATE は弱いロックで済む）。
+--
+--    何度流しても同じ結果になる（冪等）ように書いてある。
+-- ==================================================================
+
+-- --- dish_id 列（旧版のテーブルには無い） -------------------------
+ALTER TABLE dish_media_external_embeddings
+  ADD COLUMN IF NOT EXISTS dish_id uuid;
+
+-- 旧版から移行する場合だけ意味を持つ。新規作成の環境では 0 行に当たる
+UPDATE dish_media_external_embeddings dmee
+   SET dish_id = dm.dish_id
+  FROM dish_media dm
+ WHERE dm.id = dmee.dish_media_id
+   AND dmee.dish_id IS DISTINCT FROM dm.dish_id;
+
+ALTER TABLE dish_media_external_embeddings
+  ALTER COLUMN dish_id SET NOT NULL;
+
+-- --- thumbnail_url（#1399。上の CREATE TABLE に含めた分の追いつき） ---
+-- 既にテーブルがある環境（dev）では CREATE TABLE がスキップされるので、ここで足す。
+-- NULLABLE でデフォルト値を持たないため、既存行は 1 行も書き換わらない
+ALTER TABLE dish_media_external_embeddings
+  ADD COLUMN IF NOT EXISTS thumbnail_url text;
+
+-- --- published_at を落とす（#1399・#1483 オーナー判断） -------------
+-- 一度 dev にだけ足したが、**どのコードも書き込まなかった**（oEmbed は TikTok / YouTube の
+-- どちらも投稿日時を返さない）。「何も書かない列は置かない」という判断で削除する。
+-- public にはこのテーブル自体がまだ無いので、本番へは最初から存在しない列になる。
+-- この DROP は **dev を追いつかせるためだけ**にある。public 適用後は消してよい
+ALTER TABLE dish_media_external_embeddings
+  DROP COLUMN IF EXISTS published_at;
+
+-- --- 複合 FK ------------------------------------------------------
+-- 旧版が張っていた単一列 FK は複合 FK に包含されるので落とす
+ALTER TABLE dish_media_external_embeddings
+  DROP CONSTRAINT IF EXISTS dish_media_external_embeddings_dish_media_id_fkey;
+
+ALTER TABLE dish_media_external_embeddings
+  DROP CONSTRAINT IF EXISTS dmee_dish_media_dish_fk;
+ALTER TABLE dish_media_external_embeddings
+  ADD CONSTRAINT dmee_dish_media_dish_fk
+  FOREIGN KEY (dish_media_id, dish_id)
+  REFERENCES dish_media (id, dish_id)
+  ON DELETE CASCADE
+  NOT VALID;
+ALTER TABLE dish_media_external_embeddings
+  VALIDATE CONSTRAINT dmee_dish_media_dish_fk;
+
+-- --- 自然キー -----------------------------------------------------
+-- 旧版の 2 列 UNIQUE を落として 3 列へ張り替える
+ALTER TABLE dish_media_external_embeddings
+  DROP CONSTRAINT IF EXISTS dmee_provider_content_uq;
+ALTER TABLE dish_media_external_embeddings
+  DROP CONSTRAINT IF EXISTS dmee_provider_content_dish_uq;
+ALTER TABLE dish_media_external_embeddings
+  ADD CONSTRAINT dmee_provider_content_dish_uq
+  UNIQUE (provider, external_content_id, dish_id);
+
+-- --- Prisma が 1:1 を表現するために要求する複合ユニーク ------------
+ALTER TABLE dish_media_external_embeddings
+  DROP CONSTRAINT IF EXISTS dmee_media_dish_uq;
+ALTER TABLE dish_media_external_embeddings
+  ADD CONSTRAINT dmee_media_dish_uq UNIQUE (dish_media_id, dish_id);
+
+-- --- provider の値域（DB は 4 種。アプリ仕様は 3 種）---------------
+ALTER TABLE dish_media_external_embeddings
+  DROP CONSTRAINT IF EXISTS dmee_provider_check;
+ALTER TABLE dish_media_external_embeddings
+  ADD CONSTRAINT dmee_provider_check
+  CHECK (provider IN ('instagram','tiktok','youtube','x')) NOT VALID;
+ALTER TABLE dish_media_external_embeddings VALIDATE CONSTRAINT dmee_provider_check;

--- a/infra/supabase/migrations/20260824T0300_add_restaurants_name_trgm_index.sql
+++ b/infra/supabase/migrations/20260824T0300_add_restaurants_name_trgm_index.sql
@@ -1,0 +1,59 @@
+-- NOTE: 旧 20260819T0300_add_restaurants_name_trgm_index.sql からのリネーム（#1469 ブランチが dev へ旧名で先行適用済み。SQL 本体は同一で、全体が冪等なので再適用は無害）。
+-- リネーム理由: main の 20260823T0000 より後ろに並べ、「ファイル名順 = 適用順」を守るため。
+-- ==============================================================================
+-- 20260819T0300_add_restaurants_name_trgm_index.sql
+-- #1395（親 #1375）
+-- ==============================================================================
+-- 【目的】
+--   GET /v1/restaurants/search に店名の部分一致検索（q）を足すため、
+--   restaurants.name へ pg_trgm の GIN 索引を張る。
+--
+-- 【背景】
+--   - #1375 設計の正本 §5:「Google Places Autocomplete / Text Search を新規に使用しない。
+--     店舗候補は自前の restaurants テーブルから引く」
+--   - restaurants の既存索引は 20250802T0300_create_restaurants.sql:21 の
+--     idx_restaurants_location（GIST）と google_place_id の UNIQUE だけで、
+--     name に索引が無い。名前で絞ると必ず Seq Scan になる。
+--   - dish_reviews が 964MB で Disk IO Budget が枯渇間近（20260718T0000 のヘッダ）という
+--     事情を踏まえると、店舗選択のたびに Seq Scan を走らせるのは許容できない。
+--
+-- 【なぜ btree ではなく trgm GIN なのか（20251011T0400 と矛盾しないこと）】
+--   20251011T0400 では trgm 索引を「消して」text_pattern_ops の btree に置き換えたが、
+--   あちらの要件は前方一致・完全一致・IN だけであり btree で足りた。
+--   こちらの要件は「一蘭」で「らーめん 一蘭 渋谷店」を引き当てたい＝**中間一致**であり、
+--   btree では原理的に効かない。要件が違うので同じ結論にはならない。
+--   （「消したものを戻している」ように見えるが、別の要件に対する別の判断である）
+--
+-- 【拡張】
+--   pg_trgm は 20250802T0259_create_dish_category_variants.sql:1 で導入済みのため追加不要。
+--   gin_trgm_ops は apply-migration.sh が流す
+--   `SET search_path TO $DB_SCHEMA, extensions` で解決するので **無修飾**で書く
+--   （20250802T0259 に倣う）。
+--
+-- 【CREATE INDEX CONCURRENTLY について】
+--   - 本番テーブルへの書き込みを止めないため CONCURRENTLY を使う。
+--   - CONCURRENTLY はトランザクション内で実行できない。
+--     scripts/apply-migration.sh:53-58 は --single-transaction も BEGIN も使わない
+--     （autocommit）ので実行できる。前例は 20260718T0000:95 / 20251011T0400:23,27。
+--   - **失敗すると INVALID なインデックスが残る**。他の DDL と混ぜないため
+--     このファイルは索引 1 本だけにしてある。
+--
+-- 【⚠️ 適用後に必ず確認すること（#1395 レビュー m-1）】
+--   apply-migration.sh:49 は from_file 以降の全ファイルを毎回順に流す。
+--   CONCURRENTLY が失敗して INVALID index が残ると、次回以降 IF NOT EXISTS が
+--   「もう在る」と判断して**黙ってスキップし続ける**。索引は永久に作られず、
+--   エラーも出ず、店名検索だけが遅いままになる。適用後に必ず次を実行すること:
+--
+--     SELECT indisvalid FROM pg_index WHERE indexrelid = 'idx_restaurants_name_trgm'::regclass;
+--
+--   false だったら作り直す:
+--
+--     DROP INDEX CONCURRENTLY IF EXISTS idx_restaurants_name_trgm;
+--     -- そのうえで本ファイルを再実行する
+--
+-- 【ロールバック】
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_restaurants_name_trgm;
+-- ==============================================================================
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_restaurants_name_trgm
+  ON restaurants USING GIN (name gin_trgm_ops);

--- a/infra/supabase/migrations/20260824T0400_add_dish_reviews_user_dish_index.sql
+++ b/infra/supabase/migrations/20260824T0400_add_dish_reviews_user_dish_index.sql
@@ -1,0 +1,51 @@
+-- NOTE: 旧 20260819T0400_add_dish_reviews_user_dish_index.sql からのリネーム（#1469 ブランチが dev へ旧名で先行適用済み。SQL 本体は同一で、全体が冪等なので再適用は無害）。
+-- リネーム理由: main の 20260823T0000 より後ろに並べ、「ファイル名順 = 適用順」を守るため。
+-- ==============================================================================
+-- 20260819T0400_add_dish_reviews_user_dish_index.sql
+-- #1395（親 #1375）
+-- ==============================================================================
+-- 【目的】
+--   GET /v1/users/me/dishes の「食べたい」枝が使う
+--     NOT EXISTS (SELECT 1 FROM dish_reviews dr WHERE dr.user_id = $me AND dr.dish_id = ...)
+--   を 1 行あたり index 1 回の probe で済ませるため、
+--   dish_reviews (user_id, dish_id) の複合インデックスを追加する。
+--
+-- 【なぜ必要か（#1395 レビュー B-2 の宿題）】
+--   my-dishes は「状態を永続化せず導出する」設計であり、
+--   want 行は「その dish に自分の dish_reviews が 1 件も無い」ことを条件に出す。
+--   この NOT EXISTS は want 枝のスキャン中に**1 行ずつ**評価されるため、
+--   索引の有無がそのままレスポンス時間に出る。
+--
+--   既存の関連インデックス:
+--     - idx_dish_reviews_user_created_at (user_id, created_at DESC)  ← 20260718T0000
+--         user_id では絞れるが dish_id で絞れない。
+--         レビュー 3,000 件のユーザーでは、want 候補 1 行ごとに
+--         そのユーザーの全レビューを走査することになる。
+--     - idx_dish_reviews_dish (dish_id)
+--         dish_id で絞れるが user_id で絞れない。人気の料理では
+--         他人のレビューを大量に読んでから user_id で捨てることになる。
+--   どちらも「(user_id, dish_id) の存在確認」には向いていない。
+--
+-- 【なぜ既存索引の作り直しではなく追加なのか】
+--   idx_dish_reviews_user_created_at は一覧の並び順（created_at DESC）に必要で、
+--   (user_id, dish_id) では代替できない。両方要る。
+--
+-- 【コスト】
+--   dish_reviews は約 964MB（DB 使用容量の約 60%）。
+--   (uuid, uuid) の複合索引 1 本ぶんのディスクと、INSERT 時の索引更新コストが増える。
+--   dish_reviews は追記主体で更新がほぼ無いため、書き込み側の劣化は小さいと判断した。
+--
+-- 【CREATE INDEX CONCURRENTLY について】
+--   20260819T0300 と同じ理由でトランザクション外・単独ファイルにしてある。
+--
+-- 【⚠️ 適用後に必ず確認すること】
+--     SELECT indisvalid FROM pg_index WHERE indexrelid = 'idx_dish_reviews_user_dish'::regclass;
+--   false なら DROP INDEX CONCURRENTLY してから本ファイルを再実行する
+--   （IF NOT EXISTS は INVALID index を「在る」と判断して黙ってスキップするため）。
+--
+-- 【ロールバック】
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_dish_reviews_user_dish;
+-- ==============================================================================
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_dish_reviews_user_dish
+  ON dish_reviews (user_id, dish_id);

--- a/infra/supabase/migrations/README.md
+++ b/infra/supabase/migrations/README.md
@@ -1,0 +1,151 @@
+# migrations — DB 変更の進め方
+
+**このディレクトリを触る前に、必ずここを読むこと。**
+
+このリポジトリの本番と開発は「別 DB」ではなく **同じ DB の別スキーマ**である
+（本番 = `public` / 開発 = `dev` / `test`）。壊れやすく、壊れたときの影響が大きい。
+
+前提となる仕組み（`db-migrate.yml` / `scripts/apply-migration.sh`）:
+
+- DB 側に適用済み台帳（schema_migrations 的なテーブル）は**無い**。適用記録は
+  `db-migrate.yml` の dispatch ログだけである
+- 適用は「`from_file` 以降を**ファイル名昇順で毎回全部**流す」方式である
+
+したがってこの運用の成立条件はただひとつ、**「ファイル名順 = 適用順」が崩れないこと**である。
+以下の規則はすべてこの不変条件を守るためにある。
+
+---
+
+## 規則 1. migration は「migration だけの小 PR」を先に main へ（migration-first）
+
+**実適用（`dry_run: false`）は main ブランチからしか実行できない**（`db-migrate.yml` が拒否する）。
+機能ブランチから dev へ先行適用することは禁止。
+
+> 2026-08 に、機能ブランチ（#1469）から dev へ先行適用した結果、dev の schema と
+> 噛み合うコードがそのブランチにしか無くなり、**main から api-development を
+> デプロイできない**事故が起きた。DB を先行させたブランチが「唯一のデプロイ可能
+> ブランチ」になるのは構造の必然なので、運用で先回りして防ぐ。
+
+進め方:
+
+1. 親 Issue の下に **DB 変更だけのサブ Issue** を立て、承認を得る（規則 4 のフォーマット）
+2. **migration ファイルだけの小 PR** を作って main へマージする
+   （schema.prisma / Prisma Client は次の適用ステップで自動 commit されるので含めなくてよい）
+3. main から `db-migrate.yml` を dispatch して dev へ適用する
+   （`regenerate_prisma: true` なら introspect 結果が main へ自動 commit される）
+4. 機能ブランチは main を取り込み、新しいスキーマを使うコードを書く
+
+ブランチから許可されるのは `dry_run: true` のみ（適用対象と静的検査の事前確認用）。
+
+## 規則 2. ファイル名の日付は「書いた日」ではなく「適用列に並ぶ順序」
+
+新しい migration のファイル名は、**main にある全ファイルより辞書順で後ろ**でなければ
+ならない。PR の CI（`migration-order-check.yml`）が機械検査する。
+
+- マージが遅れて main の最後尾より前の名前になってしまったら、**マージ前にリネーム**する。
+  public 未適用のファイルはリネームし放題である（ファイル名は DB のどこにも記録されない）
+- 並行する複数 PR が同じタイムスタンプを名乗っていても、この規則でマージ順に直列化される
+
+## 規則 3. migration は後方互換（additive）に限る
+
+migration は「それを使うコードがまだ無い main」へ先にマージされ、DB はコードより
+先へ進む。したがって**古いコードのまま動き続けられる変更**だけを流してよい。
+
+- OK: テーブル追加・NULLABLE 列追加・インデックス追加・制約の緩和
+- NG（そのままでは流せない）: 列削除・リネーム・NOT NULL 化など、既存コードを壊す変更
+  → **expand / contract** に分ける:
+  ① 新しい形を追加（expand）→ ② コードを移行してリリース → ③ 古い形を削除（contract）。
+  ①と③は別々の migration・別々の承認になる
+
+## 規則 4. 実適用は**勝手に流さない**（1 本ごとにオーナー承認）
+
+`db-migrate.yml` を **dry run 以外で実行してよいのは、その変更についてオーナーの承認を得た後だけ**。
+
+- 「前に流してよいと言われた」は**次の変更の承認にならない**。承認は migration 1 本ごと
+- `target_schema: public` はもちろん、**`dev` でも同じ**である
+- `public` への適用は**別の承認**。`confirm_public: true` は本番 DB を変更するスイッチなので、
+  そのつど改めて承認を取る
+
+サブ Issue に書くこと:
+
+```markdown
+## 変更するテーブル
+dish_media_external_embeddings
+
+## 適用先
+dev（public はまだ未適用のテーブルなので、public への適用は別途）
+
+## SQL
+（実際に流す DDL をそのまま貼る）
+
+## 既存データへの影響
+NULLABLE 列の追加のみ。既存行は書き換わらない（テーブル rewrite なし）
+
+## ロールバック
+ALTER TABLE ... DROP COLUMN ...;
+
+## なぜ必要か
+（どの機能が、この列が無いと成立しないのか）
+```
+
+承認が下りたら `dry_run: true` で 1 回流し、対象ファイルと適用先スキーマをログで
+確認してから実適用する。
+
+## 規則 5. 本番未適用の migration は、新しいファイルを積まずに直接直す
+
+`public` にまだ当たっていない migration は、この世に「その形で存在した DB」が無い。
+そこへ ALTER を積むと履歴が «作って → すぐ足す» という嘘の経緯になり、
+
+- 後から読んだ人が「なぜ 2 段階なのか」を無駄に考える
+- ALTER で足す列は必ず NULLABLE になり、本当は NOT NULL にしたかった列が経緯だけの
+  理由で NULLABLE のまま固定される
+
+という実害が出る。**元のファイルを直接書き換える小 PR を main へ積むこと。**
+
+直接書き換えるときに必ずやること: `apply-migration.sh` は from_file 以降を毎回全部
+流すので、`CREATE TABLE IF NOT EXISTS` は既にテーブルがある環境ではスキップされる。
+つまり CREATE TABLE を直しただけでは dev に反映されない。ファイル末尾の
+「既存テーブルを現行仕様へ揃え直す」ブロックへも `ADD COLUMN IF NOT EXISTS` /
+`DROP CONSTRAINT IF EXISTS` → `ADD CONSTRAINT` の形で同じ変更を書き、
+**何度流しても同じ結果になる（冪等）**ようにすること。
+`20260824T0200_create_dish_media_external_embeddings.sql` がその実例である。
+
+## 規則 6. 本番適用済みの migration は**絶対に書き換えない**
+
+`public` に当たったファイルを後から直すと、環境ごとに DB の形が違う状態を作る。
+この場合だけ新しいファイルを積む。どちらなのかは下の手順で必ず確認すること。
+
+---
+
+## 適用状況の調べ方と現在地
+
+`db-migrate.yml` の実行履歴で、ジョブ名が `public スキーマへ migration を適用` /
+`dev スキーマへ migration を適用` の run のログを見る。`📄 Applying:` の行が実際に
+当たったファイルである。
+
+```
+gh api repos/{owner}/{repo}/actions/workflows/db-migrate.yml/runs
+```
+
+> **2026-08-23 時点の現在地**
+>
+> - `public`: `20260807T0100_drop_share_links_created_by_fkey.sql` まで適用済み
+>   （run #7 / 2026-08-11）。それ以降は 1 本も当たっていない
+> - `dev`: `20260807T0100` まで ＋ `20260824T0000`〜`T0400` の 5 本
+>   （※旧名 `20260819T*` として #1469 ブランチから適用済み。ファイルは main へ
+>   リネームして取り込み済みで、冪等なので再適用は無害）。
+>   `20260823T0000_add_restaurant_recommendation_sync_metadata.sql` は**未適用**
+> - 次に dev へ適用するときの `from_file` は `20260823T0000_...` （以降の
+>   `20260824T*` は no-op で流れる）
+
+## 補足: 適用後にやること
+
+- `regenerate_prisma: true` で流すと `schema.prisma` と Prisma Client が
+  **実行ブランチ（= main）へ自動 commit・push される**。api のデプロイ
+  （`api-deploy.yml`）はこのコミット済み schema からビルドする（デプロイ時に
+  DB を introspect しない）ので、これが型の正本である
+- `shared/supabase/database.types.ts` と `shared/converters/` は**手で追従させる**。
+  自動生成は 2026-08-21 に廃止した（`shared/converters/README.md`）
+- `CREATE INDEX CONCURRENTLY` を含む migration は、適用後に**索引が VALID か必ず確認する**。
+  失敗しても INVALID な索引が残り、`IF NOT EXISTS` が以後ずっとスキップする。
+  確認は `scripts/db-checks/assert_index_valid.py` を `db-script-run.yml` から流す

--- a/scripts/assert-migration-filename-order.sh
+++ b/scripts/assert-migration-filename-order.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# =============================================================================
+# migration ファイル名の順序ガード
+#
+# このリポジトリの migration は「ファイル名昇順 = 適用順」で成立している
+# （scripts/apply-migration.sh が from_file 以降を名前順に流す。DB 側に台帳は無い）。
+# したがって、既にある（= 適用済みかもしれない）ファイルより辞書順で前に
+# 新しいファイルを差し込むと、適用順が壊れる。詳細は
+# infra/supabase/migrations/README.md を読むこと。
+#
+# 検査内容（BASE コミットと HEAD を比較）:
+#   1. 追加された *.sql は、BASE に存在する全 *.sql より辞書順で後ろであること
+#   2. 追加された *.sql は YYYYMMDDTHHMM_説明.sql の形式であること
+#
+# 使い方: bash scripts/assert-migration-filename-order.sh <BASE_SHA>
+# =============================================================================
+set -euo pipefail
+
+MIGRATION_DIR="infra/supabase/migrations"
+BASE="${1:?BASE_SHA を渡すこと（例: PR の base ブランチの SHA）}"
+
+# BASE 時点で存在する最大のファイル名（= 適用列の最後尾）
+base_max=$(git ls-tree -r --name-only "$BASE" -- "$MIGRATION_DIR" \
+  | grep '\.sql$' | sed "s|^$MIGRATION_DIR/||" | LC_ALL=C sort | tail -1 || true)
+
+# この差分で追加されたファイル（rename の新名も含めるため diff-filter=AR）
+added=$(git diff --name-only --diff-filter=AR "$BASE" HEAD -- "$MIGRATION_DIR/*.sql" \
+  | sed "s|^$MIGRATION_DIR/||" || true)
+
+if [ -z "$added" ]; then
+  echo "✅ migration の追加なし"
+  exit 0
+fi
+
+fail=0
+for f in $added; do
+  if ! echo "$f" | grep -Eq '^[0-9]{8}T[0-9]{4}_.+\.sql$'; then
+    echo "::error::$f はファイル名形式 YYYYMMDDTHHMM_説明.sql に従っていません。"
+    fail=1
+    continue
+  fi
+  if [ -n "$base_max" ] && [ "$(printf '%s\n%s\n' "$base_max" "$f" | LC_ALL=C sort | tail -1)" != "$f" ]; then
+    echo "::error::$f は base の最後尾 $base_max より辞書順で前です。"
+    fail=1
+  elif [ "$f" = "$base_max" ]; then
+    echo "::error::$f は base に既に存在します（同名追加）。"
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  cat <<'EOS'
+
+── 直し方 ──────────────────────────────────────────────
+migration のファイル名の日付は「書いた日」ではなく「適用列に並ぶ順序」です。
+main の最後尾より後ろになる名前（例: 今日の日付 + 時刻）へ rename してください。
+
+同じ内容のファイルが既に main に別名で存在する場合（先に migration だけ
+main へマージされたケース）は、ブランチ側の古い方を削除してください。
+運用の全体像: infra/supabase/migrations/README.md
+────────────────────────────────────────────────────────
+EOS
+  exit 1
+fi
+
+echo "✅ 追加された migration ($(echo "$added" | wc -l) 件) はすべて base の最後尾より後ろです"


### PR DESCRIPTION
## 背景（2026-08 に実際に起きたこと）

- migration は「ファイル名昇順 + from_file 一括適用」で DB に台帳が無く、**«ファイル名順 = 適用順» だけが成立条件**なのに、それを守る仕組みが無かった
- 機能ブランチ #1469 が dev へ `20260819T*` を先行適用したまま、main へ `20260823T0000` が先に入り、適用列の順序逆転が確定
- さらに `api-deploy.yml` がデプロイ時に生きた DB を introspect（`pnpm db:pull`）してビルドするため、dev の schema と噛み合うコードが #1469 にしか無く、**api-development を main からデプロイできなくなった**

## 変更内容

1. **`db-migrate.yml`**: 実適用（`dry_run=false`）を main ブランチ限定に。ブランチからは dry run のみ（migration-first 運用）
2. **`api-deploy.yml`**: `db:pull` を廃止。コミット済み `schema.prisma` のスキーマ名を適用先（dev/public）へ差し替えて `prisma generate` する DB 非接続ビルドへ。置換漏れは grep で検算して fail
3. **`migration-order-check.yml`（新規）**: PR が追加する `*.sql` が base の最後尾より辞書順で後ろであることを検査（`scripts/assert-migration-filename-order.sh`。正・負ケースをローカルで実証済み）
4. **#1469 の migration 5 本を `20260824T*` へリネームして取り込み**（migration-first の第 1 号）。dev には旧名で適用済み・全ファイル冪等なので再適用は無害。public 未適用なのでリネームは安全
5. **`infra/supabase/migrations/README.md`**: 運用規則の正本（migration-first / 順序 / additive 限定 / 承認 / 現在地）

## 検証

- 順序ガード: 正常系（本 PR の 5 本）通過・異常系（過去日付ファイル）fail を実測
- `api-deploy` 新ステップを public 相当でローカル再現: sed 置換 → `prisma validate` → `prisma generate` → `nest build` すべて成功
- 3 workflow の YAML パース確認済み
- **api / app のコード・schema.prisma・Prisma Client には一切触れていない**（DB への適用も行っていない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjyJrnKiUZTbSx431fTYrr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjyJrnKiUZTbSx431fTYrr)_