### PR TITLE
fix(api): よく使っていた人ほど退会に失敗するのを直す (#1599)

### DIFF
--- a/api/src/v1/users/soft-delete-account.spec.ts
+++ b/api/src/v1/users/soft-delete-account.spec.ts
@@ -1,0 +1,137 @@
+import { UsersRepository } from './users.repository';
+
+/**
+ * #1599 退会処理の `like_total` 引き直しが N+1 だった件。
+ *
+ * 対象 1 件ごとに `count` + `updateMany` の 2 クエリを直列に投げるループで、
+ * `affectedDishMediaIds` は **そのユーザーがいいねした dish_media の数**。上限が無い。
+ * しかも全部が 1 つの `withTransaction`（PRISMA_TX_TIMEOUT の既定は 60 秒）の中で走る。
+ *
+ * 3,000 件いいねしていれば 6,000 クエリになり、**よく使っていた人ほど退会に失敗する**。
+ * 失敗の仕方が決定的なので、再実行しても同じところで落ち続ける。
+ * 利用規約は「設定画面からいつでも削除できる」と約束している。
+ */
+type Tx = {
+  $queryRaw: jest.Mock;
+  dish_media_likes: { findMany: jest.Mock; deleteMany: jest.Mock; count: jest.Mock };
+  dish_media_analysis_results: { updateMany: jest.Mock };
+  reactions: { deleteMany: jest.Mock };
+  user_device_tokens: { deleteMany: jest.Mock };
+  user_notification_cursors: { deleteMany: jest.Mock };
+  notification_recipients: { deleteMany: jest.Mock };
+  user_roles: { deleteMany: jest.Mock };
+  users: { updateMany: jest.Mock };
+};
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+
+function buildTx(likedMediaIds: string[]): Tx {
+  const none = jest.fn().mockResolvedValue({ count: 0 });
+  return {
+    // 更新できた行を RETURNING で返す想定
+    $queryRaw: jest
+      .fn()
+      .mockResolvedValue(likedMediaIds.map((id) => ({ dish_media_id: id }))),
+    dish_media_likes: {
+      findMany: jest
+        .fn()
+        .mockResolvedValue(likedMediaIds.map((id) => ({ dish_media_id: id }))),
+      deleteMany: jest.fn().mockResolvedValue({ count: likedMediaIds.length }),
+      // ループが残っていたら呼ばれてしまう
+      count: jest.fn().mockResolvedValue(0),
+    },
+    dish_media_analysis_results: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+    reactions: { deleteMany: none },
+    user_device_tokens: { deleteMany: none },
+    user_notification_cursors: { deleteMany: none },
+    notification_recipients: { deleteMany: none },
+    user_roles: { deleteMany: none },
+    users: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+  };
+}
+
+function buildRepository(tx: Tx): UsersRepository {
+  const prisma = {
+    withTransaction: (fn: (t: unknown) => unknown) => fn(tx),
+  };
+  return new UsersRepository(
+    prisma as never,
+    { debug: jest.fn(), log: jest.fn(), warn: jest.fn(), error: jest.fn() } as never,
+  );
+}
+
+/** タグ付きテンプレートで渡された SQL を 1 本の文字列に戻す */
+const sqlTextOf = (call: unknown[]): string => (call[0] as string[]).join(' ? ');
+
+describe('#1599 退会処理の like_total 引き直しは件数に依らず 1 クエリ', () => {
+  it.each([1, 10, 3000])(
+    'いいね %i 件でも $queryRaw は 1 回だけ（N+1 が消えている）',
+    async (count) => {
+      const ids = Array.from(
+        { length: count },
+        (_, i) => `22222222-2222-4222-8222-${String(i).padStart(12, '0')}`,
+      );
+      const tx = buildTx(ids);
+
+      await buildRepository(tx).softDeleteUserAccount(USER_ID);
+
+      expect(tx.$queryRaw).toHaveBeenCalledTimes(1);
+      // ループの痕跡が残っていないこと。ここが呼ばれるなら件数ぶん往復している
+      expect(tx.dish_media_likes.count).not.toHaveBeenCalled();
+      expect(tx.dish_media_analysis_results.updateMany).not.toHaveBeenCalled();
+    },
+  );
+
+  it('1 件も無いなら、そもそもクエリを投げない', async () => {
+    const tx = buildTx([]);
+
+    const result = await buildRepository(tx).softDeleteUserAccount(USER_ID);
+
+    expect(tx.$queryRaw).not.toHaveBeenCalled();
+    expect(result.likeTotalsRecalculated).toBe(0);
+  });
+
+  it('引き直した件数は RETURNING の行数から取る', async () => {
+    const ids = ['a', 'b', 'c'].map(
+      (c) => `33333333-3333-4333-8333-${c.repeat(12)}`,
+    );
+    const tx = buildTx(ids);
+    // dish_media_analysis_results が無い dish_media は更新されない（= 行が返らない）
+    tx.$queryRaw.mockResolvedValue([{ dish_media_id: ids[0] }]);
+
+    const result = await buildRepository(tx).softDeleteUserAccount(USER_ID);
+
+    expect(result.likeTotalsRecalculated).toBe(1);
+  });
+
+  it('SQL は「実数で数え直す」形を保つ（減算にすり替わっていない）', async () => {
+    const tx = buildTx(['44444444-4444-4444-8444-444444444444']);
+
+    await buildRepository(tx).softDeleteUserAccount(USER_ID);
+
+    const sql = sqlTextOf(tx.$queryRaw.mock.calls[0]);
+    expect(sql).toContain('UPDATE dish_media_analysis_results');
+    // 冪等性の要。COUNT で数え直しており、like_total - 1 のような減算ではない
+    expect(sql).toContain('COUNT(l.dish_media_id)');
+    expect(sql).not.toMatch(/like_total\s*[-+]/);
+    // いいねが 0 件になった投稿も 0 に落とす必要があるので LEFT JOIN
+    expect(sql).toContain('LEFT JOIN dish_media_likes');
+    // 対象は「控えておいた ID の集合」だけ。全件更新にすり替わっていないこと
+    expect(sql).toContain('UNNEST(');
+    expect(sql).toContain('RETURNING');
+  });
+
+  it('いいねを消してから数え直す（順序が逆だと消す前の数で埋め戻す）', async () => {
+    const tx = buildTx(['55555555-5555-4555-8555-555555555555']);
+
+    await buildRepository(tx).softDeleteUserAccount(USER_ID);
+
+    expect(tx.dish_media_likes.deleteMany.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.$queryRaw.mock.invocationCallOrder[0],
+    );
+    // 控えるのは消す前（消した後だと対象が分からなくなる）
+    expect(tx.dish_media_likes.findMany.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.dish_media_likes.deleteMany.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/api/src/v1/users/users.repository.ts
+++ b/api/src/v1/users/users.repository.ts
@@ -729,17 +729,38 @@ export class UsersRepository {
       // #1511 いいねを物理削除すると集計のトゥルース源 `like_total` とズレる。
       // 減算（`decrement`）ではなく **現在の実数を数え直す**のは、削除処理が
       // 再実行されても二重に引かれないようにするため（冪等性）。
-      let likeTotalsRecalculated = 0;
-      for (const dishMediaId of affectedDishMediaIds) {
-        const remaining = await tx.dish_media_likes.count({
-          where: { dish_media_id: dishMediaId },
-        });
-        const updated = await tx.dish_media_analysis_results.updateMany({
-          where: { dish_media_id: dishMediaId },
-          data: { like_total: remaining, updated_at: new Date() },
-        });
-        likeTotalsRecalculated += updated.count;
-      }
+      //
+      // #1599 【バグ】ここは対象 1 件ごとに `count` + `updateMany` の 2 クエリを
+      // 直列に投げるループだった。`affectedDishMediaIds` は **そのユーザーが
+      // いいねした dish_media の数**で上限が無く、しかも全部が 1 つの
+      // `withTransaction`（PRISMA_TX_TIMEOUT の既定は 60 秒）の中で走る。
+      //
+      // 3,000 件いいねしていれば 6,000 クエリになり、**よく使っていた人ほど
+      // 退会に失敗する**。しかも失敗の仕方が決定的なので、再実行しても同じところで
+      // 落ち続ける（利用規約は「いつでも削除できる」と約束している）。
+      //
+      // 1 文の集合演算に置き換える。件数に関係なくクエリは 1 本。
+      // 冪等性（実数で数え直す）はそのまま保たれる。
+      const likeTotalsRecalculated =
+        affectedDishMediaIds.length === 0
+          ? 0
+          : (
+              await tx.$queryRaw<{ dish_media_id: string }[]>`
+                UPDATE dish_media_analysis_results AS a
+                   SET like_total = c.cnt,
+                       updated_at = NOW()
+                  FROM (
+                        SELECT m.id AS dish_media_id,
+                               COUNT(l.dish_media_id)::int AS cnt
+                          FROM UNNEST(${affectedDishMediaIds}::uuid[]) AS m(id)
+                          LEFT JOIN dish_media_likes l
+                                 ON l.dish_media_id = m.id
+                         GROUP BY m.id
+                       ) AS c
+                 WHERE a.dish_media_id = c.dish_media_id
+                RETURNING a.dish_media_id
+              `
+            ).length;
 
       // ── 4. users 行の匿名化 + deleted_at ────────────────────────
       // ⚠️ `updateMany` にしているのは冪等性のため。既に削除済みでも 0 件更新で通る。


### PR DESCRIPTION
R7-B（性能レビュー）の指摘を裏取りしたもの。**これは「遅い」では済まない種類の問題**なので性能改善ではなくバグ修正として扱う。

## 何が起きるか

`softDeleteUserAccount` の `like_total` 引き直しは、対象 1 件ごとに `count` + `updateMany` の **2 クエリを直列に投げるループ**だった。

```ts
for (const dishMediaId of affectedDishMediaIds) {
  const remaining = await tx.dish_media_likes.count({ where: { dish_media_id: dishMediaId } });
  const updated = await tx.dish_media_analysis_results.updateMany({ ... });
  likeTotalsRecalculated += updated.count;
}
```

`affectedDishMediaIds` は**そのユーザーがいいねした dish_media の数**で、上限が無い。しかも全部が 1 つの `withTransaction` の中で走る（`PRISMA_TX_TIMEOUT` の既定は **60 秒**）。

3,000 件いいねしていれば **6,000 クエリ**。

> **よく使っていた人ほど退会に失敗する。** しかも失敗の仕方が決定的なので、再実行しても同じところで落ち続ける。

利用規約は「設定画面からいつでも削除できる」と約束しており、守れない相手が**一番よく使ってくれた人**になる。

## どう直したか

1 文の集合演算に置き換えた。**件数に関係なくクエリは 1 本。**

```sql
UPDATE dish_media_analysis_results AS a
   SET like_total = c.cnt, updated_at = NOW()
  FROM (SELECT m.id AS dish_media_id, COUNT(l.dish_media_id)::int AS cnt
          FROM UNNEST($1::uuid[]) AS m(id)
          LEFT JOIN dish_media_likes l ON l.dish_media_id = m.id
         GROUP BY m.id) AS c
 WHERE a.dish_media_id = c.dish_media_id
RETURNING a.dish_media_id
```

守ったこと:

- **`COUNT` で実数を数え直す形は変えていない。** 減算にすると再実行で二重に引かれる。冪等性は #1511 が意図して選んだ性質なので壊さない
- いいねが **0 件になった投稿も 0 に落とす**必要があるので `LEFT JOIN`
- 監査ログの `likeTotalsRecalculated` は `RETURNING` の行数から取る（`dish_media_analysis_results` が無い `dish_media` は更新されない ＝ 従来の `updateMany().count` 合計と同じ意味）
- 対象が 0 件ならクエリ自体を投げない

テーブル名を修飾していないのは、`withTransaction` が `search_path` を設定しているため（`my-dishes.query.ts` 等の既存の raw クエリと同じ）。

## テスト

`soft-delete-account.spec.ts`（7 件）。

- **いいね 1 / 10 / 3000 件のいずれでも `$queryRaw` が 1 回だけ**であること — 件数に依らないことが本体なので、件数を変えて 3 回検査する
- ループの痕跡（`dish_media_likes.count` / `dish_media_analysis_results.updateMany`）が**1 度も呼ばれない**こと
- SQL が「実数で数え直す」形を保つこと（`COUNT` があり、`like_total ±` の減算が**無い**）。`LEFT JOIN` / `UNNEST` / `RETURNING` の存在も固定
- **いいねを消してから数え直す順序**（逆だと消す前の数で埋め戻す）、および控えるのは消す前であること

**修正前のループへ戻すと 7 件中 6 件が落ちることを確認済み。**

## R7-B のもう 1 件は直していない

`restaurants` の近傍検索が `latitude`/`longitude` の索引不在で Seq Scan になる件（`restaurants.repository.ts:308-317` / `:162-173`）は**この PR では直さない**。

- 直し方は索引追加（= migration。**オーナー承認が必要**）か `ST_DWithin` への書き換え
- 後者は**検索結果の意味が変わりうる書き換え**（haversine → geography）であり、**DB が無い環境では正しさのエビデンスを取れない**

指摘自体は妥当だと確認した（`my-dishes.query.ts:400-402` にチーム自身が「`restaurants.latitude / longitude` に btree が無く索引を活かせていないため踏襲しない」と書いている）。根拠を #1599 へ残す。

## 検証

- `pnpm --filter api test` → **71 suites / 890 tests 全 green**
- `pnpm --filter api typecheck` → green

Refs #1599, #1511

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_