### PR TITLE
fix(app-expo): my-dishes でも追加取得が引っ張って更新に追い抜かれるのを塞ぐ (#1599)

### DIFF
--- a/app-expo/__tests__/myDishesStore.test.ts
+++ b/app-expo/__tests__/myDishesStore.test.ts
@@ -293,3 +293,70 @@ describe("#1396 pinsByQuery（Map ピン）", () => {
 		expect(getState().pinsByQuery[newest]?.map((p) => p.restaurant.id)).toEqual([`r-${newest}`]);
 	});
 });
+
+/**
+ * #1599 引っ張って更新に追い抜かれた追加取得を捨てる。
+ *
+ * #1398 が入れた `generation` ガードは **`clearQuery` を通る破棄**しか見ていない。
+ * `fetchInitial`（= 引っ張って更新）は `clearQuery` を呼ばないので `generation` を
+ * 進めず、飛行中の `fetchMore` はガードをすり抜けて書き込んでしまう。
+ *
+ * `fetchMore` は `isLoadingByQuery` を見て «更新中には始めない» が、逆
+ * （追加取得の飛行中に更新が始まる）は塞がれていない。`fetchInitial` が見ているのは
+ * `isLoadingByQuery` だけで、`isLoadingMoreByQuery` は見ていないためである。
+ *
+ * この一覧の取得は平均 4.48 秒・最大 11.23 秒（#1395 §0(A) の実測）なので、
+ * 窓はミリ秒ではなく秒の幅で開いている。
+ */
+describe("#1599 追加取得が引っ張って更新に追い抜かれたとき", () => {
+	it("遅れて返った古いページを一覧へ混ぜず、カーソルも上書きしない", async () => {
+		await getState().fetchInitial("q1", async () => page(["review:old-1"], "cursor-1"));
+		expect(selectMyDishesByQuery("q1")(getState()).itemKeys).toEqual(["review:old-1"]);
+
+		// 追加取得（cursor-1）を投げる。まだ返さない
+		let release!: (value: MyDishesFetchResult) => void;
+		const pending = new Promise<MyDishesFetchResult>((resolve) => {
+			release = resolve;
+		});
+		const morePromise = getState().fetchMore("q1", async () => pending);
+
+		// 返る前に引っ張って更新。«食べたい» を外したので old-1 は消えている
+		await getState().fetchInitial("q1", async () => page(["review:fresh-1"], "cursor-FRESH"));
+		expect(selectMyDishesByQuery("q1")(getState()).itemKeys).toEqual(["review:fresh-1"]);
+
+		// ここで遅れて cursor-1 の応答が返る
+		release(page(["review:old-2"], "cursor-2"));
+		await morePromise;
+
+		// 更新前のページが末尾へ紛れ込まないこと
+		expect(selectMyDishesByQuery("q1")(getState()).itemKeys).toEqual(["review:fresh-1"]);
+		// カーソルも «更新前の連鎖» の値で上書きされないこと。
+		// ここが壊れると、以降の「もっと読む」が画面と別系統を辿る
+		expect(getState().nextCursorByQuery["q1"]).toBe("cursor-FRESH");
+	});
+
+	it("追い抜かれていなければ、これまでどおり末尾へ追記する（直しすぎていない）", async () => {
+		await getState().fetchInitial("q1", async () => page(["review:a"], "cursor-1"));
+		await getState().fetchMore("q1", async () => page(["review:b"], "cursor-2"));
+
+		expect(selectMyDishesByQuery("q1")(getState()).itemKeys).toEqual(["review:a", "review:b"]);
+		expect(getState().nextCursorByQuery["q1"]).toBe("cursor-2");
+	});
+
+	it("追い抜かれた取得のエラーで、更新後の一覧をエラー表示にしない", async () => {
+		await getState().fetchInitial("q1", async () => page(["review:a"], "cursor-1"));
+
+		let fail!: (reason: Error) => void;
+		const pending = new Promise<MyDishesFetchResult>((_resolve, reject) => {
+			fail = reject;
+		});
+		const morePromise = getState().fetchMore("q1", async () => pending);
+
+		await getState().fetchInitial("q1", async () => page(["review:fresh"], "cursor-FRESH"));
+
+		fail(new Error("boom"));
+		await morePromise;
+
+		expect(getState().errorByQuery["q1"]).toBeNull();
+	});
+});

--- a/app-expo/features/myDishes/stores/useMyDishesStore.ts
+++ b/app-expo/features/myDishes/stores/useMyDishesStore.ts
@@ -350,6 +350,20 @@ export const useMyDishesStore = createWithEqualityFn<MyDishesStore>()((set, get)
 			// #1398 (PR4/7) 飛行中に clearQuery が走ったら、この結果は «捨てた世代» のものなので
 			// 1 バイトも書かない（書くと «記録前» の行が hasFetchedInitial 付きで復活する）
 			if (get().generation !== generation) return;
+			// #1599 【バグ】世代だけでは «引っ張って更新に追い抜かれた» を見分けられない。
+			// `fetchInitial` は `clearQuery` を通らないので **generation を進めない**からである。
+			//
+			// `fetchMore` は `isLoadingByQuery` を見て «更新中には始めない» が、逆
+			//（追加取得の飛行中に更新が始まる）は塞がれていない。`fetchInitial` が見ているのは
+			// `isLoadingByQuery` だけで、`isLoadingMoreByQuery` は見ていない。
+			//
+			// 追い抜かれたまま書くと、入れ替わった一覧の末尾へ «更新前のページ» が付き、
+			// `nextCursorByQuery` も «更新前の連鎖» の値で上書きされる。
+			// この一覧の取得は平均 4.48 秒・最大 11.23 秒なので、窓は秒の幅で開いている。
+			//
+			// 自分が使ったカーソルが今も現在値なら、まだ同じページ連鎖の上に居る。
+			// 更新が入っていれば別の値（または null）に変わっているので、そこで捨てる。
+			if (get().nextCursorByQuery[queryKey] !== cursor) return;
 			// n-1（見送り・申し送り）: ここで `queryKey` がまだ `recentQueryKeys` に生きているかは見ていない。
 			// 飛行中に他の 4 本目の queryKey で LRU から追い出されると、この結果は誰も参照しない
 			// itemByKey の行として残り続ける（次の追い出しまで）。到達には「追加取得中に他の
@@ -372,6 +386,8 @@ export const useMyDishesStore = createWithEqualityFn<MyDishesStore>()((set, get)
 			});
 		} catch (err) {
 			if (get().generation !== generation) return;
+			// #1599 追い抜かれた取得のエラーで、更新後の一覧にエラー表示を出さない
+			if (get().nextCursorByQuery[queryKey] !== cursor) return;
 			set((s) => ({ errorByQuery: { ...s.errorByQuery, [queryKey]: toErrorMessage(err) } }));
 		} finally {
 			if (get().generation === generation) {


### PR DESCRIPTION
#1619 と同じ欠陥。**ただしこのストアだけ形が違うので分けた。**

## なぜ既存のガードをすり抜けるのか

#1398 が入れた `generation` ガードは **`clearQuery` を通る破棄**しか見ていない。`fetchInitial`（= 引っ張って更新）は `clearQuery` を呼ばないので `generation` を**進めず**、飛行中の `fetchMore` はガードをすり抜けて書き込む。

> `fetchMore` は `isLoadingByQuery` を見て「更新中には始めない」が、**逆（追加取得の飛行中に更新が始まる）は塞がれていない**。`fetchInitial` が見ているのは `isLoadingByQuery` だけで、`isLoadingMoreByQuery` は見ていないためである。

この一覧の取得は**平均 4.48 秒・最大 11.23 秒**（#1395 §0(A) の実測）なので、窓はミリ秒ではなく**秒の幅**で開いている。実機で十分踏みうる。

## `generation` を進める形にしなかった理由

`fetchInitial` で `generation` を進めると、**同じ世代を共有している `fetchPins`（マップのピン取得）まで巻き添えで捨てられる**。#1398 はこの世代の意味を「`clearQuery` で捨てた」に限定したうえで 3 つの取得（`fetchInitial` / `fetchMore` / `fetchPins`）を組んでおり、そこへ別の意味を足すと噛み合わせを崩す。

代わりに **「自分が使ったカーソルが今も現在値か」** を見る。

```ts
if (get().generation !== generation) return;
// #1599 世代だけでは «引っ張って更新に追い抜かれた» を見分けられない
if (get().nextCursorByQuery[queryKey] !== cursor) return;
```

まだ同じページ連鎖の上に居るならそのまま、更新が入っていれば別の値（または `null`）になっているのでそこで捨てる。**新しい状態を増やさず、`fetchPins` にも影響しない。**

`catch` 側にも同じ判定を入れた（追い抜かれた取得のエラーで、更新後の一覧をエラー表示にしないため）。

## テスト

3 件追加。

- 遅れて返った古いページを混ぜず、**カーソルも上書きしない**こと
- **追い抜かれていなければ従来どおり末尾へ追記する**こと（直しすぎていないことの確認）
- 追い抜かれた取得のエラーで、更新後の一覧をエラー表示にしないこと

**ガードを外すと 3 件中 2 件が落ちる**ことを確認済み。

## 検証

- `pnpm --filter app-expo test` → **159 suites / 1592 tests 全 green**
- `pnpm --filter app-expo lint` → **0 errors**
- `pnpm --filter app-expo typecheck` → green

Refs #1599, #1398

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_