### PR TITLE
fix(api): 外部APIログのエンドポイントから API キーと現在地を落とす (#1599)

### DIFF
--- a/api/src/core/logger/external-api-endpoint-redaction.spec.ts
+++ b/api/src/core/logger/external-api-endpoint-redaction.spec.ts
@@ -1,0 +1,119 @@
+// api/src/core/logger/external-api-endpoint-redaction.spec.ts
+//
+// #1599 **外部 API のエンドポイントを、クエリ文字列ごとログへ残さない。**
+//
+// `external_api_logs` は BigQuery へ蓄積され、error-triage 経由で
+// **公開リポジトリの Issue へも転載される**。以下が実際に入っていた:
+//
+//   - Google Custom Search: `?key=<APIキー>&cx=<エンジンID>&q=<検索語>`
+//   - Google 逆ジオコーディング: `?key=<APIキー>&latlng=<ユーザーの現在地>`
+//
+// 呼び出し側で 1 つずつ直す方式は「次に追加された呼び出しが漏らす」ので採らない。
+// **唯一の出口である logger でクエリを丸ごと落とす。**
+
+import { AppLoggerService, sanitizeEndpointForLog } from './logger.service';
+
+describe('#1599 sanitizeEndpointForLog', () => {
+  it('Google Custom Search の API キー・エンジン ID・検索語を落とす', () => {
+    const leaked =
+      'https://www.googleapis.com/customsearch/v1?key=AIza-SECRET-KEY&cx=ENGINE-ID&q=%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%B3';
+
+    const safe = sanitizeEndpointForLog(leaked);
+
+    expect(safe).toBe('https://www.googleapis.com/customsearch/v1');
+    expect(safe).not.toContain('AIza-SECRET-KEY');
+    expect(safe).not.toContain('ENGINE-ID');
+    expect(safe).not.toContain('q=');
+  });
+
+  it('逆ジオコーディングの API キーと緯度経度（現在地）を落とす', () => {
+    const leaked =
+      'https://maps.googleapis.com/maps/api/geocode/json?latlng=35.681236%2C139.767125&key=AIza-SECRET-KEY&language=ja';
+
+    const safe = sanitizeEndpointForLog(leaked);
+
+    expect(safe).toBe('https://maps.googleapis.com/maps/api/geocode/json');
+    expect(safe).not.toContain('AIza-SECRET-KEY');
+    // 現在地が残らないこと。ここが残ると «誰がどこに居たか» がログに溜まる
+    expect(safe).not.toContain('35.681236');
+    expect(safe).not.toContain('139.767125');
+  });
+
+  it('セッショントークンも落ちる', () => {
+    const safe = sanitizeEndpointForLog(
+      'https://places.googleapis.com/v1/places/PLACE_ID?languageCode=ja&sessionToken=abc-123',
+    );
+    expect(safe).toBe('https://places.googleapis.com/v1/places/PLACE_ID');
+    expect(safe).not.toContain('abc-123');
+  });
+
+  it('フラグメントも落とす', () => {
+    expect(sanitizeEndpointForLog('https://example.test/a#secret')).toBe(
+      'https://example.test/a',
+    );
+  });
+
+  it('クエリの無い URL はそのまま（どの API を叩いたかは残す）', () => {
+    expect(sanitizeEndpointForLog('https://api.anthropic.com/v1/messages')).toBe(
+      'https://api.anthropic.com/v1/messages',
+    );
+  });
+
+  // URL として壊れていても、`?` 以降は落とす（保険）
+  it.each([
+    ['URL でない文字列', 'not a url?key=SECRET', 'not a url'],
+    ['空文字', '', ''],
+  ])('%s', (_label, input, expected) => {
+    expect(sanitizeEndpointForLog(input)).toBe(expected);
+  });
+
+  it.each([null, undefined])('%p でも throw しない', (input) => {
+    expect(sanitizeEndpointForLog(input as unknown as string)).toBe('');
+  });
+});
+
+// ヘルパー単体が正しいだけでは足りない。**実際に吐かれる 1 行**に鍵が無いことを見る。
+describe('#1599 externalApi() が実際に出力する行', () => {
+  it('API キーと現在地が 1 文字も含まれない', async () => {
+    const emitted: string[] = [];
+    const spy = jest
+      .spyOn(console, 'log')
+      .mockImplementation((line: unknown) => {
+        emitted.push(String(line));
+      });
+
+    try {
+      const logger = new AppLoggerService({
+        get: () => undefined,
+      } as never);
+
+      await logger.externalApi({
+        api_name: 'Google Geocoding API',
+        endpoint:
+          'https://maps.googleapis.com/maps/api/geocode/json?latlng=35.681236%2C139.767125&key=AIza-SECRET-KEY',
+        method: 'GET',
+        request_payload: {},
+        response_payload: null,
+        status_code: 200,
+        response_time_ms: 12,
+        function_name: 'callReverseGeocoding',
+        error_message: null,
+      } as never);
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(emitted).toHaveLength(1);
+    const line = emitted[0];
+
+    expect(line).not.toContain('AIza-SECRET-KEY');
+    expect(line).not.toContain('35.681236');
+
+    // どの API を叩いたかは残っていること（消しすぎていない）
+    const parsed = JSON.parse(line);
+    expect(parsed.endpoint).toBe(
+      'https://maps.googleapis.com/maps/api/geocode/json',
+    );
+    expect(parsed.api_name).toBe('Google Geocoding API');
+  });
+});

--- a/api/src/core/logger/logger.service.ts
+++ b/api/src/core/logger/logger.service.ts
@@ -19,6 +19,29 @@ import {
  *  - Nest LoggerService を実装
  *  - Cloud Logging 向けの構造化 JSON を stdout に出力
  */
+/**
+ * #1599 ログへ残す外部 API のエンドポイントから、**クエリ文字列とフラグメントを落とす**。
+ *
+ * 認証情報（`?key=`、`?token=`）も、ユーザー由来の値（`?latlng=`、`?q=`）も、
+ * まとめてクエリに乗る。個別のキー名を列挙して弾く方式は、
+ * **新しいキー名が増えたときに黙って漏れる**ので採らない。丸ごと落とす。
+ *
+ * どの API を叩いたかは `api_name` と `pathname` で十分に分かる。
+ * パラメータの中身が要るなら `request_payload`（マスキング付き）を見る。
+ */
+export function sanitizeEndpointForLog(endpoint: string): string {
+  if (typeof endpoint !== 'string' || endpoint.length === 0) return '';
+
+  try {
+    const url = new URL(endpoint);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    // URL として解釈できない文字列でも、`?` 以降は落としておく（保険）
+    const queryIndex = endpoint.indexOf('?');
+    return queryIndex === -1 ? endpoint : endpoint.slice(0, queryIndex);
+  }
+}
+
 @Injectable({ scope: Scope.DEFAULT })
 export class AppLoggerService implements INestLoggerService {
   constructor(private readonly cls: ClsService) {}
@@ -99,7 +122,15 @@ export class AppLoggerService implements INestLoggerService {
         request_id: this.cls.get<string>(CLS_KEY_REQUEST_ID),
         function_name: input.function_name,
         api_name: input.api_name,
-        endpoint: input.endpoint,
+        // #1599 **クエリ文字列は落としてから記録する。**
+        // 呼び出し側が `?key=<APIキー>` を含む URL をそのまま渡していたため、
+        // Google の API キーと、逆ジオコーディングの `latlng=`（ユーザーの現在地）が
+        // `external_api_logs` へ入っていた。ログは BigQuery へ蓄積され、
+        // error-triage 経由で **公開リポジトリの Issue へも転載される**。
+        //
+        // ここ（唯一の出口）で落とすことで、呼び出し側が何を渡しても漏れない。
+        // `safe-fetch.service.ts` も同じ方針で origin + pathname だけを渡している。
+        endpoint: sanitizeEndpointForLog(input.endpoint),
         method: input.method,
         request_payload: this.convertToBigQueryRecord(input.request_payload),
         response_payload: this.convertToBigQueryRecord(input.response_payload),


### PR DESCRIPTION
## 何が起きていたか

`AppLoggerService.externalApi()` が受け取った `endpoint` を、**クエリ文字列ごとそのまま** `external_api_logs` へ書いていた。呼び出し側は API キーをクエリに乗せた URL を渡している。

| 漏れていたもの | 出どころ |
| --- | --- |
| Google API キー / 検索エンジン ID / 検索語 | `api/src/core/external-api/external-api.service.ts` の Custom Search 呼び出し（`?key=${googleApiKey}&cx=...&q=...`） |
| Google API キー / **ユーザーの現在地**（`latlng=`） | 同ファイルの逆ジオコーディング（`url.searchParams.append('key', ...)` した後の `url.toString()`） |

このログは stdout → Cloud Logging → **BigQuery** へ蓄積され、`error-triage` 経由で**公開リポジトリの Issue 本文へ転載される**経路がある。つまり秘密鍵とユーザーの位置情報が公開される導線が実在した。

なお `customHeaders` 経由で渡す `X-Goog-Api-Key` / `x-api-key` はログに載らないことを確認済み（漏れていたのはクエリ経路だけ）。

## どう直したか

**呼び出し側ではなく、唯一の出口である `logger.externalApi()` で落とす。**

```ts
export function sanitizeEndpointForLog(endpoint: string): string {
  if (typeof endpoint !== 'string' || endpoint.length === 0) return '';
  try {
    const url = new URL(endpoint);
    return `${url.origin}${url.pathname}`;
  } catch {
    const queryIndex = endpoint.indexOf('?');
    return queryIndex === -1 ? endpoint : endpoint.slice(0, queryIndex);
  }
}
```

- 呼び出し側 3 箇所（`safe-fetch.service.ts:669` / `external-api.service.ts:649` / `:671`）を個別に直す方式は採らなかった。**次に増える呼び出し側が同じ事故を再現できてしまう**ため
- キー名の列挙（`key`, `token`, ...）による除去も採らなかった。**新しいキー名が増えたときに黙って漏れる**ため。クエリとフラグメントを丸ごと落とす
- 既に `safe-fetch.service.ts` が `${url.origin}${url.pathname}` を渡す方針を採っており、それに揃えた形になる

**失うもの:** クエリパラメータの中身。どの API を叩いたかは `api_name` + `pathname` で分かり、パラメータが要るならマスキング済みの `request_payload` を見る。

## テスト

新規 `api/src/core/logger/external-api-endpoint-redaction.spec.ts`（10 件）。

- 実際に流れる 2 経路の URL で、キー・エンジン ID・検索語・`latlng` が落ちること
- `sessionToken`、フラグメント、クエリの無い URL、URL でない文字列、空文字、`null` / `undefined`
- **境界テスト**: `console.log` を捕まえ、`externalApi()` が実際に出力する JSON の行そのものに `AIza-SECRET-KEY` と `35.681236` が 1 文字も含まれず、かつ `parsed.endpoint === 'https://maps.googleapis.com/maps/api/geocode/json'` であること

## 検証

- `pnpm --filter api test` → **67 suites / 838 tests 全 green**
- `pnpm --filter api typecheck` / `pnpm --filter app-expo typecheck` → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_