### PR TITLE
fix(app-expo): 引っ張って更新に追い抜かれた追加取得が古いページを混ぜるのを直す (#1599)

### DIFF
--- a/app-expo/stores/useDishCategoriesStore.ts
+++ b/app-expo/stores/useDishCategoriesStore.ts
@@ -115,6 +115,14 @@ export type DishCategoriesStore = {
 	 */
 	clearByKey: (key?: string) => void;
 
+	/**
+	 * #1599 一覧の世代。**`clearByKey` が呼ばれるたびに 1 つ進む。**
+	 * 追加取得は開始時にこの値を控え、応答時に変わっていたら結果を捨てる。
+	 * 詳細は `useDishMediaEntriesStore.listGeneration` の宣言箇所を参照
+	 *（同じ欠陥が同じ形でこちらにもあった）。
+	 */
+	listGeneration: number;
+
 	// ------ カーソルページネーション API ------
 
 	/**
@@ -199,6 +207,7 @@ export const useDishCategoriesStore = createWithEqualityFn<DishCategoriesStore>(
 	hasFetchedInitialByKey: {},
 	nextCursorByKey: {},
 	isLoadingMoreByKey: {},
+	listGeneration: 0,
 	savedByDishCategoryId: {},
 
 	// ------ 同期挿入・更新メソッド ------
@@ -266,6 +275,8 @@ export const useDishCategoriesStore = createWithEqualityFn<DishCategoriesStore>(
 			// key 未指定 → 全リセット
 			if (!key) {
 				return {
+					// #1599 飛行中の追加取得を無効化する
+					listGeneration: state.listGeneration + 1,
 					dishCategoryById: {},
 					dishCategoryIdsByKey: {},
 					isLoadingByKey: {},
@@ -321,6 +332,8 @@ export const useDishCategoriesStore = createWithEqualityFn<DishCategoriesStore>(
 				hasFetchedInitialByKey: nextHasFetchedInitialByKey,
 				nextCursorByKey: nextNextCursorByKey,
 				isLoadingMoreByKey: nextIsLoadingMoreByKey,
+				// #1599 飛行中の追加取得を無効化する
+				listGeneration: state.listGeneration + 1,
 			};
 		}),
 
@@ -347,8 +360,10 @@ export const useDishCategoriesStore = createWithEqualityFn<DishCategoriesStore>(
 		}),
 
 	fetchMoreByKey: async (key, request, fetcher) => {
-		const { nextCursorByKey, upsertDishCategories, updateDishCategoryIdsByKey } = get();
+		const { nextCursorByKey, upsertDishCategories, updateDishCategoryIdsByKey, listGeneration } = get();
 		const nextCursor = nextCursorByKey[key];
+		// #1599 応答が返るまでに一覧が入れ替わっていないかを見るための世代
+		const startGeneration = listGeneration;
 
 		// nextCursor が null の場合は何もしない
 		if (nextCursor === null || nextCursor === undefined) return;
@@ -358,6 +373,8 @@ export const useDishCategoriesStore = createWithEqualityFn<DishCategoriesStore>(
 			key,
 			fetcher({ cursor: nextCursor, request }),
 			(response) => {
+				// #1599 引っ張って更新に追い抜かれていたら、この応答は捨てる
+				if (get().listGeneration !== startGeneration) return;
 				// 1. エンティティを正規化
 				upsertDishCategories(asApiList(response.data));
 

--- a/app-expo/stores/useDishMediaEntriesStore.staleLoadMore.test.ts
+++ b/app-expo/stores/useDishMediaEntriesStore.staleLoadMore.test.ts
@@ -1,0 +1,160 @@
+import { useDishMediaEntriesStore } from "./useDishMediaEntriesStore";
+import { useDishCategoriesStore } from "./useDishCategoriesStore";
+
+/**
+ * #1599 **引っ張って更新に追い抜かれた追加取得が、古いページを混ぜ込む件。**
+ *
+ * `fetchInitialByKey`（引っ張って更新）と `fetchMoreByKey`（もっと読む）は
+ * ロード中フラグが別（`isLoadingByKey` / `isLoadingMoreByKey`）で、
+ * 互いの飛行中を見ていないので **並走できる**。
+ *
+ *   1. 下端まで送って追加取得（cursor=C1）が飛ぶ
+ *   2. 返る前に引っ張って更新 → 一覧が新しい 1 ページ目に入れ替わる
+ *   3. **遅れて返った C1 の応答**が、入れ替わった後の一覧の末尾へ «更新前のページ» を
+ *      追記し、さらに `nextCursor` を «更新前の連鎖» の値で上書きする
+ *
+ * 実害: いいねを外して引っ張って更新したのに、外した投稿が末尾に復活する。
+ * 以降の「もっと読む」は画面と別系統のカーソルを辿るので、重複や欠落も起きる。
+ */
+
+const KEY = "profileLikes";
+
+/** 応答のタイミングを外から握るための門 */
+function gate<T>() {
+	let release!: (value: T) => void;
+	const promise = new Promise<T>((resolve) => {
+		release = resolve;
+	});
+	return { promise, release };
+}
+
+const entry = (id: string) =>
+	({
+		dish_media: { id, dish_id: `dish-${id}`, user_id: "u1" },
+		restaurant: { id: "r1", name: "テスト店" },
+		dish: { id: `dish-${id}` },
+		dish_reviews: [],
+	}) as never;
+
+const idsOf = () => useDishMediaEntriesStore.getState().mediaIdsByKey[KEY] ?? [];
+const cursorOf = () => useDishMediaEntriesStore.getState().nextCursorByKey[KEY];
+
+describe("#1599 追加取得が引っ張って更新に追い抜かれたとき", () => {
+	beforeEach(() => {
+		useDishMediaEntriesStore.getState().clearByKey();
+	});
+
+	it("遅れて返った古いページを一覧へ混ぜない", async () => {
+		// 1 ページ目（old-1, old-2）が出ている状態を作る
+		await useDishMediaEntriesStore
+			.getState()
+			.fetchInitialByKey(KEY, {}, async () => ({ data: [entry("old-1"), entry("old-2")], nextCursor: "C1" }));
+		expect(idsOf()).toEqual(["old-1", "old-2"]);
+		expect(cursorOf()).toBe("C1");
+
+		// 下端まで送って追加取得（cursor=C1）。まだ返さない
+		const more = gate<{ data: never[]; nextCursor: string | null }>();
+		const morePromise = useDishMediaEntriesStore
+			.getState()
+			.fetchMoreByKey(KEY, {}, async () => more.promise as never);
+
+		// 返る前に引っ張って更新。old-2 は «いいねを外した» ので消えている
+		await useDishMediaEntriesStore
+			.getState()
+			.fetchInitialByKey(KEY, {}, async () => ({ data: [entry("fresh-1")], nextCursor: "C-FRESH" }));
+		expect(idsOf()).toEqual(["fresh-1"]);
+
+		// ここで遅れて C1 の応答が返る
+		more.release({ data: [entry("old-3")] as never[], nextCursor: "C2" });
+		await morePromise;
+
+		// 更新前のページが末尾へ紛れ込まないこと
+		expect(idsOf()).toEqual(["fresh-1"]);
+		// nextCursor も «更新前の連鎖» の値で上書きされないこと。
+		// ここが上書きされると、以降の「もっと読む」が画面と別系統を辿る
+		expect(cursorOf()).toBe("C-FRESH");
+	});
+
+	it("追い抜かれていなければ、これまでどおり末尾へ追記する", async () => {
+		await useDishMediaEntriesStore
+			.getState()
+			.fetchInitialByKey(KEY, {}, async () => ({ data: [entry("a")], nextCursor: "C1" }));
+
+		await useDishMediaEntriesStore
+			.getState()
+			.fetchMoreByKey(KEY, {}, async () => ({ data: [entry("b")], nextCursor: "C2" }) as never);
+
+		expect(idsOf()).toEqual(["a", "b"]);
+		expect(cursorOf()).toBe("C2");
+	});
+
+	it("全体リセット（ログアウト）でも飛行中の追加取得を捨てる", async () => {
+		await useDishMediaEntriesStore
+			.getState()
+			.fetchInitialByKey(KEY, {}, async () => ({ data: [entry("a")], nextCursor: "C1" }));
+
+		const more = gate<{ data: never[]; nextCursor: string | null }>();
+		const morePromise = useDishMediaEntriesStore
+			.getState()
+			.fetchMoreByKey(KEY, {}, async () => more.promise as never);
+
+		// ログアウト相当（AuthProvider が呼ぶ）
+		useDishMediaEntriesStore.getState().clearByKey();
+
+		more.release({ data: [entry("b")] as never[], nextCursor: "C2" });
+		await morePromise;
+
+		// 消したはずの一覧が «前のユーザーのデータ» で復活しないこと
+		expect(idsOf()).toEqual([]);
+	});
+
+	it("clearByKey は呼ばれるたびに世代を進める", () => {
+		const before = useDishMediaEntriesStore.getState().listGeneration;
+
+		useDishMediaEntriesStore.getState().clearByKey(KEY);
+		const afterPerKey = useDishMediaEntriesStore.getState().listGeneration;
+		expect(afterPerKey).toBeGreaterThan(before);
+
+		useDishMediaEntriesStore.getState().clearByKey();
+		expect(useDishMediaEntriesStore.getState().listGeneration).toBeGreaterThan(afterPerKey);
+	});
+});
+
+/**
+ * #1599 同じ欠陥が `useDishCategoriesStore` にも同じ形であった。
+ * 一方だけ直すと、もう一方で同じ «外したはずのものが末尾に復活する» が残る。
+ */
+describe("#1599 useDishCategoriesStore も同じ形で守る", () => {
+	beforeEach(() => {
+		useDishCategoriesStore.getState().clearByKey();
+	});
+
+	const CAT_KEY = "savedDishCategories";
+	const cat = (id: string) => ({ id, label: id }) as never;
+	const catIds = () => useDishCategoriesStore.getState().dishCategoryIdsByKey[CAT_KEY] ?? [];
+
+	it("遅れて返った古いページを一覧へ混ぜない", async () => {
+		await useDishCategoriesStore
+			.getState()
+			.fetchInitialByKey(CAT_KEY, {}, async () => ({ data: [cat("old-1")], nextCursor: "C1" }) as never);
+		expect(catIds()).toEqual(["old-1"]);
+
+		let release!: (v: unknown) => void;
+		const pending = new Promise((resolve) => {
+			release = resolve;
+		});
+		const morePromise = useDishCategoriesStore
+			.getState()
+			.fetchMoreByKey(CAT_KEY, {}, async () => pending as never);
+
+		await useDishCategoriesStore
+			.getState()
+			.fetchInitialByKey(CAT_KEY, {}, async () => ({ data: [cat("fresh-1")], nextCursor: "C-FRESH" }) as never);
+
+		release({ data: [cat("old-2")], nextCursor: "C2" });
+		await morePromise;
+
+		expect(catIds()).toEqual(["fresh-1"]);
+		expect(useDishCategoriesStore.getState().nextCursorByKey[CAT_KEY]).toBe("C-FRESH");
+	});
+});

--- a/app-expo/stores/useDishMediaEntriesStore.ts
+++ b/app-expo/stores/useDishMediaEntriesStore.ts
@@ -163,6 +163,33 @@ export type DishMediaEntriesStore = {
 	 */
 	clearByKey: (key?: string) => void;
 
+	/**
+	 * #1599 一覧の世代。**`clearByKey` が呼ばれるたびに 1 つ進む。**
+	 *
+	 * 追加取得（`fetchMore*`）は開始時にこの値を控え、応答が返った時点で
+	 * 変わっていたら **結果を捨てる**。
+	 *
+	 * ## なぜ要るのか
+	 *
+	 * 追加取得と引っ張って更新（`fetchInitial*`）は別のロード中フラグを持ち、
+	 * 互いの飛行中を見ていないので **並走できる**。この順で起きると壊れる。
+	 *
+	 *   1. 一覧の下端まで送って追加取得（cursor=C1）が飛ぶ
+	 *   2. 返る前に引っ張って更新 → 一覧が新しい 1 ページ目に入れ替わる
+	 *   3. **遅れて返った C1 の応答**が、入れ替わった後の一覧の末尾へ
+	 *      «更新前のページ» を追記し、さらに `nextCursor` を «更新前の連鎖» の
+	 *      値で上書きする
+	 *
+	 * 結果、いいねを外した投稿が末尾に復活し、以降の「もっと読む」は画面と
+	 * 別系統のカーソルを辿る（重複・欠落の原因になる）。
+	 *
+	 * ⚠️ 世代はキー別ではなく **1 本**にしてある。あるキーの更新が別キーの
+	 * 追加取得も捨てることになるが、捨てられた側は「もう一度下端まで送れば取れる」
+	 * だけで壊れない。キー別にすると全体リセット（ログアウト）の扱いが
+	 * 複雑になり、そちらを取りこぼす方が危ない。
+	 */
+	listGeneration: number;
+
 	// ------ カーソルページネーション API ------
 
 	/**
@@ -302,6 +329,7 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 	hasFetchedInitialByKey: {},
 	nextCursorByKey: {},
 	isLoadingMoreByKey: {},
+	listGeneration: 0,
 
 	// ------ 同期挿入・更新メソッド ------
 
@@ -470,6 +498,8 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 			// key 未指定 → 全リセット
 			if (!key) {
 				return {
+					// #1599 飛行中の追加取得を無効化する（宣言箇所のコメント参照）
+					listGeneration: state.listGeneration + 1,
 					entriesByMediaId: {},
 					mediaIdsByKey: {},
 					reviewsByReviewId: {},
@@ -549,6 +579,8 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 			}
 
 			return {
+				// #1599 飛行中の追加取得を無効化する（宣言箇所のコメント参照）
+				listGeneration: state.listGeneration + 1,
 				entriesByMediaId: nextEntriesById,
 				mediaIdsByKey: nextMediaIdsByKey,
 				reviewsByReviewId: nextReviewsByReviewId,
@@ -584,8 +616,10 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 		}),
 
 	fetchMoreByKey: async (key, request, fetcher) => {
-		const { nextCursorByKey, upsertDishMediaEntries, updateMediaIdsByKey } = get();
+		const { nextCursorByKey, upsertDishMediaEntries, updateMediaIdsByKey, listGeneration } = get();
 		const nextCursor = nextCursorByKey[key];
+		// #1599 応答が返るまでに一覧が入れ替わっていないかを見るための世代
+		const startGeneration = listGeneration;
 
 		// nextCursor が null の場合は何もしない
 		if (nextCursor === null || nextCursor === undefined) return;
@@ -595,6 +629,10 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 			key,
 			fetcher({ cursor: nextCursor, request }),
 			(response) => {
+				// #1599 引っ張って更新に追い抜かれていたら、この応答は捨てる。
+				// 追記すると «更新前のページ» が新しい一覧の末尾へ紛れ込み、
+				// nextCursor も «更新前の連鎖» の値で上書きされる
+				if (get().listGeneration !== startGeneration) return;
 				// 1. エンティティを正規化
 				upsertDishMediaEntries(asApiList(response.data));
 
@@ -639,8 +677,10 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 
 	// #460 【設計】fetchMoreWithReviewsByKey を新API（upsertDishMediaEntries + updateReviewIdsByKey）に移行
 	fetchMoreWithReviewsByKey: async (key, request, fetcher) => {
-		const { nextCursorByKey, upsertDishMediaEntries, updateReviewIdsByKey } = get();
+		const { nextCursorByKey, upsertDishMediaEntries, updateReviewIdsByKey, listGeneration } = get();
 		const nextCursor = nextCursorByKey[key];
+		// #1599 応答が返るまでに一覧が入れ替わっていないかを見るための世代
+		const startGeneration = listGeneration;
 
 		// nextCursor が null の場合は何もしない
 		if (nextCursor === null || nextCursor === undefined) return;
@@ -650,6 +690,10 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 			key,
 			fetcher({ cursor: nextCursor, request }),
 			(response) => {
+				// #1599 引っ張って更新に追い抜かれていたら、この応答は捨てる。
+				// 追記すると «更新前のページ» が新しい一覧の末尾へ紛れ込み、
+				// nextCursor も «更新前の連鎖» の値で上書きされる
+				if (get().listGeneration !== startGeneration) return;
 				// 1. エンティティを正規化
 				upsertDishMediaEntries(asApiList(response.data));
 


### PR DESCRIPTION
R10-A（ストアの競合レビュー）の指摘を裏取りしたもの。

## 何が起きるか

`fetchInitialByKey`（引っ張って更新）と `fetchMoreByKey`（もっと読む）は**ロード中フラグが別**（`isLoadingByKey` / `isLoadingMoreByKey`）で、互いの飛行中を見ていないので**並走できる**。

1. 一覧の下端まで送って追加取得（cursor=C1）が飛ぶ
2. 返る前に引っ張って更新 → 一覧が新しい 1 ページ目に入れ替わる
3. **遅れて返った C1 の応答**が、入れ替わった後の一覧の末尾へ「更新前のページ」を追記し、さらに `nextCursor` を「更新前の連鎖」の値で上書きする

### 実害

- **いいねを外して引っ張って更新したのに、外した投稿が末尾に復活する。** 更新の動機がまさにそれなので、ユーザーには「消えない」と見える
- 以降の「もっと読む」が画面と別系統のカーソルを辿るので、**重複・欠落**も起きる

## どう直したか

`listGeneration` を足し、`clearByKey` が呼ばれるたびに 1 つ進める。追加取得は開始時に控え、応答時に変わっていたら結果を捨てる。

```ts
const startGeneration = listGeneration;
// …
(response) => {
  if (get().listGeneration !== startGeneration) return;
  // 以下、従来どおり追記
}
```

⚠️ **世代はキー別ではなく 1 本にした。** あるキーの更新が別キーの追加取得も捨てることになるが、捨てられた側は「もう一度下端まで送れば取れる」だけで壊れない。キー別にすると全体リセットの扱いが複雑になり、そちらを取りこぼす方が危ない — 実際 `AuthProvider` はログアウト時に `clearByKey()` を引数なしで呼んでおり、そこで**前のユーザーのデータが復活する**と実害が大きい。

対象は 3 経路:

| ストア | メソッド |
| --- | --- |
| `useDishMediaEntriesStore` | `fetchMoreByKey` |
| `useDishMediaEntriesStore` | `fetchMoreWithReviewsByKey` |
| `useDishCategoriesStore` | `fetchMoreByKey`（**同じ欠陥が同じ形であった**） |

## テスト

5 件。門（`Promise` の解決を外から握る）で応答順を制御して、レースをそのまま再現している。

- 遅れて返った古いページを混ぜないこと、**`nextCursor` も上書きされないこと**
- **追い抜かれていなければ従来どおり末尾へ追記すること**（直しすぎていないことの確認）
- **全体リセット（ログアウト）でも飛行中の追加取得を捨てること**
- `clearByKey` が毎回世代を進めること
- 同じ検査を `useDishCategoriesStore` でも

**ガードを外すと 4 件中 2 件が落ちる**ことを確認済み — レースが実際に再現している証拠:

```
✕ 遅れて返った古いページを一覧へ混ぜない
✕ 全体リセット（ログアウト）でも飛行中の追加取得を捨てる
```

## この PR に含めなかったもの

R10-A は `useMyDishesStore` にも同型があると報告している（#1398 の `generation` ガードは `clearQuery` 経由だけで、素の `refresh()` を通らない）。そちらは**ストアの作りが違い、#1398 が入れた既存ガードとの噛み合わせを確かめる必要がある**ので分ける。R10-A によればこの経路は取得が平均 4.48 秒・最大 11.23 秒とレース窓が秒単位で開くため、優先度は高い。

## 検証

- `pnpm --filter app-expo test` → **159 suites / 1589 tests 全 green**
- `pnpm --filter app-expo lint` → **0 errors**
- `pnpm --filter app-expo typecheck` → green

Refs #1599

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_