### PR TITLE
fix: デプロイ後スモークが main で赤いままだった 2 件を直す

### DIFF
--- a/app-expo/__tests__/notificationsSafeArea.test.tsx
+++ b/app-expo/__tests__/notificationsSafeArea.test.tsx
@@ -144,3 +144,38 @@ describe("#1130 お知らせ一覧の SafeArea", () => {
 		expect(blockedTopicsSource).toContain('import { SafeAreaView } from "react-native-safe-area-context"');
 	});
 });
+
+/**
+ * #1503 お知らせ一覧のヘッダー testID。
+ *
+ * 【バグ】ログイン済みの分岐にしか `notifications-header-title` が無く、**ゲスト（匿名）向けの
+ * 空画面には付いていなかった**。E2E は web も native も匿名セッションで走るため、
+ * 実際に評価されるのは常にゲスト側の分岐であり、直リンクスモーク
+ *（e2e-web tests/smoke/deep-link.spec.ts）は «画面は出ているのに印が無い» で赤くなっていた
+ *（run 32716114752 / main でも同様に再現）。
+ *
+ * 画面が «描画された印» はどちらの分岐でも同じでなければならない、という不変条件をここで固定する。
+ */
+describe("お知らせ一覧のヘッダー testID", () => {
+	afterEach(() => {
+		mockCurrentUser = mockLoggedInUser;
+	});
+
+	// ⚠️ host 要素（type が文字列のもの）だけを数えること。`findAll` は合成コンポーネントの
+	//    <Text> と、その中身の host 要素の **両方** を返すため、絞らないと必ず 2 件になる
+	const findHeaderTitles = (root: ReactTestInstance): ReactTestInstance[] =>
+		root.findAll((node) => typeof node.type === "string" && node.props?.testID === "notifications-header-title");
+
+	it.each([
+		["ログイン済み", mockLoggedInUser],
+		["ゲスト（匿名）", null],
+	])("%s の画面に notifications-header-title がちょうど 1 つある", (_label, user) => {
+		mockCurrentUser = user;
+		const renderer = render();
+
+		// ⚠️ 「1 つ」まで見るのは、Detox の SafeArea 実測（e2e-mobile の
+		//    notifications-safe-area.test.ts）が «1 件だけ一致する» ことを前提に
+		//    ヘッダーの y 座標を読んでいるため
+		expect(findHeaderTitles(renderer.root)).toHaveLength(1);
+	});
+});

--- a/app-expo/app/[locale]/(tabs)/notifications/index.tsx
+++ b/app-expo/app/[locale]/(tabs)/notifications/index.tsx
@@ -242,7 +242,15 @@ export default function NotificationsScreen() {
 		return (
 			<SafeAreaView style={styles.container} edges={["top"]}>
 				<View style={styles.header}>
-					<Text style={styles.headerTitle}>{i18n.t("Notifications.title")}</Text>
+					{/* #1503 【テスト】ログイン済みの分岐と **同じ testID** を付けること。
+					    直リンクスモーク（e2e-web tests/smoke/deep-link.spec.ts）と Detox の
+					    SafeArea 実測（e2e-mobile tests/mutation/notifications-safe-area.test.ts）は
+					    どちらもこの testID を «お知らせ画面が描画された印» にしている。
+					    どちらのセッションも匿名なので、実際に評価されるのは **こちらの分岐**である。
+					    testID がこちらに無いと «画面は出ているのにテストからは見えない» 状態になる */}
+					<Text testID="notifications-header-title" style={styles.headerTitle}>
+						{i18n.t("Notifications.title")}
+					</Text>
 				</View>
 				<View style={styles.emptyContainer}>
 					<Text style={styles.emptyText}>{i18n.t("Notifications.empty")}</Text>

--- a/e2e-web/fixtures/test.ts
+++ b/e2e-web/fixtures/test.ts
@@ -26,6 +26,16 @@ type AppOptions = {
 	 * 既存の検索フローを遮らないよう既定true、専用specのみfalseにする。
 	 */
 	seedTopicsTutorialSeen: boolean;
+	/**
+	 * この spec では «出て当然» の console error / pageerror。ここに一致するものは収集しない。
+	 *
+	 * `KNOWN_CONSOLE_NOISE` との違いは **適用範囲** である。あちらは «どの spec でも無害» な
+	 * ノイズ用で、ここは «その spec の前提そのものがエラーを生む» 場合に使う。
+	 * hydration 失敗（React error #418）のような検知したい種類のエラーを
+	 * `KNOWN_CONSOLE_NOISE` へ入れると **全 spec で見えなくなる**ので、必ずこちらを使い、
+	 * `test.use()` の直近に «なぜ出て当然なのか» を書くこと。
+	 */
+	allowedConsoleErrors: RegExp[];
 };
 
 /** テストへ提供するフィクスチャ */
@@ -69,6 +79,7 @@ export const test = base.extend<AppOptions & AppFixtures>({
 	// ── オプション ──────────────────────────────────────────────
 	seedTutorialSeen: [true, { option: true }],
 	seedTopicsTutorialSeen: [true, { option: true }],
+	allowedConsoleErrors: [[], { option: true }],
 
 	// ── context: オンボーディング / スポットライトのシードを適用 ──
 	// addInitScript はページ生成前に仕込む必要があるため context を拡張する
@@ -84,17 +95,20 @@ export const test = base.extend<AppOptions & AppFixtures>({
 
 	// ── consoleErrors: 自動収集（auto） ─────────────────────────
 	consoleErrors: [
-		async ({ page }, use, testInfo) => {
+		async ({ page, allowedConsoleErrors }, use, testInfo) => {
 			const errors: string[] = [];
+			const isIgnored = (text: string) =>
+				KNOWN_CONSOLE_NOISE.some((pattern) => pattern.test(text)) ||
+				allowedConsoleErrors.some((pattern) => pattern.test(text));
 
 			// console.error と未捕捉例外 (pageerror) の両方を収集する
 			page.on("console", (message) => {
-				if (message.type() === "error" && !KNOWN_CONSOLE_NOISE.some((pattern) => pattern.test(message.text()))) {
+				if (message.type() === "error" && !isIgnored(message.text())) {
 					errors.push(message.text());
 				}
 			});
 			page.on("pageerror", (error) => {
-				if (!KNOWN_CONSOLE_NOISE.some((pattern) => pattern.test(error.message))) {
+				if (!isIgnored(error.message)) {
 					errors.push(`[pageerror] ${error.message}`);
 				}
 			});

--- a/e2e-web/fixtures/test.ts
+++ b/e2e-web/fixtures/test.ts
@@ -27,15 +27,22 @@ type AppOptions = {
 	 */
 	seedTopicsTutorialSeen: boolean;
 	/**
-	 * この spec では «出て当然» の console error / pageerror。ここに一致するものは収集しない。
+	 * この spec では «出て当然» の console error / pageerror。**部分一致**したものは収集しない。
 	 *
 	 * `KNOWN_CONSOLE_NOISE` との違いは **適用範囲** である。あちらは «どの spec でも無害» な
 	 * ノイズ用で、ここは «その spec の前提そのものがエラーを生む» 場合に使う。
 	 * hydration 失敗（React error #418）のような検知したい種類のエラーを
 	 * `KNOWN_CONSOLE_NOISE` へ入れると **全 spec で見えなくなる**ので、必ずこちらを使い、
 	 * `test.use()` の直近に «なぜ出て当然なのか» を書くこと。
+	 *
+	 * ⚠️ **正規表現の配列にしないこと。** Playwright はフィクスチャ値が
+	 * `Array.isArray(value) && typeof value[1] === "object"` を満たすと «[値, オプション]» の
+	 * タプルとみなす（playwright/lib の `isFixtureTuple`）。`RegExp` は object なので
+	 * `test.use({ allowedConsoleErrors: [/a/, /b/] })` は 2 要素目をオプション扱いで剥がされ、
+	 * 値が配列でなくなって実行時に `allowedConsoleErrors.some is not a function` で落ちる
+	 *（run 32718781438 で実測）。文字列なら `typeof value[1] === "string"` なのでこの罠を踏まない。
 	 */
-	allowedConsoleErrors: RegExp[];
+	allowedConsoleErrors: string[];
 };
 
 /** テストへ提供するフィクスチャ */
@@ -99,7 +106,7 @@ export const test = base.extend<AppOptions & AppFixtures>({
 			const errors: string[] = [];
 			const isIgnored = (text: string) =>
 				KNOWN_CONSOLE_NOISE.some((pattern) => pattern.test(text)) ||
-				allowedConsoleErrors.some((pattern) => pattern.test(text));
+				allowedConsoleErrors.some((allowed) => text.includes(allowed));
 
 			// console.error と未捕捉例外 (pageerror) の両方を収集する
 			page.on("console", (message) => {

--- a/e2e-web/tests/harness/allowed-console-errors.spec.ts
+++ b/e2e-web/tests/harness/allowed-console-errors.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "../../fixtures/test";
+import {
+	CONSOLE_HARNESS_TEST_ID,
+	drainConsoleErrors,
+	emitConsoleError,
+	emitPageError,
+	openConsoleHarnessPage,
+} from "../../utils/consoleHarness";
+
+/**
+ * 🙈 spec 単位の許容リスト `allowedConsoleErrors` の振る舞いを固定するテスト
+ *
+ * ## 何を守っているか
+ * `KNOWN_CONSOLE_NOISE`（全 spec 共通）とは別に、**その spec でだけ «出て当然» のエラー**を
+ * 許容する口が `fixtures/test.ts` にある。許容が広すぎれば REL-08 のゲートが骨抜きになり、
+ * 狭すぎれば «直せない前提» の spec が永久に赤いままになる。どちらも静かに壊れるので、
+ * ここで «一致したものだけ落ちる / それ以外は従来どおり収集される» を固定する。
+ *
+ * ## ⚠️ 値を «正規表現の配列» にしてはいけない
+ * Playwright はフィクスチャ値が `Array.isArray(value) && typeof value[1] === "object"` を
+ * 満たすと «[値, オプション]» のタプルとみなす（playwright/lib の `isFixtureTuple`）。
+ * `RegExp` は object なので `[/a/, /b/]` は 2 要素目をオプションとして剥がされ、
+ * 値が配列でなくなって実行時に `allowedConsoleErrors.some is not a function` で落ちる
+ *（run 32718781438 で実測）。**2 要素以上の文字列配列**を使うこの spec は、
+ * その形が壊れたら «型ではなく実行» で落ちるので、罠の再発もここで捕まる。
+ *
+ * ## 実行方法
+ * アプリのビルド（app-expo/dist）に依存しないダミーページだけを使う。
+ *   `pnpm --filter e2e-web test:harness`
+ */
+test.describe("allowedConsoleErrors @harness", () => {
+	// 2 要素にしてあるのは、上の «タプル誤検出» を踏むのと同じ形（要素数 2）を保つため
+	test.use({ allowedConsoleErrors: ["harness: 許容する console.error", "harness: 許容する未捕捉例外"] });
+
+	test.beforeEach(async ({ page }) => {
+		await openConsoleHarnessPage(page);
+		await expect(page.getByTestId(CONSOLE_HARNESS_TEST_ID)).toBeVisible();
+	});
+
+	// ─ テストケース: 許容リストに一致する console.error は収集されない ─
+	// 手順:
+	//   1. 許容リストの文字列を含む console.error を発生させる
+	//   2. consoleErrors が空のままであることを検証
+	//   3. drain しない = teardown のゲートも発火しないことを、このテストが緑で終わること自体で示す
+	test("一致する console.error は収集されない", async ({ page, consoleErrors }) => {
+		await emitConsoleError(page, "harness: 許容する console.error（前後に文字があっても部分一致する）");
+
+		expect(consoleErrors).toEqual([]);
+	});
+
+	// ─ テストケース: 許容リストに一致する pageerror も収集されない ─
+	// 手順:
+	//   1. 許容リストの文字列を含む未捕捉例外を発生させる
+	//   2. consoleErrors が空のままであることを検証
+	// 補足: console.error と pageerror の両方に効くことを固定する（片方だけ通す実装への退行検知）
+	test("一致する未捕捉例外も収集されない", async ({ page, consoleErrors }) => {
+		await emitPageError(page, "harness: 許容する未捕捉例外");
+
+		expect(consoleErrors).toEqual([]);
+	});
+
+	// ─ テストケース: 一致しないエラーは従来どおり収集される ─
+	// 手順:
+	//   1. 許容リストに無いメッセージで console.error を発生させる
+	//   2. consoleErrors に積まれていることを検証
+	//   3. drain して teardown のゲート発火を回避する（このテスト自体は緑で終わらせたい）
+	// 補足: 許容リストを «全部無視» に広げる実装（例: 常に true を返す）への退行はここで落ちる
+	test("一致しないエラーは従来どおり収集される", async ({ page, consoleErrors }) => {
+		await emitConsoleError(page, "harness: 許容していないエラー");
+
+		expect(consoleErrors).toHaveLength(1);
+		expect(consoleErrors[0]).toContain("harness: 許容していないエラー");
+
+		drainConsoleErrors(consoleErrors);
+	});
+});

--- a/e2e-web/tests/smoke/deep-link.spec.ts
+++ b/e2e-web/tests/smoke/deep-link.spec.ts
@@ -81,7 +81,8 @@ const markerFor = (route: string) => {
  *
  * @param route locale prefix より後ろのパス
  */
-const prerenderMarkerFor = (route: string): string => (route.startsWith("legal/") ? "legal-screen-document" : "tab-search");
+const prerenderMarkerFor = (route: string): string =>
+	route.startsWith("legal/") ? "legal-screen-document" : "tab-search";
 
 test.describe("ディープリンク @smoke", () => {
 	for (const route of DEEP_LINK_SMOKE_ROUTES) {
@@ -126,6 +127,34 @@ test.describe("ディープリンク @smoke", () => {
 			expect(body).toContain(`data-testid="${prerenderMarkerFor(route)}"`);
 		});
 	}
+});
+
+/**
+ * 存在しないパスの NotFound 画面。
+ *
+ * ## なぜ hydration 失敗（React error #418）を許容するのか
+ *
+ * Firebase Hosting は最後の rewrite `** → /index.html` で **prerender されていない URL を
+ * すべて index.html（ルート `app/index.tsx` の静的出力）で返す**（firebase.json）。
+ * 実測: `/ja-JP/this-route-does-not-exist` と `/` は **バイト単位で同一の HTML** が返る
+ *（run 32716114752 の preview で md5 一致を確認）。
+ *
+ * その HTML はロケール解決前のルートの器で、本文テキストを持たない。ブラウザ側は URL に従って
+ * `[locale]/+not-found.tsx` を描くので、サーバ HTML とクライアントの木が食い違い、
+ * React は #418 を出してクライアント側で描き直す。**画面は正しく出る**（下の 2 つの
+ * アサーションが実際に通っている）が、エラーは構造上必ず出る。
+ *
+ * これは «SPA フォールバックで配信される URL» すべてに共通する性質で、この画面固有の不具合ではない
+ *（店舗詳細のような prerender されない動的ルートも同じ経路をたどる）。根本から消すには
+ * 動的ルートごとに rewrite を張って catch-all を NotFound の静的出力へ向ける必要があり、
+ * 張り忘れたルートが «正しい URL なのに NotFound» になる副作用を持つ。この spec の範囲を超えるため、
+ * ここでは «出て当然のエラー» として明示的に許容する。
+ *
+ * ⚠️ `KNOWN_CONSOLE_NOISE` へ入れないこと。#418 は #1503 が prerender の不一致を捕まえるために
+ * 使っている検知点で、全 spec で無視すると «公開ルートの hydration 不一致» が見えなくなる。
+ */
+test.describe("存在しないパス @smoke", () => {
+	test.use({ allowedConsoleErrors: [/Minified React error #418/, /Hydration failed/] });
 
 	// ─ テストケース: 存在しないパスで NotFound 画面が表示される ─
 	// 手順:

--- a/e2e-web/tests/smoke/deep-link.spec.ts
+++ b/e2e-web/tests/smoke/deep-link.spec.ts
@@ -154,7 +154,8 @@ test.describe("ディープリンク @smoke", () => {
  * 使っている検知点で、全 spec で無視すると «公開ルートの hydration 不一致» が見えなくなる。
  */
 test.describe("存在しないパス @smoke", () => {
-	test.use({ allowedConsoleErrors: [/Minified React error #418/, /Hydration failed/] });
+	// 部分一致（本番ビルドは minify 済みの #418、dev ビルドは "Hydration failed" の文言で出る）
+	test.use({ allowedConsoleErrors: ["Minified React error #418", "Hydration failed"] });
 
 	// ─ テストケース: 存在しないパスで NotFound 画面が表示される ─
 	// 手順:


### PR DESCRIPTION
#1503 で直リンクスモークを配列駆動にしたときから赤く、main で放置されていた 2 件を直す。

どちらも feature ブランチ（run [32716114752](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/32716114752)）と **main**（run [32716924057](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/32716924057)）の両方で同一に再現することを確認してから着手した。

## 1. お知らせ画面: ゲスト分岐にヘッダーの testID が無い

`notifications-header-title` はログイン済みの分岐にしか付いておらず、ゲスト（匿名）向けの空画面には無かった。web も native も E2E は匿名セッションで走るため、**実際に評価されるのは常にゲスト側の分岐**であり、「画面は出ているのに印が見つからない」で 10 秒待って落ちていた。

- 両分岐に同じ testID を置いた
- ユニットテストで «どちらの状態でもちょうど 1 つ» を固定した。1 つに限るのは、Detox の SafeArea 実測（`e2e-mobile/tests/mutation/notifications-safe-area.test.ts`）が単一一致を前提にヘッダーの y 座標を読んでいるため
- testID を外すとゲスト側だけが赤くなることを手元で実測した

## 2. NotFound: SPA フォールバック由来の hydration 失敗（React error #418）

Firebase Hosting は最後の rewrite `** → /index.html` で、prerender されていない URL をすべて index.html で返す。実測でも `/ja-JP/this-route-does-not-exist` と `/` は **バイト単位で同一の HTML** だった。ブラウザ側は URL に従って `[locale]/+not-found.tsx` を描くため木が食い違い、React が #418 を出す。画面自体は正しく出る（テストの 2 つのアサーションは通っている）。

これは «SPA フォールバックで配信される URL» すべてに共通する性質で、この画面固有の不具合ではない。根本から消すには動的ルートごとに rewrite を張って catch-all を NotFound の静的出力へ向ける必要があり、張り忘れたルートが «正しい URL なのに NotFound» になる副作用を持つ。よってこの PR では spec 単位で «出て当然のエラー» として明示的に許容した。

許容は `KNOWN_CONSOLE_NOISE`（全 spec 共通）ではなく、新設の `allowedConsoleErrors` オプションで行う。#418 は #1503 が prerender の不一致を捕まえるための検知点なので、全 spec で無視すると公開ルートの hydration 不一致が見えなくなる。

### ⚠️ 踏んだ罠: 正規表現の配列は Playwright が剥がす

`allowedConsoleErrors: RegExp[]` の初回実装は実行時に `allowedConsoleErrors.some is not a function` で落ちた（run [32718781438](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/32718781438)）。Playwright はフィクスチャ値が `Array.isArray(value) && typeof value[1] === "object"` を満たすと «[値, オプション]» のタプルとみなす（`isFixtureTuple`）。`RegExp` は object なので 2 要素目がオプション扱いで剥がされる。

文字列の部分一致へ変更し（`typeof value[1] === "string"` なのでタプル誤検出を踏まない）、ハーネス自己検証 `tests/harness/allowed-console-errors.spec.ts` を追加した。許容リストを **2 要素**にしてあるので、この形が壊れたら型ではなく実行で落ちて再発を捕まえる。

## 検証

- `app-expo`: typecheck 0 / jest 84 suites 828 tests 全 pass（うちヘッダー testID の新規 2 件）
- `e2e-web` / `e2e-mobile`: tsc 0
- デプロイ後スモーク: 修正前 2 failed / 23 passed → **修正後 25 passed**（run [32719576329](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/32719576329) の preview デプロイで実測）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UakPhb3FSD6gsYV3nV6LtK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UakPhb3FSD6gsYV3nV6LtK)_