### PR TITLE
#1577 fix: 確認ダイアログをダークモードに追従させる

### DIFF
--- a/.claude/skills/evidence-video/scenarios/dialog-dark-1577.mjs
+++ b/.claude/skills/evidence-video/scenarios/dialog-dark-1577.mjs
@@ -1,0 +1,80 @@
+/*
+#1577 確認ダイアログのダークモード追従
+
+**この撮影の目的は «ライトとダークで別物になっていること» を示すことである。**
+修正前は DialogProvider が色を直書きしていたため、暗い画面の上に白いダイアログが浮いていた。
+light と dark のコマが md5 まで一致するなら、修正は効いていない。
+
+ダイアログの入口はマイページの「ログアウト」（testID: settings-logout）。
+**最後まで押し切らない**（キャンセルで閉じる）。ログアウトさせる必要は無い。
+
+⚠️ 認証・API・地図はモック。映っているのは «画面» であって実データではない。
+*/
+import { record, writeNote, OUT } from "./harness.mjs";
+
+const BASE = process.env.EVIDENCE_BASE || "http://localhost:8788";
+const TRIGGER = "settings-logout";
+const CONFIRM = "dialog-confirm-button";
+const CANCEL = "dialog-cancel-button";
+
+async function shootScheme(scheme) {
+	return record({
+		name: `dialog1577-${scheme}`,
+		contextOptions: { colorScheme: scheme },
+		flow: async (page, shot) => {
+			await page.addInitScript((s) => {
+				try { window.localStorage.setItem("theme_preference_v1", s); } catch {}
+				for (const k of [
+					"search_tutorial_seen_v1",
+					"topics_spotlight_tutorial_seen_v1",
+					"my_dishes_spotlight_tutorial_seen_v1",
+				]) {
+					try { window.localStorage.setItem(k, "true"); } catch {}
+				}
+			}, scheme);
+
+			await page.goto(`${BASE}/ja-JP/profile`, { waitUntil: "domcontentloaded" });
+			await page.waitForTimeout(3500);
+			await shot("01-screen");
+
+			const trigger = page.getByTestId(TRIGGER);
+			await trigger.waitFor({ state: "attached", timeout: 15000 });
+			await trigger.scrollIntoViewIfNeeded().catch(() => {});
+			await page.waitForTimeout(600);
+			await shot("02-trigger");
+
+			// ダイアログを開く。開かなければ撮る意味が無いので落とす
+			await trigger.click();
+			const confirm = page.getByTestId(CONFIRM);
+			await confirm.waitFor({ state: "visible", timeout: 10000 });
+			await page.waitForTimeout(500);
+			await shot("03-dialog");
+
+			// 押し切らずキャンセルで閉じる
+			await page.getByTestId(CANCEL).click();
+			await page.waitForTimeout(500);
+			await shot("04-cancelled");
+
+			console.log(`[${scheme}] 確認ダイアログを撮った`);
+		},
+	});
+}
+
+const light = await shootScheme("light");
+const dark = await shootScheme("dark");
+
+await writeNote("dialog1577", [
+	"# #1577 確認ダイアログのダークモード追従",
+	"",
+	"- 01-screen … マイページを開いた直後",
+	"- 02-trigger … ログアウト行までスクロールした状態",
+	"- 03-dialog … 確認ダイアログが開いた状態（**本命**）",
+	"- 04-cancelled … キャンセルで閉じた状態（ログアウトはしていない）",
+	"",
+	"⚠️ 03 の light と dark が md5 まで一致するなら、テーマ未追従のままである。",
+	"",
+	"⚠️ 認証・API・地図はモック。",
+	"",
+	...light.shots.map((p, i) => `- light: ${p}\n  dark : ${dark.shots[i]}`),
+]);
+console.log("OUT=", OUT);

--- a/app-expo/constants/Palette.ts
+++ b/app-expo/constants/Palette.ts
@@ -180,6 +180,10 @@ export interface Palette {
 	dangerTint: string;
 	/** 破壊的操作の文字（ログアウト） */
 	destructive: string;
+	/** 確認ダイアログの見出し（Material の onSurface 系。#1577） */
+	dialogTitle: string;
+	/** 確認ダイアログの本文（Material の onSurfaceVariant 系。#1577） */
+	dialogMessage: string;
 	/** 濃い警告文字（`#B91C1C` 系統。ライトでは danger より濃いため分けてある） */
 	dangerEmphasis: string;
 
@@ -240,6 +244,8 @@ const light: Palette = {
 	dangerStrong: "#EF4444", // search selectedRestrictionChip
 	dangerTint: "#FEE2E2", // search requiredBadge
 	destructive: "#FF3E33", // profile/settings.tsx ログアウト
+	dialogTitle: "#1C1B1F", // #1577 DialogProvider が直書きしていた値の写し（M3 onSurface）
+	dialogMessage: "#49454F", // 同上（M3 onSurfaceVariant）
 	dangerEmphasis: "#B91C1C", // #1469 MyDishesCalendarView.tsx footerErrorText
 
 	ctaBackground: "#000000", // search searchFab gradient(充足)
@@ -293,6 +299,8 @@ const dark: Palette = {
 	dangerStrong: "#FF6B6B",
 	dangerTint: "#4A2320", // danger を暗面へ混色
 	destructive: "#FF8A80",
+	dialogTitle: "#E5E2E1", // schemes.dark.onSurface
+	dialogMessage: "#C4C7C7", // schemes.dark.onSurfaceVariant
 	dangerEmphasis: "#FF8A80", // danger と同値へ収束（暗面では明度を上げないと文字用途で AA を割る）
 
 	ctaBackground: "#E5E2E1", // 暗面では CTA を反転させる（黒地の CTA は背景に沈む）

--- a/app-expo/contexts/DialogProvider.tsx
+++ b/app-expo/contexts/DialogProvider.tsx
@@ -1,4 +1,8 @@
 import i18n from "@/lib/i18n";
+// #1577 ダイアログは «画面の面» として開くので、テーマに追従させる。
+// 直書きのままだと暗い画面の上に白いダイアログが浮く。
+import { FixedColors, type Palette } from "@/constants/Palette";
+import { useAppTheme, useThemedStyles } from "@/contexts/ThemeProvider";
 import React, {
 	createContext,
 	useCallback,
@@ -266,6 +270,8 @@ const useIsMountedRef = () => {
 };
 
 export const DialogProvider = ({ children }: { children: ReactNode }) => {
+	const styles = useThemedStyles(createStyles);
+	const { colors } = useAppTheme();
 	const isMountedRef = useIsMountedRef();
 
 	// #958 【修正】paper の Portal は PaperProvider 直下のホスト(=CenteredAppShell の外側)に
@@ -953,8 +959,8 @@ export const DialogProvider = ({ children }: { children: ReactNode }) => {
 								<Button
 									key={a.key}
 									mode={isOk || isCancel ? "contained" : (a.mode ?? "text")}
-									buttonColor={isOk ? "#F05537" : isCancel ? "#F8F9FA" : undefined}
-									textColor={isOk ? "#FFFFFF" : isCancel ? "#6B7280" : undefined}
+									buttonColor={isOk ? colors.brand : isCancel ? colors.surfaceMuted : undefined}
+									textColor={isOk ? FixedColors.onFilled : isCancel ? colors.textSecondary : undefined}
 									style={isOk || isCancel ? styles.actionButton : undefined}
 									contentStyle={isOk || isCancel ? styles.actionButtonContent : undefined}
 									labelStyle={[styles.actionButtonLabel, isOk && styles.confirmButtonLabel]}
@@ -986,43 +992,44 @@ export const DialogProvider = ({ children }: { children: ReactNode }) => {
 	);
 };
 
-const styles = StyleSheet.create({
-	dialog: {
-		backgroundColor: "#FFFFFF",
-		borderRadius: 20,
-	},
-	title: {
-		fontSize: 20,
-		fontWeight: "700",
-		color: "#1C1B1F",
-		letterSpacing: -0.3,
-	},
-	message: {
-		fontSize: 16,
-		fontWeight: "500",
-		lineHeight: 24,
-		color: "#49454F",
-	},
-	actions: {
-		gap: 4,
-		paddingHorizontal: 24,
-		paddingBottom: 20,
-	},
-	actionButton: {
-		borderRadius: 16,
-	},
-	actionButtonContent: {
-		minHeight: 48,
-		paddingHorizontal: 8,
-	},
-	actionButtonLabel: {
-		fontSize: 16,
-		fontWeight: "600",
-	},
-	confirmButtonLabel: {
-		fontWeight: "700",
-	},
-});
+const createStyles = (colors: Palette) =>
+	StyleSheet.create({
+		dialog: {
+			backgroundColor: colors.surface,
+			borderRadius: 20,
+		},
+		title: {
+			fontSize: 20,
+			fontWeight: "700",
+			color: colors.dialogTitle,
+			letterSpacing: -0.3,
+		},
+		message: {
+			fontSize: 16,
+			fontWeight: "500",
+			lineHeight: 24,
+			color: colors.dialogMessage,
+		},
+		actions: {
+			gap: 4,
+			paddingHorizontal: 24,
+			paddingBottom: 20,
+		},
+		actionButton: {
+			borderRadius: 16,
+		},
+		actionButtonContent: {
+			minHeight: 48,
+			paddingHorizontal: 8,
+		},
+		actionButtonLabel: {
+			fontSize: 16,
+			fontWeight: "600",
+		},
+		confirmButtonLabel: {
+			fontWeight: "700",
+		},
+	});
 
 /** useDialog フック */
 export const useDialog = (): DialogContextType => {

--- a/app-expo/contexts/ThemeProvider.test.tsx
+++ b/app-expo/contexts/ThemeProvider.test.tsx
@@ -205,6 +205,10 @@ describe("Palette（#1509 絶対条件: ライトの色を 1 つも変えない�
 		dangerStrong: "#EF4444",
 		dangerTint: "#FEE2E2",
 		destructive: "#FF3E33",
+		// #1577 確認ダイアログの見出し・本文。どちらも DialogProvider.tsx が
+		// 直書きしていたリテラルの写しなので、ライトの見た目は 1px も変わらない。
+		dialogTitle: "#1C1B1F",
+		dialogMessage: "#49454F",
 		dangerEmphasis: "#B91C1C",
 		ctaBackground: "#000000",
 		ctaBackgroundDisabled: "#999999",

--- a/app-expo/scripts/assert-no-hardcoded-colors.mjs
+++ b/app-expo/scripts/assert-no-hardcoded-colors.mjs
@@ -130,8 +130,6 @@ const EXCLUSIONS = {
 		"main 由来のレガシー（#1509 のトークン化が未達）。#1469 ダークモード追従のスコープ外。トークン化したらこの行を消す",
 	"components/deepLinking/OpenInAppBanner.tsx":
 		"main 由来のレガシー（#1509 のトークン化が未達）。#1469 ダークモード追従のスコープ外。トークン化したらこの行を消す",
-	"contexts/DialogProvider.tsx":
-		"main 由来のレガシー（#1509 のトークン化が未達）。#1469 ダークモード追従のスコープ外。トークン化したらこの行を消す",
 	"features/auth/components/LoginForm.tsx":
 		"main 由来のレガシー（#1509 のトークン化が未達）。#1469 ダークモード追従のスコープ外。トークン化したらこの行を消す",
 	"features/contributionTasks/legacyBlurModal/useLegacyBlurModal.tsx":


### PR DESCRIPTION
Closes #1577（親: #1375 / 統合ブランチ宛）

## 何が起きていたか

ダークモードでも**ダイアログ本体だけが白いまま**描画されていました。背景の画面は暗いので、白い箱が浮きます。#1511（ACC-01 アカウント削除）のエビデンス撮影中に見つけたものです。

`contexts/DialogProvider.tsx` が `useThemedStyles` / `useAppTheme` を**1 つも使っておらず**、色を 7 箇所直書きしていました。`assert:no-hardcoded-colors` の EXCLUSIONS にも「main 由来のレガシー」として登録済みで、既知の未対応でした。

## 進行中の PR には一切触れていません

`DialogProvider` はアプリ全体の確認ダイアログの土台なので、影響範囲が広い変更です。#1533 などへ混ぜず、この PR 単独に切り出してあります。

## 変更内容

### 既存トークンと完全一致した色（ライトの見た目は不変）

| 直書き | 置き換え先 | light の値 |
| --- | --- | --- |
| `#FFFFFF`（ダイアログの地） | `colors.surface` | #FFFFFF（一致） |
| `#F05537`（OK ボタンの地） | `colors.brand` | #F05537（一致） |
| `#F8F9FA`（キャンセルの地） | `colors.surfaceMuted` | #F8F9FA（一致） |
| `#6B7280`（キャンセルの文字） | `colors.textSecondary` | #6B7280（一致） |

OK ボタンの文字はブランド色の塗り潰しの上に載るので `FixedColors.onFilled` にしました。地がライト / ダークで変わらないため、文字も振りません。

### 一致するトークンが無かった 2 色

見出しと本文は Material の `onSurface` / `onSurfaceVariant` の値でした。Palette へ追加しています。

| トークン | light | dark |
| --- | --- | --- |
| `dialogTitle` | #1C1B1F | #E5E2E1（`schemes.dark.onSurface`） |
| `dialogMessage` | #49454F | #C4C7C7（`schemes.dark.onSurfaceVariant`） |

**light はどちらも `DialogProvider.tsx` が直書きしていたリテラルの写し**なので、ライトの見た目は 1px も変わりません。`ThemeProvider.test.tsx` の LIGHT_SNAPSHOT（#1509「ライトの色を 1 つも変えない」のガード）にも、写しである旨のコメントを添えて追記しました。

### 除外リスト

`contexts/DialogProvider.tsx` を EXCLUSIONS から削除しました。凍結ファイル数は **67 → 66**（ラチェットは減る方向にのみ動きます）。

## 検証

| 項目 | 結果 |
| --- | --- |
| `pnpm --filter shared build` | ✅ |
| `pnpm --filter app-expo typecheck` | ✅ 0 errors |
| `pnpm --filter app-expo test` | ✅ 129 suites / 1363 tests |
| `pnpm --filter app-expo assert:no-hardcoded-colors` | ✅ 直書き 0（走査 188 / 凍結 67 → 66） |

## エビデンス

撮影シナリオ `dialog-dark-1577.mjs` を同梱しました。入口はマイページの「ログアウト」で、**最後まで押し切らず**キャンセルで閉じます。ダイアログが開かなければシナリオごと落ちるので、「開いていない絵」を納品する事故は起きません。

判定基準は明確です。**`03-dialog` の light と dark が md5 まで一致するなら、修正は効いていません。**

### 撮影結果

- **run**: https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/32812056996
- **commit**: `d1ce57b7f580d2a14fb7f461135b01e724dab907`
- **一覧ページ**: https://storage.googleapis.com/nanitabeyo-public/e2e-evidence/Ayato-kosaka/nanitabeyo/runs/32812056996/claude-shoot-1577-dialog-dark-32812056996-1/index.html

03-dialog の light と dark は別の md5 になっており、**テーマに追従している**。

### ダイアログ内のコントラスト比（実測）

| | 地 | 見出し | 本文 |
| --- | --- | --- | --- |
| ライト | #FFFFFF | 17.13:1 | 9.34:1 |
| ダーク | #201F1F | 12.76:1 | 9.66:1 |

ライトの文字色は実測で #1C1B1F / #49454F となり、修正前に直書きされていた値とバイト一致している。つまり **ライトの見た目は変わっていない**。WCAG AA は 4.5:1 であり、いずれも十分なコントラストを確保している。

### スクリーンショット

| | ライト | ダーク |
| --- | --- | --- |
| 01-screen（マイページ） | <img src="https://storage.googleapis.com/nanitabeyo-public/e2e-evidence/Ayato-kosaka/nanitabeyo/runs/32812056996/claude-shoot-1577-dialog-dark-32812056996-1/evidence/dialog1577-light-01-screen.png" width="220"> | <img src="https://storage.googleapis.com/nanitabeyo-public/e2e-evidence/Ayato-kosaka/nanitabeyo/runs/32812056996/claude-shoot-1577-dialog-dark-32812056996-1/evidence/dialog1577-dark-01-screen.png" width="220"> |
| 02-trigger（ログアウト行） | <img src="https://storage.googleapis.com/nanitabeyo-public/e2e-evidence/Ayato-kosaka/nanitabeyo/runs/32812056996/claude-shoot-1577-dialog-dark-32812056996-1/evidence/dialog1577-light-02-trigger.png" width="220"> | <img src="https://storage.googleapis.com/nanitabeyo-public/e2e-evidence/Ayato-kosaka/nanitabeyo/runs/32812056996/claude-shoot-1577-dialog-dark-32812056996-1/evidence/dialog1577-dark-02-trigger.png" width="220"> |
| 03-dialog（**確認ダイアログ・本命**） | <img src="https://storage.googleapis.com/nanitabeyo-public/e2e-evidence/Ayato-kosaka/nanitabeyo/runs/32812056996/claude-shoot-1577-dialog-dark-32812056996-1/evidence/dialog1577-light-03-dialog.png" width="220"> | <img src="https://storage.googleapis.com/nanitabeyo-public/e2e-evidence/Ayato-kosaka/nanitabeyo/runs/32812056996/claude-shoot-1577-dialog-dark-32812056996-1/evidence/dialog1577-dark-03-dialog.png" width="220"> |
| 04-cancelled（キャンセルで閉じた状態） | <img src="https://storage.googleapis.com/nanitabeyo-public/e2e-evidence/Ayato-kosaka/nanitabeyo/runs/32812056996/claude-shoot-1577-dialog-dark-32812056996-1/evidence/dialog1577-light-04-cancelled.png" width="220"> | <img src="https://storage.googleapis.com/nanitabeyo-public/e2e-evidence/Ayato-kosaka/nanitabeyo/runs/32812056996/claude-shoot-1577-dialog-dark-32812056996-1/evidence/dialog1577-dark-04-cancelled.png" width="220"> |

最後まで押し切っていない（ログアウトはしていない）。認証・API・地図はモックしている。

## 承認しなかったらどうなるか

機能は動きます。ダークモードのユーザーに、暗い画面の上で白いダイアログが出続けるだけです。ただし ACC-01 の「取り消せません」のように落ち着いて読んでほしい面がここを通るため、優先度は低くないと考えます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
