### PR TITLE
#843 fix: 日次クォータ枯渇で即停止し、api_errorをresume対象に戻す

### DIFF
--- a/scripts/20260808T0000_restaurant/3_2_search_google_place_ids.py
+++ b/scripts/20260808T0000_restaurant/3_2_search_google_place_ids.py
@@ -19,6 +19,7 @@ from google.cloud import bigquery
 
 from google_place_matching import (
     ALGORITHM_VERSION,
+    DailyQuotaExhausted,
     TIGHT_HALF_SIDE_M,
     WIDE_HALF_SIDE_M,
     PlacesTextSearchClient,
@@ -102,6 +103,11 @@ def fetch_candidates(
             AND a.run_id = @run_id
             AND a.seed_id = s.seed_id
             AND a.algorithm_version = @algorithm_version
+            -- api_error は「照合を試したが答えが出ていない」状態である。
+            -- これを済み扱いにすると、日次クォータ枯渇や一過性の5xxで
+            -- 落ちた seed が resume 対象から外れ、二度と照合されない
+            -- （実際に429で15,376件がこの状態になった）。次回は引き直す。
+            AND a.result_status != 'api_error'
         )
       ORDER BY s.seed_id
       LIMIT @limit
@@ -325,8 +331,18 @@ def main() -> None:
                     )
                     for seed in chunk
                 ]
+                quota_exhausted = False
                 for future in as_completed(futures):
-                    buffer.append(future.result())
+                    try:
+                        buffer.append(future.result())
+                    except DailyQuotaExhausted as error:
+                        # 日次クォータは翌日まで回復しない。残りを走らせても
+                        # api_error を書き込むだけなので、ここで打ち切る。
+                        # 未処理分は次回 run が resume で引き直す。
+                        if not quota_exhausted:
+                            LOGGER.error("日次クォータ枯渇で打ち切る: %s", error)
+                        quota_exhausted = True
+                        continue
                     done += 1
                     if len(buffer) >= 100:
                         flush_rows(pipeline, buffer)
@@ -334,8 +350,16 @@ def main() -> None:
                         LOGGER.info("Google照合: %d/%d件", done, len(candidates))
                 futures.clear()
                 flush_rows(pipeline, buffer)
+                if quota_exhausted:
+                    break
         flush_rows(pipeline, buffer)
-        step["row_count"] = len(candidates)
+        step["row_count"] = done
+        step["quota_exhausted"] = quota_exhausted
+        if quota_exhausted:
+            raise RuntimeError(
+                f"日次クォータ枯渇で {done}/{len(candidates)} 件で打ち切った。"
+                "太平洋時間の日付が変わってから再実行すると、未処理分だけ引き直す。"
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/20260808T0000_restaurant/google_place_matching.py
+++ b/scripts/20260808T0000_restaurant/google_place_matching.py
@@ -194,6 +194,17 @@ def decide_match(
     return MatchDecision(candidate, "box_unique_strict")
 
 
+# 日次クォータ枯渇のマーカー。分次（per minute）は数十秒待てば回復するので
+# 再試行するが、日次（per day）は翌日まで回復しないため即座に止める。
+# これが無いと、枯渇後の全 seed に api_error の attempt 行が書かれ、
+# resume の対象から外れて「二度と照合されない」状態になる（実際に15,376件で発生）。
+DAILY_QUOTA_MARKERS = ("per day", "PerDayPerProject")
+
+
+class DailyQuotaExhausted(RuntimeError):
+    """Text Search の日次クォータを使い切った。その日はもう送れない。"""
+
+
 class PlacesTextSearchClient:
     """標準ライブラリだけでText Search (New)を呼ぶ小さなclient。
 
@@ -260,6 +271,11 @@ class PlacesTextSearchClient:
             except urllib.error.HTTPError as error:
                 status = int(error.code)
                 message = error.read(4096).decode("utf-8", errors="replace")
+                if status == 429 and any(
+                    marker in message for marker in DAILY_QUOTA_MARKERS
+                ):
+                    # 再試行しても回復しない。呼び出し側で run 全体を止める。
+                    raise DailyQuotaExhausted(message[:2000]) from error
                 if (
                     status not in {429, 500, 502, 503, 504}
                     or attempt >= self.max_retries


### PR DESCRIPTION
## 何が起きたか

Text Search の日次クォータ（3,000,000）を 04:51 UTC に使い切りました。それ自体は復旧待ちで済む話ですが、**二次被害**がありました。

1. 429 が返り続ける中、`--limit` の残り全部に対して api_error の attempt 行が書き込まれた（**15,376件**）
2. resume クエリは「attempt 行があれば済み」と判定するため、**この seed 群が二度と照合されない状態**になっていた

つまり、クォータが戻っても取りこぼしが恒久化する作りでした。

## 修正

**`google_place_matching.py`** — 429 の本文に `per day` / `PerDayPerProject` があれば `DailyQuotaExhausted` を即送出します。日次は翌日まで回復しないため、従来の指数バックオフ4回はクォータを無駄に消費するだけでした。分次（per minute）の429は従来どおり再試行します。

**`3_2_search_google_place_ids.py`**
- `DailyQuotaExhausted` を掴んだら chunk 境界で run を打ち切り、`step.quota_exhausted` を残して `RuntimeError` で終わる（黙って部分成功にしない）
- resume クエリに `result_status != 'api_error'` を追加。答えの出ていない seed を次回引き直します

## 検証

- 単体テスト12件 green
- 日次429 → 1リクエストで即送出（再試行なし）、分次429 → 従来どおり再試行、を実測
- 修正後の resume クエリで対象が **232,021 → 246,592** に回復（api_error 分が戻った）

## 枯渇の主因

昨日の BigQuery 書き込みハング（13:22〜15:52）中に worker が API を叩き続け、**記録されないまま約40万リクエストを消費**したことです。記録済みは 2,712,742 リクエストで、これだけなら3M以内に収まっていました。ハング自体は #1540 で対策済みです。

残り 246,592 seed × 実測2.13 = 約53万リクエストで、翌日枠には余裕をもって収まります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCVVMHHhHRMMUCUtMj5d2A

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCVVMHHhHRMMUCUtMj5d2A)_