### PR TITLE
fix(api): 退会処理の集合演算が id の重複で like_total を倍にしうるのを塞ぐ (#1599)

### DIFF
--- a/api/src/v1/users/soft-delete-account.spec.ts
+++ b/api/src/v1/users/soft-delete-account.spec.ts
@@ -121,6 +121,37 @@ describe('#1599 退会処理の like_total 引き直しは件数に依らず 1 �
     expect(sql).toContain('RETURNING');
   });
 
+  // ⚠️ SQL 側の DISTINCT は「呼び出し側が new Set しているから冗長」ではない。
+  // 同じ id が配列に 2 回入ると UNNEST がその id の行を 2 行返し、LEFT JOIN が
+  // いいね 1 件につき 2 行に増え、COUNT が **2 倍の値**になる。
+  // like_total は画面に出る数字なので、静かに倍になる壊れ方をする。
+  // 「片方を消したら壊れる」形にしないため、両側を別々に固定しておく。
+  it('重複した id を渡されても数え上げが倍にならない（SQL 側で DISTINCT する）', async () => {
+    const tx = buildTx(['66666666-6666-4666-8666-666666666666']);
+
+    await buildRepository(tx).softDeleteUserAccount(USER_ID);
+
+    const sql = sqlTextOf(tx.$queryRaw.mock.calls[0]);
+    expect(sql).toMatch(/SELECT\s+DISTINCT/);
+  });
+
+  it('呼び出し側も重複を除いてから渡す（無駄な行を作らない）', async () => {
+    const duplicated = '77777777-7777-4777-8777-777777777777';
+    const tx = buildTx([]);
+    // 同じ dish_media に対する行が複数返る状況（実際には起こりにくいが、
+    // dish_media_likes の行が重複していれば起こりうる）
+    tx.dish_media_likes.findMany.mockResolvedValue([
+      { dish_media_id: duplicated },
+      { dish_media_id: duplicated },
+    ]);
+    tx.$queryRaw.mockResolvedValue([{ dish_media_id: duplicated }]);
+
+    await buildRepository(tx).softDeleteUserAccount(USER_ID);
+
+    const [, ...values] = tx.$queryRaw.mock.calls[0];
+    expect(values[0]).toEqual([duplicated]);
+  });
+
   it('いいねを消してから数え直す（順序が逆だと消す前の数で埋め戻す）', async () => {
     const tx = buildTx(['55555555-5555-4555-8555-555555555555']);
 

--- a/api/src/v1/users/users.repository.ts
+++ b/api/src/v1/users/users.repository.ts
@@ -741,6 +741,12 @@ export class UsersRepository {
       //
       // 1 文の集合演算に置き換える。件数に関係なくクエリは 1 本。
       // 冪等性（実数で数え直す）はそのまま保たれる。
+      //
+      // ⚠️ SQL 側の `SELECT DISTINCT` は **上の `new Set` があるから冗長、ではない**。
+      // 同じ id が配列に 2 回入ると `UNNEST` はその id の行を 2 行返し、
+      // `LEFT JOIN` がいいね 1 件につき 2 行に増え、`COUNT` が **2 倍の値**になる。
+      // like_total は表示される数字なので、静かに倍になる壊れ方をする。
+      // 「呼び出し側が必ず重複を除いている」に依存させない（片方を消したら壊れる形にしない）。
       const likeTotalsRecalculated =
         affectedDishMediaIds.length === 0
           ? 0
@@ -752,7 +758,8 @@ export class UsersRepository {
                   FROM (
                         SELECT m.id AS dish_media_id,
                                COUNT(l.dish_media_id)::int AS cnt
-                          FROM UNNEST(${affectedDishMediaIds}::uuid[]) AS m(id)
+                          FROM (SELECT DISTINCT id
+                                  FROM UNNEST(${affectedDishMediaIds}::uuid[]) AS u(id)) AS m
                           LEFT JOIN dish_media_likes l
                                  ON l.dish_media_id = m.id
                          GROUP BY m.id


### PR DESCRIPTION
**#1615 のセルフレビューで見つけた、自分が入れた穴。**

## 何が起きうるか

```sql
FROM UNNEST(${affectedDishMediaIds}::uuid[]) AS m(id)
LEFT JOIN dish_media_likes l ON l.dish_media_id = m.id
GROUP BY m.id
```

同じ id が配列に 2 回入ると `UNNEST` は**その id の行を 2 行**返す。`LEFT JOIN` でいいね 1 件につき 2 行に増え、`GROUP BY` で畳んだ `COUNT` は**本来の 2 倍**になる。

`like_total` は画面に出る数字なので、**例外にもならず静かに倍になる**。

## 今日は起きない。それでも直す理由

呼び出し側が `Array.from(new Set(...))` で重複を除いているので、現状は発現しない。

**が、それは「片方を消したら壊れる」形である。**

- SQL 側だけを読んだ人には、`DISTINCT` が要る理由が見えない
- 呼び出し側だけを読んだ人には、`new Set` が冗長に見える

どちらを消しても壊れるので、**両側で担保する**。SQL 側を `SELECT DISTINCT id FROM UNNEST(...)` にし、**なぜ冗長ではないのか**をコメントへ書いた。

## テスト

2 件追加。

- SQL に `SELECT DISTINCT` があること
- **呼び出し側も重複を除いてから渡すこと**（`dish_media_likes` に同じ `dish_media` の行が複数あっても、パラメータは 1 件になる）

片方だけを検査すると、もう片方を消したときに気づけない。だから両方を別々に固定した。

## 検証

- `pnpm --filter api test` → **71 suites / 892 tests 全 green**
- `pnpm --filter api typecheck` → green

Refs #1599, #1615

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_