### PR TITLE
fix(app-expo): 不正なロケールの URL で画面全体がエラーに落ちるのを直す (#1599)

### DIFF
--- a/app-expo/features/map/components/BidForm.tsx
+++ b/app-expo/features/map/components/BidForm.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/Card";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import i18n from "@/lib/i18n";
 import { LoadingIndicator } from "@/components/LoadingIndicator";
+import { useLocale } from "@/hooks/useLocale";
 
 interface BidFormProps {
 	/** Initial bid amount */
@@ -24,6 +25,11 @@ interface BidFormProps {
 export function BidForm({ initialBidAmount = "", onSubmit, onCancel, isProcessing = false }: BidFormProps) {
 	// Internal state - isolated from parent re-renders
 	const [bidAmount, setBidAmount] = useState(initialBidAmount);
+	// #1599 隣のラベル（Map.labels.endDate）は 8 ロケール全てに翻訳があるのに、
+	// 日付の書式だけ "ja-JP" 固定だった。この画面にロケール限定のガードは無いので、
+	// 日本語以外のユーザーには «ラベルは英語・日付は 2026/9/25（年/月/日）» という
+	// ちぐはぐな表示になっていた。
+	const { locale } = useLocale();
 
 	const handleSubmit = useCallback(() => {
 		onSubmit(bidAmount);
@@ -52,7 +58,7 @@ export function BidForm({ initialBidAmount = "", onSubmit, onCancel, isProcessin
 				<View style={styles.bidInfoRow}>
 					<Calendar size={16} color="#666" />
 					<Text style={styles.bidInfoText}>
-						{i18n.t("Map.labels.endDate")} {new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toLocaleDateString("ja-JP")}
+						{i18n.t("Map.labels.endDate")} {new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toLocaleDateString(locale)}
 					</Text>
 				</View>
 			</View>

--- a/app-expo/hooks/useLocale.test.ts
+++ b/app-expo/hooks/useLocale.test.ts
@@ -82,6 +82,39 @@ describe("#1194 useLocale", () => {
 		expect(localeOf("/pt-BR/search")).toBe("pt-BR");
 	});
 
+	// #1599 LOCALE_LIKE は BCP 47 の «形» の近似でしかなく、実際のタグ規則より緩い。
+	// サブタグに [A-Za-z0-9]{2,8} を許すが、リージョンは «英字 2» か «数字 3» なので
+	// `ja-01` / `en-A1` は正規表現を通るのに Intl が RangeError を投げる。
+	//
+	//   new Date().toLocaleDateString("ja-01")  // RangeError
+	//
+	// profile/content-reports と profile/dish-category-group-votes が
+	// toLocaleDateString(locale) を直接呼んでいるため、そういう URL で入ると
+	// レンダー中に例外が飛び、画面全体が ErrorBoundary のフォールバックへ置き換わる。
+	describe("#1599 Intl へ渡して壊れるロケールは返さない", () => {
+		it.each(["ja-01", "en-A1", "ja-JP-JP-JP-JP-JP-JP-JP-JP-JP"])(
+			"%s は採らず、フォールバックへ落とす",
+			(bogus) => {
+				expect(localeOf(`/${bogus}/profile/content-reports`)).toBe("ja-JP");
+			},
+		);
+
+		it("返ってきたロケールは toLocaleDateString へ渡しても投げない", () => {
+			// ここが本体。上の 3 件は «弾けたか» だが、これは «契約が守られているか»。
+			// 新しい抜け道が増えても、この検査は落ちる
+			for (const pathname of ["/ja-01/x", "/en-A1/x", "/pt-BR/x", "/ja-JP/x", "/s/s1_AbCdEf", "/"]) {
+				const locale = localeOf(pathname);
+				expect(() => new Date(0).toLocaleDateString(locale)).not.toThrow();
+			}
+		});
+
+		// «妥当だが未対応» は従来どおり素通しであること（上の pt-BR のテストと同じ意図）。
+		// Intl 検証を «対応ロケール一覧との突き合わせ» にしてしまうと、ここが落ちる
+		it("妥当だが未対応のロケールは弾かない", () => {
+			expect(localeOf("/xx-YY/search")).toBe("xx-YY");
+		});
+	});
+
 	it("isJapanese は解決後のロケールで判定する", () => {
 		expect(renderUseLocale("/").isJapanese).toBe(true);
 		expect(renderUseLocale("/en-US/search").isJapanese).toBe(false);

--- a/app-expo/hooks/useLocale.ts
+++ b/app-expo/hooks/useLocale.ts
@@ -15,6 +15,39 @@ import { resolvePublicLocale } from "@/constants/seoLocales";
 const LOCALE_LIKE = /^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$/;
 
 /**
+ * #1599 その文字列を `Intl` 系 API（`toLocaleDateString` 等）へ渡して安全か。
+ *
+ * 【バグ】`LOCALE_LIKE` は BCP 47 の «形» の近似でしかなく、実際のタグ規則より緩い。
+ * サブタグに `[A-Za-z0-9]{2,8}` を許すが、BCP 47 のリージョンは «英字 2» か «数字 3» で、
+ * `ja-01` や `en-A1` はそのどちらでもない。**正規表現は通るのに `Intl` は例外を投げる。**
+ *
+ * ```
+ * new Date().toLocaleDateString("ja-01")  // RangeError: Incorrect locale information provided
+ * ```
+ *
+ * 実際に `profile/content-reports` と `profile/dish-category-group-votes` が
+ * `toLocaleDateString(locale)` を直接呼んでおり、`/ja-01/profile/content-reports` のような
+ * URL（手打ち・改変された共有リンク・クローラの誤生成）で入ると**レンダー中に例外が飛び、
+ * 画面全体が ErrorBoundary のフォールバックへ置き換わる**。一覧が一切見られなくなる。
+ *
+ * 【設計】上のコメントにあるとおり «未対応ロケールの URL ではそのセグメントを使う» のは
+ * 意図した挙動なので、対応ロケール一覧との突き合わせでは弾かない。弾くのは
+ * **`Intl` が受け付けない = 渡すと必ず壊れる**ものだけにする。
+ * `pt-BR` や `xx-YY` のような «妥当だが未対応» は従来どおり素通しになる。
+ */
+const isIntlUsableLocale = (tag: string): boolean => {
+	// Intl が無い環境（web の一部・一部の JS エンジン）では検証しようがない。
+	// その環境では toLocaleDateString も Intl を使わないので、素通しでよい。
+	if (typeof Intl === "undefined" || typeof Intl.DateTimeFormat !== "function") return true;
+	try {
+		new Intl.DateTimeFormat(tag);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/**
  * 🌐 現在のロケールを URL から取り出す。
  *
  * ## ⚠️ 空文字を返してはいけない（実機で踏んだ）
@@ -41,14 +74,17 @@ const LOCALE_LIKE = /^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$/;
  * どちらも「パス先頭が必ずロケールである」という前提が崩れる経路です。
  * 呼び出し側は 38 箇所あるので、**ここで必ず妥当な値へ寄せる**のが唯一の直し方です。
  *
- * @returns locale はロケールらしい文字列であることが保証される（空文字にはならない）
+ * @returns locale はロケールらしい文字列であることが保証される。空文字にはならず、
+ *          **`Intl` 系 API（`toLocaleDateString` 等）へ渡しても例外にならない**ことも保証する（#1599）
  */
 export const useLocale = () => {
 	const pathname = usePathname();
 
 	const locale = useMemo(() => {
 		const fromPath = pathname.split("/")[1];
-		if (fromPath && LOCALE_LIKE.test(fromPath)) return fromPath;
+		// #1599 `Intl` へ渡して壊れるものは «ロケールらしい» とは言えない。
+		// 弾いたものは以降のフォールバック（端末の言語設定）へ落ちる。
+		if (fromPath && LOCALE_LIKE.test(fromPath) && isIntlUsableLocale(fromPath)) return fromPath;
 
 		// ## ⚠️ `i18n.locale` を先に読んではいけない（#1375 実機で踏んだ）
 		//


### PR DESCRIPTION
R6-B（日時・ロケールレビュー）の指摘 2 件を、`node -e` で自分でも再現させたうえで直したもの。

---

## 1. 不正なロケールの URL で画面全体が ErrorBoundary に落ちる

`useLocale()` は URL パス先頭のセグメントが `LOCALE_LIKE` に当たればそのまま返す。

```ts
const LOCALE_LIKE = /^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$/;
```

この正規表現は BCP 47 の「形」の近似でしかなく、**実際のタグ規則より緩い**。サブタグに `[A-Za-z0-9]{2,8}` を許すが、BCP 47 のリージョンは「英字 2」か「数字 3」なので、`ja-01` や `en-A1` はそのどちらでもない。

実測（`node -e`）:

```
"ja-01"                          regex: true → RangeError: Incorrect locale information provided
"en-A1"                          regex: true → RangeError: Incorrect locale information provided
"ja-JP-JP-JP-JP-JP-JP-JP-JP-JP"  regex: true → RangeError: Incorrect locale information provided
"pt-BR"                          regex: true → 01/01/1970     ← 通ってほしいもの
"xx-YY"                          regex: true → 1/1/1970       ← 通ってほしいもの
```

`profile/content-reports` と `profile/dish-category-group-votes` は `toLocaleDateString(locale)` を**直接**呼んでいる。`/ja-01/profile/content-reports` のような URL（手打ち・改変された共有リンク・クローラの誤生成）で入ると**レンダー中に例外が飛び、画面全体が ErrorBoundary のフォールバックへ置き換わる**。通報一覧も投票一覧も見られなくなる。

### どこを直したか

**呼び出し側 38 箇所ではなく `useLocale` 側。** docstring は既にこう約束していた:

> `@returns locale はロケールらしい文字列であることが保証される`

**その保証が弱すぎたのが実体である**（「正規表現に当たる」であって「使える」ではなかった）。保証を「`Intl` へ渡しても例外にならない」まで強め、docstring も更新した。

```ts
const isIntlUsableLocale = (tag: string): boolean => {
	if (typeof Intl === "undefined" || typeof Intl.DateTimeFormat !== "function") return true;
	try { new Intl.DateTimeFormat(tag); return true; } catch { return false; }
};
```

⚠️ **対応ロケール一覧との突き合わせでは弾かない。** 「未対応ロケールの URL では従来どおりそのセグメントを使う」のは意図した挙動で、元のコメントに明記されている:

> 完全一致（`PUBLIC_LOCALES` に含まれるか）で判定しないのは、`/xx-YY/...` のような未対応ロケールの URL で **従来どおりそのセグメントを使う**挙動を変えないため。

弾くのは**渡すと必ず壊れるもの**だけ。`pt-BR` / `xx-YY` は素通しのまま（既存テスト「未対応ロケールの URL はそのセグメントを維持する」は緑のまま通っている）。

---

## 2. BidForm の終了日がロケール無視で `"ja-JP"` 固定

`features/map/components/BidForm.tsx`

隣のラベル `Map.labels.endDate` は 8 ロケール全ての `locales/*.json` に翻訳があるのに、**日付の書式だけ `"ja-JP"` 固定**だった。この画面（Map の入札）にロケール限定のガードは無く、`isJapanese` によるフィルタも掛かっていない。

| | 期待 | 実際（修正前） |
| --- | --- | --- |
| 英語 UI | `9/25/2026` | `2026/9/25` |
| アラビア語 UI | `٢٥/٩/٢٠٢٦` | `2026/9/25` |

`useLocale()` を通すよう直した。1 の修正が入っているので、ここへ渡る値はもう例外を投げない。

---

## テスト

`useLocale.test.ts` に 5 件追加。

- `ja-01` / `en-A1` / サブタグ重複超過 を**採らず**フォールバックへ落とすこと
- **返ってきたロケールは `toLocaleDateString` へ渡しても投げないこと** — これが本体。上の 3 件は「弾けたか」だが、これは**契約が守られているか**を見る。新しい抜け道が増えてもこの検査は落ちる
- **妥当だが未対応（`xx-YY`）は弾かないこと** — `Intl` 検証を「対応ロケール一覧との突き合わせ」にしてしまうと、ここが落ちる

**修正前のコードへ戻すと 16 件中 4 件が落ちることを確認済み。**

## R6-B が「見つからなかった」と報告したもの

自分でも確認した。UTC/ローカルの日境界（`myDishes/calendar.ts`）、月末繰り上がり（`addMonths` は日を 1 固定で呼ぶ）、DST（手計算の 86400000 加算は使っていない）はいずれも問題なし。`eaten_at` の UTC フォールバックは書き込みが常に `null` で未配線のため現状の影響なし。

## 検証

- `pnpm --filter app-expo test` → **156 suites / 1558 tests 全 green**
- `pnpm --filter app-expo lint` → **0 errors**
- `pnpm --filter app-expo typecheck` → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_