### PR TITLE
fix(#1560): 投稿とレビューを 1 トランザクションで作り、写真の孤児を無くす

### DIFF
--- a/api/src/v1/dish-media/dish-media.repository.ts
+++ b/api/src/v1/dish-media/dish-media.repository.ts
@@ -20,6 +20,7 @@ import { AppLoggerService } from 'src/core/logger/logger.service';
 
 import {
   CreateDishMediaDto,
+  CreateDishMediaReviewDto,
   SearchDishMediaDto,
   QueryRestaurantDishMediaDto,
   ReactionActionType,
@@ -1107,6 +1108,37 @@ export class DishMediaRepository {
     });
 
     return newMedia;
+  }
+
+  /**
+   * #1560 投稿と同時に作るレビュー。
+   *
+   * `createDishMedia` と **同じ `tx` で呼ぶこと**。別トランザクションにすると
+   * «写真だけ残ってレビューが無い» 孤児（#1560）がそのまま復活する。
+   *
+   * `dish_id` と `created_dish_media_id` は引数の `dish_media` から取る。
+   * クライアントに決めさせないのは、取り違えたときに «別の料理へレビューが付く» を
+   * サーバー側で検出できなくなるため（DTO 側の JSDoc も参照）。
+   */
+  async createDishReviewForMedia(
+    tx: Prisma.TransactionClient,
+    review: CreateDishMediaReviewDto,
+    dishMedia: { id: string; dish_id: string },
+    userId: string,
+  ) {
+    return tx.dish_reviews.create({
+      data: {
+        dish_id: dishMedia.dish_id,
+        user_id: userId,
+        // 【設計】comment は翻訳せず入力のまま保存する（dish-reviews.repository と同じ）
+        comment: review.comment,
+        original_language_code: review.languageCode,
+        rating: review.rating,
+        price_cents: review.priceCents,
+        currency_code: review.currencyCode,
+        created_dish_media_id: dishMedia.id,
+      },
+    });
   }
 
   /* ------------------------------------------------------------------ */

--- a/api/src/v1/dish-media/dish-media.service.spec.ts
+++ b/api/src/v1/dish-media/dish-media.service.spec.ts
@@ -30,6 +30,7 @@ import { TranscoderService } from '../../core/transcoder/transcoder.service';
 import { CloudTasksService } from '../../core/cloud-tasks/cloud-tasks.service';
 import { ClsService } from 'nestjs-cls';
 import type { CreateDishMediaViewDto } from '@shared/v1/dto';
+import { env } from '../../core/config/env';
 
 const DISH_MEDIA_ID = 'dish-media-uuid';
 const IMPRESSION_ID = 'impression-uuid';
@@ -380,5 +381,162 @@ describe('DishMediaService テレメトリの FK 違反ハンドリング', () =
         service.addReaction(DISH_MEDIA_ID, 'like', USER_ID, false),
       ).rejects.toBe(error);
     });
+  });
+});
+
+/*
+#1560 【回帰】投稿とレビューを **同じトランザクション** で作る。
+
+分かれていた頃は `POST /v1/dish-media` → `POST /v1/dish-reviews` の 2 本立てで、
+1 本目が成功して 2 本目が落ちると dish_media だけが残った。
+`GET /v1/users/me/dishes` の候補集合は want（reactions）と eaten（dish_reviews）の
+2 系統しか無く **dish_media を起点にした系統が無い**ため、その行は一覧にもピンにも出ず、
+本人が到達する導線が消える。#1513 の「投稿を削除」でも消せない。
+
+ここで固定するのは 3 点:
+1. `review` を渡したら **同じ tx** でレビューまで作る
+2. `review` を渡さなければレビューを作らない（従来の 2 本立ては壊さない）
+3. 外部呼び出し（トランスコード起動・リサイズ enqueue）は **コミット後**に行う。
+   ロールバックされた行に対してジョブだけが走ると、実体の無い record_id を参照し続ける
+*/
+describe('DishMediaService #1560 投稿とレビューの 1 トランザクション化', () => {
+  const DISH_ID = '11111111-1111-4111-8111-111111111111';
+  const CREATOR_ID = '22222222-2222-4222-8222-222222222222';
+  const NEW_MEDIA = {
+    id: '33333333-3333-4333-8333-333333333333',
+    dish_id: DISH_ID,
+    user_id: CREATOR_ID,
+    media_path: 'users/u/x.jpg',
+    media_type: 'image',
+    thumbnail_path: 'users/u/x.jpg',
+    created_at: new Date('2026-08-20T00:00:00.000Z'),
+    media_processing_status: 'processing',
+    thumbnail_processing_status: 'processing',
+  };
+  const NEW_REVIEW = {
+    id: '44444444-4444-4444-8444-444444444444',
+    dish_id: DISH_ID,
+    user_id: CREATOR_ID,
+    comment: 'おいしかった',
+    original_language_code: 'ja-JP',
+    rating: 5,
+    price_cents: 1000,
+    currency_code: 'JPY',
+    created_dish_media_id: NEW_MEDIA.id,
+    created_at: new Date('2026-08-20T00:00:00.000Z'),
+  };
+
+  /**
+   * `isValidUserUploadedPath` は `${API_NODE_ENV}/user-uploads/${userId}/` 始まりだけを通す
+   * （storage.utils.ts）。ここを満たさないと本題の手前で 404 になる
+   */
+  const UPLOAD_PREFIX = `${env.API_NODE_ENV}/user-uploads/${CREATOR_ID}/`;
+  const baseDto = {
+    dishId: DISH_ID,
+    mediaPath: `${UPLOAD_PREFIX}x.jpg`,
+    thumbnailPath: `${UPLOAD_PREFIX}x.jpg`,
+    mediaType: 'image' as const,
+  };
+
+  /** 実行順を 1 本の列で観測する（«コミット後に enqueue» を順序で固定するため） */
+  let calls: string[];
+  let service: DishMediaService;
+  let repo: {
+    dishExists: jest.Mock;
+    createDishMedia: jest.Mock;
+    createDishReviewForMedia: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    calls = [];
+    repo = {
+      dishExists: jest.fn().mockResolvedValue(true),
+      createDishMedia: jest.fn().mockImplementation(() => {
+        calls.push('createDishMedia');
+        return Promise.resolve(NEW_MEDIA);
+      }),
+      createDishReviewForMedia: jest.fn().mockImplementation(() => {
+        calls.push('createDishReviewForMedia');
+        return Promise.resolve(NEW_REVIEW);
+      }),
+    };
+    const cloudTasks = {
+      enqueueResizeImage: jest.fn().mockImplementation(() => {
+        calls.push('enqueueResizeImage');
+        return Promise.resolve(undefined);
+      }),
+    };
+    const prisma = {
+      withTransaction: jest.fn(async (exec: (tx: unknown) => unknown) => {
+        calls.push('tx:begin');
+        const out = await exec({ __tx: true });
+        calls.push('tx:commit');
+        return out;
+      }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DishMediaService,
+        { provide: DishMediaRepository, useValue: repo },
+        { provide: DishMediaAssembler, useValue: {} },
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: AppLoggerService,
+          useValue: { debug: jest.fn(), warn: jest.fn(), error: jest.fn(), log: jest.fn() },
+        },
+        { provide: TranscoderService, useValue: {} },
+        { provide: CloudTasksService, useValue: cloudTasks },
+        { provide: ClsService, useValue: { get: jest.fn() } },
+      ],
+    }).compile();
+    service = module.get<DishMediaService>(DishMediaService);
+  });
+
+  it('review を渡すと、メディアと同じトランザクションでレビューまで作る', async () => {
+    const result = await service.createDishMedia(
+      {
+        ...baseDto,
+        review: {
+          comment: 'おいしかった',
+          languageCode: 'ja-JP',
+          rating: 5,
+          priceCents: 1000,
+          currencyCode: 'JPY',
+        },
+      },
+      CREATOR_ID,
+    );
+
+    expect(repo.createDishReviewForMedia).toHaveBeenCalledTimes(1);
+    // 同じ tx オブジェクトを共有していること（別トランザクションだと孤児が復活する）
+    const txForMedia = repo.createDishMedia.mock.calls[0][0];
+    const txForReview = repo.createDishReviewForMedia.mock.calls[0][0];
+    expect(txForReview).toBe(txForMedia);
+
+    // dish_id / created_dish_media_id はサーバーが作ったメディアから取る
+    expect(repo.createDishReviewForMedia.mock.calls[0][2]).toBe(NEW_MEDIA);
+
+    expect(result.dishReview?.id).toBe(NEW_REVIEW.id);
+  });
+
+  it('外部呼び出し（リサイズの enqueue）はコミット後に行う', async () => {
+    await service.createDishMedia(
+      { ...baseDto, review: { comment: 'x', languageCode: 'ja-JP', rating: 5 } },
+      CREATOR_ID,
+    );
+
+    const commitAt = calls.indexOf('tx:commit');
+    const firstEnqueueAt = calls.indexOf('enqueueResizeImage');
+    expect(commitAt).toBeGreaterThanOrEqual(0);
+    expect(firstEnqueueAt).toBeGreaterThan(commitAt);
+    // レビュー作成はコミット前（= トランザクションの中）
+    expect(calls.indexOf('createDishReviewForMedia')).toBeLessThan(commitAt);
+  });
+
+  it('review を渡さなければレビューを作らない（従来の 2 本立てを壊さない）', async () => {
+    const result = await service.createDishMedia(baseDto, CREATOR_ID);
+
+    expect(repo.createDishReviewForMedia).not.toHaveBeenCalled();
+    expect(result.dishReview).toBeUndefined();
   });
 });

--- a/api/src/v1/dish-media/dish-media.service.ts
+++ b/api/src/v1/dish-media/dish-media.service.ts
@@ -22,6 +22,7 @@ import { AppLoggerService } from '../../core/logger/logger.service';
 import { TranscoderService } from '../../core/transcoder/transcoder.service';
 import { env } from '../../core/config/env';
 import { convertPrismaToSupabase_DishMedia } from '../../../../shared/converters/convert_dish_media';
+import { convertPrismaToSupabase_DishReviews } from '../../../../shared/converters/convert_dish_reviews';
 import { CloudTasksService } from '../../core/cloud-tasks/cloud-tasks.service';
 import {
   buildTranscodedPath,
@@ -164,21 +165,47 @@ export class DishMediaService {
     if (!isValidUserUploadedPath(dto.mediaPath, creatorId))
       throw new NotFoundException('Invalid mediaPath');
 
-    // トランザクションで dish_media + 付随レコード作成
-    const result = await this.prisma.withTransaction(
-      (tx: Prisma.TransactionClient) =>
-        this.repo.createDishMedia(tx, dto, {
+    /*
+    #1560 【設計】レビューを一緒に受け取ったら **同じトランザクションで** 書く。
+
+    分かれていた頃は `POST /v1/dish-media` → `POST /v1/dish-reviews` の 2 本立てで、
+    1 本目が成功して 2 本目が落ちると dish_media だけが残った。
+    `GET /v1/users/me/dishes` の候補集合は want（reactions）と eaten（dish_reviews）の
+    2 系統しか無く **dish_media を起点にした系統が無い**ため、その行は一覧にもピンにも
+    出ず、本人が到達する導線が消える。#1513 の「投稿を削除」でも消せない。
+    ストレージに写真が残り続けるのに本人は見ることも消すこともできなくなる。
+
+    ⚠️ トランザクションの中で外部呼び出し（トランスコード起動・リサイズの enqueue）を
+       してはいけない。それらはコミット後に行う（下）。ロールバックされた行に対して
+       ジョブだけが走ると、実体の無い record_id をずっと参照し続ける。
+    */
+    const { media: result, review } = await this.prisma.withTransaction(
+      async (tx: Prisma.TransactionClient) => {
+        const media = await this.repo.createDishMedia(tx, dto, {
           user_id: creatorId,
           thumbnail_path: dto.thumbnailPath,
           media_processing_status: 'processing',
           thumbnail_processing_status: 'processing',
-        }),
+        });
+        const dishReview = dto.review
+          ? await this.repo.createDishReviewForMedia(
+              tx,
+              dto.review,
+              media,
+              creatorId,
+            )
+          : null;
+        return { media, review: dishReview };
+      },
     );
 
     this.logger.log('DishMediaCreated', 'createDishMedia', {
       mediaId: result.id,
       dishId: dto.dishId,
       mediaType: dto.mediaType,
+      // #1560 «同じトランザクションでレビューまで作れたか» をログから判別できるようにする。
+      // 孤児が再発したときに «2 本立ての経路を通っていた» のか «1 本で落ちた» のかが分かる
+      reviewId: review?.id ?? null,
     });
 
     if (dto.mediaType === 'video') {
@@ -228,7 +255,13 @@ export class DishMediaService {
       originalPath: dto.thumbnailPath,
     });
 
-    return convertPrismaToSupabase_DishMedia(result);
+    return {
+      ...convertPrismaToSupabase_DishMedia(result),
+      // #1560 レビューを一緒に作ったときだけ返す。送らなかった従来の呼び出しでは undefined
+      ...(review
+        ? { dishReview: convertPrismaToSupabase_DishReviews(review) }
+        : {}),
+    };
   }
 
   /* ------------------------------------------------------------------ */

--- a/app-expo/features/map/components/ReviewForm.tsx
+++ b/app-expo/features/map/components/ReviewForm.tsx
@@ -721,6 +721,12 @@ export function ReviewForm({
 			let dish: DishMediaEntry["dish"] | null = null;
 			/** レビューを書く対象の dish。写真ありは `dish_media.dish_id`、写真なしは get-or-create の結果 */
 			let dishId: string;
+			/**
+			 * #1560 新規写真投稿では `POST /v1/dish-media` が **同じトランザクションで**
+			 * 作ったレビューを返す。その場合 `POST /v1/dish-reviews` は投げない。
+			 * null のままなら従来どおり単独で投げる（写真なし / 他人のメディアへの追記）。
+			 */
+			let createdDishReviewFromMedia: CreateDishMediaResponse["dishReview"] | null = null;
 			if (mediaState.status === "none") {
 				/**
 				 * #1398 (c-2) 写真なしの記録。
@@ -779,6 +785,19 @@ export function ReviewForm({
 				 * Video のアップロードが完了してからでないと、
 				 * transcoer API が失敗する可能性があるため、直列で実行する
 				 */
+				/*
+				#1560 【設計】レビューを **この 1 本に同梱する**。
+
+				以前は `POST /v1/dish-media` の直後に `POST /v1/dish-reviews` を投げていたが、
+				1 本目が成功して 2 本目が落ちる（通信断・5xx）と **写真だけが残った**。
+				`GET /v1/users/me/dishes` の候補集合は want（reactions）と eaten（dish_reviews）の
+				2 系統しか無く dish_media を起点にした系統が無いため、その行は一覧にもピンにも
+				出ず、本人が到達する導線が消える。#1513 の「投稿を削除」でも消せない（#1560）。
+
+				サーバーは media と review を同じトランザクションで書くので、部分成功が
+				原理的に起きなくなる。アップロードは依然この前に完了させること
+				（トランスコーダがアップロード済みオブジェクトを読むため）。
+				*/
 				const createDishMediaResponse = await callBackend<CreateDishMediaDto, CreateDishMediaResponse>(
 					"v1/dish-media",
 					{
@@ -789,9 +808,17 @@ export function ReviewForm({
 							thumbnailPath,
 							mediaType: mediaState.media.type,
 							videoDurationMs: mediaState.media.durationSec ? mediaState.media.durationSec * 1000 : undefined,
+							review: {
+								comment: reviewText,
+								languageCode: locale,
+								priceCents: parsedPrice,
+								currencyCode: currencyCode ?? undefined,
+								rating,
+							},
 						},
 					},
 				);
+				createdDishReviewFromMedia = createDishMediaResponse.dishReview ?? null;
 				dish_media = {
 					...createDishMediaResponse,
 					isMine: true,
@@ -812,7 +839,10 @@ export function ReviewForm({
 				dishId = dish_media.dish_id;
 			}
 
-			const createdDishReview = await callBackend<CreateDishReviewDto, CreateDishReviewResponse>("/v1/dish-reviews", {
+			// #1560 メディアと同時に作れていれば 2 本目は投げない（部分成功の窓を作らない）
+			const createdDishReview =
+				createdDishReviewFromMedia ??
+				(await callBackend<CreateDishReviewDto, CreateDishReviewResponse>("/v1/dish-reviews", {
 				method: "POST",
 				requestPayload: {
 					dishId,
@@ -824,8 +854,8 @@ export function ReviewForm({
 					// #1398 B4 写真なしのときは `createdDishMediaId` を**送らない**。
 					// DTO 上すでに任意で、API は未指定なら `created_dish_media_id` に NULL を書く
 					...(dish_media ? { createdDishMediaId: dish_media.id } : {}),
-				},
-			});
+					},
+				}));
 
 			/**
 			 * #1398 R2 【重要】写真なし（`dish_media === null`）ではストアを 1 つも触らない。

--- a/app-expo/features/map/components/ReviewFormSubmit.test.tsx
+++ b/app-expo/features/map/components/ReviewFormSubmit.test.tsx
@@ -105,7 +105,9 @@ jest.mock("@/hooks/useAPICall", () => ({ useAPICall: () => ({ callBackend: mockC
 jest.mock("@/hooks/useDishCategorySearch", () => ({
 	useDishCategorySearch: () => ({ createDishCategoryVariant: jest.fn() }),
 }));
-jest.mock("@/hooks/useFileUploader", () => ({ useFileUploader: () => ({ uploadFile: jest.fn() }) }));
+// #1560 新規写真投稿の経路を通すため、アップロードの戻り値をテストから差し込めるようにする
+const mockUploadFile = jest.fn();
+jest.mock("@/hooks/useFileUploader", () => ({ useFileUploader: () => ({ uploadFile: mockUploadFile }) }));
 const mockShowSnackbar = jest.fn();
 jest.mock("@/contexts/SnackbarProvider", () => ({ useSnackbar: () => ({ showSnackbar: mockShowSnackbar }) }));
 jest.mock("@/features/profile/hooks/useEnsureOwnProfileLoaded", () => ({ useEnsureOwnProfileLoaded: jest.fn() }));
@@ -437,5 +439,108 @@ describe("ReviewForm の写真なし投稿（#1398 B4 / R2）", () => {
 		await submitNoMedia();
 
 		expect(onSuccess).toHaveBeenCalledWith({ dishMedia: null, dishReviewId: "dish-review-1" });
+	});
+});
+
+/*
+#1560 【回帰】新規写真投稿を **1 本の HTTP** で終わらせる。
+
+分かれていた頃は `POST /v1/dish-media` → `POST /v1/dish-reviews` の 2 本立てで、
+1 本目が成功して 2 本目が落ちる（通信断・5xx）と写真だけが残った。
+`GET /v1/users/me/dishes` の候補集合は want（reactions）と eaten（dish_reviews）の
+2 系統しか無く **dish_media を起点にした系統が無い**ため、その行は一覧にもピンにも出ず、
+本人が到達する導線が消える。#1513 の「投稿を削除」でも消せない。
+
+ここで固定するのは «2 本目を投げないこと» そのものである。投げてしまえば、
+サーバーが 1 トランザクションにしても部分成功の窓は閉じない。
+*/
+describe("ReviewForm の新規写真投稿（#1560 1 トランザクション化）", () => {
+	let tree: TestRenderer.ReactTestRenderer;
+
+	const mountWithNewPhoto = async () => {
+		(selectMedia as jest.Mock).mockResolvedValue({
+			success: true,
+			media: { type: "image", uri: "file:///tmp/pic.jpg", mimeType: "image/jpeg" },
+		});
+		mockUploadFile.mockResolvedValue("users/u1/dish-1-media.jpg");
+		await act(async () => {
+			tree = TestRenderer.create(
+				<ReviewForm
+					restaurant={restaurant}
+					onCancel={noop}
+					onSuccess={jest.fn()}
+					initialPrice="1000"
+					initialReviewText="とてもおいしかった"
+					initialRating={5}
+				/>,
+			);
+		});
+		await act(async () => {
+			useDishCategorySelectionStore
+				.getState()
+				.setResult({ status: "selected", dishCategoryId: "dish-category-1", label: "からあげ" });
+		});
+	};
+
+	const pressSubmit = () => {
+		const pressable = tree.root
+			.findAllByProps({ testID: "review-submit-button" })
+			.find((node) => node.props.android_ripple !== undefined && typeof node.props.onPress === "function");
+		if (!pressable) throw new Error("投稿ボタンの Pressable が見つかりません");
+		act(() => pressable.props.onPress({}));
+	};
+
+	const calledEndpoints = () => mockCallBackend.mock.calls.map(([endpoint]) => endpoint);
+	const payloadOf = (endpoint: string) =>
+		mockCallBackend.mock.calls.find(([called]) => called === endpoint)?.[1]?.requestPayload;
+
+	beforeEach(() => {
+		mockCallBackend.mockReset();
+		mockUploadFile.mockReset();
+	});
+
+	afterEach(() => {
+		if (tree) act(() => tree.unmount());
+	});
+
+	it("v1/dish-media がレビュー本体を同梱して 1 本で終わり、/v1/dish-reviews を叩かない", async () => {
+		await mountWithNewPhoto();
+		// v1/dishes（get-or-create）→ v1/dish-media（レビュー同梱）
+		mockCallBackend.mockResolvedValueOnce({ id: "dish-1", restaurant_id: "restaurant-1", category_id: "c-1" });
+		mockCallBackend.mockResolvedValueOnce({
+			id: "dish-media-1",
+			dish_id: "dish-1",
+			dishReview: { id: "dish-review-1" },
+		});
+		pressSubmit();
+		await act(async () => {});
+
+		expect(calledEndpoints()).toEqual(["v1/dishes", "v1/dish-media"]);
+		expect(calledEndpoints()).not.toContain("/v1/dish-reviews");
+
+		const payload = payloadOf("v1/dish-media");
+		expect(payload.review).toEqual({
+			comment: "とてもおいしかった",
+			languageCode: "ja-JP",
+			priceCents: 1000,
+			currencyCode: "JPY",
+			rating: 5,
+		});
+		// dishId / createdDishMediaId はサーバーが決める（クライアントに決めさせない）
+		expect(payload.review).not.toHaveProperty("dishId");
+		expect(payload.review).not.toHaveProperty("createdDishMediaId");
+	});
+
+	it("サーバーがレビューを返さなければ、従来どおり /v1/dish-reviews を投げる（後方互換）", async () => {
+		await mountWithNewPhoto();
+		mockCallBackend.mockResolvedValueOnce({ id: "dish-1", restaurant_id: "restaurant-1", category_id: "c-1" });
+		// dishReview を返さない旧 API を模す
+		mockCallBackend.mockResolvedValueOnce({ id: "dish-media-1", dish_id: "dish-1" });
+		mockCallBackend.mockResolvedValueOnce({ id: "dish-review-1" });
+		pressSubmit();
+		await act(async () => {});
+
+		expect(calledEndpoints()).toEqual(["v1/dishes", "v1/dish-media", "/v1/dish-reviews"]);
+		expect(payloadOf("/v1/dish-reviews").createdDishMediaId).toBe("dish-media-1");
 	});
 });

--- a/shared/api/v1/dto/dish-media/create-dish-media.dto.ts
+++ b/shared/api/v1/dto/dish-media/create-dish-media.dto.ts
@@ -1,4 +1,41 @@
-import { IsIn, IsInt, IsString, IsUUID, Min, ValidateIf } from "class-validator";
+import { IsIn, IsInt, IsNumber, IsOptional, IsString, IsUUID, Max, Min, ValidateIf, ValidateNested } from "class-validator";
+import { Type } from "class-transformer";
+
+/**
+ * #1560 投稿と一緒に作るレビュー。
+ *
+ * `dishId` を持たないのは、**メディアと同じ dish に決まっている**から。
+ * `createdDishMediaId` を持たないのは、**いま作るメディアの id が入る**から。
+ * どちらもクライアントに決めさせると、取り違えたときに «別の料理へレビューが付く» を
+ * サーバー側で検出できなくなる。
+ */
+export class CreateDishMediaReviewDto {
+	/** コメント */
+	@IsString()
+	comment!: string;
+
+	/** 言語コード (例: 'en', 'ja') */
+	@IsString()
+	languageCode!: string;
+
+	/** 価格 (セント) */
+	@IsOptional()
+	@Type(() => Number)
+	@IsNumber()
+	priceCents?: number;
+
+	/** 通貨コード */
+	@IsOptional()
+	@IsString()
+	currencyCode?: string;
+
+	/** 評価 */
+	@Type(() => Number)
+	@IsNumber()
+	@Min(1)
+	@Max(5)
+	rating!: number;
+}
 
 export class CreateDishMediaDto {
 	/** 紐付ける料理 (dishes.id) */
@@ -22,4 +59,27 @@ export class CreateDishMediaDto {
 	@IsInt()
 	@Min(0)
 	videoDurationMs?: number;
+
+	/**
+	 * #1560 【設計】投稿と同時に作るレビュー。**同じトランザクションで書かれる。**
+	 *
+	 * ## なぜ足したか
+	 *
+	 * 投稿フローは `POST /v1/dish-media` → `POST /v1/dish-reviews` の 2 本に分かれており、
+	 * 1 本目が成功して 2 本目が落ちると **dish_media だけが残る**。
+	 * `GET /v1/users/me/dishes` の候補集合は want（reactions）と eaten（dish_reviews）の
+	 * 2 系統しか無く、**dish_media を起点にした系統が無い**ため、その行は
+	 * 一覧にもピンにも出ず、本人が到達する導線が消える。#1513 の「投稿を削除」でも消せない。
+	 * ストレージに写真が残り続けるのに本人は見ることも消すこともできない状態になる（#1560）。
+	 *
+	 * ## 省略したときの意味
+	 *
+	 * 省略は「レビューを伴わない投稿を作る」ではなく、**従来どおりの 2 本立て**を指す。
+	 * 既存の呼び出し側（他人のメディアへレビューを足す `review-from-media`、
+	 * 写真なしの記録）は `POST /v1/dish-reviews` 単独のままで、この項目とは無関係。
+	 */
+	@IsOptional()
+	@ValidateNested()
+	@Type(() => CreateDishMediaReviewDto)
+	review?: CreateDishMediaReviewDto;
 }

--- a/shared/api/v1/dto/index.ts
+++ b/shared/api/v1/dto/index.ts
@@ -1,4 +1,4 @@
-export { CreateDishMediaDto } from "./dish-media/create-dish-media.dto";
+export { CreateDishMediaDto, CreateDishMediaReviewDto } from "./dish-media/create-dish-media.dto";
 export { CreateDishMediaViewDto } from "./dish-media/create-dish-media-view.dto";
 export { QueryDishMediaByIdsDto } from "./dish-media/query-dish-media-by-ids.dto";
 export { SearchDishMediaDto } from "./dish-media/search-dish-media.dto";

--- a/shared/api/v1/res/dish-media.response.ts
+++ b/shared/api/v1/res/dish-media.response.ts
@@ -110,8 +110,16 @@ export type QueryDishMediaByIdsResponse = {
 	notFound: string[];
 };
 
-/** POST /v1/dish-media のレスポンス型 */
-export type CreateDishMediaResponse = SupabaseDishMedia;
+/**
+ * POST /v1/dish-media のレスポンス型。
+ *
+ * #1560 `review` を一緒に送ったときだけ `dishReview` が入る。**同じトランザクションで
+ * 書かれたもの**なので、これが返っていれば «写真だけ残ってレビューが無い» は起こり得ない。
+ * 送らなかった従来の呼び出しでは `undefined`（形は後方互換）。
+ */
+export type CreateDishMediaResponse = SupabaseDishMedia & {
+	dishReview?: SupabaseDishReviews;
+};
 
 /** POST /v1/dish-media/view のレスポンス型 */
 export type CreateDishMediaViewResponse = {


### PR DESCRIPTION
Closes #1560

## 何が壊れていたか

投稿フローは `POST /v1/dish-media` → `POST /v1/dish-reviews` の **2 本の独立した HTTP** で、1 本目が成功して 2 本目が落ちる（通信断・5xx・バリデーション）と **`dish_media` の行だけが残ります**。

`GET /v1/users/me/dishes`（`api/src/v1/users/my-dishes.query.ts`）の候補集合は 2 系統しかありません。

- `want` … `my_saved_dishes` / `reactions`
- `eaten` … `dish_reviews`

**`dish_media` を起点にした系統がありません。** そのため、レビューを伴わない自分の `dish_media` は一覧にもピンにも出ず、本人がアプリ内から到達する導線が無い。#1513 で入れた「投稿を削除」でも消せない。ストレージに写真が残り続けるのに本人は見ることも消すこともできず、GCS の課金対象でもあります。

## 「分けている理由」を確認した結果 → **見つかりませんでした**

オーナーから「確か理由があって分けていると思う」というご指摘があったので調べました。

| 調べたこと | 結果 |
| --- | --- |
| コード上の順序制約 | 「アップロード完了 → `POST /v1/dish-media`」だけ（トランスコーダがアップロード済みオブジェクトを読むため）。**media と review を分ける理由にはなっていない** |
| `POST /v1/dish-media` のクライアント | **`ReviewForm.tsx` の 1 箇所だけ**（他はすべて GET）。まとめても影響範囲が狭い |
| サーバー側の前例 | **既に 1 トランザクションで両方作っている実装がある**（Google 一括取り込み `dishes.service.ts`） |
| DTO・設計コメント・git 履歴 | 分離の根拠は書かれておらず、v1 の DTO 一括追加時からこの形 |

以上より、案 1（API 側で 1 トランザクションに寄せる）で進めました。

## 直し方

- `CreateDishMediaDto.review`（任意・ネスト）を追加。**`dishId` と `createdDishMediaId` は持たせません**。前者はメディアと同じ dish に決まっており、後者はいま作るメディアの id が入るためです。クライアントに決めさせると「別の料理へレビューが付く」をサーバー側で検出できなくなります
- `DishMediaService.createDishMedia` が **同じ `tx`** で `createDishReviewForMedia` を呼びます。外部呼び出し（トランスコード起動・リサイズ enqueue）は**コミット後**のままです。ロールバックされた行に対してジョブだけが走ると、実体の無い `record_id` を参照し続けるためです
- `CreateDishMediaResponse.dishReview`（任意）で作ったレビューを返します
- `ReviewForm` は新規写真投稿でレビューを同梱し、**2 本目を投げません**

## 壊していないもの

| 経路 | 扱い |
| --- | --- |
| 他人のメディアへレビューを足す（`review-from-media`） | `POST /v1/dish-reviews` 単独のまま |
| 写真なしの「食べた」記録 | `POST /v1/dishes` → `POST /v1/dish-reviews` のまま |
| `review` を送らない呼び出し | 従来どおり動き、`dishReview` は `undefined`（後方互換） |

## テスト

**api**（`dish-media.service.spec.ts`）
- `review` を渡すと **同じ `tx` オブジェクト**を共有してレビューまで作る（別トランザクションだと孤児が復活するので、`toBe` で同一性を見ています）
- 外部呼び出し（リサイズの enqueue）は**コミット後**に行う（実行順を 1 本の列で観測）
- `review` を渡さなければレビューを作らない（従来の 2 本立てを壊さない）

**app-expo**（`ReviewFormSubmit.test.tsx`）
- `v1/dish-media` 1 本で終わり、**`/v1/dish-reviews` を叩かない**（投げてしまえばサーバーが 1 トランザクションでも部分成功の窓は閉じないので、ここが本丸）
- サーバーが `dishReview` を返さなければ従来どおり 2 本目を投げる（後方互換）

## 検証

| 項目 | 結果 |
| --- | --- |
| `pnpm --filter shared build` | ✅ |
| `pnpm --filter api typecheck` | ✅ 0 errors |
| `pnpm --filter api test` | ✅ **631 passed**（9 suite の失敗は `api/.env` を要する既存のもの・本 PR とは無関係） |
| `pnpm --filter app-expo typecheck` | ✅ 0 errors |
| `pnpm --filter app-expo test` | ✅ **130 suites / 1369 passed** |

## 残っている穴（この PR では扱いません）

**既に孤児になっている `dish_media`**（自分のレビューが 1 件も無く `user_id` が非 NULL の行）は、この PR では消えません。件数は未計測です。Issue #1560 の案 3（一定時間レビューが付かない `dish_media` をバッチで論理削除）は、方針が決まってから `db-script-run.yml` で件数を数えるところから始めるのが妥当だと考えます。


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyVUBm4k4Kj8KnyaxSCEVV)_