### PR TITLE
ci(pr-check): e2e の型検査と prisma validate をゲートへ足す

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -158,3 +158,12 @@ jobs:
       # ローカル実測 約 21 秒。DB へは接続しない（スキーマの静的検証のみ）。
       - name: Prisma スキーマを検証
         run: pnpm --filter api exec prisma validate
+
+      # 入れ子になった `test()` / `it()` は **1 度も実行されない**のに構文としては正しく、
+      # tsc も eslint も気づかない。実際に 2 件、«assert していないのに緑» で残っていた:
+      #   - e2e-web/tests/profile/settings.spec.ts … バージョン検証の中へ通知カード検証が入れ子
+      #   - e2e-mobile/tests/profile/settings.test.ts … ハプティクスの it が閉じずに通知の it を飲み込む
+      # どちらもベース取り込みの衝突解消で «偶然» 見つかったもので、
+      # 見つからなければそのまま出ていた。ローカル実測 1 秒未満。
+      - name: e2e の spec に入れ子の test が無いことを確認
+        run: pnpm assert:no-nested-e2e-tests

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -133,3 +133,28 @@ jobs:
       # これまでどの workflow からも実行されていなかった。
       - name: app-expo のユニットテスト
         run: pnpm --filter app-expo test
+
+      # ─────────────────────────────────────────────────────────────
+      # 2026-08-25 追加。**どれも「実際に見逃した defect」があって足している。**
+      # 推測で網を広げたのではなく、この日 1 日で 4 件すり抜けたのが根拠。
+      # ─────────────────────────────────────────────────────────────
+
+      # e2e-web / e2e-mobile はこれまでどの PR ゲートからも型検査されていなかった。
+      # 実際に以下がマージ済みブランチ上で **緑のまま**放置されていた:
+      #   - e2e-web/pages/SettingsPage.ts … 自動マージが JSDoc を縫い合わせて構文エラー
+      #     （`goto()` のコメントが `notificationToggle()` のコメントを飲み込んだ）
+      #   - e2e-mobile … #1402 で消えた `ProfileScreen.gotoSettings()` の呼び出しが 2 ファイルに残存
+      # どちらも「壊れた e2e は次に走らせるまで気づけない」形で、走らせるのは nightly か手動 dispatch。
+      # tsc なら数秒で落とせる（ローカル実測: e2e-web 約 6 秒）。
+      - name: e2e-web の型検査
+        run: pnpm --filter e2e-web typecheck
+
+      - name: e2e-mobile の型検査
+        run: pnpm --filter e2e-mobile typecheck
+
+      # `.prisma` は型検査にもテストにも掛からないため、**衝突マーカーが commit されたまま
+      # PR Check が緑**になっていた（api/prisma/schema.prisma に `<<<<<<< HEAD` が残存）。
+      # prisma validate は schema の構文とリレーションを見るので、この形は確実に落ちる。
+      # ローカル実測 約 21 秒。DB へは接続しない（スキーマの静的検証のみ）。
+      - name: Prisma スキーマを検証
+        run: pnpm --filter api exec prisma validate

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"build": "turbo run build",
 		"lint": "turbo run lint",
 		"assert:doc-hygiene": "node ./scripts/assert-doc-hygiene.mjs",
+		"assert:no-nested-e2e-tests": "node ./scripts/assert-no-nested-e2e-tests.mjs",
 		"format": "prettier --write .",
 		"typecheck": "turbo run typecheck",
 		"test:e2e": "pnpm --filter e2e-web test",

--- a/scripts/assert-no-nested-e2e-tests.mjs
+++ b/scripts/assert-no-nested-e2e-tests.mjs
@@ -1,0 +1,78 @@
+// #1590 【設計】e2e の spec に «test()/it() の入れ子» が無いことを保証する。
+//
+// 入れ子になった test は **1 度も実行されない**（Playwright / Jest とも、
+// 外側の test の実行中に登録された test は無視される）。構文としては正しいので
+// tsc も eslint も気づかず、CI は緑のまま «検証しているつもり» になる。
+//
+// このリポジトリで実際に 2 度起きた:
+//   - e2e-web/tests/profile/settings.spec.ts
+//     «バージョン情報が表示される» の中へ «匿名時は通知カードが表示されない» が入れ子になり、
+//     バージョンも通知カードもどちらも assert されていなかった
+//   - e2e-mobile/tests/profile/settings.test.ts
+//     ハプティクスの it が閉じられないまま通知の it が入れ子になっていた
+//
+// どちらもマージ後にベース取り込みで偶然見つかったもので、
+// «見つからなければそのまま出ていた» 類の欠陥である。
+//
+// 使い方: node ./scripts/assert-no-nested-e2e-tests.mjs [走査するディレクトリ...]
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOTS = process.argv.slice(2).length ? process.argv.slice(2) : ["e2e-web/tests", "e2e-mobile/tests"];
+const findings = [];
+
+function walk(dir) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p);
+    else if (/\.(spec|test)\.ts$/.test(name)) scan(p);
+  }
+}
+
+/** 文字列・テンプレート・コメントを同じ長さの空白へ潰す（行番号を保つ） */
+function blank(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
+    .replace(/\/\/[^\n]*/g, (m) => " ".repeat(m.length))
+    .replace(/`(?:\\.|[^`\\])*`/g, (m) => m.replace(/[^\n]/g, " "))
+    .replace(/"(?:\\.|[^"\\])*"/g, (m) => m.replace(/[^\n]/g, " "))
+    .replace(/'(?:\\.|[^'\\])*'/g, (m) => m.replace(/[^\n]/g, " "));
+}
+
+function scan(file) {
+  const src = readFileSync(file, "utf8");
+  const s = blank(src);
+  const lineOf = (i) => s.slice(0, i).split("\n").length;
+
+  // test( / it( の呼び出しを «開始 index → 対応する ) の index» で範囲化する
+  const calls = [];
+  const re = /(^|[^\w.$])(test|it)\s*\(/g;
+  let m;
+  while ((m = re.exec(s))) {
+    const open = m.index + m[0].length - 1; // '(' の位置
+    let depth = 0;
+    let end = -1;
+    for (let i = open; i < s.length; i++) {
+      if (s[i] === "(") depth++;
+      else if (s[i] === ")") {
+        depth--;
+        if (depth === 0) { end = i; break; }
+      }
+    }
+    if (end !== -1) calls.push({ start: m.index + m[0].length - m[2].length - 1, open, end });
+  }
+
+  for (const c of calls) {
+    const outer = calls.find((o) => o !== c && o.open < c.start && c.end < o.end);
+    if (outer) findings.push({ file, line: lineOf(c.start), outerLine: lineOf(outer.start) });
+  }
+}
+
+for (const r of ROOTS) walk(r);
+if (findings.length) {
+  console.error("❌ test()/it() の入れ子を検出しました（内側の中身は 1 度も実行されません）:");
+  for (const f of findings) console.error(`   ${f.file}:${f.line}（外側の test は ${f.outerLine} 行目）`);
+  process.exit(1);
+}
+console.log(`✅ e2e の spec に test()/it() の入れ子はありません`);


### PR DESCRIPTION
## なぜ足すのか

**推測で網を広げたのではありません。2026-08-25 の 1 日で 4 件すり抜けたのが根拠です。**

| 見逃したもの | 検出できなかった理由 |
| --- | --- |
| `e2e-web/pages/SettingsPage.ts` の構文エラー。自動マージが JSDoc を縫い合わせ、`goto()` のコメントが `notificationToggle()` のコメントを飲み込んで `Invalid character` になっていた | **e2e-web はどの PR ゲートからも型検査されていない** |
| `e2e-web/tests/profile/settings.spec.ts` の `test()` 入れ子。**バージョンも通知カードもどちらも assert されていなかった**（構文としては通るので誰も気づかない） | 入れ子は tsc も eslint も通る。**型検査を足しても捕まらない** |
| `e2e-mobile` に残った `ProfileScreen.gotoSettings()` の呼び出し（#1402 で消えたメソッド）。実行時は TypeError | e2e-mobile も型検査されていない |
| `api/prisma/schema.prisma` に **commit された衝突マーカー**（`<<<<<<< HEAD`） | `.prisma` は型検査にもテストにも掛からない |

いずれも「壊れた e2e は次に走らせるまで気づけない」形で、走らせるのは nightly か手動 dispatch です。その間ずっと **PR Check は緑を出し続けていました。**

## 足したもの（4 ステップ）

| ステップ | 何を捕まえるか | ローカル実測 |
| --- | --- | --- |
| `pnpm --filter e2e-web typecheck` | 構文エラー・消えたメソッドの呼び出し | 約 6 秒 |
| `pnpm --filter e2e-mobile typecheck` | 同上 | 同程度 |
| `pnpm --filter api exec prisma validate` | commit された衝突マーカー・壊れたリレーション | 約 21 秒 |
| `pnpm assert:no-nested-e2e-tests` | **入れ子の test / it** | 1 秒未満 |

`prisma validate` は **DB へ接続しません**（スキーマの構文とリレーションの静的検証のみ）。secrets も不要です。

api の jest を入れていないのは従来どおりです。`api/.env`（secrets）を要求するため。

## 4 本目（入れ子の test）を別に足した理由

上の表の 2 件目は **型検査では捕まりません**。入れ子の `test()` は構文として正しく、tsc も eslint も通します。しかし **外側の test の実行中に登録された test は Playwright も Jest も無視する**ので、中身は 1 度も実行されません。

実際にこのリポジトリで 2 件ありました。

| 場所 | 何が assert されていなかったか |
| --- | --- |
| `e2e-web/tests/profile/settings.spec.ts` | «バージョン情報が表示される» の中へ «匿名時は通知カードが表示されない» が入れ子。**両方とも 1 つも assert されていなかった** |
| `e2e-mobile/tests/profile/settings.test.ts` | ハプティクスの it が閉じられないまま通知の it を飲み込んでいた |

どちらもベース取り込みの衝突解消中に **偶然**見つかったもので、見つからなければそのまま出ていました。

`scripts/assert-no-nested-e2e-tests.mjs` は文字列・テンプレート・コメントを潰したうえで `test(` / `it(` の括弧を対応付け、ある呼び出しの範囲が別の呼び出しの範囲に含まれていれば入れ子とみなします。兄弟の test は入れ子になりません。

## 入れた瞬間に赤くならないことの確認

4 つとも **main の状態で緑になること**をローカルで実測してから足しています。

```
e2e-web    tsc --noEmit           → 0 errors
e2e-mobile tsc --noEmit           → 0 errors
prisma validate                   → The schema at prisma/schema.prisma is valid
assert:no-nested-e2e-tests        → 誤検知 0（e2e-web / e2e-mobile の全 spec 200 本超）
```

入れ子検出については、**実際の欠陥の形を再現した spec で落ちること**も確認しています（再現 spec は commit していません。ゲート自体のテストが要るほどの複雑さではないため）。

## 既知の追従（この PR の対象外）

`#1469`（統合ブランチ）には `shared/api/v1/dto/users/query-my-dishes.dto.ts` があり、これは class-validator のデコレータを使います。`e2e-web/tsconfig.json` に `experimentalDecorators` が無いため、**そのブランチでは `e2e-web typecheck` が `TS1240` で落ちます**。`main` にはこの DTO がまだ無いので、このゲートは今は緑です。

追従は統合ブランチ側で済ませてあります（`#1585` / `#1589` の両方に `e2e-web/tsconfig.json` への `experimentalDecorators` / `emitDecoratorMetadata` 追加が入っています）。この PR では触りません。二重に入れると `#1469` のマージで衝突するためです。