### PR TITLE
fix(app-expo): main の typecheck を壊していたテストの型キャストを直す

### DIFF
--- a/app-expo/features/topics/hooks/useTopicImageResources.web.test.tsx
+++ b/app-expo/features/topics/hooks/useTopicImageResources.web.test.tsx
@@ -59,15 +59,15 @@ describe("useTopicImageResources（web）", () => {
 		originalPlatformOS = Platform.OS;
 		// Platform.OS は素のプロパティなので差し替えで web 分岐へ入れる
 		Object.defineProperty(Platform, "OS", { configurable: true, get: () => "web" });
-		const globalWindow = (globalThis as { window?: Record<string, unknown> }).window ?? {};
-		(globalThis as { window?: Record<string, unknown> }).window = globalWindow;
+		const globalWindow = (globalThis as unknown as { window?: Record<string, unknown> }).window ?? {};
+		(globalThis as unknown as { window?: Record<string, unknown> }).window = globalWindow;
 		originalWindowImage = globalWindow.Image;
 		globalWindow.Image = FakeBrowserImage;
 	});
 
 	afterAll(() => {
 		Object.defineProperty(Platform, "OS", { configurable: true, get: () => originalPlatformOS });
-		const globalWindow = (globalThis as { window?: Record<string, unknown> }).window;
+		const globalWindow = (globalThis as unknown as { window?: Record<string, unknown> }).window;
 		if (globalWindow) globalWindow.Image = originalWindowImage;
 	});
 


### PR DESCRIPTION
## 何が起きているか

**main を base にする全 PR の PR Check が、head 側の変更と無関係に落ちる状態**になっています。

#1519 で入った `useTopicImageResources.web.test.tsx` の `globalThis as { window?: Record<string, unknown> }` が TS2352（型の重なりが不十分な変換）で `tsc -p tsconfig.dev.json` を落とします。実測: PR #1536 の run 32655289319 — 落ちた 3 箇所すべてがこのファイルで、#1536 の diff はこのファイルに触れていません。

## 修正

TS の指示どおり `as unknown as` を挟むだけ（3 箇所）。テストの挙動は変わりません。

## 検証

`npx tsc -p tsconfig.dev.json --noEmit` で該当エラー 3 件が消えることを確認済み。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyVUBm4k4Kj8KnyaxSCEVV)_