### PR TITLE
#843 perf: 3_2をworker並列化して指定qpsを実効化する

### DIFF
--- a/scripts/20260808T0000_restaurant/3_2_search_google_place_ids.py
+++ b/scripts/20260808T0000_restaurant/3_2_search_google_place_ids.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +48,14 @@ def parse_args() -> argparse.Namespace:
         "--execute", action="store_true", help="指定時だけGoogle APIとBQ書込を実行"
     )
     parser.add_argument("--qps", type=float, default=5.0)
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=32,
+        help="並列worker数。逐次だとHTTPレイテンシ律速で実効3〜4req/sに落ち、"
+        "--qpsをいくら上げても届かない（1seedあたり2.17requestを1本ずつ待つため）。"
+        "qpsの上限自体は共有throttleが守る",
+    )
     parser.add_argument("--radius-m", type=float, default=150.0)
     parser.add_argument("--resume-days", type=int, default=90)
     parser.add_argument(
@@ -222,6 +231,8 @@ def main() -> None:
         raise ValueError("--limit は1以上にしてください")
     if args.qps <= 0 or not 0 < args.radius_m <= 50_000 or args.resume_days <= 0:
         raise ValueError("--qps/--radius-m/--resume-days が不正です")
+    if not 1 <= args.workers <= 128:
+        raise ValueError("--workers は1〜128にしてください")
 
     pipeline = BigQueryPipeline()
     candidates = fetch_candidates(
@@ -248,6 +259,7 @@ def main() -> None:
     parameters = {
         "limit": args.limit,
         "qps": args.qps,
+        "workers": args.workers,
         "radius_m": args.radius_m,
         "algorithm_version": ALGORITHM_VERSION,
         "include_osm_only": args.include_osm_only,
@@ -258,19 +270,26 @@ def main() -> None:
         parameters=parameters,
         repo_root=REPO_ROOT,
     ) as step:
-        for index, seed in enumerate(candidates, start=1):
-            buffer.append(
-                attempt_row(
+        # seed単位でworkerへ分配する。1seed内のprobeは判定順序に意味があるため
+        # 逐次のまま。qpsはclient側の共有throttleがHTTP request数で守る。
+        # BQへの書き込みはこのメインスレッドだけが行う。
+        with ThreadPoolExecutor(max_workers=args.workers) as pool:
+            futures = [
+                pool.submit(
+                    attempt_row,
                     run_id=run_id,
                     seed=seed,
                     radius_m=args.radius_m,
                     client=client,
                 )
-            )
-            if len(buffer) >= 100:
-                flush_rows(pipeline, buffer)
-            if index % 1000 == 0:
-                LOGGER.info("Google照合: %d/%d件", index, len(candidates))
+                for seed in candidates
+            ]
+            for index, future in enumerate(as_completed(futures), start=1):
+                buffer.append(future.result())
+                if len(buffer) >= 100:
+                    flush_rows(pipeline, buffer)
+                if index % 1000 == 0:
+                    LOGGER.info("Google照合: %d/%d件", index, len(candidates))
         flush_rows(pipeline, buffer)
         step["row_count"] = len(candidates)
 

--- a/scripts/20260808T0000_restaurant/google_place_matching.py
+++ b/scripts/20260808T0000_restaurant/google_place_matching.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import json
 import math
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -212,13 +213,18 @@ class PlacesTextSearchClient:
         self.timeout_seconds = timeout_seconds
         self.max_retries = max_retries
         self.minimum_interval_seconds = 1.0 / qps
-        self._last_request_at: float | None = None
+        self._lock = threading.Lock()
+        self._next_request_at = 0.0
 
     def _throttle(self) -> None:
-        if self._last_request_at is not None:
-            elapsed = time.monotonic() - self._last_request_at
-            time.sleep(max(0.0, self.minimum_interval_seconds - elapsed))
-        self._last_request_at = time.monotonic()
+        # 複数workerで共有する前提のスロット予約式。lockの中では「自分の送信時刻」を
+        # 予約するだけで、sleepはlockの外で行う。lock内でsleepすると全workerが
+        # 直列化され、逐次実行（実効3〜4req/s）に戻ってしまう。
+        with self._lock:
+            now = time.monotonic()
+            start = max(now, self._next_request_at)
+            self._next_request_at = start + self.minimum_interval_seconds
+        time.sleep(max(0.0, start - time.monotonic()))
 
     def search(self, payload: dict[str, Any]) -> TextSearchResult:
         encoded = json.dumps(payload, ensure_ascii=False).encode("utf-8")


### PR DESCRIPTION
## 概要

3_2 の逐次実行は HTTP レイテンシ律速で実効 3〜4 req/s に落ち、`--qps 45` を指定しても届きません（実測: 33分で 3,290 seed ≈ 100 seed/分。45万 seed に75時間かかるペース）。

- seed 単位で `ThreadPoolExecutor` に分配（`--workers`、既定32、1〜128）
- qps はクライアント側の**スロット予約式の共有 throttle**（lock 外 sleep）が HTTP リクエスト数で守る
- 1 seed 内の probe 順序は判定に意味があるため逐次のまま。BigQuery 書き込みはメインスレッドのみ

## 検証

- 単体テスト12件 green、throttle の並列実測（qps200 指定 → 100スロット / 0.50s ちょうど、直列化なし）
- ブランチ ref での本番実行（[run](https://github.com/Ayato-kosaka/nanitabeyo/actions)、`--limit 450000 --qps 45 --workers 32`）で **25.6 seed/s** を実測（24分で36,900 seed、`box_unique_strict` 48.6%、api_error 0件）— 45万 seed ≈ 5時間で当初計画どおり

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCVVMHHhHRMMUCUtMj5d2A

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCVVMHHhHRMMUCUtMj5d2A)_