### PR TITLE
fix(app-expo): サインアップ直後に「プロフィールを読み込めません」に落ちるのを直す (#1599)

### DIFF
--- a/app-expo/features/profile/generateUsername.test.ts
+++ b/app-expo/features/profile/generateUsername.test.ts
@@ -1,0 +1,52 @@
+import { generateUsername, USERNAME_RANDOM_DIGITS } from "./generateUsername";
+
+/**
+ * #1599 自動採番する username の衝突耐性。
+ *
+ * `users.username` には UNIQUE (`uq_users_username`) が張ってある。以前の実装は
+ * `Date.now() + Math.floor(Math.random() * 1000)` で、乱数がタイムスタンプへ
+ * **足し込まれていた**ため、同じ 1 秒のあいだのサインアップが現実的な確率で衝突した。
+ */
+describe("#1599 generateUsername", () => {
+	it("user + 数字のみ（citext の大小無視とぶつからない形）", () => {
+		expect(generateUsername(1756166400000, () => 0.123456)).toMatch(/^user\d+$/);
+	});
+
+	it("タイムスタンプと乱数を連結する（足さない）", () => {
+		// 足していると桁が繰り上がって混ざり、タイムスタンプがそのまま読めなくなる
+		const username = generateUsername(1756166400000, () => 0.5);
+		expect(username).toBe(`user1756166400000${"500000".padStart(USERNAME_RANDOM_DIGITS, "0")}`);
+		expect(username.startsWith("user1756166400000")).toBe(true);
+	});
+
+	it("乱数が 0 でも桁を落とさない（ゼロ埋め）", () => {
+		expect(generateUsername(1756166400000, () => 0)).toBe("user1756166400000000000");
+	});
+
+	it("乱数が上限直前でも桁あふれしない", () => {
+		expect(generateUsername(1756166400000, () => 0.9999999)).toBe("user1756166400000999999");
+	});
+
+	it("同じミリ秒でも、乱数が違えば別の名前になる", () => {
+		const at = 1756166400000;
+		expect(generateUsername(at, () => 0.111111)).not.toBe(generateUsername(at, () => 0.222222));
+	});
+
+	it("【回帰】同じ 1 秒のあいだに 2000 人が登録しても衝突しない", () => {
+		// 旧実装（timestamp + rand[0..999]）はこの条件で必ず衝突していた。
+		// 1 秒 = 1000 ミリ秒に 2000 件なので、鳩の巣原理でタイムスタンプは必ず重なる。
+		let seed = 1;
+		const rnd = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+
+		const names = new Set<string>();
+		for (let i = 0; i < 2000; i++) {
+			names.add(generateUsername(1756166400000 + (i % 1000), rnd));
+		}
+
+		expect(names.size).toBe(2000);
+	});
+
+	it("既定の引数でも user + 数字になる（Date.now / Math.random を差し替えない経路）", () => {
+		expect(generateUsername()).toMatch(/^user\d+$/);
+	});
+});

--- a/app-expo/features/profile/generateUsername.ts
+++ b/app-expo/features/profile/generateUsername.ts
@@ -1,0 +1,26 @@
+/**
+ * #1599 サインアップ時に自動採番するユーザー名。
+ *
+ * 【バグ】以前は `user${Date.now() + Math.floor(Math.random() * 1000)}` だった。
+ * ミリ秒のタイムスタンプに 0〜999 を足しているだけなので、**同じ 1 秒のあいだに
+ * サインアップした 2 人は現実的な確率で同じ文字列になる**。
+ * `users.username` には UNIQUE (`uq_users_username`) が張ってあるので、
+ * ぶつかった側の INSERT は 23505 で落ちる。
+ *
+ * 【設計】タイムスタンプ（13 桁）と独立した 6 桁の乱数を **連結**する（足さない）。
+ * 足すと桁が繰り上がって混ざり、乱数の意味が消える。連結なら
+ * 「同じミリ秒」かつ「同じ 6 桁」でなければぶつからない。
+ *
+ * 形は従来どおり `user` + 数字のみに保つ（citext の大小無視とも衝突しない）。
+ */
+export const USERNAME_RANDOM_DIGITS = 6;
+
+export function generateUsername(
+	now: number = Date.now(),
+	random: () => number = Math.random,
+): string {
+	const suffix = Math.floor(random() * 10 ** USERNAME_RANDOM_DIGITS)
+		.toString()
+		.padStart(USERNAME_RANDOM_DIGITS, "0");
+	return `user${now}${suffix}`;
+}

--- a/app-expo/features/profile/hooks/useProfile.test.tsx
+++ b/app-expo/features/profile/hooks/useProfile.test.tsx
@@ -96,6 +96,13 @@ describe("#1233 createUserProfile は並走した同時作成を正常系とし�
 	describe("先着の INSERT と衝突したとき", () => {
 		beforeEach(() => {
 			mockInsert.mockResolvedValue({ error: uniqueViolation });
+			// #1599 users_pkey で 23505 が返るのは、先着の行が **commit 済み**のときだけ
+			// （未 commit なら INSERT は待たされる）。PostgREST は 1 リクエスト 1
+			// トランザクションなので、衝突した後の再確認では必ずその行が見える。
+			// 先読みの SELECT は «まだ無い»、衝突後の再確認は «ある» が実際の並びになる。
+			mockSingle
+				.mockResolvedValueOnce({ data: null, error: { code: "PGRST116" } })
+				.mockResolvedValue({ data: USER_ID, error: null });
 		});
 
 		it("throw もエラーログもせずに完了する", async () => {
@@ -195,5 +202,107 @@ describe("#1233 createUserProfile は並走した同時作成を正常系とし�
 			expect(mockInsert).not.toHaveBeenCalled();
 			expect(mockUploadFile).not.toHaveBeenCalled();
 		});
+	});
+});
+
+/**
+ * #1599 23505 は users_pkey とは限らない。
+ *
+ * `users` には UNIQUE が 2 本ある（`users_pkey` = id / `uq_users_username` = username）。
+ * PostgREST はどちらでも `code: "23505"` を返すので、コードだけで #1233 の正常系
+ * （別の呼び出しが一足先に自分の行を作った）と決めつけると、
+ * **別ユーザーと username がぶつかっただけ**のときにも INSERT を諦めてしまう。
+ *
+ * その人は users 行が無いまま先へ進み、useEnsureOwnProfileLoaded の再取得が 404 →
+ * 「プロフィールを読み込めません」に落ちる。サインアップ直後の画面で起きる。
+ *
+ * 2 つは「自分の行ができているか」で見分けられることを、ここで固定する。
+ */
+const usernameViolation = {
+	code: "23505",
+	message: 'duplicate key value violates unique constraint "uq_users_username"',
+};
+
+describe("#1599 createUserProfile は id 衝突と username 衝突を見分ける", () => {
+	beforeEach(() => {
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		jest.clearAllMocks();
+		mockGetSession.mockReturnValue({ user: { id: USER_ID } });
+		mockSingle.mockResolvedValue({ data: null, error: { code: "PGRST116" } });
+		mockInsert.mockResolvedValue({ error: null });
+		mockUploadFile.mockResolvedValue(UPLOADED_AVATAR_PATH);
+		mockCallBackend.mockResolvedValue(undefined);
+	});
+
+	it("username 衝突（行がまだ無い）なら、名前を採り直して入れ直す", async () => {
+		// 1 回目の INSERT は username でぶつかる。行はまだ無い（PGRST116 のまま）。
+		mockInsert.mockResolvedValueOnce({ error: usernameViolation }).mockResolvedValueOnce({ error: null });
+
+		const createUserProfile = renderCreateUserProfile();
+		await act(async () => {
+			await createUserProfile({});
+		});
+
+		expect(mockInsert).toHaveBeenCalledTimes(2);
+		const first = mockInsert.mock.calls[0][0] as { username: string; id: string };
+		const second = mockInsert.mock.calls[1][0] as { username: string; id: string };
+		// 採り直した名前は別物でなければ、入れ直しても同じところでぶつかる
+		expect(second.username).not.toBe(first.username);
+		expect(second.id).toBe(USER_ID);
+
+		// 諦めていない = 「先着が作った」という誤った警告を出さない
+		expect(loggedEvents("user_profile_create_conflict")).toHaveLength(0);
+		expect(loggedEvents("user_profile_creation_error")).toHaveLength(0);
+		expect(loggedEvents("user_profile_username_conflict")).toHaveLength(1);
+		// 入れ直して作れているので created は出る
+		expect(loggedEvents("user_profile_created")).toHaveLength(1);
+	});
+
+	it("id 衝突（行ができている）なら #1233 どおり諦めて先へ進む", async () => {
+		mockInsert.mockResolvedValueOnce({ error: uniqueViolation });
+		// 先読みの SELECT は 0 行、衝突後の再確認では自分の行が見える
+		mockSingle
+			.mockResolvedValueOnce({ data: null, error: { code: "PGRST116" } })
+			.mockResolvedValueOnce({ data: USER_ID, error: null });
+
+		const createUserProfile = renderCreateUserProfile();
+		await act(async () => {
+			await createUserProfile({});
+		});
+
+		// 採り直して入れ直さない（先着が作っているので何度やっても同じ）
+		expect(mockInsert).toHaveBeenCalledTimes(1);
+		expect(loggedEvents("user_profile_create_conflict")).toHaveLength(1);
+		expect(loggedEvents("user_profile_username_conflict")).toHaveLength(0);
+		// 「作った」は 1 人 1 行に対して 2 件出さない
+		expect(loggedEvents("user_profile_created")).toHaveLength(0);
+		expect(loggedEvents("user_profile_creation_error")).toHaveLength(0);
+	});
+
+	it("採り直しても通らないときは握り潰さず error として残す", async () => {
+		mockInsert.mockResolvedValue({ error: usernameViolation });
+
+		const createUserProfile = renderCreateUserProfile();
+		await act(async () => {
+			await createUserProfile({});
+		});
+
+		// 無限に粘らない
+		expect(mockInsert).toHaveBeenCalledTimes(3);
+		expect(loggedEvents("user_profile_creation_error")).toHaveLength(1);
+		// 作れていないのに created を出さない
+		expect(loggedEvents("user_profile_created")).toHaveLength(0);
+	});
+
+	it("衝突以外の INSERT エラーは採り直さず、そのまま error にする", async () => {
+		mockInsert.mockResolvedValue({ error: rlsViolation });
+
+		const createUserProfile = renderCreateUserProfile();
+		await act(async () => {
+			await createUserProfile({});
+		});
+
+		expect(mockInsert).toHaveBeenCalledTimes(1);
+		expect(loggedEvents("user_profile_creation_error")).toHaveLength(1);
 	});
 });

--- a/app-expo/features/profile/hooks/useProfile.ts
+++ b/app-expo/features/profile/hooks/useProfile.ts
@@ -6,14 +6,29 @@ import type { UpdateUserProfileDto } from "@shared/api/v1/dto";
 import { supabase } from "@/lib/supabase";
 import { useLocale } from "@/hooks/useLocale";
 import { useAuth } from "@/contexts/AuthProvider";
+import { generateUsername } from "../generateUsername";
 
 /**
  * #1233 【設計】Postgres の unique_violation（SQLSTATE 23505）。
- * PostgREST は SQLSTATE をそのまま `error.code` に載せてくるので、
- * `users_pkey` 衝突（= 同じ user.id で別の呼び出しが先に INSERT した）はこの値で判別できる。
+ * PostgREST は SQLSTATE をそのまま `error.code` に載せてくる。
  * PostgREST 独自コード（PGRST116 = 0 rows）とは名前空間が違うため取り違えない。
+ *
+ * ⚠️ #1599 このコードだけでは **どの UNIQUE でぶつかったかは分からない**。
+ * `users` には `users_pkey`（id）と `uq_users_username`（username）の 2 本があり、
+ * どちらも 23505 を返す。見分け方は下の `insertUserProfileRow` を参照。
  */
 const POSTGRES_UNIQUE_VIOLATION = "23505";
+
+/** PostgREST の「0 行」。`.single()` が行を引けなかったときに返る */
+const POSTGREST_NO_ROWS = "PGRST116";
+
+/**
+ * #1599 username を採り直して再挑戦する上限。
+ *
+ * 衝突は「同じミリ秒 × 同じ 6 桁の乱数」でしか起きないので、
+ * 1 回採り直せばまず通る。無限に粘らせないための保険として置く。
+ */
+const MAX_USERNAME_ATTEMPTS = 3;
 
 export function useProfile() {
 	const { callBackend } = useAPICall();
@@ -63,34 +78,62 @@ export function useProfile() {
 				}
 
 				if (!existingProfileId) {
-					// ユーザープロフィールが存在しない場合のみ作成
-					const timestamp = Date.now();
-					const randomSuffix = Math.floor(Math.random() * 1000)
-						.toString()
-						.padStart(3, "0");
-					const username = `user${(timestamp + parseInt(randomSuffix)).toString().slice(0, 13)}`;
+					// #1599 【バグ】以前はここで 23505 を一律「別の呼び出しが一足先に作った」
+					// （= #1233 の正常系）と決めつけて INSERT を諦めていた。だが 23505 は
+					// `uq_users_username` でも返る。**別ユーザーと username がぶつかっただけ**の
+					// ときにも諦めるため、その人は users 行が無いまま先へ進み、
+					// useEnsureOwnProfileLoaded の再取得が 404 → 「プロフィールを読み込めません」
+					// に落ちる。サインアップ直後の画面なので取り返しが利かない。
+					//
+					// 2 つは「自分の行ができているか」で見分けられる。
+					//  - 行がある … users_pkey 衝突（#1233）。諦めてよい。以降の avatar 反映は続ける
+					//  - 行が無い … username 衝突。名前を採り直せば必ず通るので再挑戦する
+					let username = generateUsername();
+					let didConflict = false;
 
-					// users テーブルに新規レコードを挿入
-					const { error: insertError } = await supabase.from("users").insert({
-						id: user.id,
-						username,
-						display_name: displayName || "nickname",
-						preferred_locale: locale,
-					});
+					for (let attempt = 1; ; attempt++) {
+						const { error: insertError } = await supabase.from("users").insert({
+							id: user.id,
+							username,
+							display_name: displayName || "nickname",
+							preferred_locale: locale,
+						});
 
-					// #1233 【修正】主キー衝突だけは throw せずに続行する。ここで throw すると
-					// 下のアバターアップロードと v1/users/me への反映がスキップされる（これが Issue の実害）。
-					// 衝突以外の INSERT エラー（RLS 違反・NOT NULL 違反など）は従来どおり
-					// user_profile_creation_error として error レベルで残したいので投げ直す。
-					const didConflict = !!insertError && insertError.code === POSTGRES_UNIQUE_VIOLATION;
-					if (insertError && !didConflict) throw insertError;
+						if (!insertError) break;
+
+						// 衝突以外の INSERT エラー（RLS 違反・NOT NULL 違反など）は従来どおり
+						// user_profile_creation_error として error レベルで残したいので投げ直す。
+						if (insertError.code !== POSTGRES_UNIQUE_VIOLATION) throw insertError;
+
+						const { data: rowAfterConflict, error: recheckError } = await supabase
+							.from("users")
+							.select("id")
+							.eq("id", user.id)
+							.single<string>();
+						if (recheckError && recheckError.code !== POSTGREST_NO_ROWS) throw recheckError;
+
+						if (rowAfterConflict) {
+							// #1233 の正常系。先着が作っているので、下のアバター反映まで続行する
+							didConflict = true;
+							break;
+						}
+
+						// username 衝突。行はまだ無いので、採り直して入れ直す
+						if (attempt >= MAX_USERNAME_ATTEMPTS) throw insertError;
+						logFrontendEvent({
+							event_name: "user_profile_username_conflict",
+							error_level: "warn",
+							payload: { user_id: user.id, attempt, error: insertError.message },
+						});
+						username = generateUsername();
+					}
 
 					if (didConflict) {
 						// 起票対象にはしないが、並走の頻度は追えるようにしておく
 						logFrontendEvent({
 							event_name: "user_profile_create_conflict",
 							error_level: "warn",
-							payload: { user_id: user.id, error: insertError?.message },
+							payload: { user_id: user.id },
 						});
 					}
 


### PR DESCRIPTION
## ユーザーに何が起きるか

**サインアップ直後の画面が「プロフィールを読み込めません」になり、ユーザーが retry を押すまで自己回復しない。**

## なぜ起きるか

`createUserProfile` は INSERT が 23505（unique_violation）で落ちたとき、それを一律「別の呼び出しが一足先に**自分の行**を作った」（#1233 の正常系）と決めつけて INSERT を諦めていた。

しかし `users` には UNIQUE が **2 本**ある:

| 制約 | 列 |
| --- | --- |
| `users_pkey` | `id` |
| `uq_users_username` | `username`（citext） |

PostgREST は**どちらでも `code: "23505"`** を返すので、コードだけでは区別できない。別ユーザーと username がぶつかっただけのときにも諦めるため、その人は `users` 行が無いまま先へ進む。

呼び出し元の `useEnsureOwnProfileLoaded` は `createUserProfile({})` の直後に `GET v1/users/:id` を撃つ。行が無いので **404 が inner catch の外へ抜け**、`loadProfile().catch(() => setHasLoadFailed(true))` に落ちる。`hasLoadedRef` は `finally` で立っているので、**ユーザーが `retry()` を押すまで二度と取得しない**。

### しかも衝突しやすかった

```ts
const timestamp = Date.now();
const randomSuffix = Math.floor(Math.random() * 1000).toString().padStart(3, "0");
const username = `user${(timestamp + parseInt(randomSuffix)).toString().slice(0, 13)}`;
```

ミリ秒のタイムスタンプに 0〜999 を **足している**。桁が繰り上がって混ざるので乱数の意味がほぼ無く、**1 秒に 1000 通りしか作れない**。同じ 1 秒のあいだにサインアップした 2 人は現実的な確率で同じ文字列になる。

## どう直したか

### 1. 採番 — 足すのをやめて連結する（新規 `features/profile/generateUsername.ts`）

```ts
export function generateUsername(now = Date.now(), random = Math.random): string {
  const suffix = Math.floor(random() * 10 ** USERNAME_RANDOM_DIGITS)
    .toString()
    .padStart(USERNAME_RANDOM_DIGITS, "0");
  return `user${now}${suffix}`;
}
```

同じミリ秒**かつ**同じ 6 桁でなければぶつからない。形は従来どおり `user` + 数字のみに保つ（citext の大小無視とも衝突しない）。

### 2. 見分け — 「自分の行ができているか」で分岐する（`useProfile.ts`）

23505 を受けたら SELECT で再確認する。

| 再確認の結果 | 意味 | 動作 |
| --- | --- | --- |
| 行がある | `users_pkey` 衝突（#1233） | 従来どおり諦めて avatar 反映へ進む |
| 行が無い | `uq_users_username` 衝突 | **名前を採り直して入れ直す**（最大 3 回） |

採り直しても通らなければ握り潰さず `user_profile_creation_error` にする。衝突以外の INSERT エラー（RLS 違反など）は従来どおり即 throw。

**この判別が成立する根拠**: `users_pkey` で 23505 が返るのは先着の行が **commit 済み**のときだけ（未 commit なら INSERT は待たされる）。PostgREST は 1 リクエスト 1 トランザクションなので、衝突後の再確認では必ずその行が見える。

## テスト

**`generateUsername.test.ts`（7 件）** — 連結であること（足していると桁が混ざる）、ゼロ埋め、上限直前で桁あふれしないこと、そして

> **【回帰】同じ 1 秒のあいだに 2000 人が登録しても衝突しない**
> 旧実装（`timestamp + rand[0..999]`）はこの条件で**必ず**衝突していた。1 秒 = 1000 ミリ秒に 2000 件なので、鳩の巣原理でタイムスタンプは必ず重なる。

**`useProfile.test.tsx` に 4 件追加** — username 衝突では**別の名前で**入れ直すこと（同じ名前で入れ直しても同じところでぶつかるので、名前が変わっていることを検査）、id 衝突では採り直さないこと、上限で諦めたら `error` を残し `created` を出さないこと、衝突以外は採り直さないこと。

**既存 #1233 テストの mock を実際の並びへ直した。** これまで `mockSingle` は全呼び出しで PGRST116（0 行）を返していたが、上に書いたとおり pkey 衝突の直後に行が見えないという状態は実際には起こりえない。先読みの SELECT は「まだ無い」、衝突後の再確認は「ある」が現実の並びなので、そう直した（検査内容は変えていない）。

## 検証

- `pnpm --filter app-expo test` → **156 suites / 1553 tests 全 green**
- `pnpm --filter app-expo lint` → **0 errors**
- `pnpm --filter app-expo typecheck` → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_