### PR TITLE
test(api): findFirst → create の TOCTOU を静的に禁じるラチェットを足す (#1599)

### DIFF
--- a/api/src/prisma/create-after-find-boundary.spec.ts
+++ b/api/src/prisma/create-after-find-boundary.spec.ts
@@ -1,0 +1,150 @@
+// api/src/prisma/create-after-find-boundary.spec.ts
+//
+// #1599 **同じモデルに対する `findFirst` / `findUnique` → `create` を禁じる**ラチェット。
+//
+// ## なぜ要るのか
+//
+// 「無ければ作る」を `findFirst` で確認してから `create` する形は TOCTOU である。
+// 同じ自然キーのリクエストが同時に 2 本来ると、**両方の find が空振りして両方が
+// create し、後発が UNIQUE 制約に衝突して P2002 → 500** になる。
+//
+// このリポジトリでは 2026-08-26 に、この 1 つのパターンで 3 箇所が同時に見つかった。
+//
+//   - `dishes.repository.ts` の `createOrGetDishForCategory`（dishes_restaurant_category_unique）
+//   - `dish-media-imports.service.ts` の埋め込み作成（dmee_provider_content_dish_uq）
+//   - 同ファイルの reactions(save)（user_id + target_type + target_id + action_type）
+//
+// 1 つ直しても他が残る性質のものなので、人の注意ではなく機械的な検査で守る。
+//
+// ## ⚠️ 「P2002 を catch して読み直す」は **$transaction の中では成立しない**
+//
+// Postgres では P2002 が出た時点でトランザクション全体が aborted 状態になり、
+// 同じ tx での後続クエリはすべて `current transaction is aborted` で失敗する。
+// **そもそも例外を出さない**形にする必要がある。
+//
+// ## 落ちたときにどう直すか
+//
+// | 状況 | 直し方 |
+// | --- | --- |
+// | 自然キーの UNIQUE がある | `createMany({ data: [...], skipDuplicates: true })`（= `ON CONFLICT DO NOTHING`）で入れて読み直す |
+// | 一意キー 1 本で表せる | `upsert({ where: <一意キー>, update: {}, create: ... })` |
+// | 自然キーの UNIQUE が無い（PK がランダム UUID 等） | 自然キーで `pg_advisory_xact_lock` を取って区間を直列化する |
+//
+// どれも当てはまらない（競合しえない）場合だけ、**理由を書いて** EXCLUSIONS へ足す。
+
+import {
+  API_SRC,
+  lineOf,
+  listSourceFiles,
+  readCode,
+  toRepoPath,
+} from '../../test/source-scan';
+
+/** 「存在確認」に使われる読み取り。ここを通ってから create すると TOCTOU になる */
+const LOOKUP_METHODS = ['findFirst', 'findUnique'] as const;
+
+/**
+ * 存在確認から create までを何行ぶん追うか。
+ *
+ * 「無ければ作る」は 1 つの関数の中にまとまって書かれる。離れすぎた 2 つを
+ * 結びつけると誤検知になるので、実際に見つかった 3 件（最大 13 行）に余裕を見た値にする。
+ */
+const LOOKAHEAD_LINES = 30;
+
+/**
+ * 競合しえないと確認できた場所。**理由を必ず書くこと。**
+ * キーは `<api からの相対パス>#<モデル>`。
+ */
+const EXCLUSIONS: Readonly<Record<string, string>> = {};
+
+/** `tx.dishes.findFirst(` / `this.prisma.prisma.users.findUnique(` からモデル名を取る */
+const LOOKUP_PATTERN = new RegExp(
+  `\\.([a-z_][a-z0-9_]*)\\.(${LOOKUP_METHODS.join('|')})\\(`,
+  'g',
+);
+
+type Violation = { path: string; line: number; model: string };
+
+/** `text` の中の「同じモデルへの find → create」を全部返す */
+export function findCreateAfterLookup(text: string, path: string): Violation[] {
+  const lines = text.split('\n');
+  const found: Violation[] = [];
+
+  for (const match of text.matchAll(LOOKUP_PATTERN)) {
+    const model = match[1];
+    if (EXCLUSIONS[`${path}#${model}`]) continue;
+
+    const line = lineOf(text, match.index);
+    const window = lines.slice(line, line + LOOKAHEAD_LINES).join('\n');
+
+    // `createMany` は ON CONFLICT DO NOTHING なので対象外。
+    // 単数の `create(` だけを見る（`create(` の直前が `Many` でないこと）。
+    if (new RegExp(`\\.${model}\\.create\\(`).test(window)) {
+      found.push({ path, line, model });
+    }
+  }
+  return found;
+}
+
+describe('#1599 「無ければ作る」を findFirst → create で書かない', () => {
+  const files = listSourceFiles(API_SRC);
+
+  it('検査対象のソースを実際に走査できている（0 件なら検査自体が壊れている）', () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it('【自己検査】修正前の書き方を実際に検出できる', () => {
+    // #1604 で直す前の `createOrGetDishForCategory` そのもの。
+    // これが検出できないなら、下の検査が緑なのは «壊れていないから» ではなく
+    // «見えていないから» になる。
+    const before = `
+      async createOrGetDishForCategory(tx, dish) {
+        const existing = await tx.dishes.findFirst({
+          where: {
+            restaurant_id: dish.restaurant_id,
+            category_id: dish.category_id,
+          },
+        });
+
+        if (existing) {
+          return existing;
+        }
+
+        const { id: _omitId, ...createData } = dish;
+
+        return tx.dishes.create({
+          data: createData,
+        });
+      }
+    `;
+    expect(findCreateAfterLookup(before, 'sample.ts')).toEqual([
+      { path: 'sample.ts', line: 3, model: 'dishes' },
+    ]);
+
+    // 直した後（createMany + skipDuplicates）は検出されない
+    const after = before.replace(
+      'return tx.dishes.create({\n          data: createData,\n        });',
+      'await tx.dishes.createMany({ data: [createData], skipDuplicates: true });',
+    );
+    expect(findCreateAfterLookup(after, 'sample.ts')).toEqual([]);
+  });
+
+  it('別のモデルへの create は巻き込まない（誤検知しない）', () => {
+    const unrelated = `
+      const dish = await tx.dishes.findFirst({ where: { id } });
+      await tx.dish_media.create({ data: { dish_id: dish.id } });
+    `;
+    expect(findCreateAfterLookup(unrelated, 'sample.ts')).toEqual([]);
+  });
+
+  it('api のどこにも findFirst / findUnique → create が残っていない', () => {
+    const violations = files.flatMap((file) => {
+      const path = toRepoPath(file);
+      return findCreateAfterLookup(readCode(file), path).map(
+        ({ line, model }) => `${path}:${line} → ${model} の find → create`,
+      );
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/api/src/v1/dish-media/soft-delete-read-boundary.spec.ts
+++ b/api/src/v1/dish-media/soft-delete-read-boundary.spec.ts
@@ -21,8 +21,15 @@
 // 新しく `dish_reviews` を読む場所を足したなら、その where へ `deleted_at: null` を足す。
 // 「削除済みも含めて読むのが正しい」場合だけ、**理由を書いて** EXCLUSIONS へ足す。
 
-import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative, sep } from 'node:path';
+import {
+  API_SRC,
+  blankComments,
+  lineOf,
+  listSourceFiles,
+  readCallArguments,
+  toRepoPath,
+} from '../../../test/source-scan';
+import { readFileSync } from 'node:fs';
 
 /**
  * 検査対象の読み取りメソッド。
@@ -42,10 +49,6 @@ const READ_METHODS = [
   'groupBy',
 ] as const;
 
-/**
- * 削除済みも読むのが正しい場所。**理由を必ず書くこと。**
- * キーはリポジトリルートからの相対パス（POSIX 区切り）。
- */
 /** 検査対象のテーブル。schema.prisma が同じ約束をしているもの */
 const GUARDED_TABLES = ['dish_reviews', 'dish_media'] as const;
 
@@ -65,121 +68,6 @@ const EXCLUSIONS: Readonly<Record<string, string>> = {
   'src/v1/users/users.repository.ts#dish_media':
     '退会時のストレージ実体削除。削除済みの投稿のファイルも消す必要がある',
 };
-
-const API_SRC = join(__dirname, '..', '..');
-const REPO_API_ROOT = join(API_SRC, '..');
-
-function listSourceFiles(dir: string): string[] {
-  const out: string[] = [];
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) {
-      out.push(...listSourceFiles(full));
-      continue;
-    }
-    if (!entry.endsWith('.ts')) continue;
-    if (entry.endsWith('.spec.ts')) continue;
-    out.push(full);
-  }
-  return out;
-}
-
-/**
- * `text` の `openIndex`（`(` の位置）に対応する `)` までを返す。
- * 文字列リテラル・テンプレートリテラルの中の括弧は数えない。
- */
-function readCallArguments(text: string, openIndex: number): string {
-  let depth = 0;
-  let quote: string | null = null;
-
-  for (let i = openIndex; i < text.length; i += 1) {
-    const ch = text[i];
-
-    if (quote) {
-      if (ch === '\\') {
-        i += 1;
-        continue;
-      }
-      if (ch === quote) quote = null;
-      continue;
-    }
-
-    if (ch === "'" || ch === '"' || ch === '`') {
-      quote = ch;
-      continue;
-    }
-    if (ch === '(') depth += 1;
-    if (ch === ')') {
-      depth -= 1;
-      if (depth === 0) return text.slice(openIndex, i + 1);
-    }
-  }
-  return text.slice(openIndex);
-}
-
-
-/**
- * コメントを **同じ長さの空白へ置き換える**（改行は残す）。
- *
- * 取り除く（詰める）のではなく空白で潰すのは、**元ファイルの行番号と文字位置を
- * そのまま使える**ようにするため。
- *
- * ⚠️ これが無いと 2 種類の嘘が両方出る。実際に両方踏んだ。
- *   1. 見逃し: 「`deleted_at` について説明したコメント」を絞っている証拠と誤認し、
- *      絞っていないのに緑になる（fix を revert しても赤くならなかった）
- *   2. 誤検知: コメントの中に書かれた `dish_media.findMany(` という **例示**を
- *      本物の呼び出しと誤認し、正しいコードを赤くする
- *      （`notifications.service.ts` の「こう書くと壊れる」という説明で踏んだ）
- *
- * 検査の正しさは「壊した状態で赤くなること」と「正しい状態で緑であること」の
- * 両方でしか確かめられない。
- */
-function blankComments(text: string): string {
-  const out = text.split('');
-  let quote: string | null = null;
-
-  const blank = (from: number, to: number) => {
-    for (let i = from; i < to && i < out.length; i += 1) {
-      if (out[i] !== '\n') out[i] = ' ';
-    }
-  };
-
-  for (let i = 0; i < text.length; i += 1) {
-    const ch = text[i];
-    const next = text[i + 1];
-
-    if (quote) {
-      if (ch === '\\') {
-        i += 1;
-        continue;
-      }
-      if (ch === quote) quote = null;
-      continue;
-    }
-
-    if (ch === "'" || ch === '"' || ch === '`') {
-      quote = ch;
-      continue;
-    }
-
-    if (ch === '/' && next === '/') {
-      const end = text.indexOf('\n', i);
-      const stop = end === -1 ? text.length : end;
-      blank(i, stop);
-      i = stop;
-      continue;
-    }
-
-    if (ch === '/' && next === '*') {
-      const end = text.indexOf('*/', i + 2);
-      const stop = end === -1 ? text.length : end + 2;
-      blank(i, stop);
-      i = stop - 1;
-      continue;
-    }
-  }
-  return out.join('');
-}
 
 /**
  * `where: someVariable` の形で渡されているとき、その変数の宣言に
@@ -205,7 +93,7 @@ function whereVariableHasDeletedAt(fileText: string, args: string): boolean {
 }
 
 describe('#1596 論理削除テーブルの読み取りは必ず deleted_at で絞る', () => {
-  const files = listSourceFiles(API_SRC);
+  const files = listSourceFiles();
 
   it('検査対象のソースを実際に走査できている（0 件なら検査自体が壊れている）', () => {
     expect(files.length).toBeGreaterThan(50);
@@ -215,7 +103,7 @@ describe('#1596 論理削除テーブルの読み取りは必ず deleted_at で�
     const violations: string[] = [];
 
     for (const file of files) {
-      const relPath = relative(REPO_API_ROOT, file).split(sep).join('/');
+      const relPath = toRepoPath(file);
 
       // コメントを空白で潰した版だけを見る。位置と行番号は元ファイルと一致する。
       const text = blankComments(readFileSync(file, 'utf8'));
@@ -242,7 +130,7 @@ describe('#1596 論理削除テーブルの読み取りは必ず deleted_at で�
             args.includes('deleted_at') || whereVariableHasDeletedAt(text, args);
 
           if (!satisfied) {
-            const line = text.slice(0, at).split('\n').length;
+            const line = lineOf(text, at);
             violations.push(`${relPath}:${line} → ${table}.${method}()`);
           }
         }

--- a/api/test/source-scan.ts
+++ b/api/test/source-scan.ts
@@ -1,0 +1,146 @@
+// api/test/source-scan.ts
+//
+// #1599 ラチェット（静的検査テスト）が共通で使うソース走査ユーティリティ。
+//
+// このリポジトリには「1 箇所漏れれば穴」という性質の不変条件がいくつかあり、
+// それらは人の注意ではなく機械的な検査で守っている
+// （`soft-delete-read-boundary.spec.ts` / `cursor-boundary.spec.ts` /
+//  `create-after-find-boundary.spec.ts`）。
+//
+// 走査の下ごしらえ（ファイル列挙・コメント潰し・呼び出し引数の切り出し）は
+// どのラチェットでも同じなので、ここへ 1 本化する。**同じ事実を 2 箇所に書かない。**
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+/** `api/src` の絶対パス */
+export const API_SRC = join(__dirname, '..', 'src');
+/** `api/` の絶対パス。違反の表示を `src/...` から始めるための基準 */
+export const REPO_API_ROOT = join(__dirname, '..');
+
+/** `dir` 以下の `.ts` を再帰的に集める。`.spec.ts` は検査対象から外す */
+export function listSourceFiles(dir: string = API_SRC): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...listSourceFiles(full));
+      continue;
+    }
+    if (!entry.endsWith('.ts')) continue;
+    if (entry.endsWith('.spec.ts')) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/** 違反の表示に使う、`api/` からの相対パス（POSIX 区切り） */
+export function toRepoPath(file: string): string {
+  return relative(REPO_API_ROOT, file).split(sep).join('/');
+}
+
+/** ファイル内のオフセット `at` が何行目かを 1 始まりで返す */
+export function lineOf(text: string, at: number): number {
+  return text.slice(0, at).split('\n').length;
+}
+
+/**
+ * `text` の `openIndex`（`(` の位置）に対応する `)` までを返す。
+ * 文字列リテラル・テンプレートリテラルの中の括弧は数えない。
+ */
+export function readCallArguments(text: string, openIndex: number): string {
+  let depth = 0;
+  let quote: string | null = null;
+
+  for (let i = openIndex; i < text.length; i += 1) {
+    const ch = text[i];
+
+    if (quote) {
+      if (ch === '\\') {
+        i += 1;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '(') depth += 1;
+    if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) return text.slice(openIndex, i + 1);
+    }
+  }
+  return text.slice(openIndex);
+}
+
+/**
+ * コメントを **同じ長さの空白へ置き換える**（改行は残す）。
+ *
+ * 取り除く（詰める）のではなく空白で潰すのは、**元ファイルの行番号と文字位置を
+ * そのまま使える**ようにするため。
+ *
+ * ⚠️ これが無いと 2 種類の嘘が両方出る。実際に両方踏んだ。
+ *   1. 見逃し: 「`deleted_at` について説明したコメント」を絞っている証拠と誤認し、
+ *      絞っていないのに緑になる（fix を revert しても赤くならなかった）
+ *   2. 誤検知: コメントの中に書かれた `dish_media.findMany(` という **例示**を
+ *      本物の呼び出しと誤認し、正しいコードを赤くする
+ *      （`notifications.service.ts` の「こう書くと壊れる」という説明で踏んだ）
+ *
+ * 検査の正しさは「壊した状態で赤くなること」と「正しい状態で緑であること」の
+ * 両方でしか確かめられない。
+ */
+export function blankComments(text: string): string {
+  const out = text.split('');
+  let quote: string | null = null;
+
+  const blank = (from: number, to: number) => {
+    for (let i = from; i < to && i < out.length; i += 1) {
+      if (out[i] !== '\n') out[i] = ' ';
+    }
+  };
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (quote) {
+      if (ch === '\\') {
+        i += 1;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      continue;
+    }
+
+    if (ch === '/' && next === '/') {
+      const end = text.indexOf('\n', i);
+      const stop = end === -1 ? text.length : end;
+      blank(i, stop);
+      i = stop;
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      const end = text.indexOf('*/', i + 2);
+      const stop = end === -1 ? text.length : end + 2;
+      blank(i, stop);
+      i = stop - 1;
+      continue;
+    }
+  }
+  return out.join('');
+}
+
+/** ファイルを読み、コメントを潰した本文を返す（行番号は元ファイルと一致する） */
+export function readCode(file: string): string {
+  return blankComments(readFileSync(file, 'utf8'));
+}


### PR DESCRIPTION
## なぜ

今夜のループで、**まったく同じ TOCTOU が 3 箇所同時に見つかった**。

| 場所 | 効いていた UNIQUE | PR |
| --- | --- | --- |
| `dishes.repository.ts` `createOrGetDishForCategory` | `dishes_restaurant_category_unique` | [#1604](https://github.com/Ayato-kosaka/nanitabeyo/pull/1604) |
| `dish-media-imports.service.ts` の埋め込み作成 | `dmee_provider_content_dish_uq` | [#1605](https://github.com/Ayato-kosaka/nanitabeyo/pull/1605) |
| 同ファイルの `reactions(save)` | `(user_id, target_type, target_id, action_type)` | [#1605](https://github.com/Ayato-kosaka/nanitabeyo/pull/1605) |

どれも「無ければ作る」を `findFirst` で確認してから `create` する形。同じ自然キーのリクエストが同時に 2 本来ると、**両方の find が空振りして両方が create し、後発が P2002 で 500** になる。

**1 つ直しても他が残る**性質のものなので、人の注意ではなく機械的な検査で守る（`soft-delete-read-boundary` / `cursor-boundary` と同じ作法）。

## 検出のしかた

同じモデルへの `findFirst` / `findUnique` の **30 行以内**に、同じモデルへの**単数** `create(` があれば違反。`createMany`（= `ON CONFLICT DO NOTHING`）は対象外。

落ちたときの直し方も spec の冒頭に表で書いた:

| 状況 | 直し方 |
| --- | --- |
| 自然キーの UNIQUE がある | `createMany({ skipDuplicates: true })` で入れて読み直す |
| 一意キー 1 本で表せる | `upsert({ where: <一意キー>, update: {}, create: ... })` |
| 自然キーの UNIQUE が無い（PK がランダム UUID 等） | 自然キーで `pg_advisory_xact_lock` を取って直列化する |

あわせて「**P2002 を catch して読み直す**」が `$transaction` の中では成立しない理由（P2002 で tx 全体が aborted になる）も spec に残した。今夜これを 3 回説明したので、次に読む人がここで分かるようにしておく。

## ラチェットが「見えているか」を、ラチェット自身で検査する

**緑であることだけからは、«壊れていないから» なのか «見えていないから» なのかは分からない。** 実際このリポジトリでは過去に「fix を revert しても赤くならないラチェット」を書いている。

そこで自己検査を同梱した。

- **#1604 で直す前の `createOrGetDishForCategory` の本文をそのまま入力に与え**、`{ line: 3, model: 'dishes' }` として検出できることを固定
- **直した後**（`createMany` + `skipDuplicates`）では検出されないことを固定
- **別モデルへの create を巻き込まない**（`dishes.findFirst` → `dish_media.create` を誤検知しない）ことを固定

## 走査ユーティリティの重複を消した

ラチェットが共通で使う下ごしらえ（ファイル列挙・コメント潰し・呼び出し引数の切り出し）を `api/test/source-scan.ts` へ 1 本化し、`soft-delete-read-boundary.spec.ts` から重複を消した。同じ事実が 2 箇所にあると、どちらかが陳腐化し始めるため。

**重複を消した側が defang されていないことは実測で確認した。** `dish-media.repository.ts` へ `deleted_at` 無しの `dish_reviews.count()` を注入すると、正しい行番号つきで赤くなる:

```
+   "src/v1/dish-media/dish-media.repository.ts:630 → dish_reviews.count()"
```

（この検証中に、既存ラチェットは **ネストした `include: { dish_reviews: { where } }` を見ていない**ことも分かった。今回の変更の範囲外なので触っていないが、別途拾う。）

## 検証

- `pnpm --filter api test` → **68 suites / 850 tests 全 green**
- `pnpm --filter api typecheck` → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_