### PR TITLE
docs(api): 課金の穴が「未対応」と書いてあるコメントを実態へ直す (#1599)

### DIFF
--- a/api/src/v1/dishes/dishes.repository.ts
+++ b/api/src/v1/dishes/dishes.repository.ts
@@ -279,9 +279,17 @@ export class DishesRepository {
               // ID の再利用（重複防止）と Photo Media 課金の抑止は別の関心事であり、
               // ここで status を絞ると前者が壊れる。
               //
-              // failed の place で Photo Media を毎回課金してしまう件は、
-              // tryGetPhotoMedia が reuse 判定より前にある構造の問題なので、
-              // 別途 handler 側の download skip 判定とあわせて対応する。
+              // #1053 【解決済み】ここに「failed の place で Photo Media を毎回課金して
+              // しまう件は別途対応する」と書いてあったが、**その対応は #1053 で入った**。
+              // `dishes.service.ts` の `canSkipPhotoMedia` が、再利用する media_path の
+              // 実体が GCS にあることを確かめたうえで Photo Media の呼び出しごと飛ばし、
+              // handler へは photoUri 無しで enqueue して download も skip させる。
+              //
+              // したがって「resize に失敗して failed に張り付いた place を bulk-import
+              // するたびに課金される」経路は塞がっている。写真バイナリ自体が無い
+              // （media_path が無い / 実体が消えている）place で取り直すのは、
+              // 課金の漏れではなく必要な取得である。
+              //
               // 再利用が起きたことは ExistingGoogleImportDishMediaReused ログの
               // mediaProcessingStatus で数えられる。
               OR: [


### PR DESCRIPTION
## 何が問題か

`dishes.repository.ts` の #829 のコメントにこう書いてある:

> failed の place で Photo Media を毎回課金してしまう件は、`tryGetPhotoMedia` が reuse 判定より前にある構造の問題なので、**別途 handler 側の download skip 判定とあわせて対応する。**

**その対応は #1053 で既に入っている。**

`dishes.service.ts:410-422` の `canSkipPhotoMedia` が、再利用する `media_path` の実体が GCS にあることを確かめたうえで **Photo Media の呼び出しごと飛ばし**、handler へは `photoUri` 無しで enqueue して download も skip させる（`:448-456`）。

## なぜ直すか

放置すると、次に読む人が**「課金の穴がまだ開いている」と誤解する**。

コード自体は正しいのにコメントだけが古い状態は、たちが悪い方の陳腐化である:

- 対応済みのものをもう一度直しに行く
- 「まだ開いている」と思って別の場所を疑い、時間を溶かす

CLAUDE.md にも「陳腐化した記述を見つけたら、その場で直すか消す。放置を禁止する」とある。

## どう直したか

実態に合わせて書き直し、**どの経路が塞がっていて、どの経路はそもそも塞ぐ対象ではないか**まで書いた:

> 写真バイナリ自体が無い（`media_path` が無い / 実体が消えている）place で取り直すのは、**課金の漏れではなく必要な取得である。**

これが無いと、次の人が「まだ Photo Media を呼ぶ経路がある」と見て、また同じ調査をやり直すことになる。

## 見つけ方

R12-A（再実行安全性レビュー）を回すのと並行して、自分でも「二重課金しうる経路」を辿った。`tryGetPhotoMedia` の呼び出し元を追ったところ、コメントが指す問題が既に解決済みであることが分かった — **バグは無く、あったのは古いコメントだった。**

## 検証

コメントのみの変更。

- `pnpm --filter api test` → **71 suites / 892 tests 全 green**
- `pnpm --filter api typecheck` → green

Refs #1599, #829, #1053

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_