### PR TITLE
#843 fix: place_id衝突で既存PG店舗を巻き添えにしない

### DIFF
--- a/scripts/20260808T0000_restaurant/3_3_build_google_place_match_catalog.py
+++ b/scripts/20260808T0000_restaurant/3_3_build_google_place_match_catalog.py
@@ -109,7 +109,25 @@ def main() -> None:
       duplicate_checked AS (
         SELECT
           *,
-          COUNTIF(google_place_id IS NOT NULL) OVER (PARTITION BY google_place_id) AS place_id_count
+          COUNTIF(google_place_id IS NOT NULL) OVER (PARTITION BY google_place_id) AS place_id_count,
+          -- 同じ place_id に複数 seed が当たったとき、既存PG由来（現行DBに
+          -- 実在する店）と手動確定は「その place_id である」ことが確定して
+          -- いるので勝たせ、open data 側だけを隔離する。両方落とすと本番の
+          -- 実在店舗が catalog から消え、8_1 の
+          -- existing_pg_restaurants_preserved が落ちる（実測673件）。
+          -- 優先度が同じ seed 同士が競合した場合は従来どおり両方隔離する。
+          ROW_NUMBER() OVER (
+            PARTITION BY google_place_id
+            ORDER BY
+              CASE base_status
+                WHEN 'existing_pg_matched' THEN 0
+                WHEN 'manual_matched' THEN 1
+                ELSE 2
+              END,
+              seed_id
+          ) AS place_id_rank,
+          COUNTIF(base_status IN ('existing_pg_matched', 'manual_matched'))
+            OVER (PARTITION BY google_place_id) AS authoritative_count
         FROM resolved
       )
       SELECT
@@ -117,7 +135,11 @@ def main() -> None:
         seed_id,
         google_place_id,
         CASE
-          WHEN google_place_id IS NOT NULL AND place_id_count > 1
+          WHEN google_place_id IS NOT NULL
+               AND place_id_count > 1
+               -- 権威ある seed が「ちょうど1件」あるとき、その1件だけを残す。
+               -- 2件以上あるなら既存DB側が矛盾しているので人手判断へ回す。
+               AND NOT (authoritative_count = 1 AND place_id_rank = 1)
             THEN 'conflict_duplicate_place_id'
           ELSE base_status
         END AS match_status,


### PR DESCRIPTION
## 問題

3_3 は同じ `google_place_id` に複数 seed が当たると**すべての seed** を `conflict_duplicate_place_id` で隔離していました。その結果、open data の seed が既存PG店舗と同じ place_id を引いただけで、**現行DBに実在する店舗まで catalog から消えて**いました。

本番データでの実測: **673件の既存PG店舗が巻き添え**（`existing_pg_matched` が 2,108 → 1,435 に減少）。

8_1 の `existing_pg_restaurants_preserved` は ERROR 判定なので、このままでは 9_1 の同期がブロックされます。

## 修正

既存PG由来（`existing_pg_matched`）と手動確定（`manual_matched`）は「その place_id である」ことが確定しているので勝たせ、open data 側だけを隔離します。権威ある seed が2件以上ぶつかる場合は既存DB側の矛盾なので、従来どおり両方隔離して人手判断へ回します。

## 検証（本番データ、run_id=restaurant-2026-08-23）

| match_status | 修正前 | 修正後 |
|---|---:|---:|
| `existing_pg_matched` | 1,435 | **2,108**（完全回復） |
| `conflict_duplicate_place_id` | 104,128 | 103,455 |
| `box_unique_strict` | 569,415 | 569,415（不変） |

単体テスト12件 green。

## 補足: PoC の畳み込み策は今回不要だった

#1276 PoC では「重複した seed の店名が揃えば1行に畳む」回収策を入れましたが、今回の本番データでは **回収0件**でした（重複 50,466 place_id のすべてで正規化名が食い違う）。2_2 の実体解決が同名近接を既に統合しているため、seed レベルで残る重複は真の競合です。よって畳み込みは実装せず、隔離のままとしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCVVMHHhHRMMUCUtMj5d2A

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCVVMHHhHRMMUCUtMj5d2A)_