### PR TITLE
migration: #1507 #1510 #1511 の承認済み 3 本を main へ入れる（migration-first）

### DIFF
--- a/infra/supabase/migrations/20260825T0100_add_idempotency_key_to_dish_category_group_vote_sessions.sql
+++ b/infra/supabase/migrations/20260825T0100_add_idempotency_key_to_dish_category_group_vote_sessions.sql
@@ -1,0 +1,56 @@
+-- ==============================================================================
+-- 20260825T0100_add_idempotency_key_to_dish_category_group_vote_sessions.sql
+-- #1507 (GRP-14)
+-- ==============================================================================
+-- 【目的】
+-- POST /v1/dish-category-group-votes の再送で投票セッションが二重に作られるのを、
+-- DB 制約を最終防衛線としてサーバー側で防ぐ。クライアント生成の冪等キーを
+-- session 行そのものに刻む方式にする。
+--
+-- 【背景】
+-- 現在の防御はフロントの useRef 同期ガードだけで（#1205）、
+-- app-expo/features/dishCategoryGroupVotes/hooks/useCreateDishCategoryGroupVote.ts の
+-- コメントにその限界が既に書かれている。通信のリトライ、オフライン復帰後の再送、
+-- コンポーネント再マウントでは ref が守れず、**別々の share_token を持つ
+-- 投票セッションが 2 件できる**。投票は共有リンクで完結するため、
+-- 「片方のリンクを配った参加者」と「もう片方を見ているホスト」が別の投票を見ることになり、
+-- 集計が合わないまま気付かれない。
+--
+-- 【実装方針】
+-- - NULL 許容・DEFAULT なし。冪等キー未対応の旧クライアントと既存行の挙動を変えない
+--   （PostgreSQL の UNIQUE は NULL 同士を衝突と見なさないため、キー無しの行は何件でも入る）。
+-- - 型は notifications.idempotency_key（20251031T0001_create_notifications.sql:15）と同じ text。
+--   ただしあちらはサーバー生成キーなので単独 UNIQUE なのに対し、こちらは**クライアント生成**の
+--   キーなので (host_user_id, idempotency_key) の複合一意にする。単独 UNIQUE だと
+--   (a) 別ユーザーが偶然同じキーを送っただけで 2 人目の作成が失敗する
+--   (b) 同一キー再送で他人のセッション（share_token 込み）を返す漏洩経路ができる。
+--   複合にすることで「既存行を返す」経路が本人の行しか返さないことを制約レベルで保証する。
+-- - ADD CONSTRAINT は IF NOT EXISTS を取れないため、
+--   20260825T0100_add_idempotency_key_to_dish_category_group_vote_sessions.sql:31-33 の前例に合わせて
+--   CREATE UNIQUE INDEX IF NOT EXISTS で張る（Prisma も @@unique として認識するので
+--   findUnique が使える）。
+--
+-- 【既存データへの影響】
+-- なし。NULL 許容・DEFAULT なしの列追加はテーブル書き換えを伴わないメタデータ変更で、
+-- 既存行は全て idempotency_key = NULL のまま。バックフィルは不要。
+-- unique index の作成も全行 NULL の小規模テーブルなので一瞬で終わり、CONCURRENTLY は要らない。
+--
+-- このmigrationは dev/public の各search_pathで従来どおり適用する。
+-- ==============================================================================
+
+BEGIN;
+
+ALTER TABLE dish_category_group_vote_sessions
+  ADD COLUMN IF NOT EXISTS idempotency_key text;
+
+COMMENT ON COLUMN dish_category_group_vote_sessions.idempotency_key IS
+  'クライアント生成の冪等キー（UUID v4）。同一ホストからの再送で新規セッションを作らず既存行を返すために使う。キーを送らない旧クライアント経由の行は NULL。';
+
+CREATE UNIQUE INDEX IF NOT EXISTS dcgvs_host_user_id_idempotency_key_uq
+  ON dish_category_group_vote_sessions (host_user_id, idempotency_key);
+
+COMMIT;
+
+-- rollback（必要時に手動実施）:
+-- DROP INDEX IF EXISTS dcgvs_host_user_id_idempotency_key_uq;
+-- ALTER TABLE dish_category_group_vote_sessions DROP COLUMN IF EXISTS idempotency_key;

--- a/infra/supabase/migrations/20260825T0200_create_user_notification_preferences.sql
+++ b/infra/supabase/migrations/20260825T0200_create_user_notification_preferences.sql
@@ -1,0 +1,63 @@
+-- 変更チケット: #1510 SET-02 通知をカテゴリ別にオン/オフする
+--
+-- ## 目的
+-- ユーザー × 通知カテゴリ単位の受信設定 user_notification_preferences を新設する。
+--
+-- ## 背景
+-- 通知の基盤（notifications / notification_recipients / user_device_tokens）は既にあるが、
+-- 「どの種別を受け取るか」をユーザーが選ぶ手段が無く、全部届くか OS レベルで全部切るかの二択だった。
+-- プッシュ送信の可否はサーバー側（api/src/internal/notifications/notification-job.service.ts）で
+-- 判定するため、端末ローカル保存では足りない。既読カーソル（user_notification_cursors）や
+-- デバイストークン（user_device_tokens）と同様に「ユーザー × 通知」の専用テーブルとして分離する。
+--
+-- ## 実装方針
+-- - 行が無い = 未設定 = カテゴリの既定値に従う（現状すべてオン）。
+--   リーダー判断により、既存ユーザーへのバックフィルは行わない。ユーザーがオフにしたときに初めて行が出来る。
+-- - category は text とし CHECK も enum も置かない。カテゴリの正は
+--   shared/api/v1/constants/notification-categories.ts の対応表であり、
+--   カテゴリ追加のたびに migration を要求しない構成にする
+--   （action_type / target_table に CHECK を置いていない既存方針と同じ）。
+-- - enabled は boolean。「行の存在＝オフ」にはしない。将来 既定オフのカテゴリを足したときに
+--   「明示的にオンにした」を表現できなくなるため。
+--
+-- ## 既存データへの影響
+-- 無し（新規テーブルのみ。既存テーブルは一切変更しない）。
+-- 適用直後は行が 0 件 = 全ユーザー全カテゴリ既定値（オン）= 現行挙動と完全に同一。
+--
+-- ## 適用順
+-- API のデプロイより先に適用する（API 側がこのテーブルを参照するため）。
+-- 逆順でも「テーブルが無い＝設定を引けない」だけで、実装側は既定値（オン）へフォールバックせず
+-- 例外を投げて Cloud Tasks のリトライに乗るため、通知が黙って消えることはない。
+--
+-- ## ロールバック
+-- DROP TABLE IF EXISTS user_notification_preferences;
+
+-- 依存拡張
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- =========================
+-- Table: user_notification_preferences
+-- 役割: 通知カテゴリ別の受信設定（ユーザー × カテゴリ。行が無ければ既定値）
+-- =========================
+
+CREATE TABLE IF NOT EXISTS user_notification_preferences (
+  user_id     uuid NOT NULL,
+  category    text NOT NULL,
+  enabled     boolean NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, category)
+);
+
+-- コメント
+COMMENT ON TABLE user_notification_preferences IS '通知カテゴリ別の受信設定（ユーザー×カテゴリ。行が無ければ既定値）';
+COMMENT ON COLUMN user_notification_preferences.category IS '通知カテゴリ key（likes / saves / group_votes 等。対応表は shared 側で管理し CHECK は置かない）';
+COMMENT ON COLUMN user_notification_preferences.enabled IS 'true=受け取る / false=プッシュを止める（アプリ内一覧には残る）';
+
+-- 索引
+-- 参照は送信直前の (user_id, category) 1 点引きと、設定画面の user_id 前方一致のみ。
+-- どちらも PK の複合索引で足りるため追加索引は作らない。
+
+-- RLS（有効化のみ。ポリシーは作らない＝クライアント直アクセス不可、API 経由のみ）
+-- user_device_tokens（20251031T0005）と同じ作法。
+ALTER TABLE user_notification_preferences ENABLE ROW LEVEL SECURITY;

--- a/infra/supabase/migrations/20260825T0300_add_users_deleted_at.sql
+++ b/infra/supabase/migrations/20260825T0300_add_users_deleted_at.sql
@@ -1,0 +1,75 @@
+-- =============================================================================
+-- #1511 ACC-01 アプリ内でアカウントを削除できるようにする
+--   users に論理削除カラム deleted_at を追加する
+--
+-- ## 目的
+-- 設定画面からの「アカウントを削除」を実装するために、`users` 行に
+-- 「削除済み」を表す状態を持たせる。削除処理 (DELETE /v1/users/me) は
+-- この 1 カラムを立てると同時に、同じトランザクションの中で PII
+-- (username / display_name / bio / avatar_path) を匿名値へ上書きする。
+--
+-- ## 背景 — なぜ users 行を物理削除しないのか（リーダー判断 #1511）
+-- `users.id` は dish_media / dish_reviews / dish_media_likes / restaurant_bids
+-- から参照されており、いずれの外部キーも `ON DELETE NO ACTION` である。
+-- とくに:
+--   - `dish_media_likes.user_id` と `restaurant_bids.user_id` は **NOT NULL** なので
+--     `SET NULL` に倒せない
+--   - `restaurant_bids` を CASCADE で消すと、それを参照する `payouts`（振込記録）まで
+--     連鎖して消える。会計・資金決済の記録をユーザー操作で消せる構造にはできない
+-- したがって「行は残す・中身を匿名化する・deleted_at で読み取り経路から外す」を採る。
+-- 法令（GDPR / 個人情報保護法）が求めるのは個人を識別できる情報の除去であり、
+-- 行そのものの物理削除ではない。
+--
+-- なお **Supabase Auth (auth.users) の側は物理削除**する（API が service_role で
+-- admin API を叩く）。users 行を残す設計のままアカウントも残すと「削除したはずの
+-- 資格情報でログインできる」経路が残ってしまうため、そこだけは実体を消す。
+-- 結果としてこの削除は取り消せない操作になる。
+--
+-- ## 設計判断
+-- - **索引は張らない。** deleted_at の絞り込みが効くのは
+--   `GET /v1/users/:id`（PK 引きの後段チェック）と、dish_media / dish_reviews を
+--   引くときの `users` への準結合だけで、単独のスキャン条件にはならない。
+--   行数に対して削除済みユーザーは極少数になる見込みで、部分索引を張っても
+--   プランナが選ぶ状況が想像できない。必要になってから足す。
+-- - **RLS は変更しない。** 削除処理は API（service role 相当の接続で RLS を
+--   バイパスする）だけが行い、auth.users を消した時点で本人のセッション自体が
+--   無効になるため、クライアント直読み（users_select_own）に deleted 考慮は要らない。
+-- - **既定値は NULL。** 既存行はすべて `deleted_at IS NULL`（= 有効）として扱われる。
+--   NULL 許容カラムの追加なのでテーブル書き換えは発生しない（メタデータ操作のみ）。
+--
+-- ## ロールバック
+--   ALTER TABLE users DROP COLUMN IF EXISTS deleted_at;
+-- 削除 API のデプロイより前なら無害。デプロイ後に落とす場合は削除済みユーザーの
+-- 判別手段が失われるため、API のリバートとセットで行うこと。
+-- =============================================================================
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+COMMENT ON COLUMN users.deleted_at IS
+  'アカウント削除(匿名化)の実行時刻。NULL = 有効なユーザー。削除時は username を deleted_<id> へ置換し display_name / bio / avatar_path を NULL 化する (#1511)';
+
+-- =============================================================================
+-- 事後アサーション
+--
+-- `ADD COLUMN IF NOT EXISTS` は列が既にあっても成功するので、**「流した」ことと
+-- 「対象スキーマに列がある」ことは別**である（適用先スキーマの取り違えは
+-- 適用ログが success でも起きうる）。実際の状態を検査して落とす。
+-- 再実行しても安全（冪等）。
+-- =============================================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name   = 'users'
+      AND column_name  = 'deleted_at'
+  ) THEN
+    RAISE EXCEPTION
+      'users.deleted_at が存在しません（schema: %）。アカウント削除 API が起動時に失敗します。',
+      current_schema();
+  END IF;
+
+  RAISE NOTICE '✅ users.deleted_at 追加済み（schema: %）', current_schema();
+END $$;


### PR DESCRIPTION
オーナー承認済みのマイグレーション 3 本（PR #1532 / #1534 / #1533 への「マイグレーション承認します」2026-08-23）を、#1538 の運用（migration-first / `infra/supabase/migrations/README.md` 規則 1）に従って実装 PR から切り出した **migration ファイルだけの小 PR** です。

## 内容（3 本とも additive・規則 3 適合）

| ファイル | 変更 | 実装 PR |
| --- | --- | --- |
| `20260825T0100_add_idempotency_key_to_dish_category_group_vote_sessions.sql` | `idempotency_key` 列追加 ＋ `(host_user_id, idempotency_key)` 複合 UNIQUE | #1532 (GRP-14) |
| `20260825T0200_create_user_notification_preferences.sql` | テーブル新設。行が無い＝オンで解決するため既存ユーザーへのバックフィルなし | #1534 (SET-02) |
| `20260825T0300_add_users_deleted_at.sql` | `users.deleted_at`（NULLABLE）追加 | #1533 (ACC-01) |

`scripts/assert-migration-filename-order.sh origin/main` を実測し、3 件とも base の最後尾（`20260824T0400`）より後ろであることを確認済みです。

## 適用計画

マージ後、main から `db-migrate.yml` を次の順で dispatch します。

1. `dry_run: true` / `from_file: 20260825T0100_...` / `target_schema: dev` — 適用対象がこの 3 本だけであることをログで確認
2. 実適用（dev のみ・`regenerate_prisma: true`）

**`from_file` を `20260825T0100` にするのは意図的です。** 未承認の `20260823T0000_add_restaurant_recommendation_sync_metadata.sql`（別ワークストリーム）を巻き込まないためで、規則 4（承認は 1 本ごと）に従います。**public へは適用しません**（別承認）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyVUBm4k4Kj8KnyaxSCEVV)_