### PR TITLE
refactor(app-expo): 追加取得の追い抜き判定をカーソル同一性に寄せる (#1599)

### DIFF
--- a/app-expo/stores/useDishCategoriesStore.ts
+++ b/app-expo/stores/useDishCategoriesStore.ts
@@ -115,13 +115,6 @@ export type DishCategoriesStore = {
 	 */
 	clearByKey: (key?: string) => void;
 
-	/**
-	 * #1599 一覧の世代。**`clearByKey` が呼ばれるたびに 1 つ進む。**
-	 * 追加取得は開始時にこの値を控え、応答時に変わっていたら結果を捨てる。
-	 * 詳細は `useDishMediaEntriesStore.listGeneration` の宣言箇所を参照
-	 *（同じ欠陥が同じ形でこちらにもあった）。
-	 */
-	listGeneration: number;
 
 	// ------ カーソルページネーション API ------
 
@@ -207,7 +200,6 @@ export const useDishCategoriesStore = createWithEqualityFn<DishCategoriesStore>(
 	hasFetchedInitialByKey: {},
 	nextCursorByKey: {},
 	isLoadingMoreByKey: {},
-	listGeneration: 0,
 	savedByDishCategoryId: {},
 
 	// ------ 同期挿入・更新メソッド ------
@@ -275,8 +267,6 @@ export const useDishCategoriesStore = createWithEqualityFn<DishCategoriesStore>(
 			// key 未指定 → 全リセット
 			if (!key) {
 				return {
-					// #1599 飛行中の追加取得を無効化する
-					listGeneration: state.listGeneration + 1,
 					dishCategoryById: {},
 					dishCategoryIdsByKey: {},
 					isLoadingByKey: {},
@@ -332,8 +322,6 @@ export const useDishCategoriesStore = createWithEqualityFn<DishCategoriesStore>(
 				hasFetchedInitialByKey: nextHasFetchedInitialByKey,
 				nextCursorByKey: nextNextCursorByKey,
 				isLoadingMoreByKey: nextIsLoadingMoreByKey,
-				// #1599 飛行中の追加取得を無効化する
-				listGeneration: state.listGeneration + 1,
 			};
 		}),
 
@@ -360,10 +348,8 @@ export const useDishCategoriesStore = createWithEqualityFn<DishCategoriesStore>(
 		}),
 
 	fetchMoreByKey: async (key, request, fetcher) => {
-		const { nextCursorByKey, upsertDishCategories, updateDishCategoryIdsByKey, listGeneration } = get();
+		const { nextCursorByKey, upsertDishCategories, updateDishCategoryIdsByKey } = get();
 		const nextCursor = nextCursorByKey[key];
-		// #1599 応答が返るまでに一覧が入れ替わっていないかを見るための世代
-		const startGeneration = listGeneration;
 
 		// nextCursor が null の場合は何もしない
 		if (nextCursor === null || nextCursor === undefined) return;
@@ -373,8 +359,10 @@ export const useDishCategoriesStore = createWithEqualityFn<DishCategoriesStore>(
 			key,
 			fetcher({ cursor: nextCursor, request }),
 			(response) => {
-				// #1599 引っ張って更新に追い抜かれていたら、この応答は捨てる
-				if (get().listGeneration !== startGeneration) return;
+				// #1599 引っ張って更新に追い抜かれていたら、この応答は捨てる。
+				// 判定は «自分が使ったカーソルが今も現在値か»
+				//（`useDishMediaEntriesStore.fetchMoreByKey` と同じ作法）
+				if (get().nextCursorByKey[key] !== nextCursor) return;
 				// 1. エンティティを正規化
 				upsertDishCategories(asApiList(response.data));
 

--- a/app-expo/stores/useDishMediaEntriesStore.staleLoadMore.test.ts
+++ b/app-expo/stores/useDishMediaEntriesStore.staleLoadMore.test.ts
@@ -108,15 +108,26 @@ describe("#1599 追加取得が引っ張って更新に追い抜かれたとき"
 		expect(idsOf()).toEqual([]);
 	});
 
-	it("clearByKey は呼ばれるたびに世代を進める", () => {
-		const before = useDishMediaEntriesStore.getState().listGeneration;
+	it("別のキーを片付けても、このキーの追加取得は捨てない（巻き添えにしない）", async () => {
+		// 判定を «カーソルが今も現在値か» にしたので、無関係なキーの clearByKey では
+		// 捨てられない。画面遷移のたびに他のタブの「もっと読む」が黙って消える、
+		// という副作用を避けるための性質なので、ここで固定しておく
+		await useDishMediaEntriesStore
+			.getState()
+			.fetchInitialByKey(KEY, {}, async () => ({ data: [entry("a")], nextCursor: "C1" }));
 
-		useDishMediaEntriesStore.getState().clearByKey(KEY);
-		const afterPerKey = useDishMediaEntriesStore.getState().listGeneration;
-		expect(afterPerKey).toBeGreaterThan(before);
+		const more = gate<{ data: never[]; nextCursor: string | null }>();
+		const morePromise = useDishMediaEntriesStore
+			.getState()
+			.fetchMoreByKey(KEY, {}, async () => more.promise as never);
 
-		useDishMediaEntriesStore.getState().clearByKey();
-		expect(useDishMediaEntriesStore.getState().listGeneration).toBeGreaterThan(afterPerKey);
+		// 別画面のアンマウント相当（cleanup で自分のキーだけ片付ける）
+		useDishMediaEntriesStore.getState().clearByKey("some-other-screen");
+
+		more.release({ data: [entry("b")] as never[], nextCursor: "C2" });
+		await morePromise;
+
+		expect(idsOf()).toEqual(["a", "b"]);
 	});
 });
 

--- a/app-expo/stores/useDishMediaEntriesStore.ts
+++ b/app-expo/stores/useDishMediaEntriesStore.ts
@@ -163,32 +163,6 @@ export type DishMediaEntriesStore = {
 	 */
 	clearByKey: (key?: string) => void;
 
-	/**
-	 * #1599 一覧の世代。**`clearByKey` が呼ばれるたびに 1 つ進む。**
-	 *
-	 * 追加取得（`fetchMore*`）は開始時にこの値を控え、応答が返った時点で
-	 * 変わっていたら **結果を捨てる**。
-	 *
-	 * ## なぜ要るのか
-	 *
-	 * 追加取得と引っ張って更新（`fetchInitial*`）は別のロード中フラグを持ち、
-	 * 互いの飛行中を見ていないので **並走できる**。この順で起きると壊れる。
-	 *
-	 *   1. 一覧の下端まで送って追加取得（cursor=C1）が飛ぶ
-	 *   2. 返る前に引っ張って更新 → 一覧が新しい 1 ページ目に入れ替わる
-	 *   3. **遅れて返った C1 の応答**が、入れ替わった後の一覧の末尾へ
-	 *      «更新前のページ» を追記し、さらに `nextCursor` を «更新前の連鎖» の
-	 *      値で上書きする
-	 *
-	 * 結果、いいねを外した投稿が末尾に復活し、以降の「もっと読む」は画面と
-	 * 別系統のカーソルを辿る（重複・欠落の原因になる）。
-	 *
-	 * ⚠️ 世代はキー別ではなく **1 本**にしてある。あるキーの更新が別キーの
-	 * 追加取得も捨てることになるが、捨てられた側は「もう一度下端まで送れば取れる」
-	 * だけで壊れない。キー別にすると全体リセット（ログアウト）の扱いが
-	 * 複雑になり、そちらを取りこぼす方が危ない。
-	 */
-	listGeneration: number;
 
 	// ------ カーソルページネーション API ------
 
@@ -329,7 +303,6 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 	hasFetchedInitialByKey: {},
 	nextCursorByKey: {},
 	isLoadingMoreByKey: {},
-	listGeneration: 0,
 
 	// ------ 同期挿入・更新メソッド ------
 
@@ -498,8 +471,6 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 			// key 未指定 → 全リセット
 			if (!key) {
 				return {
-					// #1599 飛行中の追加取得を無効化する（宣言箇所のコメント参照）
-					listGeneration: state.listGeneration + 1,
 					entriesByMediaId: {},
 					mediaIdsByKey: {},
 					reviewsByReviewId: {},
@@ -579,8 +550,6 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 			}
 
 			return {
-				// #1599 飛行中の追加取得を無効化する（宣言箇所のコメント参照）
-				listGeneration: state.listGeneration + 1,
 				entriesByMediaId: nextEntriesById,
 				mediaIdsByKey: nextMediaIdsByKey,
 				reviewsByReviewId: nextReviewsByReviewId,
@@ -616,10 +585,8 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 		}),
 
 	fetchMoreByKey: async (key, request, fetcher) => {
-		const { nextCursorByKey, upsertDishMediaEntries, updateMediaIdsByKey, listGeneration } = get();
+		const { nextCursorByKey, upsertDishMediaEntries, updateMediaIdsByKey } = get();
 		const nextCursor = nextCursorByKey[key];
-		// #1599 応答が返るまでに一覧が入れ替わっていないかを見るための世代
-		const startGeneration = listGeneration;
 
 		// nextCursor が null の場合は何もしない
 		if (nextCursor === null || nextCursor === undefined) return;
@@ -631,8 +598,12 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 			(response) => {
 				// #1599 引っ張って更新に追い抜かれていたら、この応答は捨てる。
 				// 追記すると «更新前のページ» が新しい一覧の末尾へ紛れ込み、
-				// nextCursor も «更新前の連鎖» の値で上書きされる
-				if (get().listGeneration !== startGeneration) return;
+				// nextCursor も «更新前の連鎖» の値で上書きされる。
+				//
+				// 判定は **自分が使ったカーソルが今も現在値か**。まだ同じページ連鎖の
+				// 上に居るならそのまま、更新や `clearByKey` が入っていれば
+				// 別の値（または undefined）になっているのでそこで捨てる。
+				if (get().nextCursorByKey[key] !== nextCursor) return;
 				// 1. エンティティを正規化
 				upsertDishMediaEntries(asApiList(response.data));
 
@@ -677,10 +648,8 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 
 	// #460 【設計】fetchMoreWithReviewsByKey を新API（upsertDishMediaEntries + updateReviewIdsByKey）に移行
 	fetchMoreWithReviewsByKey: async (key, request, fetcher) => {
-		const { nextCursorByKey, upsertDishMediaEntries, updateReviewIdsByKey, listGeneration } = get();
+		const { nextCursorByKey, upsertDishMediaEntries, updateReviewIdsByKey } = get();
 		const nextCursor = nextCursorByKey[key];
-		// #1599 応答が返るまでに一覧が入れ替わっていないかを見るための世代
-		const startGeneration = listGeneration;
 
 		// nextCursor が null の場合は何もしない
 		if (nextCursor === null || nextCursor === undefined) return;
@@ -692,8 +661,12 @@ export const useDishMediaEntriesStore = createWithEqualityFn<DishMediaEntriesSto
 			(response) => {
 				// #1599 引っ張って更新に追い抜かれていたら、この応答は捨てる。
 				// 追記すると «更新前のページ» が新しい一覧の末尾へ紛れ込み、
-				// nextCursor も «更新前の連鎖» の値で上書きされる
-				if (get().listGeneration !== startGeneration) return;
+				// nextCursor も «更新前の連鎖» の値で上書きされる。
+				//
+				// 判定は **自分が使ったカーソルが今も現在値か**。まだ同じページ連鎖の
+				// 上に居るならそのまま、更新や `clearByKey` が入っていれば
+				// 別の値（または undefined）になっているのでそこで捨てる。
+				if (get().nextCursorByKey[key] !== nextCursor) return;
 				// 1. エンティティを正規化
 				upsertDishMediaEntries(asApiList(response.data));
 


### PR DESCRIPTION
#1619 で入れた `listGeneration`（全体で 1 本の世代）を、#1620 で使った「**自分が使ったカーソルが今も現在値か**」の判定へ揃える。**自分が入れた副作用を消す PR。**

## #1619 の何が良くなかったか

世代を全体で 1 本にしたので、**あるキーの `clearByKey` が別キーの追加取得まで捨てる**。

PR 本文では「捨てられた側はもう一度下端まで送れば取れるだけ」と書いたが、マージ後に `clearByKey` の呼ばれ方を調べ直したところ、**全 6 箇所が画面のアンマウント時の cleanup** だった:

| 呼び出し元 | いつ |
| --- | --- |
| `posts.tsx` / `post/[id].tsx` | 画面のアンマウント |
| `MyDishesFeedPage.tsx`（2 箇所） | 同上 |
| `RestaurantReviewsTab.tsx` | `entriesKey` 変更・アンマウント |
| `AuthProvider.tsx` | ログアウト |

つまり**「タブを切り替えた」だけで、別のタブで飛んでいた追加取得が黙って捨てられる**。実害は 1 ページぶんの読み込みが消えるだけだが、**避けられる副作用をわざわざ残す理由が無い。**

## カーソル同一性なら副作用が無い

```ts
if (get().nextCursorByKey[key] !== nextCursor) return;
```

| 状況 | カーソル | 結果 |
| --- | --- | --- |
| 引っ張って更新 | 新しい値に変わる | 捨てる ✓ |
| 自分のキーの `clearByKey` | 消える（`undefined`） | 捨てる ✓ |
| 全体リセット（ログアウト） | 同上 | 捨てる ✓ |
| **別キーの `clearByKey`** | **自分のカーソルは無傷** | **捨てない ✓（改善点）** |

副産物として**新しい状態を増やさない**（`listGeneration` を削除）。#1620（`useMyDishesStore`）と判定の作法が揃うので、次に読む人が 2 通りの考え方を覚えなくて済む。

## テスト

「`clearByKey` が世代を進める」を「**別のキーを片付けても、このキーの追加取得は捨てない（巻き添えにしない）**」へ差し替えた。守りたい性質が変わったので、検査もそこへ寄せる。

**ガードを外すと 5 件中 2 件が落ちる**ことは変わらず確認済み（元のレースは引き続き捕まえている）。

## 検証

- `pnpm --filter app-expo test` → **159 suites / 1592 tests 全 green**
- `pnpm --filter app-expo lint` → **0 errors**
- `pnpm --filter app-expo typecheck` → green

Refs #1599, #1619, #1620

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_