### PR TITLE
fix(app-expo): 失敗を成功として見せる 2 経路を直す (#1599)

### DIFF
--- a/app-expo/app/[locale]/contribution-tasks/dish-category-manual-image-supply.tsx
+++ b/app-expo/app/[locale]/contribution-tasks/dish-category-manual-image-supply.tsx
@@ -432,18 +432,45 @@ export default function DishCategoryManualImageSupplyScreen() {
 				});
 				successCount++;
 			} catch (err) {
-				console.error("Failed to submit item", item.category_id, err);
+				// #1599 【バグ】ここで失敗しても uploadState は "success" のまま据え置かれていた。
+				// uploadState は «画像をストレージへ上げられたか» であって «送信できたか» ではない。
+				// 据え置くと、サンクス画面の remainingItems（uploadState !== "success"）から漏れ、
+				// 「もう協力できる料理は無い」と判定されて router.back() される。
+				// ユーザーの投稿は誰にも気づかれないまま消える。
+				//
+				// 送信に失敗した item は "error" へ戻し、«まだ残っている» ものとして扱う。
+				// state.uploaded（アップロード済みのパス）は捨てないので、上げ直しにはならない。
+				setItemStates((prev) => ({
+					...prev,
+					[item.category_id]: { ...prev[item.category_id], uploadState: "error" },
+				}));
+				logFrontendEvent({
+					event_name: "dish_manual_image_supply_submit_item_failed",
+					error_level: "warn",
+					payload: { categoryId: item.category_id, error: toErrorLogMessage(err) },
+				});
 				failCount++;
 			}
 		}
 
 		logFrontendEvent({
 			event_name: "dish_manual_image_supply_submit_result",
-			error_level: "log",
+			// #1599 全滅は障害。log のままだと error-triage に乗らず、誰も気づけない
+			error_level: failCount > 0 ? "warn" : "log",
 			payload: { successCount, failCount },
 		});
 
-		setShowThanks(true);
+		// #1599 【バグ】以前は successCount / failCount を一切見ずに無条件で
+		// サンクス画面を出していた。全件失敗しても「ありがとうございました」が出るので、
+		// ユーザーは貢献できたと思い込む。1 件も通っていないならサンクスは出さない。
+		if (successCount === 0) {
+			showSnackbar("送信に失敗しました。通信環境を確認して、もう一度お試しください。");
+		} else {
+			if (failCount > 0) {
+				showSnackbar(`${successCount} 件を送信しました。${failCount} 件は失敗したので、もう一度お試しください。`);
+			}
+			setShowThanks(true);
+		}
 		} finally {
 			// #1205 ⚠️ この try..finally は今回追加した。元は最後に setIsSubmitting(false) を
 			// 直接書いており、**ループの途中で例外が抜けると解除されず送信不能のまま固まる**
@@ -451,7 +478,7 @@ export default function DishCategoryManualImageSupplyScreen() {
 			isSubmittingRef.current = false;
 			setIsSubmitting(false);
 		}
-	}, [items, itemStates, callBackend, logFrontendEvent, cdnJsonPath, taskKey]);
+	}, [items, itemStates, callBackend, logFrontendEvent, cdnJsonPath, taskKey, showSnackbar]);
 
 	/* -------------------------------------------------------------------------- */
 	/*                              サンクス画面                                  */

--- a/app-expo/features/dishMedia/components/DishReviewsSection.test.tsx
+++ b/app-expo/features/dishMedia/components/DishReviewsSection.test.tsx
@@ -38,6 +38,11 @@ jest.mock("react-native-gesture-handler", () => {
  * 通報シートは ReportContentSheet.test.tsx が別途固定しているので、
  * ここでは **どんな props で描かれたか** だけを観測できる代役に置き換える。
  */
+// #1599 レビューいいねの失敗を Snackbar で伝えるようになったため、
+// このテスト（通報導線だけを見る）でも Provider の代役が要る。
+// ロールバック側の挙動は DishReviewsSectionLike.test.tsx が固定している。
+jest.mock("@/contexts/SnackbarProvider", () => ({ useSnackbar: () => ({ showSnackbar: jest.fn() }) }));
+
 jest.mock("./ReportContentSheet", () => {
 	const { View } = require("react-native");
 	return {

--- a/app-expo/features/dishMedia/components/DishReviewsSection.tsx
+++ b/app-expo/features/dishMedia/components/DishReviewsSection.tsx
@@ -22,6 +22,7 @@ import { shallow } from "zustand/shallow";
 import { toErrorLogMessage } from "@/lib/errorMessage";
 import { useAuth } from "@/contexts/AuthProvider";
 import { ReportContentSheet } from "./ReportContentSheet";
+import { useSnackbar } from "@/contexts/SnackbarProvider";
 
 interface DishReviewsSectionProps {
 	id: string;
@@ -36,6 +37,11 @@ export function DishReviewsSection({ id, idType, paddingRight, carouselRef }: Di
 	const { logFrontendEvent } = useLogger();
 	const { lightImpact } = useHaptics();
 	const { user } = useAuth();
+	const { showSnackbar } = useSnackbar();
+	// #1599 二重タップで 2 発飛ぶのを防ぐ。楽観更新より前に弾くこと
+	// （後にすると 2 発目がトグルを戻してから弾かれ、表示だけ巻き戻る）。
+	// ActionButtons の inFlightActionsRef（#1205）と同じ役割。
+	const inFlightLikesRef = useRef<Set<string>>(new Set());
 
 	const selector = useCallback(
 		(state: DishMediaEntriesStore) => {
@@ -101,52 +107,84 @@ export function DishReviewsSection({ id, idType, paddingRight, carouselRef }: Di
 		});
 	};
 
-	const handleReviewLike = async (reviewId: string) => {
-		lightImpact();
-		const { reviewsByReviewId, updateReview } = useDishMediaEntriesStore.getState();
-		const review = reviewsByReviewId[reviewId];
-		if (!review) return;
-		const currentLikeState = review.isLiked || false;
-		const willLike = !currentLikeState;
-		let newLikeCount = willLike ? review.likeCount + 1 : Math.max(0, review.likeCount - 1);
-		updateReview(review.id, (r) => ({
-			...r,
-			isLiked: willLike,
-			likeCount: newLikeCount,
-		}));
+	// #1599 【バグ】ここは楽観更新だけして、**失敗しても戻していなかった**。
+	// オフライン・タイムアウト・5xx で callBackend が reject しても catch はログを送るだけで、
+	// 画面は「いいね済み」のまま残る。通知も出ないので、ユーザーには
+	// サーバーへ届いていないことを知る手段が無い（次にこの画面を開き直すと消えている）。
+	//
+	// 投稿本体のいいね（ActionButtons.tsx）は #1501 でロールバックとリトライ Snackbar を
+	// 入れてある。**同じ画面の同じジェスチャーで、レビュー側だけが取り残されていた。**
+	// 挙動を揃える。
+	const handleReviewLike = useCallback(
+		async (reviewId: string) => {
+			// 楽観更新より前に弾く（下の #1205 のコメント参照）
+			if (inFlightLikesRef.current.has(reviewId)) return;
+			inFlightLikesRef.current.add(reviewId);
 
-		logFrontendEvent({
-			event_name: currentLikeState ? "review_unliked" : "review_liked",
-			error_level: "log",
-			payload: {
-				reviewId: review.id,
-			},
-		});
-
-		try {
-			if (willLike) {
-				await callBackend<{}, void>(`v1/dish-reviews/${review.id}/likes`, {
-					method: "POST",
-					requestPayload: {},
-				});
-			} else {
-				await callBackend<{}, void>(`v1/dish-reviews/${review.id}/likes`, {
-					method: "DELETE",
-					requestPayload: {},
-				});
+			lightImpact();
+			const { reviewsByReviewId, updateReview } = useDishMediaEntriesStore.getState();
+			const review = reviewsByReviewId[reviewId];
+			if (!review) {
+				inFlightLikesRef.current.delete(reviewId);
+				return;
 			}
-		} catch (error) {
+			const currentLikeState = review.isLiked || false;
+			const willLike = !currentLikeState;
+			// #1501 と同じ作法。戻す値は `!willLike`（トグルの反転）ではなく、
+			// **楽観更新の直前に読んだ値そのもの**を持つ。反転で戻すと、他端末や
+			// 別画面からの更新が割り込んでいた場合に誤った値を書き戻す。
+			const previousIsLiked = currentLikeState;
+			const previousLikeCount = review.likeCount;
+			const newLikeCount = willLike ? review.likeCount + 1 : Math.max(0, review.likeCount - 1);
+			updateReview(review.id, (r) => ({
+				...r,
+				isLiked: willLike,
+				likeCount: newLikeCount,
+			}));
+
 			logFrontendEvent({
-				event_name: "review_like_reaction_failed",
+				event_name: currentLikeState ? "review_unliked" : "review_liked",
 				error_level: "log",
 				payload: {
-					error: toErrorLogMessage(error),
-					target_id: review.id,
-					action_type: "like",
+					reviewId: review.id,
 				},
 			});
-		}
-	};
+
+			try {
+				await callBackend<{}, void>(`v1/dish-reviews/${review.id}/likes`, {
+					method: willLike ? "POST" : "DELETE",
+					requestPayload: {},
+				});
+			} catch (error) {
+				// 表示をサーバーと一致させるため、操作前の値へ戻す
+				updateReview(review.id, (r) => ({
+					...r,
+					isLiked: previousIsLiked,
+					likeCount: previousLikeCount,
+				}));
+
+				logFrontendEvent({
+					event_name: "review_like_reaction_failed",
+					// 黙って戻すと «勝手に取り消された» に見えるので、起票対象の warn へ上げる
+					error_level: "warn",
+					payload: {
+						error: toErrorLogMessage(error),
+						target_id: review.id,
+						action_type: "like",
+					},
+				});
+				// 文言は投稿本体のいいねと共用（「いいねの更新に失敗しました」）。
+				// レビュー専用の文言を足すと 8 ロケール増えるが、伝える内容は同じ
+				showSnackbar(i18n.t("DishMediaContent.errors.likeReactionFailed"), {
+					action: { label: i18n.t("Common.retry"), onPress: () => void handleReviewLike(reviewId) },
+				});
+			} finally {
+				// #1205 失敗しても押し直せるよう、成功・失敗のいずれでも必ず解除する
+				inFlightLikesRef.current.delete(reviewId);
+			}
+		},
+		[callBackend, lightImpact, logFrontendEvent, showSnackbar],
+	);
 
 	// #1514 (SAF-01) レビューの通報。
 	//
@@ -219,6 +257,7 @@ export function DishReviewsSection({ id, idType, paddingRight, carouselRef }: Di
 								<View style={styles.commentActions}>
 									<TouchableOpacity
 										style={styles.commentLikeButton}
+										testID={`review-action-like-${review.id}`}
 										onPress={() => handleReviewLike(review.id)}
 										accessibilityRole="button"
 										accessibilityLabel={i18n.t("DishMediaContent.accessibility.reviewLike", {

--- a/app-expo/features/dishMedia/components/DishReviewsSectionLike.test.tsx
+++ b/app-expo/features/dishMedia/components/DishReviewsSectionLike.test.tsx
@@ -1,0 +1,188 @@
+// #1599 レビューのいいねが、API 失敗時に「操作前の値」へ戻ることを固定するテスト。
+//
+// `handleReviewLike` は 1) ストアを楽観更新 → 2) API を叩く → 3) 失敗しても catch で
+// ログを出すだけ、という形になっていた。オフライン・タイムアウト・5xx で
+// **画面は「いいね済み」のまま残り、サーバーには何も届いていない**。Snackbar も出ないので、
+// ユーザーには不整合に気づく手段が無い（次にこの画面を開き直すと消えている）。
+//
+// 投稿本体のいいね（ActionButtons.tsx）は #1501 で同じ問題を直してある。
+// **同じ画面の同じジェスチャーで、レビュー側だけが取り残されていた。**
+// ここは ActionButtons.test.tsx と同じ作法（実ストアを使う）で挙動を揃えたことを固定する。
+
+import React, { act } from "react";
+import TestRenderer from "react-test-renderer";
+
+const mockCallBackend = jest.fn();
+jest.mock("@/hooks/useAPICall", () => ({ useAPICall: () => ({ callBackend: mockCallBackend }) }));
+jest.mock("@/hooks/useLogger", () => ({ useLogger: () => ({ logFrontendEvent: jest.fn() }) }));
+jest.mock("@/hooks/useHaptics", () => ({ useHaptics: () => ({ lightImpact: jest.fn() }) }));
+jest.mock("@/lib/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+jest.mock("@/contexts/AuthProvider", () => ({ useAuth: () => ({ user: { id: "me" } }) }));
+jest.mock("@/lib/remoteConfig", () => ({
+	getRemoteConfig: () => ({ v1_dish_comment_review_show_number: "100" }),
+}));
+jest.mock("@/components/Stars", () => ({ __esModule: true, default: () => null }));
+jest.mock("expo-linear-gradient", () => {
+	const { View } = require("react-native");
+	return { LinearGradient: View };
+});
+jest.mock("react-native-gesture-handler", () => {
+	const { ScrollView } = require("react-native");
+	return { ScrollView };
+});
+jest.mock("./ReportContentSheet", () => ({ ReportContentSheet: () => null }));
+
+const mockShowSnackbar = jest.fn();
+jest.mock("@/contexts/SnackbarProvider", () => ({ useSnackbar: () => ({ showSnackbar: mockShowSnackbar }) }));
+
+import { DishReviewsSection } from "./DishReviewsSection";
+import { useDishMediaEntriesStore } from "@/stores/useDishMediaEntriesStore";
+
+// React 19 では初期描画がスケジューラのタスクへ回されるため act() で包む必要がある
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const MEDIA_ID = "dm-1";
+const REVIEW_ID = "rv-1";
+
+function seedStore(overrides: { isLiked?: boolean; likeCount?: number }) {
+	useDishMediaEntriesStore.setState({
+		entriesByMediaId: {
+			[MEDIA_ID]: {
+				dish_media: { id: MEDIA_ID },
+				restaurant: { id: "r-1", name: "テスト店" },
+				dishReviewIds: [REVIEW_ID],
+			},
+		} as never,
+		reviewsByReviewId: {
+			[REVIEW_ID]: {
+				id: REVIEW_ID,
+				user_id: "someone-else",
+				username: "someone",
+				comment: "おいしい",
+				rating: 5,
+				created_at: "2026-08-26T00:00:00.000Z",
+				isLiked: overrides.isLiked ?? false,
+				likeCount: overrides.likeCount ?? 3,
+			},
+		} as never,
+	});
+}
+
+const getReview = () => useDishMediaEntriesStore.getState().reviewsByReviewId[REVIEW_ID]!;
+
+let activeRenderer: TestRenderer.ReactTestRenderer | undefined;
+
+function renderSection() {
+	let renderer!: TestRenderer.ReactTestRenderer;
+	act(() => {
+		renderer = TestRenderer.create(
+			<DishReviewsSection id={MEDIA_ID} idType="dish_media" paddingRight={0} carouselRef={undefined} />,
+		);
+	});
+	activeRenderer = renderer;
+	return renderer;
+}
+
+/** testID に一致する要素のうち、実際に onPress を持つもの（TouchableOpacity 本体）を返す */
+function findLikeButton(renderer: TestRenderer.ReactTestRenderer) {
+	const matches = renderer.root.findAllByProps({ testID: `review-action-like-${REVIEW_ID}` });
+	const pressable = matches.find((instance) => typeof instance.props.onPress === "function");
+	if (!pressable) throw new Error("like button not found");
+	return pressable;
+}
+
+describe("#1599 レビューいいねの楽観更新ロールバック", () => {
+	beforeEach(() => {
+		mockCallBackend.mockReset();
+		mockShowSnackbar.mockReset();
+		useDishMediaEntriesStore.setState({ entriesByMediaId: {}, reviewsByReviewId: {} } as never);
+	});
+
+	afterEach(() => {
+		act(() => activeRenderer?.unmount());
+		activeRenderer = undefined;
+	});
+
+	it("いいね失敗時、isLiked・likeCount が操作前の値へ戻る", async () => {
+		seedStore({ isLiked: false, likeCount: 3 });
+		mockCallBackend.mockRejectedValueOnce(new Error("boom"));
+
+		const renderer = renderSection();
+		await act(async () => {
+			await findLikeButton(renderer).props.onPress();
+		});
+
+		expect(getReview().isLiked).toBe(false);
+		expect(getReview().likeCount).toBe(3);
+		// 黙って戻すと «勝手に取り消された» に見えるので、失敗を伝えて再試行させる
+		expect(mockShowSnackbar).toHaveBeenCalledTimes(1);
+		const [, options] = mockShowSnackbar.mock.calls[0];
+		expect(typeof options?.action?.onPress).toBe("function");
+	});
+
+	it("いいね解除（true → false 操作）の失敗時も、操作前の値へ戻る", async () => {
+		seedStore({ isLiked: true, likeCount: 5 });
+		mockCallBackend.mockRejectedValueOnce(new Error("boom"));
+
+		const renderer = renderSection();
+		await act(async () => {
+			await findLikeButton(renderer).props.onPress();
+		});
+
+		expect(getReview().isLiked).toBe(true);
+		expect(getReview().likeCount).toBe(5);
+	});
+
+	it("成功時は楽観更新のまま残り、Snackbar も出さない", async () => {
+		seedStore({ isLiked: false, likeCount: 3 });
+		mockCallBackend.mockResolvedValueOnce(undefined);
+
+		const renderer = renderSection();
+		await act(async () => {
+			await findLikeButton(renderer).props.onPress();
+		});
+
+		expect(getReview().isLiked).toBe(true);
+		expect(getReview().likeCount).toBe(4);
+		expect(mockShowSnackbar).not.toHaveBeenCalled();
+	});
+
+	it("連打しても API は 1 回しか飛ばない（多重実行ガード）", async () => {
+		seedStore({ isLiked: false, likeCount: 3 });
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		mockCallBackend.mockImplementation(() => gate);
+
+		const renderer = renderSection();
+		const button = findLikeButton(renderer);
+
+		await act(async () => {
+			const first = button.props.onPress();
+			// 1 発目が飛んでいる最中の 2 発目
+			const second = button.props.onPress();
+			release();
+			await Promise.all([first, second]);
+		});
+
+		expect(mockCallBackend).toHaveBeenCalledTimes(1);
+		// 2 発目がトグルを戻していないこと（ガードが楽観更新より前にある証拠）
+		expect(getReview().isLiked).toBe(true);
+		expect(getReview().likeCount).toBe(4);
+	});
+
+	it("解除は DELETE、付与は POST（メソッドを取り違えない）", async () => {
+		seedStore({ isLiked: true, likeCount: 5 });
+		mockCallBackend.mockResolvedValueOnce(undefined);
+
+		const renderer = renderSection();
+		await act(async () => {
+			await findLikeButton(renderer).props.onPress();
+		});
+
+		const [path, options] = mockCallBackend.mock.calls[0];
+		expect(path).toBe(`v1/dish-reviews/${REVIEW_ID}/likes`);
+		expect(options.method).toBe("DELETE");
+	});
+});


### PR DESCRIPTION
R6-A（エラー握りつぶしレビュー）の指摘を 1 件ずつ裏取りし、**実害が確認できた 2 件**を直した。どちらも「サーバーには何も届いていないのに、ユーザーには成功したように見える」形。

---

## 1. レビューのいいねが、失敗しても戻らない

`features/dishMedia/components/DishReviewsSection.tsx`

楽観更新したあと API を叩き、**失敗しても catch でログを出すだけ**だった。オフライン・タイムアウト・5xx で画面は「いいね済み」のまま残り、Snackbar も出ないので、ユーザーには気づく手段が無い（次に開き直すと消えている）。

**投稿本体のいいね（`ActionButtons.tsx`）は #1501 で同じ問題を直してある。同じ画面の同じジェスチャーで、レビュー側だけが取り残されていた。**

| | 投稿本体 (#1501 済) | レビュー (修正前) |
| --- | --- | --- |
| 失敗時のロールバック | ✅ | ❌ |
| 失敗の Snackbar + リトライ | ✅ | ❌ |
| 連打ガード (#1205) | ✅ | ❌ |

直したこと:

- 失敗時に `isLiked` / `likeCount` を操作前の値へ戻す。戻す値は `!willLike`（トグルの反転）ではなく**楽観更新の直前に読んだ値そのもの**（#1501 と同じ作法。反転で戻すと、他端末や別画面からの更新が割り込んでいた場合に誤った値を書き戻す）
- 失敗を Snackbar で伝え、リトライを出す。文言は投稿本体と共用（`DishMediaContent.errors.likeReactionFailed` = 「いいねの更新に失敗しました」）。レビュー専用の文言を足すと 8 ロケール増えるが、伝える内容は同じ
- 連打ガードを足す。**楽観更新より前に弾く**（後にすると 2 発目がトグルを戻してから弾かれ、表示だけ巻き戻る）
- ログを `log` から `warn` へ。黙って戻すと「勝手に取り消された」に見えるので、起票対象に上げる

---

## 2. 貢献タスクの送信が全件失敗しても「ありがとうございました」が出る

`app/[locale]/contribution-tasks/dish-category-manual-image-supply.tsx`

`setShowThanks(true)` が `successCount` / `failCount` を**一切見ずに無条件で**呼ばれていた。

さらに悪いことに、送信に失敗した item の `uploadState` は `"success"` のまま据え置かれる。**`uploadState` は「画像をストレージへ上げられたか」であって「送信できたか」ではない。** その結果:

```ts
const remainingItems = items.filter((item) => itemStates[item.category_id]?.uploadState !== "success");
if (remainingItems.length > 0) { /* 続ける */ } else { router.back(); }
```

失敗した item がここから漏れ、「もう協力できる料理は無い」と判定されて `router.back()`。**ユーザーの投稿は誰にも気づかれないまま消える。**

直したこと:

- 送信に失敗した item は `"error"` へ戻し、「まだ残っている」ものとして扱う。`state.uploaded`（アップロード済みのパス）は捨てないので、**上げ直しにはならない**
- 1 件も通っていないならサンクスを出さず、失敗を伝える
- 一部失敗なら件数を伝えたうえでサンクスへ進む
- 失敗の記録を `log` から `warn` へ（`log` のままだと error-triage に乗らず、誰も気づけない）

この画面は i18n を使っておらず生の日本語文字列で書かれているため（`showSnackbar("プロンプトをコピーしました")` 等）、既存の書き方に合わせた。

---

## テスト

**`DishReviewsSectionLike.test.tsx` を新規追加（5 件）。** 実ストアを使う `ActionButtons.test.tsx` と同じ作法。

- ロールバック（**付与・解除の両方向**）
- 成功時は楽観更新のまま残り、Snackbar も出さないこと
- 連打で API が 1 回しか飛ばず、かつ 2 発目がトグルを戻していないこと（ガードが楽観更新より前にある証拠）
- 解除が `DELETE`、付与が `POST`（メソッドの取り違えが無いこと）

**修正前のコードへ戻すと 5 件中 3 件が落ちることを確認済み**（テストが実際に回帰を捕まえることの確認）。

あわせて、いいねボタンへ `testID` を足した（通報ボタンには既にある）。既存 `DishReviewsSection.test.tsx` には `SnackbarProvider` の代役を足した（コンポーネントが `useSnackbar` を使うようになったため）。

## R6-A の残り 2 件について

- **`maintenance.guard.ts` の `console.warn`（中）** — 指摘は正しい。`api/src` で唯一構造化ログを経由していない catch で、GCS 障害中にメンテナンスゲートが fail-open していても error-triage に乗らない。別 PR で拾う
- **`dish-category-image-optimizer.tsx` の送信処理がコメントアウト（高）** — dead code であって握りつぶしではない。**意図的な無効化なのか消し忘れなのかコードからは判断できない**ので、勝手に復活させない。#1599 の未解決事項として残す

## 検証

- `pnpm --filter app-expo test` → **157 suites / 1558 tests 全 green**
- `pnpm --filter app-expo lint` → **0 errors**
- `pnpm --filter app-expo typecheck` → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_