### PR TITLE
#843 fix: restaurants経路をPG devまで通す（food_permitのID衝突 / 同期ゲート / statement_timeout）

### DIFF
--- a/scripts/20260808T0000_restaurant/2_1_build_restaurant_source_records.py
+++ b/scripts/20260808T0000_restaurant/2_1_build_restaurant_source_records.py
@@ -319,7 +319,13 @@ def iter_source_records(
         result = build_common_row(
             run_id=run_id,
             source="food_permit",
-            source_record_id=row.source_record_id,
+            # 1_6 の旧実装は source_record_id をファイル名の先頭48文字から
+            # 作っており、同じ自治体の別ファイルどうしで衝突した（根本は
+            # food_permits.py で修正済み）。既に取り込んだ raw を作り直さずに
+            # 「1 source record = 1 row」を保つため、内容ハッシュを添えて
+            # ここでも一意性を担保する。ID が既に一意な新しい raw でも
+            # 決定的に同じ値になり、二重に付くことはない。
+            source_record_id=f"{row.source_record_id}#{row.record_hash[:12]}",
             source_release=row.source_release,
             name=row.name,
             name_language_code="ja",

--- a/scripts/20260808T0000_restaurant/8_1_validate_catalogs.py
+++ b/scripts/20260808T0000_restaurant/8_1_validate_catalogs.py
@@ -22,6 +22,18 @@ from pipeline_common import BigQueryPipeline, configure_logging, require_run_id,
 LOGGER = logging.getLogger(__name__)
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
+# dish_media 経路（4_1/4_2）を流していない run では意味を成さない検査。
+# 空の catalog に対して «S2セル×134カテゴリの全直積が未充足» と出るだけで、
+# restaurants 側の健全性とは無関係である。
+DISH_MEDIA_CHECKS = frozenset({
+    "dish_media_id_unique",
+    "dish_media_publish_rules",
+    "dish_media_references_exist",
+    "coverage_cross_product_complete",
+    "coverage_pair_unique",
+    "all_area_category_pairs_filled",
+})
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -29,6 +41,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--run-id")
     parser.add_argument("--expected-category-count", type=int, default=134)
+    parser.add_argument(
+        "--skip-dish-media-checks",
+        action="store_true",
+        help="dish_media 経路（4_1/4_2）を実行していない run で、media/coverage の"
+        "チェックを外す。restaurants だけを先に公開する納品では 4_2 を流さないため、"
+        "coverage_cross_product_complete が «S2セル×134カテゴリの全直積が未充足» と"
+        "して必ず ERROR になる。restaurant 側の検査だけで 9_1 の可否を判断したいときに使う",
+    )
     parser.add_argument(
         "--fail-on-warning",
         action="store_true",
@@ -270,6 +290,14 @@ def main() -> None:
         repo_root=REPO_ROOT,
     ) as step:
         results = list(pipeline.execute(validation_sql(pipeline), parameters))
+        if args.skip_dish_media_checks:
+            skipped = [r.check_name for r in results if r.check_name in DISH_MEDIA_CHECKS]
+            results = [r for r in results if r.check_name not in DISH_MEDIA_CHECKS]
+            step["skipped_dish_media_checks"] = skipped
+            LOGGER.warning(
+                "dish_media 経路の検査を外した: %s。restaurants だけを公開する納品でのみ使うこと",
+                ", ".join(skipped),
+            )
         rows: list[dict[str, Any]] = []
         for result in results:
             passed = bool(result.passed)

--- a/scripts/20260808T0000_restaurant/9_1_sync_restaurants.py
+++ b/scripts/20260808T0000_restaurant/9_1_sync_restaurants.py
@@ -13,6 +13,7 @@ from typing import Any
 from google.cloud import bigquery
 
 from pg_sync_common import (
+    RESTAURANT_ERROR_CHECKS,
     SyncStats,
     assert_quality_gate_passed,
     backup_table_to_gcs,
@@ -259,7 +260,9 @@ def main() -> None:
     args = parse_args()
     run_id = require_run_id(args.run_id)
     pipeline = BigQueryPipeline()
-    assert_quality_gate_passed(pipeline, run_id)
+    assert_quality_gate_passed(
+        pipeline, run_id, required_checks=RESTAURANT_ERROR_CHECKS
+    )
     sync_id = new_sync_id()
     started_at = utc_now()
     stats = SyncStats()
@@ -272,7 +275,9 @@ def main() -> None:
         if row_count == 0:
             raise RuntimeError("restaurant_catalogが0件です")
         # 大きなCSV export中に同じrunのcatalogが再生成された場合を検知する。
-        assert_quality_gate_passed(pipeline, run_id)
+        assert_quality_gate_passed(
+            pipeline, run_id, required_checks=RESTAURANT_ERROR_CHECKS
+        )
         connection = connect_postgres(args.schema, allow_public=args.allow_public)
         if not args.dry_run and not args.skip_backup:
             backup_table_to_gcs(connection, args.schema, "restaurants", run_id=run_id)

--- a/scripts/20260808T0000_restaurant/food_permits.py
+++ b/scripts/20260808T0000_restaurant/food_permits.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
 import json
 import re
 import sqlite3
@@ -256,6 +257,7 @@ def iter_permit_rows(
         latitude_column = pick(headers, LATITUDE_HINTS)
         longitude_column = pick(headers, LONGITUDE_HINTS)
         jurisdiction = path.stem.split("__")[0]
+        file_key = hashlib.sha256(path.stem.encode("utf-8")).hexdigest()[:16]
         stats["files_used"] += 1
 
         for index, row in enumerate(rows, start=2):
@@ -303,7 +305,11 @@ def iter_permit_rows(
 
             yield PermitRow(
                 jurisdiction=jurisdiction,
-                source_record_id=f"{path.stem[:48]}:{index}",
+                # ファイル名を48文字で切ると、同じ自治体の別ファイルどうしで
+                # 衝突する（実測: 334キーが最大10ファイル分を共有し、
+                # source_records と seed_catalog に重複行を生んだ）。
+                # 全体のハッシュを使えば長さを抑えたまま一意になる。
+                source_record_id=f"{file_key}:{index}",
                 name=name,
                 address=address,
                 business_type=business,

--- a/scripts/20260808T0000_restaurant/pg_sync_common.py
+++ b/scripts/20260808T0000_restaurant/pg_sync_common.py
@@ -19,9 +19,39 @@ from pipeline_common import BigQueryPipeline, utc_now
 
 LOGGER = logging.getLogger(__name__)
 ALLOWED_SCHEMAS = {"dev", "public"}
-# 8_1の現行ERROR check数。将来checkを追加することは許すが、部分insertでこれを
-# 下回るvalidationは同期判定に使わない。
-MIN_ERROR_CHECK_COUNT = 17
+
+# 8_1 が書く ERROR check の名前。「部分insertのvalidationで同期を承認しない」を、
+# 件数ではなく**名前の集合**で担保する。件数だけを見ると «17件は揃っているが
+# 中身が違う» を通してしまい、check を1件足して1件消したときに気付けない。
+#
+# 集合を restaurants 側と dish_media 側に分けているのは、同期scriptが書く表と
+# 対応させるためである。9_1 が書くのは restaurants だけなので、dish_media 経路
+# （4_x）を流さない run でも restaurants の同期は判定できる必要がある。
+RESTAURANT_ERROR_CHECKS = frozenset(
+    {
+        "source_record_key_unique",
+        "seed_non_empty",
+        "seed_id_unique",
+        "one_source_record_one_link",
+        "one_match_row_per_seed",
+        "accepted_google_place_id_unique",
+        "restaurant_catalog_non_empty",
+        "restaurant_google_place_id_unique",
+        "restaurant_required_fields_valid",
+        "existing_pg_restaurants_preserved",
+        "existing_pg_serving_values_preserved",
+        "jp_gate_category_count",
+    }
+)
+DISH_MEDIA_ERROR_CHECKS = frozenset(
+    {
+        "dish_media_id_unique",
+        "dish_media_publish_rules",
+        "dish_media_references_exist",
+        "coverage_cross_product_complete",
+        "coverage_pair_unique",
+    }
+)
 
 
 @dataclass
@@ -62,9 +92,19 @@ def connect_postgres(schema: str, *, allow_public: bool) -> PgConnection:
 
 
 def assert_quality_gate_passed(
-    pipeline: BigQueryPipeline, run_id: str, *, lookback_days: int = 30
+    pipeline: BigQueryPipeline,
+    run_id: str,
+    *,
+    required_checks: frozenset[str],
+    lookback_days: int = 30,
 ) -> None:
-    """最新8_1実行のERRORが全件PASSしたことを強制する。"""
+    """最新8_1実行のERRORが全件PASSしたことを強制する。
+
+    ``required_checks`` は、呼び出し側が書き込む表に対応する ERROR check の名前。
+    この集合が最新validationに1つでも欠けていれば同期しない。実行された ERROR
+    check のうち1件でも落ちていれば、``required_checks`` の外であっても止める
+    （catalog は互いに参照し合うので、隣の表が壊れている状態で書きたくない）。
+    """
 
     query = f"""
       WITH validation_candidates AS (
@@ -114,9 +154,9 @@ def assert_quality_gate_passed(
         ANY_VALUE(latest_validation.validation_id) AS validation_id,
         ANY_VALUE(latest_validation.checked_at) AS checked_at,
         ANY_VALUE(catalog_state.built_at) AS catalog_built_at,
-        COUNT(DISTINCT IF(
+        ARRAY_AGG(DISTINCT IF(
           latest_results.severity = 'ERROR', latest_results.check_name, NULL
-        )) AS error_check_count,
+        ) IGNORE NULLS) AS error_check_names,
         COUNTIF(latest_results.severity = 'ERROR' AND NOT latest_results.passed)
           AS failed_error_count
       FROM latest_validation
@@ -138,8 +178,14 @@ def assert_quality_gate_passed(
             )
         )
     )
-    if row.validation_id is None or row.error_check_count < MIN_ERROR_CHECK_COUNT:
-        raise RuntimeError("8_1_validate_catalogs.py の完全なERROR検証結果がありません")
+    if row.validation_id is None:
+        raise RuntimeError("8_1_validate_catalogs.py の検証結果がありません")
+    missing = sorted(required_checks - set(row.error_check_names or []))
+    if missing:
+        raise RuntimeError(
+            "8_1_validate_catalogs.py の ERROR 検証結果に必要なcheckが"
+            f"{len(missing)}件ありません: {', '.join(missing)}"
+        )
     if row.failed_error_count:
         raise RuntimeError(
             f"品質ゲートに未解決ERRORが{row.failed_error_count}件あります"

--- a/scripts/20260808T0000_restaurant/pg_sync_common.py
+++ b/scripts/20260808T0000_restaurant/pg_sync_common.py
@@ -19,6 +19,8 @@ from pipeline_common import BigQueryPipeline, utc_now
 
 LOGGER = logging.getLogger(__name__)
 ALLOWED_SCHEMAS = {"dev", "public"}
+# 同期session専用の statement_timeout（30分）。詳細は connect_postgres を参照。
+STATEMENT_TIMEOUT_MS = 30 * 60 * 1000
 
 # 8_1 が書く ERROR check の名前。「部分insertのvalidationで同期を承認しない」を、
 # 件数ではなく**名前の集合**で担保する。件数だけを見ると «17件は揃っているが
@@ -82,6 +84,13 @@ def connect_postgres(schema: str, *, allow_public: bool) -> PgConnection:
         cursor.execute(
             sql.SQL("SET search_path TO {}, public").format(sql.Identifier(schema))
         )
+        # サーバ側の既定 statement_timeout は「APIが投げる対話クエリ」を想定した
+        # 短い値である。この同期は57万行を1文でINSERTするバッチなので、その既定に
+        # 当たって落ちる（実測: dry-run が apply_sync の途中で
+        # "canceling statement due to statement timeout"）。
+        # 0（無制限）にはしない。lock待ちで無限に居座ると、advisory lockを掴んだまま
+        # 次の実行も止めてしまうため、十分大きい有限値で頭打ちにする。
+        cursor.execute(f"SET statement_timeout = '{STATEMENT_TIMEOUT_MS}ms'")
         # 手動実行でも二つのterminalから同じschemaへ同時publishされ得る。
         # transaction advisory lockで9_1/9_2を直列化し、staging判定後の競合を防ぐ。
         cursor.execute(


### PR DESCRIPTION
`8_1`（品質ゲート）の ERROR 5件と、その先の `9_1`（PostgreSQL 同期）を塞いでいた2件を直し、**BigQuery → PostgreSQL dev の `restaurants` 投入まで通した**。

## 結果（run_id = `restaurant-2026-08-23`）

| ステップ | 結果 | 所要 |
| --- | --- | --- |
| 2_1 source_records | 1,659,406行（キー重複 0） | 37分 |
| 2_2 seed_catalog | 1,513,803 seed | 55分 |
| 3_2 resume | 89,805 seed 照合 | 48分 |
| 3_3 match_catalog | 1,513,803行 | 9秒 |
| 3_4 restaurant_catalog | 571,776行 | 14秒 |
| 8_1 品質ゲート | ERROR 12件すべて pass | 3秒 |
| 9_1 PG dev 同期 | insert 569,661 / update 2,115 / skip 0 | 25分 |

Google Places の課金は **$0.00**（Text Search の IDs Only のみ）。

---

## (1) food_permit の source_record_id 衝突

fail していたチェック:

| チェック | 件数 |
| --- | --- |
| `seed_id_unique` | 1,026 |
| `source_record_key_unique` | 1,501 |
| `one_source_record_one_link` | 1,501 |
| `one_match_row_per_seed` | fail |

`1_6`（`food_permits.py`）が ID をファイル名の先頭48文字から作っており、同じ自治体の別ファイルどうしで衝突していた。実測で **334キーが最大10ファイル分を共有**し、`seed_catalog` に304の重複 seed_id（1,330行）が生まれていた。

修正は2層:

- `food_permits.py`: ファイル名全体の SHA-256 から `file_key` を作る（根本修正）
- `2_1`: 既に取り込んだ raw を作り直さずに «1 source record = 1 row» を保つため、内容ハッシュ（`record_hash[:12]`）を添えて一意性を担保する。ID が既に一意な新しい raw でも決定的に同じ値になる

これで **580ファイルの再ダウンロード + 約9万住所の再ジオコード（約4時間）** を避けつつ不変条件を回復できる。food_permit 由来の seed_id は変わるため、該当 seed は `3_2` の resume で引き直した（89,805件、48分、api_error 1件）。

再実行後の `(source, source_record_id)` 重複は **1,501 → 0**。

## (2) coverage_cross_product_complete が構造上必ず ERROR になる

このチェックは `4_2`（dish_media coverage）の出力を前提にしている。今回の納品は restaurants 経路だけで `4_x` を流さないため、空の catalog に対して «S2セル 122,146 × 134カテゴリ = 16,367,564 組が未充足» と出続ける。

`--skip-dish-media-checks` を足し、restaurants だけを公開する run では media/coverage 系6件を検査対象から外せるようにした。**既定は従来どおり全件検査**で、除外したチェック名は `step["skipped_dish_media_checks"]` に記録される。

## (3) 同期ゲートが ERROR check を「件数」で見ていた

(2) の結果、`9_1` が `8_1_validate_catalogs.py の完全なERROR検証結果がありません` で止まった。ゲートは `MIN_ERROR_CHECK_COUNT = 17`（8_1 の全 ERROR check 数）を下回る validation を «部分insert» とみなして弾く作りで、restaurants だけを公開する run を通せない。

件数での判定は元々弱い。17件が揃っていても中身が違えば通ってしまい、check を1件足して1件消したときに気付けない。**チェック名の集合**で見るよう変えた。

- `RESTAURANT_ERROR_CHECKS`（12件）/ `DISH_MEDIA_ERROR_CHECKS`（5件）を定義し、`assert_quality_gate_passed` に `required_checks` を必須引数として渡す
- `9_1` が書くのは `restaurants` だけなので `RESTAURANT_ERROR_CHECKS` を要求する。欠けている check は名前を挙げて報告する
- 「実行された ERROR check が1件でも落ちていれば止める」は従来どおり（catalog は互いを参照するので、隣の表が壊れた状態では書きたくない）

## (4) 同期 session に statement_timeout が無い

ゲート通過後、dry-run が `apply_sync` の途中で `canceling statement due to statement timeout` に当たった。接続・staging・件数計算までは通っており、落ちたのは57万行を1文で書く DML である。サーバ側の既定 `statement_timeout` は「API が投げる対話クエリ」を想定した短い値で、このバッチの想定時間を下回っていた。

同期 session に限って30分へ引き上げた。`0`（無制限）にはしない — lock 待ちで無限に居座ると advisory lock を掴んだまま次の実行も止めるため、十分大きい有限値で頭打ちにする。

---

## 残課題（このPRの範囲外）

**OSM 単独由来の seed 125,415件（全 seed の 8.3%）が照合対象外**。`3_2` の `--include-osm-only` ガードによるもので、今回の変更で生じたものではない。ODbL の派生データベース条項に対する公開方針が未承認のため既定で送らない設計になっている。方針が決まればフラグを付けて `3_2` を再実行するだけで取り込める（IDs Only なので追加費用なし）。