### PR TITLE
fix(#1596): release/1.13 差分レビューの指摘 3 件を直し、api のテストを CI ゲートへ載せる

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,8 +13,13 @@ name: PR Check
 #     6. app-expo の lint（#1366。既存 48 errors を解消したうえで新規に追加した）
 # - 4-2（実際の config.json との値の突き合わせ）は EAS の env が要るのでここでは SKIP される。
 #   SKIP した旨は必ずログへ出る。4-2 は引き続き nightly の e2e-web-test.yml が担当する。
-# - api は入れていない。pnpm --filter api test は api/.env（secrets）を要求し、
-#   かつ現状 red（env 起因 5 suite ＋ env と無関係な DI 失敗 3 件）のため（#1112 のコメント参照）。
+# - #1596 api の jest をゲートへ入れた。以前は「api/.env（secrets）を要求し、かつ現状 red」を
+#   理由に外していたが、**外していた期間にモックが本体から静かにズレ、3 suite / 26 件が
+#   «1 度も実行されないまま緑扱い» になっていた**（アカウント削除 #1511 と通知設定 #1510 の
+#   回帰テスト。どちらも «テストがあるから安全» を根拠に出荷したもの）。
+#   secrets 依存は api/test/setup-test-env.ts が「未設定のキーだけ」ダミーで埋めて外した
+#   （実 .env / CI secret があればそちらが勝つ）。赤の実体は本体変更への追随漏れだったので、
+#   直したうえでゲートへ載せている。
 # - step は「安い順・失敗原因が特定しやすい順」に並べてある（fail-fast）。
 # - branches / paths のフィルタは意図的に付けていない。統合ブランチ宛ての PR でも回す必要があり、
 #   かつ 4-1 の入力の片方は shared/remoteConfig/remoteConfig.schema.ts なので、
@@ -151,6 +156,22 @@ jobs:
       # これまでどの workflow からも実行されていなかった。
       - name: app-expo のユニットテスト
         run: pnpm --filter app-expo test
+
+      # #1596 api のユニットテスト。ここが外れていた間に、本体の変更へ追随し忘れた
+      # モックが 3 suite（26 件）を «実行されないまま» にしていた:
+      #   - users.service.delete-me.spec.ts … UsersService へ後から足された 3 つの依存を
+      #     provider へ入れ忘れ、Nest の組み立てごと失敗（アカウント削除の回帰テスト 6 件）
+      #   - notification-job.service.spec.ts … #1510 で足した isPushAllowedForKind が
+      #     モックに無く「is not a function」（14 件）
+      #   - notification-job.preferences.spec.ts … 本体が findUnique → findFirst へ変わり、
+      #     さらに #1557 の getUsersByIdsIncludingDeleted も未追随（6 件）
+      # いずれも型検査では捕まらない（モックは any 相当で通る）。テストを回す以外に
+      # 検出手段が無い種類のズレなので、ここへ載せる。
+      #
+      # 外部 I/O は無く、api/test/setup-test-env.ts が env を埋めるので secrets 不要。
+      # ローカル実測 約 90 秒。
+      - name: api のユニットテスト
+        run: pnpm --filter api test
 
       # ─────────────────────────────────────────────────────────────
       # 2026-08-25 追加。**どれも「実際に見逃した defect」があって足している。**

--- a/api/package.json
+++ b/api/package.json
@@ -114,6 +114,9 @@
     "moduleNameMapper": {
       "^src/(.*)$": "<rootDir>/$1",
       "^@shared/v1/(.*)$": "<rootDir>/../../shared/api/v1/$1"
-    }
+    },
+    "setupFiles": [
+      "<rootDir>/../test/setup-test-env.ts"
+    ]
   }
 }

--- a/api/src/core/external-api/external-api.service.spec.ts
+++ b/api/src/core/external-api/external-api.service.spec.ts
@@ -3,6 +3,14 @@
 // Test for external API service error handling
 //
 
+// #1596 `getCorrectedSpelling` は **モジュール読み込み時に確定した** `env` を読む
+// （`env.GOOGLE_API_KEY`）。テストの中で `process.env` を消しても `env` は変わらないため、
+// 「資格情報が無いとき null を返す」経路はこの mock 無しでは到達できない。
+// 旧 spec は process.env を消して検査しており、実際には一度も «資格情報なし» を
+// 通っていなかった（env 起因で suite ごと落ちていたため誰も気づけなかった）。
+const mockEnv: Record<string, unknown> = {};
+jest.mock('../config/env', () => ({ env: mockEnv }));
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { ExternalApiService } from './external-api.service';
 import { AppLoggerService } from '../logger/logger.service';
@@ -43,14 +51,13 @@ describe('ExternalApiService Error Handling', () => {
     const query = 'test query';
 
     beforeEach(() => {
-      // Mock environment variables
-      process.env.GOOGLE_API_KEY = 'test-api-key';
-      process.env.GOOGLE_SEARCH_ENGINE_ID = 'test-engine-id';
+      mockEnv.GOOGLE_API_KEY = 'test-api-key';
+      mockEnv.GOOGLE_SEARCH_ENGINE_ID = 'test-engine-id';
     });
 
     afterEach(() => {
-      delete process.env.GOOGLE_API_KEY;
-      delete process.env.GOOGLE_SEARCH_ENGINE_ID;
+      delete mockEnv.GOOGLE_API_KEY;
+      delete mockEnv.GOOGLE_SEARCH_ENGINE_ID;
     });
 
     it('should log 403 errors as warning instead of error', async () => {
@@ -61,7 +68,11 @@ describe('ExternalApiService Error Handling', () => {
         ok: false,
         status: 403,
         text: jest.fn().mockResolvedValue('Forbidden'),
-        json: jest.fn(),
+        // #1596 makeExternalApiCall は成功・失敗にかかわらず
+        // `response.clone().json().catch(() => null)` でログ用の本文を読む。
+        // `jest.fn()` のままだと undefined が返り `.catch` で TypeError になり、
+        // «403 は warn» を検査するはずのこのテストが別の理由で落ちていた。
+        json: jest.fn().mockResolvedValue(null),
         clone: jest.fn().mockReturnThis(),
       } as any);
 
@@ -87,7 +98,11 @@ describe('ExternalApiService Error Handling', () => {
         ok: false,
         status: 500,
         text: jest.fn().mockResolvedValue('Internal Server Error'),
-        json: jest.fn(),
+        // #1596 makeExternalApiCall は成功・失敗にかかわらず
+        // `response.clone().json().catch(() => null)` でログ用の本文を読む。
+        // `jest.fn()` のままだと undefined が返り `.catch` で TypeError になり、
+        // «403 は warn» を検査するはずのこのテストが別の理由で落ちていた。
+        json: jest.fn().mockResolvedValue(null),
         clone: jest.fn().mockReturnThis(),
       } as any);
 
@@ -154,8 +169,8 @@ describe('ExternalApiService Error Handling', () => {
     });
 
     it('should return null when no credentials are configured', async () => {
-      delete process.env.GOOGLE_API_KEY;
-      delete process.env.GOOGLE_SEARCH_ENGINE_ID;
+      delete mockEnv.GOOGLE_API_KEY;
+      delete mockEnv.GOOGLE_SEARCH_ENGINE_ID;
 
       const result = await service.getCorrectedSpelling(query);
 

--- a/api/src/core/external-api/external-api.service.ts
+++ b/api/src/core/external-api/external-api.service.ts
@@ -195,6 +195,12 @@ export class ExternalApiService {
 
     const endpoint = `https://www.googleapis.com/customsearch/v1?key=${googleApiKey}&cx=${searchEngineId}&q=${encodeURIComponent(query)}`;
 
+    // #1596 失敗時のログレベルを分けるために、HTTP ステータスを catch まで持ち越す。
+    // 403 は「クォータ超過・鍵の権限不足」で、こちらの運用で起こりうる想定内の失敗。
+    // それ以外（5xx・ネットワーク断）は Google 側の障害かこちらのバグであり、
+    // **error として拾えないと気付けない**。
+    let responseStatus: number | null = null;
+
     try {
       const response = await this.makeExternalApiCall({
         api_name: 'Google Custom Search API',
@@ -203,6 +209,7 @@ export class ExternalApiService {
         function_name: 'getCorrectedSpelling',
         request_payload: {},
       });
+      responseStatus = response.status;
 
       if (!response.ok) {
         throw new Error(
@@ -226,14 +233,24 @@ export class ExternalApiService {
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      this.logger.warn(
-        'GoogleCustomSearchAPICallError',
-        'getCorrectedSpelling',
-        {
-          error_message: errorMessage,
-          query,
-        },
-      );
+
+      // #1596 403 だけ warn、それ以外は error。
+      //
+      // ここは **元々 spec がそう書いてあったのに実装が追いついていなかった**箇所。
+      // `external-api.service.spec.ts` の «should log 403 errors as warning instead of
+      // error» / «should log non-403 errors as error level» は、api の jest が
+      // env 起因で suite ごと落ちていたため一度も実行されておらず、
+      // 実装は全部 warn のままだった。結果、Google Custom Search の 5xx・ネットワーク断が
+      // error レベルに乗らず、error-triage の起票対象から外れていた。
+      const logFailure =
+        responseStatus === 403
+          ? this.logger.warn.bind(this.logger)
+          : this.logger.error.bind(this.logger);
+
+      logFailure('GoogleCustomSearchAPICallError', 'getCorrectedSpelling', {
+        error_message: errorMessage,
+        query,
+      });
       return null;
     }
   }

--- a/api/src/internal/notifications/notification-job.preferences.spec.ts
+++ b/api/src/internal/notifications/notification-job.preferences.spec.ts
@@ -57,7 +57,7 @@ describe('#1510 SET-02 通知カテゴリ別のプッシュ抑止', () => {
   };
   let prisma: {
     withTransaction: jest.Mock;
-    prisma: { dish_media: { findUnique: jest.Mock } };
+    prisma: { dish_media: { findFirst: jest.Mock } };
   };
   let logger: {
     debug: jest.Mock;
@@ -89,7 +89,10 @@ describe('#1510 SET-02 通知カテゴリ別のプッシュ抑止', () => {
       ),
       prisma: {
         dish_media: {
-          findUnique: jest.fn().mockResolvedValue({ user_id: RECIPIENT_ID }),
+          // #1513 で本体が `findUnique` から `findFirst`（+ `deleted_at: null`）へ
+          // 変わったのに、このモックだけ取り残されていた。結果この suite の 6 件は
+          // «findFirst is not a function» で全滅したまま緑扱いになっていた。
+          findFirst: jest.fn().mockResolvedValue({ user_id: RECIPIENT_ID }),
         },
       },
     };
@@ -105,6 +108,13 @@ describe('#1510 SET-02 通知カテゴリ別のプッシュ抑止', () => {
       getUserByIds: jest.fn().mockResolvedValue([
         { id: ACTOR_ID, display_name: 'Actor', preferred_locale: 'ja' },
         { id: RECIPIENT_ID, display_name: 'Recipient', preferred_locale: 'ja' },
+      ]),
+      // #1557 «退会した» と «そもそも users 行が無い（匿名）» を区別するために
+      // 本体が後から使い始めた取得。ここも更新し忘れていた 3 つ目のズレ。
+      // 既定は「誰も退会していない」= deleted_at なしで両者を返す。
+      getUsersByIdsIncludingDeleted: jest.fn().mockResolvedValue([
+        { id: ACTOR_ID, deleted_at: null },
+        { id: RECIPIENT_ID, deleted_at: null },
       ]),
     };
 

--- a/api/src/internal/notifications/notification-job.service.spec.ts
+++ b/api/src/internal/notifications/notification-job.service.spec.ts
@@ -60,6 +60,7 @@ describe('NotificationJobService GRP-04 投票完了通知', () => {
   };
   let notificationsService: {
     sendPushNotification: jest.Mock;
+    isPushAllowedForKind: jest.Mock;
   };
   let prisma: {
     withTransaction: jest.Mock;
@@ -117,6 +118,13 @@ describe('NotificationJobService GRP-04 投票完了通知', () => {
 
     notificationsService = {
       sendPushNotification: jest.fn().mockResolvedValue(undefined),
+      // #1510 SET-02 で processNotificationJob が push 直前に呼ぶようになった判定。
+      // 本体へ足したときにこのモックを更新し忘れ、**この suite の 14 件が
+      // «is not a function» で全滅したまま緑扱いになっていた**（api の jest は
+      // PR ゲートに載っていないため誰も気づけなかった）。既定は「送ってよい」。
+      isPushAllowedForKind: jest
+        .fn()
+        .mockResolvedValue({ allowed: true, category: 'votes' }),
     };
 
     prisma = {

--- a/api/src/v1/dish-category-group-votes/dish-category-group-votes.repository.spec.ts
+++ b/api/src/v1/dish-category-group-votes/dish-category-group-votes.repository.spec.ts
@@ -72,8 +72,19 @@ function matchesWhere(session: FakeSession, where: any): boolean {
       return session.host_user_id === value;
     }
     if (key === 'updated_at') {
+      // #1596 複合カーソルでは `updated_at: <Date>`（同値）と
+      // `updated_at: { lt: <Date> }`（より古い）の両方が来る。
+      // 片方しか解さないと、fake が本物と違う答えを返してテストが嘘をつく。
+      if (value instanceof Date) {
+        return session.updated_at.getTime() === value.getTime();
+      }
       const { lt } = value as { lt: Date };
       return session.updated_at.getTime() < lt.getTime();
+    }
+    if (key === 'id') {
+      // #1596 複合カーソルの第 2 キー。同一 updated_at の中を id で切る
+      const { lt } = value as { lt: string };
+      return session.id < lt;
     }
     if (key === 'dish_category_group_vote_participants') {
       const some = (value as any).some as { user_id: string };
@@ -87,7 +98,14 @@ function buildFakeDb(sessions: FakeSession[]) {
   const findMany = jest.fn(async (args: any) => {
     const filtered = sessions
       .filter((s) => matchesWhere(s, args.where))
-      .sort((a, b) => b.updated_at.getTime() - a.updated_at.getTime())
+      // #1596 本物の orderBy は [{updated_at:'desc'},{id:'desc'}]。
+      // fake 側も id で tie-break しないと、同時刻のとき «複合カーソルが
+      // 効いていない» ことを検出できない
+      .sort(
+        (a, b) =>
+          b.updated_at.getTime() - a.updated_at.getTime() ||
+          (a.id < b.id ? 1 : a.id > b.id ? -1 : 0),
+      )
       .slice(0, args.take);
 
     const participantsSelect =
@@ -322,7 +340,10 @@ describe('DishCategoryGroupVotesRepository.findMeSessions', () => {
       'session-2',
       'session-1',
     ]);
-    expect(firstPage.nextCursor).toBe(sessions[1].updated_at.toISOString());
+    // #1596 カーソルは `<ISO8601>|<id>` の複合
+    expect(firstPage.nextCursor).toBe(
+      `${sessions[1].updated_at.toISOString()}|session-1`,
+    );
 
     const secondPage = await repository.findMeSessions(
       db,
@@ -334,6 +355,102 @@ describe('DishCategoryGroupVotesRepository.findMeSessions', () => {
     expect(secondPage.nextCursor).toBeNull();
 
     expect(findMany).toHaveBeenCalledTimes(2);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // #1596 同一 updated_at がページ境界をまたぐケース
+  //
+  // 旧実装は `updated_at < cursor` の単一カーソルだったため、20 件目と 21 件目が
+  // 同時刻だと **21 件目以降が一覧から永久に消えた**（次ページの起点が 20 件目の
+  // 時刻そのもので、`<` が同時刻の行をまとめて落とす）。
+  // touchSession は候補追加・削除・投票のたびに走るので、同一ミリ秒での複数更新は
+  // «稀» であって «起きない» ではない。
+  // ─────────────────────────────────────────────────────────────────
+  it('#1596 updated_at が同一の行がページ境界をまたいでも欠落しない', () => {
+    const sameMoment = new Date('2026-08-10T00:00:00.000Z');
+    const sessions: FakeSession[] = ['session-a', 'session-b', 'session-c'].map(
+      (id) => ({
+        id,
+        host_user_id: 'user-me',
+        share_token: `token-${id}`,
+        created_at: sameMoment,
+        updated_at: sameMoment,
+        candidates: [],
+        participants: [],
+      }),
+    );
+
+    const { db } = buildFakeDb(sessions);
+
+    return (async () => {
+      const firstPage = await repository.findMeSessions(
+        db,
+        'user-me',
+        undefined,
+        2,
+      );
+      // id 降順で c, b
+      expect(firstPage.items.map((i) => i.id)).toEqual([
+        'session-c',
+        'session-b',
+      ]);
+      expect(firstPage.nextCursor).toBe(
+        `${sameMoment.toISOString()}|session-b`,
+      );
+
+      const secondPage = await repository.findMeSessions(
+        db,
+        'user-me',
+        firstPage.nextCursor!,
+        2,
+      );
+      // 旧実装ではここが [] になり session-a が永久に見えなくなっていた
+      expect(secondPage.items.map((i) => i.id)).toEqual(['session-a']);
+      expect(secondPage.nextCursor).toBeNull();
+    })();
+  });
+
+  it('#1596 旧形式（ISO8601 のみ）のカーソルも受け付ける（配信済みクライアント互換）', async () => {
+    const sessions: FakeSession[] = Array.from({ length: 3 }, (_, i) => ({
+      id: `session-${i}`,
+      host_user_id: 'user-me',
+      share_token: `token-${i}`,
+      created_at: new Date(2026, 7, i + 1),
+      updated_at: new Date(2026, 7, i + 1),
+      candidates: [],
+      participants: [],
+    }));
+
+    const { db } = buildFakeDb(sessions);
+
+    const page = await repository.findMeSessions(
+      db,
+      'user-me',
+      sessions[1].updated_at.toISOString(),
+      2,
+    );
+
+    expect(page.items.map((i) => i.id)).toEqual(['session-0']);
+  });
+
+  it('#1596 壊れたカーソルは 500 にせず先頭ページを返す', async () => {
+    const sessions: FakeSession[] = [
+      {
+        id: 'session-0',
+        host_user_id: 'user-me',
+        share_token: 'token-0',
+        created_at: new Date('2026-08-01T00:00:00Z'),
+        updated_at: new Date('2026-08-01T00:00:00Z'),
+        candidates: [],
+        participants: [],
+      },
+    ];
+
+    const { db } = buildFakeDb(sessions);
+
+    const page = await repository.findMeSessions(db, 'user-me', 'not-a-date', 2);
+
+    expect(page.items.map((i) => i.id)).toEqual(['session-0']);
   });
 
   // ─────────────────────────────────────────────────────────────────

--- a/api/src/v1/dish-category-group-votes/dish-category-group-votes.repository.ts
+++ b/api/src/v1/dish-category-group-votes/dish-category-group-votes.repository.ts
@@ -22,6 +22,10 @@ import {
   DishCategoryGroupVoteSearchContext,
 } from '@shared/v1/res';
 import { pickWinnerCandidate } from './dish-category-group-votes.ranking';
+import {
+  formatMeSessionsCursor,
+  parseMeSessionsCursor,
+} from './me-sessions-cursor';
 
 export type PrismaExecutor = Prisma.TransactionClient | PrismaClient;
 
@@ -285,13 +289,28 @@ export class DishCategoryGroupVotesRepository {
     const whereClause: Prisma.dish_category_group_vote_sessionsWhereInput = {
       host_user_id: userId,
     };
-    if (cursor) {
-      whereClause.updated_at = { lt: new Date(cursor) };
+    // #1596 カーソルは (updated_at, id) の複合。updated_at 単独だと、同じ
+    // updated_at を持つ行がページ境界をまたいだとき `lt` が **同時刻の行をまとめて
+    // 飛ばす**（20 件目と 21 件目が同時刻なら 21 件目以降が一覧から消える）。
+    // touchSession は候補追加・削除・投票のたびに走るので、同一ミリ秒での複数更新は
+    // «稀» であって «起きない» ではない。
+    const parsed = parseMeSessionsCursor(cursor);
+    if (parsed?.id) {
+      whereClause.OR = [
+        { updated_at: { lt: parsed.updatedAt } },
+        { updated_at: parsed.updatedAt, id: { lt: parsed.id } },
+      ];
+    } else if (parsed) {
+      // 旧形式（ISO8601 のみ）。配信済みクライアントが持っているカーソルを
+      // 無効にしないため、従来どおりの絞り込みで受ける。
+      whereClause.updated_at = { lt: parsed.updatedAt };
     }
 
     const sessions = await db.dish_category_group_vote_sessions.findMany({
       where: whereClause,
-      orderBy: { updated_at: 'desc' },
+      // id を副次キーに入れて同点時の並びを固定する。ここが無いと複合カーソルの
+      // 比較と実際の並びがズレ、やはり重複・欠落が出る。
+      orderBy: [{ updated_at: 'desc' }, { id: 'desc' }],
       take: limit + 1,
       select: {
         id: true,
@@ -320,7 +339,10 @@ export class DishCategoryGroupVotesRepository {
     const hasMore = sessions.length > limit;
     const page = hasMore ? sessions.slice(0, limit) : sessions;
     const nextCursor = hasMore
-      ? page[page.length - 1].updated_at.toISOString()
+      ? formatMeSessionsCursor(
+          page[page.length - 1].updated_at,
+          page[page.length - 1].id,
+        )
       : null;
 
     // #1505 【設計】候補と得票は **ページ全体を 2 クエリでまとめて引く**。

--- a/api/src/v1/dish-category-group-votes/me-sessions-cursor.ts
+++ b/api/src/v1/dish-category-group-votes/me-sessions-cursor.ts
@@ -1,0 +1,58 @@
+// api/src/v1/dish-category-group-votes/me-sessions-cursor.ts
+//
+// #1596 GET /v1/users/me/dish-category-group-votes のページングカーソル。
+//
+// ## なぜ複合キーなのか
+//
+// 元の実装は `updated_at` 単独の ISO 文字列で、絞り込みは `updated_at < cursor` だった。
+// この形は **同じ `updated_at` を持つ行がページ境界をまたぐと、同時刻の行をまとめて飛ばす**。
+// 20 件目と 21 件目が同一時刻なら、21 件目以降は一覧から永久に消える（次ページの
+// 起点が 20 件目の時刻そのものなので、`<` が 21 件目も落とす）。
+//
+// `touchSession` は候補追加・候補削除・dish_media 固定・投票のたびに走るため、
+// 同一ミリ秒に複数セッションが更新されることは «稀» であって «起きない» ではない。
+//
+// ## 形式
+//
+// `"<ISO8601>|<uuid>"`。区切りは UUID にも ISO8601 にも現れない `|` を使う。
+//
+// **旧形式（ISO8601 のみ）も受ける。** 配信済みクライアントが持っている次ページの
+// カーソルを無効にすると、更新するまで «次を読むと落ちる» ことになるため。
+// 旧形式のときは id を持たないので、従来どおり `updated_at < cursor` で絞る
+// （同時刻スキップは残るが、旧クライアントの挙動を変えないほうが安全側）。
+
+/** 解釈できたカーソル。`id` は旧形式のとき `null` */
+export type MeSessionsCursor = {
+  updatedAt: Date;
+  id: string | null;
+};
+
+const SEPARATOR = '|';
+
+/** `updated_at` と `id` からカーソル文字列を作る */
+export function formatMeSessionsCursor(updatedAt: Date, id: string): string {
+  return `${updatedAt.toISOString()}${SEPARATOR}${id}`;
+}
+
+/**
+ * カーソル文字列を解釈する。**解釈できなければ `null`**。
+ *
+ * 壊れた文字列で `new Date()` を作ると `Invalid Date` になり、そのまま Prisma へ渡すと
+ * 500 になる。カーソルはクライアントから来る任意の文字列なので、ここで弾いて
+ * 「先頭ページを返す」へ倒す（一覧が見られなくなるより良い）。
+ */
+export function parseMeSessionsCursor(
+  cursor: string | null | undefined,
+): MeSessionsCursor | null {
+  if (typeof cursor !== 'string' || cursor.length === 0) return null;
+
+  const separatorIndex = cursor.indexOf(SEPARATOR);
+  const timestampText =
+    separatorIndex === -1 ? cursor : cursor.slice(0, separatorIndex);
+  const idText = separatorIndex === -1 ? '' : cursor.slice(separatorIndex + 1);
+
+  const updatedAt = new Date(timestampText);
+  if (Number.isNaN(updatedAt.getTime())) return null;
+
+  return { updatedAt, id: idText.length > 0 ? idText : null };
+}

--- a/api/src/v1/dish-category-variants/dish-category-variants.controller.spec.ts
+++ b/api/src/v1/dish-category-variants/dish-category-variants.controller.spec.ts
@@ -6,6 +6,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DishCategoryVariantsController } from './dish-category-variants.controller';
 import { DishCategoryVariantsService } from './dish-category-variants.service';
+// #1596 コントローラに付いている AuthAnonGuard が ClsService と AppLoggerService を要求する。
+// 後者を provider に入れていなかったため、この suite は組み立てに失敗して全件落ちていた
+// （env 起因の失敗に隠れて誰も見ていなかった）。
+import { AppLoggerService } from '../../core/logger/logger.service';
 
 describe('DishCategoryVariantsController', () => {
   let controller: DishCategoryVariantsController;
@@ -20,6 +24,16 @@ describe('DishCategoryVariantsController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DishCategoryVariantsController],
       providers: [
+        {
+          provide: AppLoggerService,
+          useValue: {
+            debug: jest.fn(),
+            log: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+            externalApi: jest.fn(),
+          },
+        },
         {
           provide: DishCategoryVariantsService,
           useValue: mockDishCategoryVariantsService,
@@ -63,29 +77,37 @@ describe('DishCategoryVariantsController', () => {
   describe('createDishCategoryVariant', () => {
     it('should call service.createDishCategoryVariant', async () => {
       const dto = { name: 'ラーメン' };
-      const expectedResult = [
-        {
-          id: 'test-id',
-          label_en: 'Ramen',
-          labels: {},
-          image_url: 'test-url',
-          origin: [],
-          cuisine: [],
-          tags: [],
-          created_at: new Date(),
-          updated_at: new Date(),
-          lock_no: 0,
-        },
-      ];
+
+      // #1596 service は **単一の** PrismaDishCategories を返し、controller は
+      // それを convertPrismaToSupabase_DishCategories で Supabase 形へ変換して返す。
+      // 旧 spec は「配列を返してそのまま素通しされる」前提で書かれており、
+      // 実装とまるごとズレていた（env 起因の suite 落ちに隠れて誰も見ていなかった）。
+      const createdAt = new Date('2026-08-01T00:00:00.000Z');
+      const serviceResult = {
+        id: 'test-id',
+        label_en: 'Ramen',
+        labels: {},
+        image_url: 'test-url',
+        origin: [],
+        cuisine: [],
+        tags: [],
+        created_at: createdAt,
+        updated_at: createdAt,
+        lock_no: 0,
+      };
 
       mockDishCategoryVariantsService.createDishCategoryVariant.mockResolvedValue(
-        expectedResult,
+        serviceResult,
       );
 
       const result = await controller.createDishCategoryVariant(dto);
 
       expect(service.createDishCategoryVariant).toHaveBeenCalledWith(dto);
-      expect(result).toEqual(expectedResult);
+      // 変換後も «どの料理カテゴリを作ったか» が失われないことを固定する。
+      // ここが undefined へ落ちると、クライアントは作成結果を特定できない。
+      expect(result.id).toBe('test-id');
+      expect(result.label_en).toBe('Ramen');
+      expect(result.image_url).toBe('test-url');
     });
   });
 });

--- a/api/src/v1/dish-media/dish-media.repository.ts
+++ b/api/src/v1/dish-media/dish-media.repository.ts
@@ -953,7 +953,12 @@ export class DishMediaRepository {
     const eatenDishIds = new Set<string>();
     if (userId && dishIds.length > 0) {
       const myReviewedDishes = await this.prisma.prisma.dish_reviews.findMany({
-        where: { user_id: userId, dish_id: { in: dishIds } },
+        // #1513 削除済みレビューは «食べた» 記録として数えない。
+        // schema.prisma の deleted_at は「読み取り経路は必ず deleted_at IS NULL で絞る」と
+        // 定めており、dish_reviews を読む他の経路（618 / 893 / 1224 行、restaurants /
+        // users の集計）はすべて絞っている。**ここだけが漏れていた**。
+        // 漏れていると、レビューを消しても «食べたを記録» が記録済みの見た目のまま戻らない。
+        where: { user_id: userId, dish_id: { in: dishIds }, deleted_at: null },
         distinct: ['dish_id'],
         select: { dish_id: true },
       });

--- a/api/src/v1/dish-media/dish-reviews-soft-delete-boundary.spec.ts
+++ b/api/src/v1/dish-media/dish-reviews-soft-delete-boundary.spec.ts
@@ -1,0 +1,231 @@
+// api/src/v1/dish-media/dish-reviews-soft-delete-boundary.spec.ts
+//
+// #1596 **`dish_reviews` を読むすべての経路が `deleted_at` で絞っていること**を
+// 静的に強制するラチェット。
+//
+// ## なぜ要るのか
+//
+// `shared/prisma/schema.prisma` の `dish_reviews.deleted_at` には
+// 「読み取り経路は必ず deleted_at IS NULL で絞る」と書いてある。にもかかわらず
+// `dish-media.repository.ts` の «この dish を自分が食べたか»（isEaten）判定 1 本だけが
+// 絞り忘れており、**レビューを削除しても «食べたを記録» が記録済みの見た目のまま**だった。
+//
+// 兄弟の読み取り（一覧・平均点・件数・Calendar の最古日・店舗集計）は
+// すべて絞っていたので、レビューでも型検査でも気づけない。**1 箇所漏れれば穴**という
+// 性質の不変条件は、人の注意ではなくこういう機械的な検査で守るしかない。
+//
+// 同じ作法のものが app-expo 側にもある（assert:no-hardcoded-colors 等）。
+//
+// ## 落ちたときにやること
+//
+// 新しく `dish_reviews` を読む場所を足したなら、その where へ `deleted_at: null` を足す。
+// 「削除済みも含めて読むのが正しい」場合だけ、**理由を書いて** EXCLUSIONS へ足す。
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+/**
+ * 検査対象の読み取りメソッド。
+ *
+ * **`findUnique` / `findUniqueOrThrow` は意図的に外している。** Prisma の
+ * `findUnique.where` は一意キーしか受け付けないため、`deleted_at: null` を
+ * **構造的に書けない**。この 2 つを使う経路は、取得後に呼び出し側で
+ * `deleted_at` を見る責任がある（例: `findReviewForMutation` は «消えている(404)» と
+ * «他人のもの(403)» を区別するため、削除済みも返すのが正しい）。
+ */
+const READ_METHODS = [
+  'findMany',
+  'findFirst',
+  'findFirstOrThrow',
+  'count',
+  'aggregate',
+  'groupBy',
+] as const;
+
+/**
+ * 削除済みも読むのが正しい場所。**理由を必ず書くこと。**
+ * キーはリポジトリルートからの相対パス（POSIX 区切り）。
+ */
+const EXCLUSIONS: Readonly<Record<string, string>> = {
+  // 通報の対象が «実在するか» の存在確認。削除済みのレビューを通報しようとしたときに
+  // 「そんなものは無い」と返すと、通報者からは «消えたのに通報できない» に見える。
+  // ここは意図的に deleted_at を見ない。
+  'src/v1/content-reports/content-reports.repository.ts':
+    '通報対象の存在確認。削除済みでも «存在した» として扱う',
+  // 論理削除そのものを行う経路。deleted_at を立てる対象を探すので、
+  // ここで deleted_at: null を要求するのは自己矛盾ではないが、
+  // 更新系の where は本ファイルの検査対象外（find* のみを見る）。
+};
+
+const API_SRC = join(__dirname, '..', '..');
+const REPO_API_ROOT = join(API_SRC, '..');
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...listSourceFiles(full));
+      continue;
+    }
+    if (!entry.endsWith('.ts')) continue;
+    if (entry.endsWith('.spec.ts')) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/**
+ * `text` の `openIndex`（`(` の位置）に対応する `)` までを返す。
+ * 文字列リテラル・テンプレートリテラルの中の括弧は数えない。
+ */
+function readCallArguments(text: string, openIndex: number): string {
+  let depth = 0;
+  let quote: string | null = null;
+
+  for (let i = openIndex; i < text.length; i += 1) {
+    const ch = text[i];
+
+    if (quote) {
+      if (ch === '\\') {
+        i += 1;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '(') depth += 1;
+    if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) return text.slice(openIndex, i + 1);
+    }
+  }
+  return text.slice(openIndex);
+}
+
+
+/**
+ * コメントを取り除く。
+ *
+ * ⚠️ これが無いと **「`deleted_at` について説明したコメント」が本文と見分けられず、
+ * 絞っていないのに緑になる**。実際、この検査を書いた直後にその形で一度騙された
+ * （fix を revert しても赤くならなかった）。検査の正しさは
+ * 「壊した状態で赤くなること」でしか確かめられない。
+ */
+function stripComments(text: string): string {
+  let out = '';
+  let quote: string | null = null;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (quote) {
+      out += ch;
+      if (ch === '\\') {
+        out += next ?? '';
+        i += 1;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      out += ch;
+      continue;
+    }
+
+    if (ch === '/' && next === '/') {
+      const end = text.indexOf('\n', i);
+      i = end === -1 ? text.length : end - 1;
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      const end = text.indexOf('*/', i + 2);
+      i = end === -1 ? text.length : end + 1;
+      continue;
+    }
+
+    out += ch;
+  }
+  return out;
+}
+
+/**
+ * `where: someVariable` の形で渡されているとき、その変数の宣言に
+ * `deleted_at` が含まれるかを見る。
+ *
+ * 完全な解析はしない（それは型検査器の仕事）。**「変数名で渡している」だけの理由で
+ * 誤検知して、正しいコードを直させることを防ぐ**のが目的。
+ */
+function whereVariableHasDeletedAt(fileText: string, args: string): boolean {
+  const match = args.match(/where:\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*[,}]/);
+  if (!match) return false;
+
+  const declaration = new RegExp(
+    `(?:const|let|var)\\s+${match[1]}\\s*(?::[^=]+)?=`,
+  ).exec(fileText);
+  if (!declaration) return false;
+
+  const start = declaration.index;
+  // 宣言から次の «行頭が閉じ括弧だけ» まで、あるいは 2000 文字ぶんを見る。
+  // where の組み立ては宣言直後にまとまって書かれる前提。
+  const scope = fileText.slice(start, start + 2000);
+  return scope.includes('deleted_at');
+}
+
+describe('#1596 dish_reviews の読み取りは必ず deleted_at で絞る', () => {
+  const files = listSourceFiles(API_SRC);
+
+  it('検査対象のソースを実際に走査できている（0 件なら検査自体が壊れている）', () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it('dish_reviews を読むすべての経路が deleted_at を条件に含む', () => {
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const relPath = relative(REPO_API_ROOT, file).split(sep).join('/');
+      if (EXCLUSIONS[relPath]) continue;
+
+      const text = readFileSync(file, 'utf8');
+      const commentFreeText = stripComments(text);
+
+      for (const method of READ_METHODS) {
+        const needle = `dish_reviews.${method}(`;
+        let from = 0;
+
+        for (;;) {
+          const at = text.indexOf(needle, from);
+          if (at === -1) break;
+          from = at + needle.length;
+
+          const openIndex = at + needle.length - 1;
+          const args = readCallArguments(text, openIndex);
+
+          // `where: whereClause` のように変数で渡している場合は、
+          // その変数の宣言まで見に行く（`dish-media.repository.ts` の一覧がこの形）。
+          const code = stripComments(args);
+          const satisfied =
+            code.includes('deleted_at') ||
+            whereVariableHasDeletedAt(commentFreeText, code);
+
+          if (!satisfied) {
+            const line = text.slice(0, at).split('\n').length;
+            violations.push(`${relPath}:${line} → dish_reviews.${method}()`);
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/api/src/v1/dish-media/soft-delete-read-boundary.spec.ts
+++ b/api/src/v1/dish-media/soft-delete-read-boundary.spec.ts
@@ -1,12 +1,12 @@
 // api/src/v1/dish-media/dish-reviews-soft-delete-boundary.spec.ts
 //
-// #1596 **`dish_reviews` を読むすべての経路が `deleted_at` で絞っていること**を
+// #1596 **`dish_reviews` / `dish_media` を読むすべての経路が `deleted_at` で絞っていること**を
 // 静的に強制するラチェット。
 //
 // ## なぜ要るのか
 //
-// `shared/prisma/schema.prisma` の `dish_reviews.deleted_at` には
-// 「読み取り経路は必ず deleted_at IS NULL で絞る」と書いてある。にもかかわらず
+// `shared/prisma/schema.prisma` は `dish_reviews.deleted_at` と `dish_media.deleted_at` の
+// **両方**に「読み取り経路は必ず deleted_at IS NULL で絞る」と書いてある。にもかかわらず
 // `dish-media.repository.ts` の «この dish を自分が食べたか»（isEaten）判定 1 本だけが
 // 絞り忘れており、**レビューを削除しても «食べたを記録» が記録済みの見た目のまま**だった。
 //
@@ -46,15 +46,24 @@ const READ_METHODS = [
  * 削除済みも読むのが正しい場所。**理由を必ず書くこと。**
  * キーはリポジトリルートからの相対パス（POSIX 区切り）。
  */
+/** 検査対象のテーブル。schema.prisma が同じ約束をしているもの */
+const GUARDED_TABLES = ['dish_reviews', 'dish_media'] as const;
+
+/**
+ * 削除済みも読むのが正しい場所。**理由を必ず書くこと。**
+ * キーは `<リポジトリ相対パス>#<テーブル>`。
+ */
 const EXCLUSIONS: Readonly<Record<string, string>> = {
   // 通報の対象が «実在するか» の存在確認。削除済みのレビューを通報しようとしたときに
   // 「そんなものは無い」と返すと、通報者からは «消えたのに通報できない» に見える。
   // ここは意図的に deleted_at を見ない。
-  'src/v1/content-reports/content-reports.repository.ts':
+  'src/v1/content-reports/content-reports.repository.ts#dish_reviews':
     '通報対象の存在確認。削除済みでも «存在した» として扱う',
-  // 論理削除そのものを行う経路。deleted_at を立てる対象を探すので、
-  // ここで deleted_at: null を要求するのは自己矛盾ではないが、
-  // 更新系の where は本ファイルの検査対象外（find* のみを見る）。
+  // 退会時に GCS の実体を消すための一覧。論理削除で行は残すが、
+  // 「参照が消えたあとに実体を残す理由がない」ので **削除済みも含めて**引くのが正しい。
+  // ここで deleted_at: null を要求すると、消した投稿のファイルが永久に残る。
+  'src/v1/users/users.repository.ts#dish_media':
+    '退会時のストレージ実体削除。削除済みの投稿のファイルも消す必要がある',
 };
 
 const API_SRC = join(__dirname, '..', '..');
@@ -110,25 +119,37 @@ function readCallArguments(text: string, openIndex: number): string {
 
 
 /**
- * コメントを取り除く。
+ * コメントを **同じ長さの空白へ置き換える**（改行は残す）。
  *
- * ⚠️ これが無いと **「`deleted_at` について説明したコメント」が本文と見分けられず、
- * 絞っていないのに緑になる**。実際、この検査を書いた直後にその形で一度騙された
- * （fix を revert しても赤くならなかった）。検査の正しさは
- * 「壊した状態で赤くなること」でしか確かめられない。
+ * 取り除く（詰める）のではなく空白で潰すのは、**元ファイルの行番号と文字位置を
+ * そのまま使える**ようにするため。
+ *
+ * ⚠️ これが無いと 2 種類の嘘が両方出る。実際に両方踏んだ。
+ *   1. 見逃し: 「`deleted_at` について説明したコメント」を絞っている証拠と誤認し、
+ *      絞っていないのに緑になる（fix を revert しても赤くならなかった）
+ *   2. 誤検知: コメントの中に書かれた `dish_media.findMany(` という **例示**を
+ *      本物の呼び出しと誤認し、正しいコードを赤くする
+ *      （`notifications.service.ts` の「こう書くと壊れる」という説明で踏んだ）
+ *
+ * 検査の正しさは「壊した状態で赤くなること」と「正しい状態で緑であること」の
+ * 両方でしか確かめられない。
  */
-function stripComments(text: string): string {
-  let out = '';
+function blankComments(text: string): string {
+  const out = text.split('');
   let quote: string | null = null;
+
+  const blank = (from: number, to: number) => {
+    for (let i = from; i < to && i < out.length; i += 1) {
+      if (out[i] !== '\n') out[i] = ' ';
+    }
+  };
 
   for (let i = 0; i < text.length; i += 1) {
     const ch = text[i];
     const next = text[i + 1];
 
     if (quote) {
-      out += ch;
       if (ch === '\\') {
-        out += next ?? '';
         i += 1;
         continue;
       }
@@ -138,25 +159,26 @@ function stripComments(text: string): string {
 
     if (ch === "'" || ch === '"' || ch === '`') {
       quote = ch;
-      out += ch;
       continue;
     }
 
     if (ch === '/' && next === '/') {
       const end = text.indexOf('\n', i);
-      i = end === -1 ? text.length : end - 1;
+      const stop = end === -1 ? text.length : end;
+      blank(i, stop);
+      i = stop;
       continue;
     }
 
     if (ch === '/' && next === '*') {
       const end = text.indexOf('*/', i + 2);
-      i = end === -1 ? text.length : end + 1;
+      const stop = end === -1 ? text.length : end + 2;
+      blank(i, stop);
+      i = stop - 1;
       continue;
     }
-
-    out += ch;
   }
-  return out;
+  return out.join('');
 }
 
 /**
@@ -182,25 +204,28 @@ function whereVariableHasDeletedAt(fileText: string, args: string): boolean {
   return scope.includes('deleted_at');
 }
 
-describe('#1596 dish_reviews の読み取りは必ず deleted_at で絞る', () => {
+describe('#1596 論理削除テーブルの読み取りは必ず deleted_at で絞る', () => {
   const files = listSourceFiles(API_SRC);
 
   it('検査対象のソースを実際に走査できている（0 件なら検査自体が壊れている）', () => {
     expect(files.length).toBeGreaterThan(50);
   });
 
-  it('dish_reviews を読むすべての経路が deleted_at を条件に含む', () => {
+  it('dish_reviews / dish_media を読むすべての経路が deleted_at を条件に含む', () => {
     const violations: string[] = [];
 
     for (const file of files) {
       const relPath = relative(REPO_API_ROOT, file).split(sep).join('/');
-      if (EXCLUSIONS[relPath]) continue;
 
-      const text = readFileSync(file, 'utf8');
-      const commentFreeText = stripComments(text);
+      // コメントを空白で潰した版だけを見る。位置と行番号は元ファイルと一致する。
+      const text = blankComments(readFileSync(file, 'utf8'));
 
-      for (const method of READ_METHODS) {
-        const needle = `dish_reviews.${method}(`;
+      for (const [table, method] of GUARDED_TABLES.flatMap((t) =>
+        READ_METHODS.map((m) => [t, m] as const),
+      )) {
+        if (EXCLUSIONS[`${relPath}#${table}`]) continue;
+
+        const needle = `${table}.${method}(`;
         let from = 0;
 
         for (;;) {
@@ -213,14 +238,12 @@ describe('#1596 dish_reviews の読み取りは必ず deleted_at で絞る', () 
 
           // `where: whereClause` のように変数で渡している場合は、
           // その変数の宣言まで見に行く（`dish-media.repository.ts` の一覧がこの形）。
-          const code = stripComments(args);
           const satisfied =
-            code.includes('deleted_at') ||
-            whereVariableHasDeletedAt(commentFreeText, code);
+            args.includes('deleted_at') || whereVariableHasDeletedAt(text, args);
 
           if (!satisfied) {
             const line = text.slice(0, at).split('\n').length;
-            violations.push(`${relPath}:${line} → dish_reviews.${method}()`);
+            violations.push(`${relPath}:${line} → ${table}.${method}()`);
           }
         }
       }

--- a/api/src/v1/locations/locations.controller.spec.ts
+++ b/api/src/v1/locations/locations.controller.spec.ts
@@ -6,6 +6,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LocationsController } from './locations.controller';
 import { LocationsService } from './locations.service';
+// #1596 コントローラに付いている AuthAnonGuard が ClsService と AppLoggerService を要求する。
+// 後者を provider に入れていなかったため、この suite は組み立てに失敗して全件落ちていた
+// （env 起因の失敗に隠れて誰も見ていなかった）。
+import { AppLoggerService } from '../../core/logger/logger.service';
 
 describe('LocationsController', () => {
   let controller: LocationsController;
@@ -20,6 +24,16 @@ describe('LocationsController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [LocationsController],
       providers: [
+        {
+          provide: AppLoggerService,
+          useValue: {
+            debug: jest.fn(),
+            log: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+            externalApi: jest.fn(),
+          },
+        },
         {
           provide: LocationsService,
           useValue: mockLocationsService,

--- a/api/src/v1/users/users.service.delete-me.spec.ts
+++ b/api/src/v1/users/users.service.delete-me.spec.ts
@@ -41,6 +41,13 @@ import { RestaurantsRepository } from '../restaurants/restaurants.repository';
 import { RestaurantsAssembler } from '../restaurants/restaurants.assembler';
 import { CloudTasksService } from '../../core/cloud-tasks/cloud-tasks.service';
 import { StorageService } from '../../core/storage/storage.service';
+// #1596 UsersService のコンストラクタへ後から足された 3 つ。
+// 足したときにこの suite を更新し忘れたため、Nest が
+// «DishMediaAssembler at index [9] is available?» で組み立てに失敗し、
+// **アカウント削除の回帰テスト 6 件が 1 度も走っていなかった**。
+import { DishMediaAssembler } from '../dish-media/dish-media.assembler';
+import { DishCategoryGroupVotesRepository } from '../dish-category-group-votes/dish-category-group-votes.repository';
+import { PrismaService } from '../../prisma/prisma.service';
 import {
   SupabaseAdminNotConfiguredError,
   SupabaseAdminService,
@@ -127,6 +134,9 @@ describe('UsersService#deleteMe (#1511)', () => {
         { provide: CloudTasksService, useValue: {} },
         { provide: RestaurantsRepository, useValue: {} },
         { provide: RestaurantsAssembler, useValue: {} },
+        { provide: DishMediaAssembler, useValue: {} },
+        { provide: DishCategoryGroupVotesRepository, useValue: {} },
+        { provide: PrismaService, useValue: {} },
         { provide: StorageService, useValue: storage },
         { provide: SupabaseAdminService, useValue: supabaseAdmin },
       ],

--- a/api/test/setup-test-env.ts
+++ b/api/test/setup-test-env.ts
@@ -1,0 +1,70 @@
+// api/test/setup-test-env.ts
+//
+// #1596 jest の `setupFiles` から、**テストファイルより前に**実行される。
+//
+// ## なぜ要るのか
+//
+// `core/config/env.ts` は import された瞬間に `process.env` を zod で検証し、
+// 足りなければ throw する。logger → ほぼ全ての service が推移的にこれを読むため、
+// **実 DB にも実 API にも触れない純粋な単体テストでも `.env` が無いと suite ごと落ちる。**
+//
+// そのせいで `pnpm --filter api test` は「env 起因で 9 suite が赤」の状態が常態化し、
+// PR ゲート（.github/workflows/pr-check.yml）から api の jest が丸ごと外されていた。
+// ゲートが無い間に、本体の変更へ追随し忘れたモックが 3 つの suite（26 件）を
+// «1 度も実行されないまま» にしていた（アカウント削除と通知設定の回帰テスト）。
+//
+// 個々の spec が `jest.mock('../../core/config/env')` で塞ぐ作法もリポジトリ内に既にあるが、
+// **spec を 1 本足すたびに書き忘れられる**ので、ここ 1 箇所で塞ぐ。
+//
+// ## 約束
+//
+// - **既に値があるものは絶対に上書きしない。** 実 `.env` や CI の secret がある環境では
+//   そちらが勝つ（この形でないと、意図せず本物の設定を隠してしまう）。
+// - 埋めるのは「zod schema で必須（optional でも default でもない）」ものだけ。
+// - 値はすべて明らかにダミーと分かる形にする。ここの値に依存するテストを書かせないため。
+
+import * as dotenv from 'dotenv';
+
+// 実 .env があるならそれを先に読む（この後の穴埋めより優先させる）。
+dotenv.config();
+
+/**
+ * `core/config/env.ts` の envSchema で必須（optional でも default でも無い）なキー。
+ *
+ * ⚠️ envSchema へ必須キーを足したら、ここにも足すこと。足し忘れると
+ * `pnpm --filter api test` が「Invalid environment variables」で赤くなるので、
+ * 黙って壊れることはない。
+ */
+const REQUIRED_TEST_ENV: Readonly<Record<string, string>> = {
+  API_COMMIT_ID: 'test-commit',
+  API_NODE_ENV: 'test',
+  CORS_ORIGIN: 'https://test.invalid',
+  DATABASE_URL: 'postgresql://test:test@127.0.0.1:5432/test?schema=test',
+  DB_SCHEMA: 'test',
+  SUPABASE_JWT_SECRET: 'test-supabase-jwt-secret',
+  GOOGLE_PLACE_API_KEY: 'test-google-place-api-key',
+  GCS_BUCKET_NAME: 'test-bucket',
+  GCS_BUCKET_PUBLIC_NAME: 'test-bucket-public',
+  GCS_STATIC_MASTER_DIR_PATH: 'test/static-master',
+  CLAUDE_API_KEY: 'test-claude-api-key',
+  GOOGLE_API_KEY: 'test-google-api-key',
+  GOOGLE_SEARCH_ENGINE_ID: 'test-search-engine-id',
+  GCP_PROJECT: 'test-project',
+  TASKS_LOCATION: 'asia-northeast1',
+  TRANSCODER_LOCATION: 'asia-northeast1',
+  TRANSCODER_PUBSUB_TOPIC: 'test-transcoder-topic',
+  CLOUD_RUN_URL: 'https://test-run.invalid',
+  TASKS_INVOKER_SA: 'test-tasks-invoker@test.invalid',
+  PUBSUB_PUSH_SA: 'test-pubsub-push@test.invalid',
+  CDN_HOST: 'test-cdn.invalid',
+  CDN_KEY_NAME: 'test-cdn-key',
+  // base64 として読める必要があるので、実際に base64 な文字列にしておく
+  CDN_KEY_SECRET_B64: Buffer.from('test-cdn-key-secret').toString('base64'),
+  CDN_PUBLIC_HOST: 'test-cdn-public.invalid',
+};
+
+for (const [key, value] of Object.entries(REQUIRED_TEST_ENV)) {
+  if (process.env[key] === undefined || process.env[key] === '') {
+    process.env[key] = value;
+  }
+}


### PR DESCRIPTION
`main` と `release/1.13` のツリー差分（1,097 ファイル / +167k 行）を 8 レーンで多角レビューした結果の修正。

Related: #1596

> `main` と `release/1.13` は**共通祖先を持たない**ため、commit ではなくツリー差分で比較している。

## 本体の欠陥（3 件）

### 1. 削除したレビューが «食べた» 記録として残る（High）

`api/src/v1/dish-media/dish-media.repository.ts`

`schema.prisma` は `dish_reviews.deleted_at` に「**読み取り経路は必ず deleted_at IS NULL で絞る**」と
定めているが、isEaten 判定 1 本だけが絞っていなかった。レビューを消しても
「食べたを記録」が記録済みの見た目のまま戻らない。

兄弟の読み取り（一覧 618 / 平均点 893 / Calendar の最古日 1224 / restaurants / users の集計）は
**すべて絞っており、ここだけが漏れていた**。型検査でもレビューでも捕まらない形。

### 2. 主催投票一覧のページングで行が欠落しうる（Medium）

`api/src/v1/dish-category-group-votes/dish-category-group-votes.repository.ts`

カーソルが `updated_at` 単独だったため、20 件目と 21 件目が同一 `updated_at` だと
`lt` が同時刻の行をまとめて落とし、**21 件目以降が一覧から永久に消えた**。
`touchSession` は候補追加・削除・投票のたびに走るので «稀» であって «起きない» ではない。

`(updated_at, id)` の複合カーソルへ変更し、`orderBy` にも `id` を足して並びを固定（新規 `me-sessions-cursor.ts`）。
旧形式（ISO8601 のみ）のカーソルも受け続ける（配信済みクライアント互換）。
壊れたカーソルで 500 になる経路も併せて塞いだ。

この形はリポジトリの既存作法と一致している（`contribution-tasks.service.ts:133` が既に
`` `${created_at.toISOString()}|${id}` `` を使用。今回の差分の新規コードも一貫して tie-break を入れている）。

### 3. Google Custom Search の障害が error レベルに乗らない（Medium）

`api/src/core/external-api/external-api.service.ts`

spec は «403 は warn / それ以外は error» を要求していたが、**実装は全部 warn だった**。
5xx・ネットワーク断が error-triage の起票対象から外れていた。

## テストが 26 件、動いていなかった（High）

`pnpm --filter api test` は「env を要求し、かつ現状 red」を理由に **PR ゲートから外されていた**
（`pr-check.yml` の冒頭コメントに明記されていた）。その間にモックが本体から静かにズレ、
**3 suite / 26 件が «1 度も実行されないまま緑扱い»** になっていた。
いずれも **この差分で入った機能そのものの回帰テスト**である。

| suite | 件数 | ズレの内容 |
| --- | --- | --- |
| `users.service.delete-me.spec.ts` | 6 | `UsersService` へ後から足された 3 依存が provider に無く、Nest の組み立てごと失敗（アカウント削除 #1511） |
| `notification-job.service.spec.ts` | 14 | #1510 で足した `isPushAllowedForKind` が未追随 |
| `notification-job.preferences.spec.ts` | 6 | `findUnique`→`findFirst`、さらに #1557 の `getUsersByIdsIncludingDeleted` も未追随（**3 段のズレ**） |

env 依存は `api/test/setup-test-env.ts` が「**未設定のキーだけ**」ダミーで埋めて外した
（実 `.env` / CI secret があればそちらが勝つ）。これで env 起因の 9 suite も動き出し、
隠れていた spec の壊れ（locations / dish-category-variants / external-api）も表面化したので併せて修正。

**49 → 62 suites / 703 → 788 tests が全て green。** `pnpm --filter api test` をゲートへ追加した。

## 再発防止: 論理削除ラチェット

`api/src/v1/dish-media/soft-delete-read-boundary.spec.ts` を追加。
`dish_reviews` / `dish_media` を読む全経路が `deleted_at` で絞っていることを静的に強制する。
1 の型は人の注意では守れない（1 箇所漏れれば穴）。

- `findUnique` は Prisma の制約上 `where` に `deleted_at` を書けないため対象外
- 通報の存在確認と、退会時のストレージ実体削除は理由付きで EXCLUSIONS

**この検査自身が最初は両方向に嘘をついたので直してある。**
（a）fix に添えた説明コメント内の `deleted_at` を «絞っている証拠» と誤認して見逃す
（b）コメント内に例示された `dish_media.findMany(` を本物と誤認して誤検知する
コメントを**同じ長さの空白へ潰す**ことで両方を塞いだ（行番号がズレないため報告位置も正確）。

## 検証

```
pnpm --filter api test         → 62 suites / 788 tests 全 green（修正前: 12 suites / 26 tests が red）
pnpm --filter api typecheck    → OK
pnpm --filter app-expo test    → 154 suites / 1537 tests 全 green
pnpm --filter app-expo typecheck / lint / assert:no-hardcoded-colors → OK
pnpm --filter shared test      → OK
pnpm --filter e2e-web typecheck / e2e-mobile typecheck / prisma validate → OK
pnpm assert:doc-hygiene / assert:no-nested-e2e-tests / assert:remote-config-defaults → OK
```

pr-check.yml のゲート全 19 step をローカルで通してある。

**ラチェットの有効性は「壊すと赤・直すと緑」で実測済み。**

- `dish_reviews`: isEaten の `deleted_at` を外す → `dish-media.repository.ts:955` を検出
- `dish_media`: `tools-dish-categories.repository.ts:106` の `deleted_at` を外す → 同行を検出

独立レビュー run の結論は **「マージしてよい」**:
https://github.com/Ayato-kosaka/nanitabeyo/issues/1596#issuecomment-5418453670

## 今回は触っていないもの

`dish-media.repository.ts:620`（自分のレビュー一覧）と `:698`（いいね一覧）にも同じ
tie-break 漏れがあるが、**どちらも 1.13 以前から存在**しており今回の差分が持ち込んだ劣化ではない。
別途対応する。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_