### PR TITLE
fix(app-expo): 壊れたキャッシュで Push 通知が二度と登録されなくなるのを直す (#1599)

### DIFF
--- a/app-expo/components/PushTokenRegistration.tsx
+++ b/app-expo/components/PushTokenRegistration.tsx
@@ -14,14 +14,9 @@ import { useLogger } from "../hooks/useLogger";
 import type { CreateDeviceTokenResponse } from "@shared/api/v1/res";
 import { Env } from "@/constants/Env";
 import type { CreateDeviceTokenDto } from "@shared/api/v1/dto";
+import { readPushCache, type PushCache } from "./pushTokenCache";
 
 const SECURE_STORE_KEY = "expo_push_token";
-type PushCache = {
-	token: string;
-	userId: string;
-	platform: string;
-	appVersion?: string | null;
-};
 
 /**
  * 📲 Push 通知トークン登録コンポーネント
@@ -126,7 +121,10 @@ export function PushTokenRegistration() {
 
 				// #通知機能 【設計】Secure Storage にキャッシュされたトークンを確認
 				const raw = await SecureStore.getItemAsync(SECURE_STORE_KEY);
-				const cached: PushCache | null = raw ? JSON.parse(raw) : null;
+				// #1599 壊れた値は «キャッシュ無し» に倒す（詳細は readPushCache）。
+				// ここで throw すると、下の setItemAsync（壊れた値の上書き）へ辿り着けず
+				// **Push 通知が二度と登録されない**まま再試行が回り続ける
+				const cached: PushCache | null = readPushCache(raw);
 
 				const current: PushCache = {
 					token: currentToken,

--- a/app-expo/components/pushTokenCache.test.ts
+++ b/app-expo/components/pushTokenCache.test.ts
@@ -36,7 +36,7 @@ describe("#1599 readPushCache", () => {
 		["", "空文字"],
 		[null, "null"],
 		[undefined, "undefined"],
-	])("%s は «キャッシュ無し» として null（%s）", (raw) => {
+	])("%s は «キャッシュ無し» として null（%s）", (raw, _label) => {
 		expect(readPushCache(raw as string | null | undefined)).toBeNull();
 	});
 
@@ -44,7 +44,7 @@ describe("#1599 readPushCache", () => {
 		["{", "途中で切れた JSON"],
 		["not json at all", "JSON ではない"],
 		['{"token":', "キーだけ"],
-	])("壊れた値でも throw せず null を返す: %s（%s）", (raw) => {
+	])("壊れた値でも throw せず null を返す: %s（%s）", (raw, _label) => {
 		expect(() => readPushCache(raw)).not.toThrow();
 		expect(readPushCache(raw)).toBeNull();
 	});
@@ -58,7 +58,7 @@ describe("#1599 readPushCache", () => {
 		['{"userId":"u","platform":"ios"}', "token が無い"],
 		['{"token":"t","platform":"ios"}', "userId が無い"],
 		['{"token":"t","userId":"u"}', "platform が無い"],
-	])("JSON として読めても形が違えば null: %s（%s）", (raw) => {
+	])("JSON として読めても形が違えば null: %s（%s）", (raw, _label) => {
 		expect(readPushCache(raw)).toBeNull();
 	});
 

--- a/app-expo/components/pushTokenCache.test.ts
+++ b/app-expo/components/pushTokenCache.test.ts
@@ -1,0 +1,73 @@
+import { readPushCache } from "./pushTokenCache";
+
+/**
+ * #1599 SecureStore の値が壊れていると `JSON.parse` が throw していた件。
+ *
+ * 投げた先の catch は「番人を外して次の再描画で再試行する」作りなので、
+ * 壊れた値がある限り
+ *
+ *   再描画 → parse で throw → error ログ → 番人を外す → 再描画 → …
+ *
+ * を繰り返す。しかも throw は `SecureStore.setItemAsync`（壊れた値を上書きする行）
+ * **より前**で起きるので、**キャッシュは永遠に直らない**。
+ * その端末では Push 通知が二度と登録されない。
+ *
+ * キャッシュは «速くするためだけのもの» なので、読めない値は «無い» に倒す。
+ * そうすれば needsSync が立ち、通常の登録経路が走って壊れた値を上書きする（自己修復）。
+ */
+describe("#1599 readPushCache", () => {
+	const valid = {
+		token: "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]",
+		userId: "11111111-1111-4111-8111-111111111111",
+		platform: "ios",
+		appVersion: "1.14.0",
+	};
+
+	it("正しいキャッシュはそのまま返す", () => {
+		expect(readPushCache(JSON.stringify(valid))).toEqual(valid);
+	});
+
+	it("appVersion が無くても通す（省略可能なので）", () => {
+		const { appVersion: _omit, ...withoutVersion } = valid;
+		expect(readPushCache(JSON.stringify(withoutVersion))).toEqual(withoutVersion);
+	});
+
+	it.each([
+		["", "空文字"],
+		[null, "null"],
+		[undefined, "undefined"],
+	])("%s は «キャッシュ無し» として null（%s）", (raw) => {
+		expect(readPushCache(raw as string | null | undefined)).toBeNull();
+	});
+
+	it.each([
+		["{", "途中で切れた JSON"],
+		["not json at all", "JSON ではない"],
+		['{"token":', "キーだけ"],
+	])("壊れた値でも throw せず null を返す: %s（%s）", (raw) => {
+		expect(() => readPushCache(raw)).not.toThrow();
+		expect(readPushCache(raw)).toBeNull();
+	});
+
+	it.each([
+		["null", "JSON としては妥当だがオブジェクトでない"],
+		["[]", "配列"],
+		["123", "数値"],
+		['"string"', "文字列"],
+		['{"token":123,"userId":"u","platform":"ios"}', "token が数値"],
+		['{"userId":"u","platform":"ios"}', "token が無い"],
+		['{"token":"t","platform":"ios"}', "userId が無い"],
+		['{"token":"t","userId":"u"}', "platform が無い"],
+	])("JSON として読めても形が違えば null: %s（%s）", (raw) => {
+		expect(readPushCache(raw)).toBeNull();
+	});
+
+	it("【回帰】どんな入力でも決して throw しない", () => {
+		// ここが本体。throw する経路が 1 つでも残ると、その端末の Push 登録が
+		// 永久に直らなくなる
+		const inputs = ["", "{", "}", "[", "undefined", "NaN", "{'token':'t'}", "\\", '{"a":', "🙂", "a".repeat(10000)];
+		for (const raw of inputs) {
+			expect(() => readPushCache(raw)).not.toThrow();
+		}
+	});
+});

--- a/app-expo/components/pushTokenCache.ts
+++ b/app-expo/components/pushTokenCache.ts
@@ -1,0 +1,47 @@
+/**
+ * #1599 Push トークン登録が使う SecureStore キャッシュの読み取り。
+ *
+ * 【バグ】以前は `raw ? JSON.parse(raw) : null` と直に書いていた。
+ * SecureStore の値が壊れていると **JSON.parse がそのまま throw する**。
+ *
+ * 投げた先の catch は「番人（registeredUserIdRef）を外して次の再描画で再試行する」
+ * 作りなので、壊れた値がある限り
+ *
+ *   再描画 → parse で throw → error ログ → 番人を外す → 再描画 → …
+ *
+ * を繰り返す。しかも throw は `SecureStore.setItemAsync`（＝壊れた値を上書きする行）
+ * **より前**で起きるので、**キャッシュは永遠に直らない**。
+ * 結果、その端末では **Push 通知が二度と登録されない**まま、
+ * `push_token_registration_error` が出続ける。
+ *
+ * 【設計】キャッシュは «速くするためだけのもの» であって、正しさの根拠ではない。
+ * 読めない値は「キャッシュが無い」と同じに倒す。そうすれば `needsSync` が立ち、
+ * 通常の登録経路が走って壊れた値を上書きする（＝自己修復する）。
+ */
+export type PushCache = {
+	token: string;
+	userId: string;
+	platform: string;
+	appVersion?: string | null;
+};
+
+/** 形が合っているか。JSON として読めても中身が別物なら使えない */
+const isPushCache = (value: unknown): value is PushCache => {
+	if (typeof value !== "object" || value === null) return false;
+	const v = value as Record<string, unknown>;
+	return typeof v.token === "string" && typeof v.userId === "string" && typeof v.platform === "string";
+};
+
+/**
+ * SecureStore から読んだ生文字列を `PushCache` にする。
+ * **読めない・形が違うものはすべて `null`（= キャッシュ無し）** に倒す。決して throw しない。
+ */
+export function readPushCache(raw: string | null | undefined): PushCache | null {
+	if (!raw) return null;
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		return isPushCache(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
## 何が起きるか

`PushTokenRegistration` は SecureStore のキャッシュを直に読んでいた。

```ts
const raw = await SecureStore.getItemAsync(SECURE_STORE_KEY);
const cached: PushCache | null = raw ? JSON.parse(raw) : null;
```

値が壊れていると `JSON.parse` がそのまま throw する。投げた先の catch は**番人（`registeredUserIdRef`）を外して次の再描画で再試行する**作りなので、壊れた値がある限り:

```
再描画 → parse で throw → error ログ → 番人を外す → 再描画 → …
```

しかも throw は `SecureStore.setItemAsync`（= **壊れた値を上書きする行**）**より前**で起きる。つまり:

> **キャッシュは永遠に直らない。その端末では Push 通知が二度と登録されないまま、`push_token_registration_error` が出続ける。**

自己修復を意図した catch が、逆に**回り続けて直らないループ**になっている。

## どう直したか

**キャッシュは「速くするためだけのもの」であって、正しさの根拠ではない。** 読めない値は「キャッシュが無い」と同じに倒す。そうすれば `needsSync` が立ち、通常の登録経路が走って**壊れた値を上書きする**（= 自己修復する）。

読み取りを `components/pushTokenCache.ts` の `readPushCache` へ切り出した。

```ts
export function readPushCache(raw: string | null | undefined): PushCache | null {
  if (!raw) return null;
  try {
    const parsed: unknown = JSON.parse(raw);
    return isPushCache(parsed) ? parsed : null;
  } catch {
    return null;
  }
}
```

**JSON として読めても形が違うもの**（配列・数値・`token` が無い等）も `null` に倒している。「読めた」と「使える」は別で、後者を担保しないと `cached.token !== current.token` の比較が意図しない結果になる。

## テスト

`pushTokenCache.test.ts`（17 件）。

- 正しいキャッシュはそのまま返す / `appVersion` 省略も通す
- 壊れた JSON（途中で切れた・JSON でない・キーだけ）
- JSON として読めても形が違うもの（`null` / 配列 / 数値 / 文字列 / `token` が数値 / 各キー欠落）
- 空文字 / `null` / `undefined`
- **【回帰】どんな入力でも決して throw しない** ← 本体。throw する経路が 1 つでも残ると、その端末の Push 登録が永久に直らなくなる

## 見つけ方

app-expo 全体の `JSON.parse` / `new URL` / `decodeURIComponent` / `Intl` 系を洗い、try/catch の有無を機械的に突き合わせた結果、**ガードが無いのはここ 1 箇所だけ**だった。他はすべて適切に包まれている（URL クエリを `JSON.parse` する `search/dish-categories.tsx` / `search/result.tsx` も try/catch 済み）。

## 検証

- `pnpm --filter app-expo test` → **158 suites / 1580 tests 全 green**
- `pnpm --filter app-expo lint` → **0 errors**
- `pnpm --filter app-expo typecheck` → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_