### PR TITLE
fix(app-expo): 壊れた /posts URL を弾き、ユーザー起因の失敗を warn へ落とす (#1433 #1475 #1476 #1477)

### DIFF
--- a/app-expo/__tests__/authCallbackScreen.test.tsx
+++ b/app-expo/__tests__/authCallbackScreen.test.tsx
@@ -118,6 +118,13 @@ const identityConflictError = {
 const loggedEventNames = (): string[] =>
 	mockLogFrontendEvent.mock.calls.map(([event]) => (event as { event_name: string }).event_name);
 
+type LoggedEvent = { event_name: string; error_level: string; payload?: Record<string, unknown> };
+
+const findLoggedEvent = (eventName: string): LoggedEvent | undefined =>
+	mockLogFrontendEvent.mock.calls
+		.map(([event]) => event as LoggedEvent)
+		.find((event) => event.event_name === eventName);
+
 beforeEach(() => {
 	// 認証結果は router params 側に載っている形にする（`code` があるものが選ばれる）
 	mockParams = { locale: "ja-JP", intent: "link", provider: "google", code: "dummy-code" };
@@ -201,6 +208,44 @@ describe("#1370 プロバイダ競合の告知（DialogProvider の confirm）",
 		expect(mockConfirm).not.toHaveBeenCalled();
 		expect(mockReplace).toHaveBeenCalledWith({ pathname: "/[locale]/profile", params: { locale: "ja-JP" } });
 		expect(loggedEventNames()).toContain("oauth_callback_error");
+	});
+
+	// #1433 ユーザーが同意画面で止めたときのレベル。
+	// 本番（2026-08-18T11:19:49Z / 1 ユーザー）では、直前に oauth_signin_browser_dismissed が
+	// log レベルで出ているのに、同じ 1 回の操作がここで error としても積まれていた。
+	it("access_denied（ユーザーが自分で止めた）は warn で記録する", async () => {
+		mockParams = {
+			locale: "ja-JP",
+			intent: "link",
+			provider: "google",
+			error: "access_denied",
+			error_description: "The user denied the request",
+		};
+		// 本番と同じく message が空の Error が飛んでくる形にする
+		mockHandleOAuthResultUrl.mockRejectedValue(new Error());
+
+		await render();
+
+		const logged = findLoggedEvent("oauth_callback_error");
+		expect(logged).toBeDefined();
+		expect(logged?.error_level).toBe("warn");
+		expect(logged?.payload).toMatchObject({ url_shape: expect.objectContaining({ error: "access_denied" }) });
+	});
+
+	// ⚠️ 判定を «error があること» まで広げないための番人。
+	// server_error / temporarily_unavailable はプロバイダ側の障害なので error のまま残す
+	it("access_denied 以外のプロバイダエラーは error のまま記録する", async () => {
+		mockParams = {
+			locale: "ja-JP",
+			intent: "link",
+			provider: "google",
+			error: "server_error",
+		};
+		mockHandleOAuthResultUrl.mockRejectedValue(new Error());
+
+		await render();
+
+		expect(findLoggedEvent("oauth_callback_error")?.error_level).toBe("error");
 	});
 });
 

--- a/app-expo/__tests__/postsIdsGuard.test.tsx
+++ b/app-expo/__tests__/postsIdsGuard.test.tsx
@@ -1,0 +1,123 @@
+// #1477 【バグ】`/posts?ids=` の値は URL のクエリそのもので、信用できない。
+//
+// 本番（2026-08-20T15:12:39Z / ヒンディー語環境の 1 ユーザー）の実測:
+//   {"endpoint":"https://api.nanitabeyo.net/v1/dish-media?ids=","status":400,
+//    "requestPayload":{"ids":[]},
+//    "errorPayload":{"errorCode":"VALIDATION_ERROR","message":"each value in ids must be a UUID"}}
+//
+// ids 無しで開いたため `{ ids: [] }` を送り、`?ids=` として直列化され、サーバの Transform が
+// `"".split(",")` で `[""]` にしたため `@IsUUID` が落ちた。その 400 は握り潰されず
+// DishMediaMap のオーバーレイに出るので、**英語の内部バリデーション文が画面に出ていた**。
+//
+// ここで固定するのは 2 つ。「送る前に弾く」ことと、「弾いたときに何を見せるか」。
+import React from "react";
+import TestRenderer from "react-test-renderer";
+
+jest.mock("expo-linear-gradient", () => {
+	const { View: RNView } = require("react-native");
+	return { LinearGradient: RNView };
+});
+jest.mock("@/features/dishMedia/components/DishMediaMap", () => ({ __esModule: true, default: () => null }));
+jest.mock("@/components/deepLinking/OpenInAppBanner", () => ({ OpenInAppBanner: () => null }));
+jest.mock("@/contexts/SeoContext", () => ({ useSeo: () => {} }));
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key, locale: "ja-JP" } }));
+
+const mockCallBackend = jest.fn();
+jest.mock("@/hooks/useAPICall", () => {
+	const value = { callBackend: (...args: unknown[]) => mockCallBackend(...(args as [])) };
+	return { useAPICall: () => value };
+});
+
+const mockLogFrontendEvent = jest.fn();
+jest.mock("@/hooks/useLogger", () => {
+	const value = { logFrontendEvent: (event: unknown) => mockLogFrontendEvent(event) };
+	return { useLogger: () => value };
+});
+
+// ⚠️ 戻り値の参照を固定すること（毎回新しい関数を返すとレンダーが収束しない）
+jest.mock("@/stores/useDishMediaEntriesStore", () => {
+	const state = {
+		upsertDishMediaEntries: jest.fn(),
+		updateMediaIdsByKeyAsync: jest.fn(),
+		clearByKey: jest.fn(),
+	};
+	return { useDishMediaEntriesStore: Object.assign(() => ({}), { getState: () => state }) };
+});
+
+let mockParams: Record<string, string | string[] | undefined> = {};
+jest.mock("expo-router", () => ({ useLocalSearchParams: () => mockParams }));
+
+import PostsScreen from "@/app/[locale]/(tabs)/posts";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const VALID_ID = "e2731728-3ee1-404b-8e0d-966cd5259fdc";
+const OTHER_ID = "0a6797a3-bffc-40bd-b878-73176b37fc89";
+
+const render = (): TestRenderer.ReactTestRenderer => {
+	let created: TestRenderer.ReactTestRenderer | undefined;
+	TestRenderer.act(() => {
+		created = TestRenderer.create(<PostsScreen />);
+	});
+	return created!;
+};
+
+const findLoggedEvent = (eventName: string) =>
+	mockLogFrontendEvent.mock.calls
+		.map(([e]) => e as { event_name: string; error_level: string })
+		.find((e) => e.event_name === eventName);
+
+describe("#1477 /posts の ids ガード", () => {
+	let tree: TestRenderer.ReactTestRenderer | undefined;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockCallBackend.mockResolvedValue({ items: [] });
+	});
+
+	afterEach(() => {
+		if (tree) {
+			TestRenderer.act(() => tree!.unmount());
+			tree = undefined;
+		}
+	});
+
+	it.each([
+		["ids そのものが無い", undefined],
+		["空文字（?ids= の実測ケース）", ""],
+		["UUID ではない値", "not-a-uuid"],
+		["区切りだけ", ",,"],
+	])("%s なら API を呼ばず「見つかりません」を出す", (_label, ids) => {
+		mockParams = { locale: "ja-JP", ids };
+		tree = render();
+
+		// ここが通ると 400 になり、その本文が画面に出る
+		expect(mockCallBackend).not.toHaveBeenCalled();
+		expect(tree.root.findAllByProps({ testID: "posts-not-found" }).length).toBeGreaterThan(0);
+
+		// 壊れた URL を開かれただけなのでアプリは壊れていない = warn
+		expect(findLoggedEvent("posts_ids_invalid")?.error_level).toBe("warn");
+	});
+
+	it("正常な UUID なら従来どおり API を呼ぶ（ガードが正常系を止めていないこと）", () => {
+		mockParams = { locale: "ja-JP", ids: VALID_ID };
+		tree = render();
+
+		expect(mockCallBackend).toHaveBeenCalledTimes(1);
+		expect(mockCallBackend).toHaveBeenCalledWith(
+			"v1/dish-media",
+			expect.objectContaining({ requestPayload: { ids: [VALID_ID] } }),
+		);
+		expect(findLoggedEvent("posts_ids_invalid")).toBeUndefined();
+	});
+
+	it("壊れた値が混ざっていても、有効な UUID だけを送る", () => {
+		mockParams = { locale: "ja-JP", ids: `${VALID_ID},not-a-uuid,${OTHER_ID}` };
+		tree = render();
+
+		expect(mockCallBackend).toHaveBeenCalledWith(
+			"v1/dish-media",
+			expect.objectContaining({ requestPayload: { ids: [VALID_ID, OTHER_ID] } }),
+		);
+	});
+});

--- a/app-expo/app/[locale]/(tabs)/posts.tsx
+++ b/app-expo/app/[locale]/(tabs)/posts.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect, useState } from "react";
-import { StyleSheet } from "react-native";
+import React, { useEffect, useMemo, useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
 import { useLocalSearchParams } from "expo-router";
 import { LinearGradient } from "expo-linear-gradient";
 import DishMediaMap from "@/features/dishMedia/components/DishMediaMap";
 import type { QueryDishMediaByIdsResponse } from "@shared/api/v1/res";
 import type { QueryDishMediaByIdsDto } from "@shared/api/v1/dto";
 import { useAPICall } from "@/hooks/useAPICall";
+import { useLogger } from "@/hooks/useLogger";
 import { useDishMediaEntriesStore } from "@/stores/useDishMediaEntriesStore";
 import { OpenInAppBanner } from "@/components/deepLinking/OpenInAppBanner";
 import { useSeo } from "@/contexts/SeoContext";
@@ -13,9 +14,33 @@ import i18n from "@/lib/i18n";
 import { SeoOverride } from "@/contexts/SeoContext/SeoProvider";
 import { resolvePublicLocale, SITE_NAME_BY_PUBLIC_LOCALE } from "@/constants/seoLocales";
 
+/**
+ * #1477 【仕様】`?ids=` は **URL のクエリそのもの**なので、中身は信用できない。
+ *
+ * この画面は共有リンクの着地先で、`__tests__/sitemap.test.ts` にも
+ * 「`?ids=` のクエリ前提で、クエリ無しでは対象が決まらない」と書いてある公開 URL である。
+ * リンクが途中で切れた・クローラが加工した・手打ちした、のいずれでも壊れた値が届く。
+ *
+ * 実測（本番 2026-08-20T15:12:39Z / 1 ユーザー）: `/hi/posts` を **ids 無し**で開いた結果、
+ * クライアントが `{ ids: [] }` を送り、`?ids=` として直列化され、サーバの Transform が
+ * `"".split(",")` で `[""]` にしたため `@IsUUID` が落ちて 400。その 400 は握り潰されず
+ * `DishMediaMap` のオーバーレイに出るため、**ヒンディー語環境のユーザーが
+ * `each value in ids must be a UUID` という英語の内部バリデーション文を画面で見た**。
+ *
+ * したがって「送る前に弾く」のが正しい。UUID の形をしていない値は落とし、
+ * 1 件も残らなければ API を呼ばずに「見つかりません」を出す。
+ */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const parseDishMediaIds = (ids: string | string[] | undefined): string[] => {
+	const raw = typeof ids === "string" ? ids.split(",") : Array.isArray(ids) ? ids.flatMap((v) => v.split(",")) : [];
+	return raw.map((v) => v.trim()).filter((v) => UUID_PATTERN.test(v));
+};
+
 export default function PostsScreen() {
 	const { ids, entriesKey: entriesKeyParam } = useLocalSearchParams<{ ids?: string | string[]; entriesKey?: string | string[] }>();
 	const { callBackend } = useAPICall();
+	const { logFrontendEvent } = useLogger();
 	const entriesKey = typeof entriesKeyParam === "string" && entriesKeyParam.length > 0 ? entriesKeyParam : "PostsScreen";
 
 	const [seoData, setSeoData] = useState<SeoOverride["data"]>({});
@@ -24,11 +49,23 @@ export default function PostsScreen() {
 	// #717 【設計】i18n を使用して多言語対応（ハードコードではなく翻訳キー使用）
 	useSeo(seoData);
 
+	const idArray = useMemo(() => parseDishMediaIds(ids), [ids]);
+	const hasValidIds = idArray.length > 0;
+
 	useEffect(() => {
 		const { upsertDishMediaEntries, updateMediaIdsByKeyAsync, clearByKey } = useDishMediaEntriesStore.getState();
+		// #1477 有効な id が 1 件も無いなら API を呼ばない。呼べば必ず 400 になり、
+		// その本文（英語のバリデーション文）がそのまま画面に出る。
+		if (!hasValidIds) {
+			logFrontendEvent({
+				event_name: "posts_ids_invalid",
+				// 壊れた URL を開かれただけで、アプリは壊れていない（人間の対応は要らない）
+				error_level: "warn",
+				payload: { hasIdsParam: ids !== undefined, rawCount: typeof ids === "string" ? ids.split(",").length : Array.isArray(ids) ? ids.length : 0 },
+			});
+			return;
+		}
 		const fetchData = async () => {
-			const idArray =
-				typeof ids === "string" ? ids.split(",") : Array.isArray(ids) ? ids.flatMap((v) => v.split(",")) : [];
 			const requestPayload: QueryDishMediaByIdsDto = { ids: idArray };
 			const responsePromise = callBackend<QueryDishMediaByIdsDto, QueryDishMediaByIdsResponse>("v1/dish-media", {
 				method: "GET",
@@ -54,10 +91,23 @@ export default function PostsScreen() {
 		return () => {
 			clearByKey(entriesKey);
 		};
-	}, [callBackend, entriesKey, ids]);
+	}, [callBackend, entriesKey, ids, idArray, hasValidIds, logFrontendEvent]);
 
 	// #721 testID は共有リンク（/s/:token）が «捨てられず投稿画面へ着地したか» を E2E から見るための目印。
 	// 解決画面は resolve の往復の間しか出ず観測できないため、着地先そのものを観測点にしている。見た目には影響しない
+	// #1477 壊れた URL で着地した人には、内部エラー文ではなく «見つかりません» を出す。
+	if (!hasValidIds) {
+		return (
+			<LinearGradient colors={["#FFFFFF", "#F8F9FA"]} style={styles.container} testID="posts-screen">
+				<View style={styles.notFoundContainer}>
+					<Text style={styles.notFoundText} testID="posts-not-found">
+						{i18n.t("Common.errors.notFound")}
+					</Text>
+				</View>
+			</LinearGradient>
+		);
+	}
+
 	return (
 		<LinearGradient colors={["#FFFFFF", "#F8F9FA"]} style={styles.container} testID="posts-screen">
 			{/* #688 【設計】Web Deep Linking バナー（アプリ未インストール時の導線） */}
@@ -69,4 +119,6 @@ export default function PostsScreen() {
 
 const styles = StyleSheet.create({
 	container: { flex: 1 },
+	notFoundContainer: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
+	notFoundText: { fontSize: 16, color: "#6B7280", textAlign: "center" },
 });

--- a/app-expo/app/[locale]/auth/callback.tsx
+++ b/app-expo/app/[locale]/auth/callback.tsx
@@ -261,9 +261,21 @@ export default function AuthCallbackScreen() {
 					goAfterCallback();
 				}
 
+				// #1433 【設計】`access_denied` は **ユーザーが自分で止めたとき**にプロバイダが返すコード。
+				// 同意画面で拒否した / ブラウザを閉じた、が該当する。障害ではないので人間の対応は要らない。
+				//
+				// 実測（本番 2026-08-18T11:19:49Z / 1 ユーザー）: 直前に `oauth_signin_browser_dismissed` が
+				// **log レベルで**記録されており、同じ 1 回の操作をここで error として二重に積んでいた。
+				// そのユーザーはこの直後そのまま検索へ戻り、普通にアプリを使い続けている。
+				//
+				// ⚠️ 判定は `access_denied` に限ること。error があること自体を warn にすると、
+				// `server_error` や `temporarily_unavailable`（＝プロバイダ側の障害で、こちらは知りたい）まで畳む。
+				const urlShape = describeOAuthUrl(picked.url);
+				const isUserCancelled = urlShape?.error === "access_denied";
+
 				logFrontendEvent({
 					event_name: "oauth_callback_error",
-					error_level: "error",
+					error_level: isUserCancelled ? "warn" : "error",
 					payload: {
 						// #1249 【バグ】旧実装は `error instanceof Error ? error.message : String(error)` で、
 						// message が空の Error / plain object が来ると本文に何も残らず、
@@ -281,7 +293,7 @@ export default function AuthCallbackScreen() {
 						provider: rest.provider ?? null,
 						// #1062 【設計】生の URL は code / access_token を含むため記録しない
 						source: picked.source,
-						url_shape: describeOAuthUrl(picked.url),
+						url_shape: urlShape,
 					},
 				});
 			}

--- a/app-expo/app/[locale]/contribution-tasks/dish-category-image-optimizer.tsx
+++ b/app-expo/app/[locale]/contribution-tasks/dish-category-image-optimizer.tsx
@@ -20,7 +20,7 @@ import { Image } from "expo-image";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Check } from "lucide-react-native";
 
-import { useAPICall } from "@/hooks/useAPICall";
+import { useAPICall, type ApiError } from "@/hooks/useAPICall";
 import { useWithLoading } from "@/hooks/useWithLoading";
 import { useLegacyBlurModal } from "@/features/contributionTasks/legacyBlurModal/useLegacyBlurModal";
 import { useSnackbar } from "@/contexts/SnackbarProvider";
@@ -101,9 +101,18 @@ export default function DishCategoryImageOptimizerPage() {
 				payload: { count: result.length },
 			});
 		} catch (error) {
+			// #1476 【設計】403（forbidden）は **権限機構が正しく拒否した結果**で、壊れていない。
+			// この画面は内部作業用（sitemap 対象外・アプリ内リンク無し）なので、権限の無い人が
+			// URL を直接開けば必ずこうなる。人間の対応は要らない。
+			//
+			// 実測（本番 2026-08-20T12:33:08Z / 1 ユーザー）: 匿名のまま ko-KR でこの URL を開き、
+			// 403 を受けてそのまま離脱している。壊れた機能を踏んだのではなく、入れない扉を押しただけ。
+			//
+			// ⚠️ forbidden 以外は error のまま残すこと。tools API 自体が落ちたときの信号を消さない。
+			const isForbidden = (error as ApiError | null | undefined)?.code === "forbidden";
 			logFrontendEvent({
 				event_name: "tools_categories_error",
-				error_level: "error",
+				error_level: isForbidden ? "warn" : "error",
 				payload: { error },
 			});
 			showSnackbar(i18n.t("Common.error"));

--- a/app-expo/contexts/AuthProvider.tsx
+++ b/app-expo/contexts/AuthProvider.tsx
@@ -444,9 +444,20 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 				setAuthError(null);
 			} catch (err: any) {
 				const status = getAuthErrorStatus(err);
+				// #1475 【設計】status 0 = **HTTP 応答に到達していない**（端末の回線断）。
+				// supabase-js が fetch 失敗を AuthRetryableFetchError でラップするときの値で、
+				// 運用側にできることは無い。再試行ボタンとフォアグラウンド復帰の 2 経路で回復する。
+				//
+				// 実測（本番 2026-08-20T09:29:25Z / 1 ユーザー）: 直前に位置情報の
+				// backend 失敗 → expo フォールバック失敗 が warn で並んでおり、回線が一瞬切れていた。
+				// **2 秒後には検索の API が成功しており**、認証エラー画面は出ていない。設計どおり回復した例。
+				//
+				// ⚠️ status 0 だけに限ること。undefined まで含めると、初期化中に起きた
+				// こちら側の実装バグ（status を持たない TypeError 等）まで warn へ落ちて見えなくなる。
+				const isClientNetworkFailure = status === 0;
 				logFrontendEvent({
 					event_name: "authInitError",
-					error_level: "error",
+					error_level: isClientNetworkFailure ? "warn" : "error",
 					payload: { message: err.message, status },
 				});
 				// #1089 認証が確立できていないときは logQueue がアクセストークンを用意できず、


### PR DESCRIPTION
open だった 4 件の対応です。**いずれも BigQuery の生ログで「そのユーザーに何が起きたか」を確認してから**判断しました。結果、**実バグは 1 件だけ**で、残り 3 件はログレベルの誤りでした。

## #1477 `/posts` の ids ガード — 唯一の実バグ

実測（2026-08-20T15:12:39Z / ヒンディー語環境の 1 ユーザー）:

```json
{"endpoint":".../v1/dish-media?ids=","status":400,"requestPayload":{"ids":[]},
 "errorPayload":{"errorCode":"VALIDATION_ERROR","message":"each value in ids must be a UUID"}}
```

`ids` 無しで `/posts` を開いたため `{ids: []}` を送り、`?ids=` として直列化され、サーバの `Transform` が `"".split(",")` で `[""]` にしたため `@IsUUID` が落ちて 400。**その 400 は握り潰されず `DishMediaMap` のオーバーレイに出る**ので、英語の内部バリデーション文がそのまま画面に出ていました。そのユーザーはこれを見て**即離脱**しています（以降ログ無し）。

`/posts` は共有リンクの着地先で、`?ids=` の中身は URL のクエリそのもの＝信用できません（`__tests__/sitemap.test.ts` にも「クエリ無しでは対象が決まらない」と既に書いてあります）。UUID の形をしていない値は落とし、1 件も残らなければ API を呼ばずに `Common.errors.notFound` を出します。**文言キーは既存のものを使い、新規追加していません。**

## severity の誤り 3 件

いずれも「ユーザーが自分でやったこと」か「端末側の事情」で、**人間の対応は要りません**。判定はすべて狭く取り、広げないことをテストで固定しています。

| # | 条件 | 実測で分かったこと |
|---|---|---|
| #1433 | `url_shape.error === "access_denied"` のときだけ warn | 同意画面でブラウザを閉じただけ。**直前に `oauth_signin_browser_dismissed` が log レベルで出ており、同じ 1 回の操作を別レベルで二重記録していた**。そのユーザーは直後に検索へ戻って使い続けている |
| #1475 | `status === 0` のときだけ warn | supabase-js が fetch 失敗をラップした値＝HTTP 応答に到達していない（回線断）。**2 秒後には検索 API が成功しており、認証エラー画面は出ていない** |
| #1476 | `ApiError.code === "forbidden"` のときだけ warn | 内部作業用画面（sitemap 対象外・アプリ内リンク無し）を権限の無い匿名ユーザーが直接開いただけ。権限機構は正しく動いている |

**広げなかった理由**を残しておきます。

- #1433: `error` があること自体を warn にすると、`server_error` / `temporarily_unavailable`（＝プロバイダ側の障害で、こちらは知りたい）まで畳んでしまう
- #1475: `undefined` まで含めると、初期化中に起きた**こちら側の実装バグ**（status を持たない TypeError 等）が warn に落ちて見えなくなる
- #1476: forbidden 以外は `error` のまま。tools API 自体が落ちたときの信号を消さない

## 副産物：除外ルールの穴（今回は直していません）

#1476 では**同じ 1 回の失敗が 2 本記録**されており、

- `api_call_error` → `payload.status = 403` がトップレベル → **E4 が除外**（Issue にならない）
- `tools_categories_error` → `payload: { error: { status: 403 } }` と入れ子 → **E4 に見えず起票**

**ペイロードの形だけで、除外されるかどうかが分かれています。** E5 の件（文言で割れる）とは別種の穴です。今回は範囲を広げる変更を避け、スキルへの記録は別途行います。

## テスト

| | 結果 |
|---|---|
| `app-expo` jest | **83 suites / 824 tests / 失敗 0**（新規 8 件） |
| typecheck | 変更前後とも **同じ 11 件**。いずれも `data/` `notifications/` など**触っていないファイル**で、main に元からあるもの |

追加したテスト:

- `__tests__/postsIdsGuard.test.tsx`（6 件・新規）— ids 無し / 空文字 / 非 UUID / 区切りだけ で API を呼ばず「見つかりません」を出す、正常な UUID は従来どおり呼ぶ、壊れた値が混ざっても有効なものだけ送る
- `__tests__/authCallbackScreen.test.tsx`（2 件追加）— `access_denied` は warn、**それ以外のプロバイダエラーは error のまま**

## Migration

**ありません**（DB 変更なし）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoysKNnizjrnvz2dQGhjRr)_