### PR TITLE
fix(api): ISO 8601 だが new Date() が解釈できない日付で一覧が壊れるのを直す (#1599)

### DIFF
--- a/api/src/v1/users/query-my-dishes.dto.spec.ts
+++ b/api/src/v1/users/query-my-dishes.dto.spec.ts
@@ -156,3 +156,57 @@ describe('QueryMyDishesDto', () => {
     ]);
   });
 });
+
+/**
+ * #1599 `@IsISO8601()` は ISO 8601 の «形» を見るだけで、JavaScript の `Date` が
+ * 解釈できるかは見ない。ISO 8601 には週日付（`2026-W01`）や基本形式（`20260826`）もあり、
+ * 規格として正しいのに `new Date()` では Invalid Date になる。
+ *
+ * `my-dishes.query.ts` の `rangeFilter` / `saveBounds` は受け取った文字列を
+ * `new Date(...)` して **そのままクエリの条件に載せる**（4 箇所）ので、
+ * この差がそのままバグになる。
+ */
+describe('#1599 QueryMyDishesDto の from / to は new Date() が解釈できる形だけ通す', () => {
+  it.each([
+    ['2026-08-26', '日付だけ'],
+    ['2026-08-26T00:00:00Z', '日時（Z）'],
+    ['2026-08-26T09:30:00+09:00', '日時（オフセット）'],
+    ['2026-08-26T00:00:00.000Z', 'ミリ秒つき'],
+    ['2026-08', '年月'],
+    ['2026', '年だけ'],
+  ])('%s は通る（%s）', (value) => {
+    expect(propertiesWithErrors({ from: value })).toEqual([]);
+    expect(propertiesWithErrors({ to: value })).toEqual([]);
+    // 通した以上、呼び出し側が new Date() しても壊れないこと
+    expect(Number.isNaN(new Date(value).getTime())).toBe(false);
+  });
+
+  it.each([
+    ['2026-W01', '週日付。ISO 8601 だが new Date() は Invalid Date'],
+    ['2026-W01-1', '週日付（曜日つき）。同上'],
+    ['20260826', '基本形式（ハイフン無し）。同上'],
+  ])('%s は弾く（%s）', (value) => {
+    // 前提: これらは @IsISO8601() だけなら通ってしまう形である
+    expect(Number.isNaN(new Date(value).getTime())).toBe(true);
+
+    expect(propertiesWithErrors({ from: value })).toEqual(['from']);
+    expect(propertiesWithErrors({ to: value })).toEqual(['to']);
+  });
+
+  it('2026-02-30 は弾く（new Date() が黙って 3/2 へ繰り上げてしまう）', () => {
+    // 通してしまうと「2 月 30 日以降」で検索したつもりが 3 月 2 日以降になる。
+    // 例外にならないぶん、こちらの方が気づきにくい
+    expect(new Date('2026-02-30').toISOString()).toBe('2026-03-02T00:00:00.000Z');
+
+    expect(propertiesWithErrors({ from: '2026-02-30' })).toEqual(['from']);
+  });
+
+  it('そもそも日付でない文字列も従来どおり弾く', () => {
+    expect(propertiesWithErrors({ from: 'not-a-date' })).toEqual(['from']);
+    expect(propertiesWithErrors({ from: '' })).toEqual(['from']);
+  });
+
+  it('未指定なら検査しない（省略可能のまま）', () => {
+    expect(propertiesWithErrors({})).toEqual([]);
+  });
+});

--- a/shared/api/v1/dto/contribution-tasks/list-contribution-tasks.query.ts
+++ b/shared/api/v1/dto/contribution-tasks/list-contribution-tasks.query.ts
@@ -1,4 +1,5 @@
 import { IsOptional, IsString, IsInt, Min, Max, IsISO8601 } from "class-validator";
+import { IsParsableDateString } from "../is-parsable-date-string";
 import { Transform } from "class-transformer";
 
 /**
@@ -29,12 +30,16 @@ export class ListContributionTasksQueryDto {
 
 	/** 作成日時の開始（ISO8601形式、created_at >= from） */
 	@IsOptional()
-	@IsISO8601()
+	// #1599 contribution-tasks.service.ts が new Date(query.from) して Prisma の
+	// where へ載せるので、Invalid Date を通すと 500 になる。詳細は IsParsableDateString。
+	@IsISO8601({ strict: true })
+	@IsParsableDateString()
 	from?: string;
 
 	/** 作成日時の終了（ISO8601形式、created_at < to） */
 	@IsOptional()
-	@IsISO8601()
+	@IsISO8601({ strict: true })
+	@IsParsableDateString()
 	to?: string;
 
 	/** キーセットページングのカーソル（形式: {createdAt}|{id}） */

--- a/shared/api/v1/dto/index.ts
+++ b/shared/api/v1/dto/index.ts
@@ -1,3 +1,5 @@
+export { IsParsableDateString } from "./is-parsable-date-string";
+
 export { CreateDishMediaDto, CreateDishMediaReviewDto } from "./dish-media/create-dish-media.dto";
 export { CreateDishMediaViewDto } from "./dish-media/create-dish-media-view.dto";
 export { QueryDishMediaByIdsDto } from "./dish-media/query-dish-media-by-ids.dto";

--- a/shared/api/v1/dto/is-parsable-date-string.ts
+++ b/shared/api/v1/dto/is-parsable-date-string.ts
@@ -1,0 +1,52 @@
+import { registerDecorator, type ValidationOptions } from "class-validator";
+
+/**
+ * #1599 その文字列を `new Date()` に渡して**実在の時刻になる**ことを要求する。
+ *
+ * ## なぜ `@IsISO8601()` だけでは足りないのか
+ *
+ * `@IsISO8601()`（validator.js の `isISO8601`）は **ISO 8601 の «形»** を見るだけで、
+ * JavaScript の `Date` が解釈できるかは見ない。ISO 8601 には週日付や基本形式もあり、
+ * それらは規格として正しいのに `new Date()` では **Invalid Date** になる。
+ *
+ * ```
+ * value        @IsISO8601()   new Date(value)
+ * "2026-W01"   通る            Invalid Date
+ * "2026-W01-1" 通る            Invalid Date
+ * "20260826"   通る            Invalid Date
+ * "2026-02-30" 通る            2026-03-02（黙って別の日になる）
+ * ```
+ *
+ * この差はそのままバグになる。`my-dishes.query.ts` と
+ * `contribution-tasks.service.ts` は受け取った文字列を `new Date(...)` して
+ * そのままクエリの条件に載せており、Invalid Date が Prisma まで流れる。
+ * ユーザーからは `?from=20260826`（ISO 8601 の基本形式として妥当な入力）で
+ * 一覧が壊れて見える。
+ *
+ * ## この検査の契約
+ *
+ * **「`new Date()` に渡して安全」** ちょうどそれだけを保証する。呼び出し側が
+ * 実際にやることと同じ判定にしてあるので、判定と用途がずれない。
+ *
+ * `@IsISO8601({ strict: true })` と併用すること。こちらは «実在しない日付»
+ * （`2026-02-30`）を弾かない — `new Date()` が黙って繰り上げてしまうため。
+ */
+export function IsParsableDateString(validationOptions?: ValidationOptions) {
+	return function (object: object, propertyName: string) {
+		registerDecorator({
+			name: "isParsableDateString",
+			target: object.constructor,
+			propertyName,
+			options: validationOptions,
+			validator: {
+				validate(value: unknown) {
+					if (typeof value !== "string") return false;
+					return !Number.isNaN(new Date(value).getTime());
+				},
+				defaultMessage() {
+					return `${propertyName} must be a date string that JavaScript can parse (e.g. 2026-08-26 or 2026-08-26T00:00:00Z)`;
+				},
+			},
+		});
+	};
+}

--- a/shared/api/v1/dto/users/query-my-dishes.dto.ts
+++ b/shared/api/v1/dto/users/query-my-dishes.dto.ts
@@ -15,6 +15,7 @@ import {
 	Min,
 	ValidateIf,
 } from "class-validator";
+import { IsParsableDateString } from "../is-parsable-date-string";
 
 /**
  * #1395 my-dishes（食べたい/食べた）の状態。
@@ -190,12 +191,17 @@ export class QueryMyDishesDto {
 
 	/** `occurredAt` の下限（Calendar の月窓 / 期間絞り込み）。境界を含む */
 	@IsOptional()
-	@IsISO8601()
+	// #1599 strict は «実在しない日付»（2026-02-30）を弾き、
+	// IsParsableDateString は «new Date() が解釈できない形»（2026-W01 / 20260826）を弾く。
+	// 下の rangeFilter が new Date(dto.from) をそのままクエリへ載せるので、両方要る。
+	@IsISO8601({ strict: true })
+	@IsParsableDateString()
 	from?: string;
 
 	/** `occurredAt` の上限。境界を含む */
 	@IsOptional()
-	@IsISO8601()
+	@IsISO8601({ strict: true })
+	@IsParsableDateString()
 	to?: string;
 
 	/** 並び順。既定は `-occurredAt` */


### PR DESCRIPTION
## 何が問題か

`@IsISO8601()`（validator.js の `isISO8601`）は **ISO 8601 の「形」**を見るだけで、JavaScript の `Date` が解釈できるかは見ない。ISO 8601 には**週日付**や**基本形式**もあり、それらは規格として正しいのに `new Date()` では Invalid Date になる。

実測:

| value | `@IsISO8601()` | `@IsISO8601({strict:true})` | `new Date(value)` |
| --- | --- | --- | --- |
| `2026-W01` | 通る | **通る** | Invalid Date |
| `2026-W01-1` | 通る | **通る** | Invalid Date |
| `20260826` | 通る | **通る** | Invalid Date |
| `2026-02-30` | 通る | 弾く | `2026-03-02`（黙って別の日） |
| `2026-08-26` | 通る | 通る | ok |

この差がそのままバグになる。**受け取った文字列を `new Date(...)` して、そのままクエリの条件へ載せている箇所が 6 つある。**

| ファイル | 箇所 |
| --- | --- |
| `api/src/v1/users/my-dishes.query.ts` | 4（`rangeFilter` ×2 / `saveBounds` ×2）— `Prisma.sql\`... >= ${new Date(dto.from)}::timestamptz\`` |
| `api/src/v1/contribution-tasks/contribution-tasks.service.ts:112` | 1 — `from: query.from ? new Date(query.from) : undefined` を Prisma の `where` へ |

`GET /v1/users/me/dishes?from=20260826` のような、**ISO 8601 の基本形式として妥当な入力**で一覧が壊れる。`2026-02-30` は例外にならないぶん、「2/30 以降で検索したつもりが 3/2 以降になる」という**気づきにくい形**で間違う。

## どう直したか

**境界（DTO）に置いた。** ここで弾けば 500 ではなく **400** になり、かつ 6 つの呼び出し側すべてが一度に守られる。

新規 `shared/api/v1/dto/is-parsable-date-string.ts`:

```ts
validate(value: unknown) {
  if (typeof value !== "string") return false;
  return !Number.isNaN(new Date(value).getTime());
}
```

**「`new Date()` に渡して安全」ちょうどそれだけ**を保証する。呼び出し側が実際にやることと**同じ判定**にしてあるので、判定と用途がずれない。

### なぜ両方の検査が要るのか

- `@IsISO8601({ strict: true })` は**実在しない日付**（`2026-02-30`）を弾くが、**週日付や基本形式は弾かない**（上の表）
- `IsParsableDateString` は逆に `2026-02-30` を**通してしまう**（`new Date()` が繰り上げるので、JS 的には「解釈できる」）

片方だけでは穴が残るので、両方を並べた。

適用先は `QueryMyDishesDto` と `ListContributionTasksQuery`（`@IsISO8601()` を使っている DTO はこの 2 つだけであることを確認済み）。

## テスト

`query-my-dishes.dto.spec.ts` に 12 件追加。

- **通る形 6 種**（`2026-08-26` / タイムゾーン付き / ミリ秒付き / `2026-08` / `2026` など）は「通る」ことに加えて、**通した以上 `new Date()` しても壊れないこと**も検査する（契約と用途を一致させる）
- **弾く形 3 種**は、まず「`@IsISO8601()` だけなら通ってしまう形である」という前提（`new Date` が Invalid になること）を検査してから、弾かれることを検査する。前提が崩れたらテストの意味も変わるので、そこも固定する
- `2026-02-30` は**実際に 3/2 へ繰り上がることを示してから**弾かれることを検査

## 検証

- `pnpm --filter api test` → **69 suites / 870 tests 全 green**
- `pnpm --filter app-expo test` → **157 suites / 1563 tests 全 green**（DTO は共有なので両方回した）
- `pnpm --filter shared build` / `api typecheck` / `app-expo typecheck` → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_