### PR TITLE
fix(api): メンテナンスゲートの fail-open が観測できないのを直す (#1599)

### DIFF
--- a/api/src/core/guards/maintenance.guard.spec.ts
+++ b/api/src/core/guards/maintenance.guard.spec.ts
@@ -4,6 +4,7 @@ import { ExecutionContext, HttpException, HttpStatus } from '@nestjs/common';
 import { MaintenanceGuard } from './maintenance.guard';
 import { RemoteConfigService } from '../remote-config/remote-config.service';
 import { ClsService } from 'nestjs-cls';
+import { AppLoggerService } from '../logger/logger.service';
 
 // Mock request object
 const createMockRequest = (
@@ -25,12 +26,15 @@ const createMockContext = (request: any): ExecutionContext =>
 describe('MaintenanceGuard', () => {
   let guard: MaintenanceGuard;
   let remoteConfigService: jest.Mocked<RemoteConfigService>;
+  // #1599 fail-open したことが構造化ログへ残るかを見るため、代役を握っておく
+  const mockLogger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
 
   beforeEach(async () => {
     const mockRemoteConfigService = {
       getRemoteConfigValue: jest.fn(),
     };
     const mockClsService = { set: jest.fn() } as unknown as ClsService;
+    mockLogger.warn.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -42,6 +46,10 @@ describe('MaintenanceGuard', () => {
         {
           provide: ClsService,
           useValue: mockClsService,
+        },
+        {
+          provide: AppLoggerService,
+          useValue: mockLogger,
         },
       ],
     }).compile();
@@ -161,6 +169,35 @@ describe('MaintenanceGuard', () => {
       const result = await guard.canActivate(context);
 
       expect(result).toBe(true);
+    });
+
+    // #1599 fail-open 自体は妥当な設計判断だが、**開いたことが見えない**のは別の問題。
+    // 生の console.warn は error-triage（BigQuery の log_type で絞る）の網にかからず、
+    // GCS が落ち続けてメンテナンスゲートが機能しなくなっても誰も気づけなかった。
+    it('should record the fail-open through the structured logger, not console', async () => {
+      const consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+      remoteConfigService.getRemoteConfigValue.mockRejectedValue(
+        new Error('GCS connection failed'),
+      );
+
+      const request = createMockRequest('/health', {
+        'x-app-version': '1.0.0',
+      });
+
+      await guard.canActivate(createMockContext(request));
+
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      const [eventName, functionName, payload] = mockLogger.warn.mock.calls[0];
+      expect(eventName).toBe('MaintenanceConfigUnavailable');
+      expect(functionName).toBe('canActivate');
+      // 原因を追えるだけの情報が残ること（どのパスで、何が起きたか）
+      expect(payload).toMatchObject({
+        path: '/health',
+        error: 'GCS connection failed',
+      });
+      // 生テキストへ戻っていないこと
+      expect(consoleWarn).not.toHaveBeenCalled();
+      consoleWarn.mockRestore();
     });
   });
 });

--- a/api/src/core/guards/maintenance.guard.ts
+++ b/api/src/core/guards/maintenance.guard.ts
@@ -11,6 +11,7 @@ import { RemoteConfigService } from '../remote-config/remote-config.service';
 import { isVersionGreaterOrEqual } from '../utils/version.util';
 import { ClsService } from 'nestjs-cls';
 import { CLS_KEY_APP_VERSION } from '../cls/cls.constants';
+import { AppLoggerService } from '../logger/logger.service';
 
 /**
  * 🔒 メンテナンス・バージョン制御ガード
@@ -37,6 +38,7 @@ export class MaintenanceGuard implements CanActivate {
   constructor(
     private readonly remoteConfigService: RemoteConfigService,
     private readonly cls: ClsService,
+    private readonly logger: AppLoggerService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -96,11 +98,21 @@ export class MaintenanceGuard implements CanActivate {
         throw error;
       }
 
-      // GCS設定取得エラー等の場合はフォールバック（通す）
-      console.warn(
-        'MaintenanceGuard: Failed to retrieve configuration, allowing request:',
-        error,
-      );
+      // GCS設定取得エラー等の場合はフォールバック（通す）。
+      //
+      // #1599 【バグ】ここは `console.warn` で生テキストを吐いていた。api/src で
+      // 構造化ログを経由しない catch はここだけである（他はすべて this.logger.*）。
+      //
+      // AppLoggerService は `log_type: 'backend_event_logs'` の JSON を stdout へ出し、
+      // error-triage はまさにそのフィールドで BigQuery を絞り込む。生テキストは
+      // その網に一切かからない。つまり **GCS / RemoteConfig が継続的に落ちていて、
+      // メンテナンスモードと強制アップデートのゲートが両方 fail-open している間、
+      // 自動検知には乗らず誰も気づけない**。fail-open という設計判断は妥当だが、
+      // 「開いたことが見えない」のは別の問題である。
+      this.logger.warn('MaintenanceConfigUnavailable', 'canActivate', {
+        path,
+        error: error instanceof Error ? error.message : String(error),
+      });
       return true;
     }
   }

--- a/api/src/core/logger/console-usage-boundary.spec.ts
+++ b/api/src/core/logger/console-usage-boundary.spec.ts
@@ -1,0 +1,80 @@
+// api/src/core/logger/console-usage-boundary.spec.ts
+//
+// #1599 **api のアプリケーションコードから `console.*` を締め出す**ラチェット。
+//
+// ## なぜ要るのか
+//
+// `AppLoggerService` は `log_type: 'backend_event_logs'` の JSON を stdout へ出し、
+// error-triage は **まさにそのフィールドで BigQuery を絞り込む**。
+// `console.warn('...', error)` の生テキストはその網に一切かからない。
+//
+// 実際に `maintenance.guard.ts` の catch がこの形で、**GCS / RemoteConfig が
+// 落ちていてメンテナンスモードと強制アップデートのゲートが両方 fail-open している間、
+// 自動検知には乗らず誰も気づけない**状態になっていた。
+//
+// 「見えないものは «無い» ではない」（CLAUDE.md）。観測できない障害は、
+// オーナーが踏むまで誰にも見えない。
+//
+// ## 落ちたときにやること
+//
+// `this.logger.log / warn / error`（`AppLoggerService`）を使う。DI が使えない場所
+// （logger 自身の出力・env 検証のようにログ基盤より前に走るもの）だけ、
+// **理由を書いて** ALLOWED へ足す。
+
+import { lineOf, listSourceFiles, readCode, toRepoPath } from '../../../test/source-scan';
+
+/**
+ * `console.*` を使ってよい場所。**理由を必ず書くこと。**
+ * キーは `api/` からの相対パス。
+ */
+const ALLOWED: Readonly<Record<string, string>> = {
+  // 構造化ログの出口そのもの。ここが console.log を呼ばないと何も出ない
+  'src/core/logger/logger.service.ts': '構造化ログを stdout へ書く出口',
+  // Prisma のクエリログを同じ JSON 形式へ整形して流す。logger と同じ層
+  'src/prisma/prisma.service.ts': 'Prisma のログを構造化 JSON として流す出口',
+  // 環境変数の検証は DI コンテナが立ち上がる前に走るので logger を使えない
+  'src/core/config/env.ts': 'DI 起動前に走る env 検証。logger がまだ無い',
+};
+
+const CONSOLE_PATTERN = /\bconsole\s*\.\s*(log|warn|error|info|debug|trace)\s*\(/g;
+
+describe('#1599 api のアプリケーションコードは console.* を使わない', () => {
+  const files = listSourceFiles();
+
+  it('検査対象のソースを実際に走査できている（0 件なら検査自体が壊れている）', () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it('【自己検査】console.warn を実際に検出できる', () => {
+    const sample = `
+      } catch (error) {
+        console.warn('MaintenanceGuard: Failed to retrieve configuration', error);
+        return true;
+      }
+    `;
+    expect([...sample.matchAll(CONSOLE_PATTERN)]).toHaveLength(1);
+  });
+
+  it('logger 以外から console.* が呼ばれていない', () => {
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const path = toRepoPath(file);
+      if (ALLOWED[path]) continue;
+
+      // コメントを潰した本文だけを見る（「console.warn を使うな」と書いた
+      // 説明コメント自体を違反と誤認しないため）
+      const text = readCode(file);
+      for (const match of text.matchAll(CONSOLE_PATTERN)) {
+        violations.push(`${path}:${lineOf(text, match.index)} → console.${match[1]}()`);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('ALLOWED に挙げた場所は実在する（消えた行が居座らない）', () => {
+    const known = new Set(files.map(toRepoPath));
+    expect(Object.keys(ALLOWED).filter((path) => !known.has(path))).toEqual([]);
+  });
+});


### PR DESCRIPTION
R6-A の【中】指摘を裏取りして直したもの。

## 何が問題か

`MaintenanceGuard` は GCS / RemoteConfig の取得に失敗したとき **fail-open** でリクエストを通す。設計判断としては妥当（設定が読めないだけで全 API を止めるのは過剰）だが、その事実を `console.warn` で**生テキストとして**吐いていた。

```ts
} catch (error) {
  if (error instanceof HttpException) throw error;
  console.warn('MaintenanceGuard: Failed to retrieve configuration, allowing request:', error);
  return true;
}
```

`AppLoggerService` は `log_type: 'backend_event_logs'` の JSON を stdout へ出し、**error-triage はまさにそのフィールドで BigQuery を絞り込む**。生テキストはその網に一切かからない。

つまり **GCS / RemoteConfig が継続的に落ちていて、メンテナンスモードと強制アップデートのゲートが両方 fail-open している間、自動検知には乗らず誰も気づけない。**

`api/src` で構造化ログを経由しない catch は**ここだけ**だった（他はすべて `this.logger.*`）。実際に grep で確認した残りの `console.*` は 3 箇所で、いずれも logger 基盤そのものか DI 起動前のコードだった。

> 「見えないものは «無い» ではない。」— CLAUDE.md

## どう直したか

**fail-open 自体は残す。開いたことが見えるようにする。**

```ts
this.logger.warn('MaintenanceConfigUnavailable', 'canActivate', {
  path,
  error: error instanceof Error ? error.message : String(error),
});
```

`LoggerModule` は `@Global()` なので、グローバル登録されているこの guard へ DI するだけで済む。

## 再発防止のラチェット

同じことが起きないよう、`api/src` から `console.*` を締め出すラチェットを足した（`console-usage-boundary.spec.ts`）。

DI が使えない 3 箇所だけ**理由つきで** ALLOWED に置いた:

| 場所 | 理由 |
| --- | --- |
| `src/core/logger/logger.service.ts` | 構造化ログを stdout へ書く出口そのもの |
| `src/prisma/prisma.service.ts` | Prisma のログを同じ JSON 形式へ整形して流す出口 |
| `src/core/config/env.ts` | DI 起動前に走る env 検証。logger がまだ無い |

**ALLOWED に挙げた行が実在することも検査する** — ファイルが消えたあとに除外指定だけが居座り、いつのまにか穴になるのを防ぐため。

## テスト

- **`maintenance.guard.spec.ts` に 1 件追加** — fail-open が `MaintenanceConfigUnavailable` として構造化ログへ残り、原因を追える payload（`path` と error message）が付くこと。あわせて **`console.warn` へ戻っていないことも spy で検査**する
- **`console-usage-boundary.spec.ts`（4 件）** — 自己検査として、**修正前の `console.warn` の行そのものを入力に与えて検出できること**を固定した（ラチェットが緑なのが「壊れていないから」なのか「見えていないから」なのかを、ラチェット自身で確かめる）

## 検証

- `pnpm --filter api test` → **69 suites / 855 tests 全 green**
- `pnpm --filter api typecheck` → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_