### PR TITLE
fix(api): 同じ料理カテゴリの同時登録が P2002 で 500 になるのを直す (#1599)

### DIFF
--- a/api/src/v1/dishes/dishes.repository.spec.ts
+++ b/api/src/v1/dishes/dishes.repository.spec.ts
@@ -40,3 +40,129 @@ describe('DishesRepository.createOrGetRestaurant', () => {
     });
   });
 });
+
+describe('#1599 DishesRepository.createOrGetDishForCategory', () => {
+  const findFirst = jest.fn();
+  const createMany = jest.fn();
+  const create = jest.fn();
+  const tx = {
+    dishes: { findFirst, createMany, create },
+  } as unknown as Prisma.TransactionClient;
+
+  const dish = {
+    restaurant_id: 'restaurant-1',
+    category_id: 'category-1',
+    name: 'ラーメン',
+  };
+  const where = { restaurant_id: 'restaurant-1', category_id: 'category-1' };
+
+  let repository: DishesRepository;
+
+  beforeEach(() => {
+    findFirst.mockReset();
+    createMany.mockReset().mockResolvedValue({ count: 1 });
+    create.mockReset();
+    repository = new DishesRepository(
+      {} as never,
+      { debug: jest.fn() } as never,
+    );
+  });
+
+  it('既にあるなら 1 クエリで返し、書き込みを試みない', async () => {
+    findFirst.mockResolvedValueOnce({ id: 'dish-1', ...dish });
+
+    await expect(repository.createOrGetDishForCategory(tx, dish)).resolves.toEqual(
+      { id: 'dish-1', ...dish },
+    );
+
+    expect(findFirst).toHaveBeenCalledTimes(1);
+    expect(findFirst).toHaveBeenCalledWith({ where });
+    expect(createMany).not.toHaveBeenCalled();
+  });
+
+  it('無いなら ON CONFLICT DO NOTHING で入れて読み直す', async () => {
+    findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'dish-2', ...dish });
+
+    await expect(repository.createOrGetDishForCategory(tx, dish)).resolves.toEqual(
+      { id: 'dish-2', ...dish },
+    );
+
+    // #1599 `create` は P2002 を投げうるので、この経路では絶対に使わない。
+    // tx 内で P2002 が出るとトランザクション全体が aborted になり、
+    // catch して読み直すこともできなくなる。
+    expect(create).not.toHaveBeenCalled();
+    expect(createMany).toHaveBeenCalledWith({
+      data: [dish],
+      skipDuplicates: true,
+    });
+    expect(findFirst).toHaveBeenCalledTimes(2);
+  });
+
+  it('id を渡されても create 入力からは落とす（DB 側の default に任せる）', async () => {
+    findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'generated', ...dish });
+
+    await repository.createOrGetDishForCategory(tx, {
+      ...dish,
+      id: 'caller-supplied-id',
+    });
+
+    expect(createMany).toHaveBeenCalledWith({
+      data: [dish],
+      skipDuplicates: true,
+    });
+  });
+
+  it('競合: 2 本が同時に走っても、両方が同じ 1 行を返す（P2002 で 500 にならない）', async () => {
+    // 実際の並行実行を模す。どちらの findFirst も空振りしたあと、
+    // 片方の insert だけが実行され、もう片方は ON CONFLICT DO NOTHING で
+    // 何もしない（= 例外にならない）。読み直しは両方が同じ行を見る。
+    const rows: { id: string; restaurant_id: string; category_id: string }[] =
+      [];
+
+    findFirst.mockImplementation(async () => {
+      // 1 本目・2 本目の先行 findFirst はまだ何も無いので空を返す
+      return (
+        rows.find(
+          (r) =>
+            r.restaurant_id === where.restaurant_id &&
+            r.category_id === where.category_id,
+        ) ?? null
+      );
+    });
+    createMany.mockImplementation(async () => {
+      const duplicate = rows.some(
+        (r) =>
+          r.restaurant_id === where.restaurant_id &&
+          r.category_id === where.category_id,
+      );
+      if (duplicate) {
+        // ON CONFLICT DO NOTHING: 投げずに 0 件
+        return { count: 0 };
+      }
+      rows.push({ id: 'winner', ...where });
+      return { count: 1 };
+    });
+
+    const [a, b] = await Promise.all([
+      repository.createOrGetDishForCategory(tx, dish),
+      repository.createOrGetDishForCategory(tx, dish),
+    ]);
+
+    expect(a).toEqual({ id: 'winner', ...where });
+    expect(b).toEqual({ id: 'winner', ...where });
+    expect(rows).toHaveLength(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('読み直しても見つからないなら黙って壊れず、原因の分かる例外にする', async () => {
+    findFirst.mockResolvedValue(null);
+
+    await expect(
+      repository.createOrGetDishForCategory(tx, dish),
+    ).rejects.toThrow(/createOrGetDishForCategory/);
+  });
+});

--- a/api/src/v1/dishes/dishes.repository.ts
+++ b/api/src/v1/dishes/dishes.repository.ts
@@ -100,12 +100,26 @@ export class DishesRepository {
       lock_no?: number;
     },
   ) {
-    const existing = await tx.dishes.findFirst({
-      where: {
-        restaurant_id: dish.restaurant_id,
-        category_id: dish.category_id,
-      },
-    });
+    // #1599 【バグ】ここは `findFirst` → 無ければ `create` という
+    // TOCTOU（time-of-check to time-of-use）だった。dishes には
+    // `@@unique([restaurant_id, category_id])`（dishes_restaurant_category_unique）が
+    // 張ってあるため、同じ (restaurant_id, category_id) のリクエストが同時に来ると
+    // 両方の findFirst が空振りし、後発の create が P2002 で落ちて 500 になる。
+    //
+    // ⚠️ **catch して読み直す方式は Postgres では成立しない。** ここは `tx`
+    //    （$transaction 内）で動いており、P2002 が出た時点でトランザクション全体が
+    //    aborted 状態になるので、同じ tx 内での後続クエリはすべて失敗する。
+    //    **そもそも例外を出さない**必要がある。
+    //
+    // そこで `createMany({ skipDuplicates: true })`（= INSERT ... ON CONFLICT DO NOTHING）
+    // を使う。競合しても例外にならず、トランザクションも生きたままになる。
+    // 既に dish_reviews で採っているのと同じ手（createDishReviews 参照）。
+    const where = {
+      restaurant_id: dish.restaurant_id,
+      category_id: dish.category_id,
+    };
+
+    const existing = await tx.dishes.findFirst({ where });
 
     if (existing) {
       return existing;
@@ -113,9 +127,26 @@ export class DishesRepository {
 
     const { id: _omitId, ...createData } = dish;
 
-    return tx.dishes.create({
-      data: createData,
+    await tx.dishes.createMany({
+      data: [createData],
+      skipDuplicates: true,
     });
+
+    // ON CONFLICT DO NOTHING は「自分が入れた」「他が入れた」を区別しないので、
+    // どちらの場合も読み直して確定した行を返す。
+    //
+    // 【設計】READ COMMITTED（Postgres の既定 = Prisma $transaction の既定）を前提にしている。
+    // 文ごとに新しいスナップショットを取るため、DO NOTHING が競合相手の commit を待った後の
+    // この findFirst は、その行を必ず見られる。REPEATABLE READ 以上へ上げるとここが破れる。
+    const persisted = await tx.dishes.findFirst({ where });
+
+    if (!persisted) {
+      throw new Error(
+        `createOrGetDishForCategory: dish が見つからない (restaurant_id=${dish.restaurant_id}, category_id=${dish.category_id})`,
+      );
+    }
+
+    return persisted;
   }
 
   /**


### PR DESCRIPTION
## 何が起きていたか

`DishesRepository.createOrGetDishForCategory` は **`findFirst` → 無ければ `create`** という TOCTOU（time-of-check to time-of-use）だった。

`dishes` には複合ユニークが張ってある（`api/prisma/schema.prisma:413`）:

```prisma
@@unique([restaurant_id, category_id], map: "dishes_restaurant_category_unique")
```

同じ `(restaurant_id, category_id)` のリクエストが同時に来ると、**両方の `findFirst` が空振りし、後発の `create` が P2002 で落ちて 500** になる。

同じ店の同じカテゴリは複数ユーザーが同時に踏みやすい経路で、実際に `dishes.service.ts` の catch には既に観測コメントがある:

> `#1223 【観測】…同時実行で同じ google_place_id を insert した場合の P2002 などが典型。`

呼び出し元は 3 箇所（`dishes.service.ts:127` / `:851` / `internal/dishes/create-dish-media-entry.service.ts:367`）、いずれも `$transaction` の中。

## なぜ「catch して読み直す」ではないか

**Postgres では成立しないため。** ここは `$transaction` 内で動いており、P2002 が出た時点でトランザクション全体が aborted 状態になる。同じ `tx` での後続クエリはすべて `current transaction is aborted` で失敗するので、catch しても読み直せない。**そもそも例外を出さない**必要がある。

`upsert` も採らなかった。Prisma がネイティブの `INSERT ... ON CONFLICT` へ落とせる条件を満たさなかった場合、内部で find→create にフォールバックして同じ P2002 を投げうるため、バージョン依存の賭けになる。

## どう直したか

`createMany({ skipDuplicates: true })`（= `INSERT ... ON CONFLICT DO NOTHING`）を使う。競合しても例外にならず、トランザクションも生きたまま残る。

```ts
const existing = await tx.dishes.findFirst({ where });
if (existing) return existing;              // 既存の速い経路は 1 クエリのまま

await tx.dishes.createMany({ data: [createData], skipDuplicates: true });

// DO NOTHING は「自分が入れた」「他が入れた」を区別しないので、どちらも読み直す
const persisted = await tx.dishes.findFirst({ where });
if (!persisted) throw new Error(`createOrGetDishForCategory: dish が見つからない (...)`);
return persisted;
```

- **既存行がある通常経路のクエリ数は変わらない**（`findFirst` 1 本）。増えるのは新規作成時だけ
- `dish_reviews` が既に同じ手を採っている（`createDishReviews`）ので、リポジトリ内の既存イディオムに揃う
- **前提**: READ COMMITTED（Postgres の既定 = Prisma `$transaction` の既定）。文ごとに新しいスナップショットを取るため、`DO NOTHING` が競合相手の commit を待った後の読み直しは必ずその行を見られる。REPEATABLE READ 以上へ上げるとここが破れるので、コードにその旨をコメントで残した

## テスト

`dishes.repository.spec.ts` に 5 件追加。

- 既存行があるときは 1 クエリで返し、書き込みを試みない
- 無いときは `create` ではなく `createMany({skipDuplicates:true})` を使う（`create` が呼ばれないことを明示的に検査）
- 呼び出し側が `id` を渡しても create 入力からは落とす
- **並行実行を模したケース**: 2 本が同時に走り、両方の先行 `findFirst` が空振り → 片方だけが insert、もう片方は `count: 0` で no-op → **両方が同じ 1 行を返し、行は 1 件しかできない**
- 読み直しでも見つからない場合は原因の分かる例外にする（黙って `undefined` を返さない）

**修正前のコードへ戻すと 7 件中 4 件が落ちることを確認済み**（テストが実際に回帰を捕まえることの確認）。

## 検証

- `pnpm --filter api test` → **67 suites / 843 tests 全 green**
- `pnpm --filter api typecheck` → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_