### PR TITLE
fix(#1599): 店舗の料理メディア一覧で、壊れたカーソルが 500 になるのを塞ぐ

### DIFF
--- a/api/src/v1/dish-media/dish-media.repository.ts
+++ b/api/src/v1/dish-media/dish-media.repository.ts
@@ -45,6 +45,10 @@ import {
   buildCursorOrderBy,
   formatCompositeCursor,
 } from '../../core/pagination/composite-cursor';
+import {
+  formatRestaurantDishMediaCursor,
+  parseRestaurantDishMediaCursor,
+} from './restaurant-dish-media-cursor';
 
 /** #817 優先言語のレビュー先読みクエリの戻り値 */
 type DishReviewWithUser = Prisma.dish_reviewsGetPayload<{
@@ -501,12 +505,16 @@ export class DishMediaRepository {
     restaurantId: string,
     { limit = 42, cursor: cursorStr }: QueryRestaurantDishMediaDto,
   ) {
-    const cursor = cursorStr
-      ? {
-          likeCount: Number(cursorStr.split('_')[0]),
-          mediaId: cursorStr.split('_')[1],
-        }
-      : null;
+    // #1599 カーソルはクライアントから来る任意の文字列なので、形を検証してから使う。
+    //
+    // 以前は `Number(...)` と `split('_')[1]` の結果を無検証で raw SQL へ流していた。
+    // 壊れたカーソルを渡すと:
+    //   - `?cursor=abc`        → mediaId が undefined
+    //   - `?cursor=1_notauuid` → `'notauuid'::uuid` で **PostgreSQL が例外を投げる（500）**
+    //   - `?cursor=abc_<uuid>` → like_count が NaN になり比較が壊れる
+    // どれも «一覧が開けない» になる。**壊れたカーソルは先頭ページへ倒す**のが正しい
+    // （`core/pagination/composite-cursor.ts` と同じ方針）。
+    const cursor = parseRestaurantDishMediaCursor(cursorStr);
     const cursorWhere = cursor
       ? Prisma.sql`
           AND (
@@ -572,7 +580,7 @@ export class DishMediaRepository {
     const last = items[items.length - 1];
     const nextCursor: string | null =
       hasMore && items.length > 0
-        ? `${last.like_count}_${last.dish_media_id}`
+        ? formatRestaurantDishMediaCursor(last.like_count, last.dish_media_id)
         : null;
 
     return { items, nextCursor };

--- a/api/src/v1/dish-media/restaurant-dish-media-cursor.spec.ts
+++ b/api/src/v1/dish-media/restaurant-dish-media-cursor.spec.ts
@@ -1,0 +1,57 @@
+// api/src/v1/dish-media/restaurant-dish-media-cursor.spec.ts
+//
+// #1599 `GET /v1/restaurants/:id/dish-media` のカーソル検証。
+//
+// ここが無かったせいで、壊れたカーソルが raw SQL の `${mediaId}::uuid` まで届き、
+// **PostgreSQL の `invalid input syntax for type uuid` で 500** になっていた。
+// カーソルは `@IsString()` しか掛かっていないので、任意の文字列が届く。
+
+import {
+  formatRestaurantDishMediaCursor,
+  parseRestaurantDishMediaCursor,
+} from './restaurant-dish-media-cursor';
+
+const UUID = '3f1a2b4c-5d6e-4f70-8a9b-0c1d2e3f4a5b';
+
+describe('#1599 restaurant dish-media カーソル', () => {
+  it('往復して同じ値になる', () => {
+    const cursor = formatRestaurantDishMediaCursor(12, UUID);
+    expect(cursor).toBe(`12_${UUID}`);
+    expect(parseRestaurantDishMediaCursor(cursor)).toEqual({
+      likeCount: 12,
+      mediaId: UUID,
+    });
+  });
+
+  it('いいね 0 件のカーソルも通る（0 は有効な値）', () => {
+    expect(parseRestaurantDishMediaCursor(`0_${UUID}`)).toEqual({
+      likeCount: 0,
+      mediaId: UUID,
+    });
+  });
+
+  // ここが本題。どれも以前は raw SQL まで到達していた。
+  it.each([
+    ['区切りが無い', 'abc'],
+    ['UUID でない', '1_notauuid'],
+    ['UUID が空', '1_'],
+    ['いいね数が数値でない', `abc_${UUID}`],
+    ['いいね数が空', `_${UUID}`],
+    ['いいね数が負', `-1_${UUID}`],
+    ['いいね数が小数', `1.5_${UUID}`],
+    ['いいね数が Infinity', `Infinity_${UUID}`],
+    ['SQL に見える文字列', `1_'; DROP TABLE dish_media; --`],
+    ['空文字', ''],
+    ['null', null],
+    ['undefined', undefined],
+  ])('壊れたカーソル（%s）は null（先頭ページ）へ倒す', (_label, input) => {
+    expect(
+      parseRestaurantDishMediaCursor(input as string | null | undefined),
+    ).toBeNull();
+  });
+
+  // UUID に `_` は現れないので、最初の `_` で割って問題ない
+  it('UUID 部分に `_` が混ざっていたら弾く', () => {
+    expect(parseRestaurantDishMediaCursor('1_3f1a2b4c_5d6e')).toBeNull();
+  });
+});

--- a/api/src/v1/dish-media/restaurant-dish-media-cursor.ts
+++ b/api/src/v1/dish-media/restaurant-dish-media-cursor.ts
@@ -1,0 +1,52 @@
+// api/src/v1/dish-media/restaurant-dish-media-cursor.ts
+//
+// #1599 `GET /v1/restaurants/:id/dish-media` のカーソル。
+//
+// 形式は `"<like_count>_<dish_media_id(UUID)>"`。UUID に `_` は現れないので
+// 最初の `_` で 2 つに割れる。
+//
+// **壊れた入力は `null`（＝先頭ページ）へ倒す。** カーソルはクライアントから来る
+// 任意の文字列で、そのまま raw SQL へ流すと `'notauuid'::uuid` で PostgreSQL が
+// 例外を投げ、一覧が丸ごと開けなくなる（500）。
+
+/** 解釈できたカーソル */
+export type RestaurantDishMediaCursor = {
+  likeCount: number;
+  mediaId: string;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** `like_count` と `dish_media_id` からカーソル文字列を作る */
+export function formatRestaurantDishMediaCursor(
+  likeCount: number,
+  mediaId: string,
+): string {
+  return `${likeCount}_${mediaId}`;
+}
+
+/** カーソル文字列を解釈する。解釈できなければ `null`（先頭ページ） */
+export function parseRestaurantDishMediaCursor(
+  cursor: string | null | undefined,
+): RestaurantDishMediaCursor | null {
+  if (typeof cursor !== 'string' || cursor.length === 0) return null;
+
+  const separatorIndex = cursor.indexOf('_');
+  if (separatorIndex === -1) return null;
+
+  const likeCountText = cursor.slice(0, separatorIndex);
+  const mediaId = cursor.slice(separatorIndex + 1);
+
+  // `Number('')` は 0 になってしまうので、空文字を先に弾く
+  if (likeCountText.length === 0) return null;
+
+  const likeCount = Number(likeCountText);
+  // NaN / Infinity / 小数 を弾く。like_count は非負整数
+  if (!Number.isInteger(likeCount) || likeCount < 0) return null;
+
+  // `::uuid` へキャストするので、UUID でないものは絶対に通さない
+  if (!UUID_PATTERN.test(mediaId)) return null;
+
+  return { likeCount, mediaId };
+}


### PR DESCRIPTION
夜間オーケストレーションループ ラウンド 2。Related: #1599

## 何が起きていたか

`GET /v1/restaurants/:id/dish-media` のカーソルは `"<like_count>_<dish_media_id>"` という
独自形式だが、**無検証で raw SQL へ流していた**。

```ts
const cursor = cursorStr
  ? { likeCount: Number(cursorStr.split('_')[0]), mediaId: cursorStr.split('_')[1] }
  : null;
```

DTO は `@IsString()` しか掛かっていないので、**任意の文字列が届く**。

| 入力 | 起きること |
| --- | --- |
| `?cursor=1_notauuid` | `'notauuid'::uuid` で **PostgreSQL が例外 → 500** |
| `?cursor=abc` | `mediaId` が `undefined` のまま SQL へ |
| `?cursor=abc_<uuid>` | `like_count` が `NaN` になり比較が壊れる |

いちばん重いのは 1 番目で、**店舗詳細の一覧が丸ごと開けなくなる**。

> ⚠️ これは SQL インジェクションではない（Prisma がパラメータ化している）。
> **`::uuid` へのキャストが失敗する**ので、パラメータ化では防げない種類の失敗である。

## 直し方

`restaurant-dish-media-cursor.ts` を追加し、形を検証してから使う。
壊れていたら `null`（＝先頭ページ）へ倒す — `core/pagination/composite-cursor.ts` と同じ方針。
**一覧が丸ごと 500 になるより、先頭ページが返るほうがまし。**

- `like_count` は非負整数のみ（`NaN` / `Infinity` / 小数 / 負 を弾く）
- `dish_media_id` は UUID の形にマッチするものだけ（`::uuid` へ渡すので絶対に通さない）
- 区切りが無い / 空文字 / `null` / `undefined` も先頭ページへ

## 見つけ方について

ラウンド 1 で入れたラチェット（`new Date(cursor)` の禁止）は **この経路を拾えなかった**。
カーソルが日付ではなく `likeCount_uuid` という別形式だったため。
レビューワーカー（R2-B）が「NaN が SQL に流れる」として拾ったもの。

なお、ワーカーの見立ては **「結果が 0 件になる可能性」** だったが、
自分で追ったところ **`::uuid` のキャスト失敗で 500 になる**のが本体だった。
報告をそのまま採用せず、実際の失敗経路を確かめている。

## 検証

```
pnpm --filter api test      → 66 suites / 828 tests 全 green
pnpm --filter api typecheck → OK
```

追加テスト 15 件。上の表の壊れた入力（`1_notauuid` / `abc` / `abc_<uuid>` /
負 / 小数 / `Infinity` / SQL に見える文字列 / 空 / `null` / `undefined`）が
**すべて先頭ページへ倒れる**ことを固定した。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_