### PR TITLE
fix(api): SNS 取り込みの同時実行が P2002 で 500 になるのを直す (#1599)

### DIFF
--- a/api/src/v1/dish-media-imports/dish-media-imports.service.spec.ts
+++ b/api/src/v1/dish-media-imports/dish-media-imports.service.spec.ts
@@ -887,9 +887,15 @@ function createSaveTx(options?: {
     // #1513 論理削除されていた既存行の復活（deleted_at を戻す）
     mediaUndelete: jest.fn().mockResolvedValue({ id: 'media-existing' }),
     embeddingCreate: jest.fn().mockResolvedValue({}),
-    reactionCreate: jest.fn().mockResolvedValue({}),
+    // #1599 ON CONFLICT DO NOTHING。count が «新しく保存したか» になる
+    reactionCreate: jest
+      .fn()
+      .mockResolvedValue({ count: options?.alreadySaved ? 0 : 1 }),
+    // #1599 同じ (provider, 投稿, 料理) の同時取り込みを直列化する advisory lock
+    advisoryLock: jest.fn().mockResolvedValue([{}]),
   };
   const tx = {
+    $queryRaw: calls.advisoryLock,
     dishes: { upsert: calls.dishUpsert },
     dish_media: {
       create: calls.mediaCreate,
@@ -914,10 +920,7 @@ function createSaveTx(options?: {
       updateMany: jest.fn().mockResolvedValue({ count: 1 }),
     },
     reactions: {
-      findUnique: jest
-        .fn()
-        .mockResolvedValue(options?.alreadySaved ? { id: 'r-1' } : null),
-      create: calls.reactionCreate,
+      createMany: calls.reactionCreate,
     },
   };
   return { tx, calls };
@@ -959,7 +962,8 @@ describe('#1399 SNS 取り込みの保存', () => {
     expect(embeddingData.provider).toBe('tiktok');
 
     expect(calls.reactionCreate).toHaveBeenCalledTimes(1);
-    expect(calls.reactionCreate.mock.calls[0][0].data).toMatchObject({
+    // #1599 create({data:{...}}) から createMany({data:[{...}]}) へ変えた
+    expect(calls.reactionCreate.mock.calls[0][0].data[0]).toMatchObject({
       user_id: 'user-1',
       target_type: 'dish_media',
       action_type: 'save',
@@ -1110,7 +1114,13 @@ describe('#1399 SNS 取り込みの保存', () => {
       'user-2',
     );
 
-    expect(calls.reactionCreate).not.toHaveBeenCalled();
+    // #1599 ON CONFLICT DO NOTHING にしたので «呼ばない» ではなく
+    // «呼んでも 1 行も増えない（count: 0）» が正しい形になった。
+    // 二重に «保存した» と報告しないことをここで固定する。
+    expect(calls.reactionCreate).toHaveBeenCalledTimes(1);
+    expect(calls.reactionCreate.mock.calls[0][0]).toMatchObject({
+      skipDuplicates: true,
+    });
     expect(result).toMatchObject({ created: false, saved: false });
   });
 
@@ -1190,5 +1200,84 @@ describe('#1399 SNS 取り込みの保存', () => {
         'user-1',
       ),
     ).rejects.toThrow(/IMPORT_UNSUPPORTED/);
+  });
+});
+
+/**
+ * #1599 取り込みトランザクションの競合安全性。
+ *
+ * 「同じ SNS 投稿を、同じ料理へ、同時に 2 本取り込む」は findFirst → create の
+ * TOCTOU を踏む。tx 内で P2002 が出るとトランザクション全体が aborted になり、
+ * catch して読み直すこともできないので、«そもそも同時に来ない» 形にしてある。
+ */
+describe('#1599 取り込みの競合', () => {
+  const URL = 'https://www.tiktok.com/@scout2015/video/6718335390845095173';
+
+  const run = async (
+    tx: unknown,
+    userId = 'user-1',
+  ): Promise<{ saved: boolean }> => {
+    const { service, transport } = createHarness();
+    transport.route(TIKTOK_OEMBED, {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body: tiktokOembedBody('味噌ラーメン'),
+    });
+    (service as unknown as { prisma: { withTransaction: unknown } }).prisma = {
+      withTransaction: (cb: (t: unknown) => unknown) => cb(tx),
+    };
+    return (await service.create(
+      {
+        url: URL,
+        restaurantId: '11111111-1111-1111-1111-111111111111',
+        dishCategoryId: 'Q2',
+      },
+      userId,
+    )) as unknown as { saved: boolean };
+  };
+
+  it('dish_media を作る前に自然キーで advisory lock を取る', async () => {
+    const { tx, calls } = createSaveTx();
+    await run(tx);
+
+    expect(calls.advisoryLock).toHaveBeenCalledTimes(1);
+    // タグ付きテンプレートなので第 1 引数が文字列配列、第 2 引数以降が値
+    const [fragments, ...values] = calls.advisoryLock.mock.calls[0];
+    expect(fragments.join('?')).toContain('pg_advisory_xact_lock');
+    // ロックキーは (provider, 外部コンテンツ ID, dish) の自然キーで作る。
+    // ここが dish だけ／provider だけになると、別の投稿どうしまで直列化して
+    // しまうか、逆に同じ投稿の競合を取りこぼす。
+    expect(String(values[0])).toBe(
+      'dish_media_import:tiktok:6718335390845095173:dish-1',
+    );
+    // ロックは «無ければ作る» を判定する findFirst より前でなければ意味が無い
+    expect(calls.advisoryLock.mock.invocationCallOrder[0]).toBeLessThan(
+      calls.mediaCreate.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('reactions は P2002 を投げうる create ではなく ON CONFLICT DO NOTHING で入れる', async () => {
+    const { tx, calls } = createSaveTx();
+    await run(tx);
+
+    expect(calls.reactionCreate).toHaveBeenCalledTimes(1);
+    const arg = calls.reactionCreate.mock.calls[0][0];
+    expect(arg.skipDuplicates).toBe(true);
+    expect(arg.data).toHaveLength(1);
+    expect(arg.data[0]).toMatchObject({
+      user_id: 'user-1',
+      target_type: 'dish_media',
+      action_type: 'save',
+    });
+    // 生の create が残っていると、そこだけ P2002 で 500 になる
+    expect((tx as { reactions: Record<string, unknown> }).reactions.create).toBeUndefined();
+  });
+
+  it('競合して 1 行も増えなかったときは saved: true と偽らない', async () => {
+    const { tx, calls } = createSaveTx();
+    // ON CONFLICT DO NOTHING で弾かれた（= 別経路が先に保存していた）状況
+    calls.reactionCreate.mockResolvedValue({ count: 0 });
+
+    await expect(run(tx)).resolves.toMatchObject({ saved: false });
   });
 });

--- a/api/src/v1/dish-media-imports/dish-media-imports.service.ts
+++ b/api/src/v1/dish-media-imports/dish-media-imports.service.ts
@@ -245,6 +245,29 @@ export class DishMediaImportsService {
           update: {},
         });
 
+        /* 1.5 #1599 【バグ】以降の «無ければ作る» はすべて findFirst → create の
+           TOCTOU である。同じ SNS 投稿を同じ料理へ同時に取り込むリクエストが
+           2 本来ると、両方の findFirst が空振りして両方が create し、後発が
+           `dmee_provider_content_dish_uq` で P2002 になって 500 になる。
+
+           ⚠️ **catch して読み直す方式は取れない。** ここは `$transaction` 内で、
+              Postgres では P2002 が出た時点でトランザクション全体が aborted に
+              なるため、同じ tx での後続クエリはすべて失敗する。
+              «そもそも同時に来ない» ようにするしかない。
+
+           ⚠️ dish_media には自然キーの UNIQUE が無い（PK はランダム UUID）ので、
+              dmee 側だけを ON CONFLICT DO NOTHING にする手も使えない。
+              先に作った dish_media が «どこからも参照されない孤児» として
+              残ってしまう。
+
+           そこで自然キーで xact 単位の advisory lock を取り、この区間を直列化する。
+           `pg_advisory_xact_lock` は commit / rollback のどちらでも自動解放される
+           （明示的な unlock が不要で、途中で例外が出てもロックが残らない）。
+           待つのはまったく同じ (provider, 投稿, 料理) を同時に取り込む相手だけで、
+           tx 本体は短いので実質的な直列化コストは無い。 */
+        const importLockKey = `dish_media_import:${provider}:${externalContentId}:${dish.id}`;
+        await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext(${importLockKey})::bigint)`;
+
         /* 2. 同じ SNS 投稿が同じ料理へ既に取り込まれていないか */
         const existing = await tx.dish_media_external_embeddings.findFirst({
           where: {
@@ -336,21 +359,18 @@ export class DishMediaImportsService {
         }
 
         /* 5. 「食べたい」= reactions(save)。ここがユーザーとの唯一の紐付けである */
-        const alreadySaved = await tx.reactions.findUnique({
-          where: {
-            user_id_target_type_target_id_action_type: {
-              user_id: userId,
-              target_type: 'dish_media',
-              target_id: dishMediaId,
-              action_type: 'save',
-            },
-          },
-          select: { id: true },
-        });
-
-        if (!alreadySaved) {
-          await tx.reactions.create({
-            data: {
+        // #1599 ここも findUnique → create の TOCTOU だった。上の advisory lock は
+        // 取り込み経路どうしの競合しか直列化しないので、別経路（通常の save）と
+        // 同時に走ると `reactions` の複合 UNIQUE
+        // (user_id, target_type, target_id, action_type) で P2002 になりうる。
+        //
+        // `createMany({ skipDuplicates: true })` = INSERT ... ON CONFLICT DO NOTHING
+        // なら競合しても例外にならず、返ってくる count がそのまま
+        // «今回このユーザーのために新しく保存したか» になる（1 = 新規 / 0 = 既存）。
+        // findUnique + create の 2 クエリが 1 クエリに減る副産物もある。
+        const savedNow = await tx.reactions.createMany({
+          data: [
+            {
               user_id: userId,
               target_type: 'dish_media',
               target_id: dishMediaId,
@@ -359,14 +379,15 @@ export class DishMediaImportsService {
               created_version: appVersion,
               lock_no: 0,
             },
-          });
-        }
+          ],
+          skipDuplicates: true,
+        });
 
         return {
           dishMediaId,
           dishId: dish.id,
           created,
-          saved: !alreadySaved,
+          saved: savedNow.count === 1,
         };
       })
       .then(async (result) => {


### PR DESCRIPTION
#1604 と同じ TOCTOU が SNS 取り込みトランザクションにも 2 箇所あった（#1604 を直した流れで、`findFirst` → `create` を全 api にわたって機械的に洗い直して見つけたもの）。

## 何が起きていたか

`dish-media-imports.service.ts` の `withTransaction` の中に、`findFirst`／`findUnique` → 無ければ `create` が 2 箇所。

| # | テーブル | 効いている UNIQUE | 同時に踏むケース |
| --- | --- | --- | --- |
| 1 | `dish_media_external_embeddings` | `dmee_provider_content_dish_uq` (`provider, external_content_id, dish_id`) | バズった投稿を複数ユーザーが同時に同じ料理へ取り込む／同一ユーザーの二重タップ・リトライ |
| 2 | `reactions` | `(user_id, target_type, target_id, action_type)` | 同一ユーザーの二重タップ／取り込みと通常の save が同時 |

どちらも後発が **P2002 で落ちて 500**。

なお step 1 の `dishes` は既に `upsert` になっていた（この tx の作者はこの種の競合を意識していた）が、その先の 2 箇所が素通しだった。

## なぜ「catch して読み直す」ではないか

**Postgres では成立しない。** ここは `withTransaction` の中で、P2002 が出た時点でトランザクション全体が aborted になる。同じ `tx` での後続クエリはすべて `current transaction is aborted` で失敗するので、catch しても読み直せない。**そもそも例外を出さない**必要がある。

## どう直したか

### 1. `dish_media` + `dmee` → 自然キーの advisory lock で直列化

ここは #1604 のように `createMany({skipDuplicates:true})` へ置き換えられない。**`dish_media` には自然キーの UNIQUE が無い**（PK はランダム UUID）ため、dmee 側だけを `ON CONFLICT DO NOTHING` にすると、先に作った `dish_media` が**どこからも参照されない孤児として commit されてしまう**。

そこで自然キーで xact 単位の advisory lock を取り、`findFirst` → `create` の区間を直列化した。

```ts
const importLockKey = `dish_media_import:${provider}:${externalContentId}:${dish.id}`;
await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext(${importLockKey})::bigint)`;
```

- `pg_advisory_xact_lock` は **commit / rollback のどちらでも自動解放される**。明示的な unlock が不要で、途中で例外が出てもロックが残らない
- 待つのは**まったく同じ (provider, 投稿, 料理) を同時に取り込む相手だけ**。tx 本体は短いので実質的な直列化コストは無い
- ロックキーを dish だけ／provider だけにすると、無関係な投稿どうしまで直列化するか、逆に競合を取りこぼす。**キーの中身をテストで固定した**

### 2. `reactions` → `ON CONFLICT DO NOTHING`

```ts
const savedNow = await tx.reactions.createMany({ data: [{...}], skipDuplicates: true });
// ...
saved: savedNow.count === 1,
```

返る `count` がそのまま「今回このユーザーのために新しく保存したか」になるので、レスポンスの `saved` もこれで決まる。`findUnique` + `create` の 2 クエリが 1 クエリに減る副産物つき。

上の advisory lock は取り込み経路どうしの競合しか直列化しないので、別経路（通常の save）と同時に走る場合はこちらが要る。

## テスト

`dish-media-imports.service.spec.ts` に競合まわり 3 件を追加。

- **`dish_media` を作る前に、自然キーで advisory lock を取っている** — SQL に `pg_advisory_xact_lock` が含まれること、ロックキーが `dish_media_import:tiktok:6718335390845095173:dish-1` であること、そして `invocationCallOrder` で **`mediaCreate` より前に呼ばれている**ことを固定（後ろだと意味が無いので）
- **`reactions` が `create` ではなく `skipDuplicates` 付き `createMany`** — あわせて、mock tx に生の `reactions.create` が**存在しない**ことも検査（残っているとそこだけ 500 になる）
- **`ON CONFLICT` で 1 行も増えなかったときに `saved: true` と偽らない**

既存テスト「既に保存済みなら reactions を二重に作らない」は、`ON CONFLICT DO NOTHING` にしたことで「呼ばない」ではなく「**呼んでも 1 行も増えない (count: 0)**」が正しい形になったため、その意図（二重に「保存した」と報告しない）を保ったまま検査内容を書き換えた。

## 検証

- `pnpm --filter api test` → **67 suites / 846 tests 全 green**
- `pnpm --filter api typecheck` → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_