### PR TITLE
fix(api): currencyCode の検証漏れで 4 文字を送ると 500 になるのを直す (#1599)

### DIFF
--- a/api/src/v1/dish-reviews/currency-code.dto.spec.ts
+++ b/api/src/v1/dish-reviews/currency-code.dto.spec.ts
@@ -1,0 +1,104 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import { CreateDishReviewDto } from '@shared/v1/dto/dish-reviews/create-dish-review.dto';
+import { CreateDishMediaReviewDto } from '@shared/v1/dto/dish-media/create-dish-media.dto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * #1599 `currencyCode` は DB 側が `currency_code CHAR(3)`。
+ *
+ * DTO が `@IsString()` だけだったので、
+ *  - 4 文字以上 → Postgres が `value too long for type character(3)` で落ち、**500**
+ *  - 3 文字未満 → 空白で右詰めされて**黙って保存**される
+ *
+ * どちらもユーザー入力に対する応答としては誤り。境界で 400 にする。
+ */
+const errorsFor = (
+  Dto: typeof CreateDishReviewDto,
+  currencyCode: unknown,
+): string[] => {
+  const dto = plainToInstance(Dto, {
+    dishId: '11111111-1111-4111-8111-111111111111',
+    comment: 'おいしい',
+    languageCode: 'ja',
+    rating: 5,
+    currencyCode,
+  });
+  return validateSync(dto)
+    .map((e) => e.property)
+    .sort();
+};
+
+describe('#1599 currencyCode は英字 3 文字だけ通す', () => {
+  it.each(['JPY', 'USD', 'EUR', 'jpy'])('%s は通る', (code) => {
+    expect(errorsFor(CreateDishReviewDto, code)).not.toContain('currencyCode');
+  });
+
+  it.each([
+    ['JPYY', '4 文字。CHAR(3) に入らず 500 になっていた'],
+    ['J', '1 文字。空白で右詰めされて黙って保存されていた'],
+    ['JP', '2 文字。同上'],
+    ['12345', '数字'],
+    ['J$Y', '記号'],
+    ['', '空文字'],
+  ])('%s は弾く（%s）', (code) => {
+    expect(errorsFor(CreateDishReviewDto, code)).toContain('currencyCode');
+  });
+
+  it('未指定なら検査しない（省略可能のまま）', () => {
+    expect(errorsFor(CreateDishReviewDto, undefined)).not.toContain(
+      'currencyCode',
+    );
+  });
+
+  it('dish-media 側の同じ項目にも同じ検査が掛かっている', () => {
+    const build = (currencyCode: unknown) =>
+      validateSync(
+        plainToInstance(CreateDishMediaReviewDto, {
+          comment: 'おいしい',
+          rating: 5,
+          currencyCode,
+        }),
+      )
+        .map((e) => e.property)
+        .sort();
+
+    expect(build('JPY')).not.toContain('currencyCode');
+    expect(build('JPYY')).toContain('currencyCode');
+  });
+
+  /**
+   * ⚠️ ここが本命。`@IsISO4217CurrencyCode()` へ «改善» したくなるが、
+   * class-validator の一覧は古く、**アプリ自身が送りうる ZWG
+   * （ジンバブエ・ゴールド、2024 年導入）を弾いてしまう**。
+   * 通貨の一覧を 2 箇所で持つとずれるので、形だけを見る方針を固定する。
+   */
+  it('アプリが実際に送りうる通貨コードを 1 つも弾かない', () => {
+    // 対応表は app-expo 側にあり、expo 依存を引くので import できない。
+    // **一覧をここへ書き写すと必ずずれる**ので、正本のソースから読み取る。
+    // 対応通貨が増えたときに、この検査が «その通貨は弾かれる» と教えてくれる。
+    const source = readFileSync(
+      join(__dirname, '..', '..', '..', '..', 'app-expo', 'lib', 'googlePlaces.ts'),
+      'utf8',
+    );
+    const start = source.indexOf('export const COUNTRY_TO_CURRENCY_MAP');
+    expect(start).toBeGreaterThan(-1);
+    const block = source.slice(start, source.indexOf('} as const', start));
+
+    const codes = [...new Set(block.match(/:\s*"([A-Z]{3})"/g) ?? [])].map(
+      (m) => m.replace(/[:\s"]/g, ''),
+    );
+    // 走査が壊れていたら 0 件で «全部通った» ように見えるので、件数も固定する
+    expect(codes.length).toBeGreaterThan(100);
+    // 2024 年導入の新しい通貨。class-validator の ISO-4217 一覧はこれを知らない
+    expect(codes).toContain('ZWG');
+
+    const rejected = codes.filter((code) =>
+      errorsFor(CreateDishReviewDto, code).includes('currencyCode'),
+    );
+
+    expect(rejected).toEqual([]);
+  });
+});

--- a/shared/api/v1/currency-code.ts
+++ b/shared/api/v1/currency-code.ts
@@ -1,0 +1,14 @@
+/**
+ * #1599 通貨コードの «形» の正本。
+ *
+ * DB 側は `currency_code CHAR(3)`。ここを緩くすると、4 文字以上で Postgres が
+ * `value too long for type character(3)` を投げて **400 ではなく 500** になり、
+ * 3 文字未満は空白で右詰めされて黙って保存される。
+ *
+ * ⚠️ **通貨コードの «一覧» はここで持たない。** class-validator の
+ * `@IsISO4217CurrencyCode()` を使わないのも同じ理由で、あちらの一覧は古く、
+ * アプリ自身が送りうる `ZWG`（ジンバブエ・ゴールド、2024 年導入）を弾いてしまう。
+ * どの通貨を扱うかの正本は `app-expo/lib/googlePlaces.ts` の
+ * `COUNTRY_TO_CURRENCY_MAP` であり、一覧を 2 箇所に置けば必ずずれる。
+ */
+export const CURRENCY_CODE_PATTERN = /^[A-Za-z]{3}$/;

--- a/shared/api/v1/dto/dish-media/create-dish-media.dto.ts
+++ b/shared/api/v1/dto/dish-media/create-dish-media.dto.ts
@@ -1,4 +1,5 @@
-import { IsIn, IsInt, IsNumber, IsOptional, IsString, IsUUID, Max, Min, ValidateIf, ValidateNested } from "class-validator";
+import { IsIn, IsInt, IsNumber, IsOptional, IsString, IsUUID, Matches, Max, Min, ValidateIf, ValidateNested } from "class-validator";
+import { CURRENCY_CODE_PATTERN } from "../../currency-code";
 import { Type } from "class-transformer";
 
 /**
@@ -25,8 +26,24 @@ export class CreateDishMediaReviewDto {
 	priceCents?: number;
 
 	/** 通貨コード */
+	/**
+	 * ISO-4217 の通貨コード（3 文字）。
+	 *
+	 * #1599 `@IsString()` だけだった。DB 側は `currency_code CHAR(3)` なので、
+	 * 4 文字以上を送ると Postgres が `value too long for type character(3)` で落ち、
+	 * **400 ではなく 500** になる。3 文字未満は空白で右詰めされて黙って保存される。
+	 *
+	 * ⚠️ `@IsISO4217CurrencyCode()` は使わない。class-validator が持つ ISO-4217 の
+	 * 一覧が古く、**アプリ自身が送りうる `ZWG`（ジンバブエ・ゴールド、2024 年導入）を
+	 * 弾いてしまう**（`COUNTRY_TO_CURRENCY_MAP` の 151 コードを実際に通して確認）。
+	 * 通貨の一覧を 2 箇所で持つと必ずずれるので、ここでは **DB の制約と同じ «英字 3 文字»**
+	 * だけを見る。どの通貨を扱うかは `googlePlaces.ts` の対応表が正本。
+	 */
 	@IsOptional()
 	@IsString()
+	@Matches(CURRENCY_CODE_PATTERN, {
+		message: "currencyCode must be a 3-letter currency code (e.g. JPY, USD)",
+	})
 	currencyCode?: string;
 
 	/** 評価 */

--- a/shared/api/v1/dto/dish-reviews/create-dish-review.dto.ts
+++ b/shared/api/v1/dto/dish-reviews/create-dish-review.dto.ts
@@ -1,4 +1,5 @@
-import { IsNumber, IsOptional, IsString, IsUUID, Max, Min } from "class-validator";
+import { IsNumber, IsOptional, IsString, IsUUID, Matches, Max, Min } from "class-validator";
+import { CURRENCY_CODE_PATTERN } from "../../currency-code";
 import { Type } from "class-transformer";
 
 /** POST /v1/dish-reviews のボディ */
@@ -22,8 +23,24 @@ export class CreateDishReviewDto {
 	priceCents?: number;
 
 	/** 通貨コード */
+	/**
+	 * ISO-4217 の通貨コード（3 文字）。
+	 *
+	 * #1599 `@IsString()` だけだった。DB 側は `currency_code CHAR(3)` なので、
+	 * 4 文字以上を送ると Postgres が `value too long for type character(3)` で落ち、
+	 * **400 ではなく 500** になる。3 文字未満は空白で右詰めされて黙って保存される。
+	 *
+	 * ⚠️ `@IsISO4217CurrencyCode()` は使わない。class-validator が持つ ISO-4217 の
+	 * 一覧が古く、**アプリ自身が送りうる `ZWG`（ジンバブエ・ゴールド、2024 年導入）を
+	 * 弾いてしまう**（`COUNTRY_TO_CURRENCY_MAP` の 151 コードを実際に通して確認）。
+	 * 通貨の一覧を 2 箇所で持つと必ずずれるので、ここでは **DB の制約と同じ «英字 3 文字»**
+	 * だけを見る。どの通貨を扱うかは `googlePlaces.ts` の対応表が正本。
+	 */
 	@IsOptional()
 	@IsString()
+	@Matches(CURRENCY_CODE_PATTERN, {
+		message: "currencyCode must be a 3-letter currency code (e.g. JPY, USD)",
+	})
 	currencyCode?: string;
 
 	/** 評価 */


### PR DESCRIPTION
## 何が問題か

DB 側は `currency_code CHAR(3)`（`schema.prisma:373` / `:500` / `:612`）なのに、DTO は `@IsString()` だけだった。

| 入力 | 起きること |
| --- | --- |
| `"JPYY"`（4 文字） | Postgres が `value too long for type character(3)` で落ち、**400 ではなく 500** |
| `"J"`（1 文字） | 空白で右詰めされて**黙って保存**される（`"J  "`） |

どちらもユーザー入力に対する応答として誤りなので、境界（DTO）で 400 にする。対象は `create-dish-review.dto.ts` と `create-dish-media.dto.ts` の 2 つ。

## ⚠️ `@IsISO4217CurrencyCode()` を使わなかった理由

class-validator は `@IsISO4217CurrencyCode()` を持っており、一見こちらが正解に見える。

**が、実際に通して確かめたところ `ZWG`（ジンバブエ・ゴールド、2024 年導入）を弾いた。**

```
COUNTRY_TO_CURRENCY_MAP distinct codes: 151
rejected by IsISO4217CurrencyCode: [ 'ZWG' ]
```

`ZWG` は `app-expo/lib/googlePlaces.ts` の `COUNTRY_TO_CURRENCY_MAP` に載っており、**アプリ自身が送りうる値**である。そのまま入れていたら**ジンバブエのレビュー投稿が 400 で通らなくなっていた** — バグを直すつもりで別のバグを入れるところだった。

class-validator の ISO-4217 一覧が古いのが原因だが、追随を待つ話でもない。**通貨の一覧を 2 箇所で持てば必ずずれる**ので、**DB の制約と同じ「英字 3 文字」だけ**を見る方針にした。どの通貨を扱うかの正本は `googlePlaces.ts` の対応表である。

正本は `shared/api/v1/currency-code.ts` の `CURRENCY_CODE_PATTERN` に置き、**なぜ一覧を持たないか**もそこへ書いた（次に「改善」しようとした人が同じ罠を踏まないように）。

## テスト

`currency-code.dto.spec.ts`（13 件）。

- 通る形（`JPY` / `USD` / `EUR` / 小文字 `jpy`）
- 弾く形（`JPYY` / `J` / `JP` / 数字 / 記号 / 空文字）— それぞれ「なぜ弾くのか」をケース名に書いた
- 未指定は省略可能のまま
- `dish-media` 側の同じ項目にも同じ検査が掛かっていること
- **アプリが実際に送りうる 151 コードを 1 つも弾かないこと** ← 本命

最後のものは、一覧を書き写すとずれるので**正本のソースから読み取って**回している。対応通貨が増えたら、この検査が「その通貨は弾かれる」と教えてくれる。走査が壊れて 0 件になると「全部通った」ように見えるので、**件数（>100）と `ZWG` の存在も固定**した。

## 検証

- `pnpm --filter api test` → **70 suites / 871 tests 全 green**
- `pnpm --filter app-expo test` → **157 suites / 1563 tests 全 green**（DTO は共有）
- `pnpm --filter shared build` / 両 typecheck → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_