### PR TITLE
fix(ci): claude-worker と evidence-collect が落ちる真因を潰す

### DIFF
--- a/.claude/skills/parallel-development/CORE.md
+++ b/.claude/skills/parallel-development/CORE.md
@@ -794,16 +794,27 @@ dispatchしたrunが `pending` のまま動かないときは、ランナー不�
 ここを取り違えると、直すべき場所（プロンプト・権限）ではなく、関係の無い場所
 （利用上限・再実行のタイミング）を疑い続けることになる。
 
-### ⚠️ 「50 秒で落ちて Claude の出力が無い」は Claude の失敗ではない（2026-08-24 実測）
+### ⚠️ 「1 分以内に落ちて Claude の出力が無い」は Claude の失敗ではない（2026-08-24 / 08-26 実測）
 
 `読み取りワーカーが成果物を1文字も出力せずに終了しました` というエラーで 40〜60 秒で
 落ちる run が続いたとき、**並列数が多すぎる / 利用枠だと決めつけて再 dispatch を繰り返した**。
 実際の原因は step 6 **「sharedパッケージをビルド」** の型エラーで、
 **Claude Code を実行する step まで到達していなかった**（step 12 は skipped）。
+2026-08-26 には同じ形で、step 2 **「リポジトリを取得」** が `base_ref` の短縮 SHA を
+解決できずに落ちた run が、同じ «1 文字も出力せず» のエラーを出した。
 
-見分け方は下の `list_workflow_jobs` を**必ず先に**取ること。step の一覧を見れば
-「Claude Codeを実行」が `skipped` かどうかが一目で分かる。ここを飛ばすと、
-Claude 側の問題を延々と疑って何本も無駄に dispatch することになる（実際にそうなった）。
+**この誤報自体は直した。** 検証 step は `steps.claude.outcome` を見るようになったので、
+Claude が skip された run は
+
+> Claude Codeは実行されていません（前段のstepが失敗したためskipされました）。…
+> このjobで**最初に赤くなったstep**です
+
+と言う。このエラーが出たら Claude・権限・利用枠を疑わず、**ログの先頭から最初に
+赤くなった step を見る**。`base_ref` の解決ミスは validate job が dispatch 直後に
+弾く（runner を消費しない）。
+
+それでも `list_workflow_jobs` で step 一覧を取るのが最短である場合は多い。
+「Claude Codeを実行」が `skipped` かどうかが一目で分かる。
 
 このときの根本原因は `db-migrate.yml` の `regenerate_prisma` が `schema.prisma` だけを
 main へ自動 commit し、**`shared/supabase/database.types.ts` と `shared/converters/` の

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -75,6 +75,10 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+    outputs:
+      # 両ワーカーが checkout する ref。base_ref が指定されたときは
+      # 「GitHubが解決した40桁のcommit SHA」へ正規化してから渡す（下の step の説明を参照）。
+      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
     steps:
       - name: 入力値を安全な範囲に制限
         shell: bash
@@ -126,6 +130,61 @@ jobs:
             fi
           fi
 
+      # ⚠️ base_ref は «checkout できる形» まで、runner を1つも使う前に確定させる。
+      #
+      # 2026-08-26、run 32913852426 は base_ref に短縮SHA `f528bc69` を渡された。
+      # この validate job は base_ref を1文字も検査していなかったので素通りし、
+      # 8秒後に checkout が
+      #   「A branch or tag with the name 'f528bc69' could not be found」
+      # で落ちた。actions/checkout が ref として解決できるのは
+      # «リモートに実在するブランチ名 / タグ名» か «ちょうど40桁のcommit SHA» だけで、
+      # 短縮SHAはどちらにも当たらないためである。
+      #
+      # ここで弾くだけでなく **解決して full SHA へ正規化する**。そうすれば短縮SHAは
+      # 「エラーにならず、意図どおり動く」ようになり、加えて validate と checkout の間に
+      # ブランチが動いても両ワーカーが同じcommitを見ることが保証される。
+      - name: checkoutするrefを解決する
+        id: resolve
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ inputs.base_ref }}
+          BASE_BRANCH: ${{ inputs.base_branch || github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$BASE_REF" ]]; then
+            # base_ref 未指定のときの挙動は従来どおり «ブランチ名のまま checkout» にする。
+            # ここを SHA へ正規化すると CLAUDE_BRANCH がブランチ名でなくなり、
+            # 既定経路の挙動を変えてしまうため、あえて解決しない。
+            if ! gh api "repos/${GITHUB_REPOSITORY}/branches/${BASE_BRANCH}" --jq '.name' >/dev/null 2>&1; then
+              echo "::error::base_branch '$BASE_BRANCH' がこのリポジトリに存在しません。checkoutは必ず失敗するので、ここで止めます。"
+              exit 1
+            fi
+            echo "checkout_ref=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "base_ref 未指定のため、base_branch '$BASE_BRANCH' をcheckoutします。"
+            exit 0
+          fi
+
+          # commits API はブランチ名・タグ名・full SHA・短縮SHA のいずれも解決し、
+          # full SHA を返す。解決できないものだけがここで落ちる。
+          if ! RESOLVED="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${BASE_REF}" --jq '.sha' 2>/dev/null)"; then
+            echo "::error::base_ref '$BASE_REF' をこのリポジトリのcommitとして解決できません（ブランチ名・タグ名・commit SHAのいずれでもない、または削除済みです）。"
+            exit 1
+          fi
+
+          if [[ ! "$RESOLVED" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::base_ref '$BASE_REF' の解決結果 '$RESOLVED' が40桁のcommit SHAではありません。"
+            exit 1
+          fi
+
+          echo "checkout_ref=$RESOLVED" >> "$GITHUB_OUTPUT"
+          if [[ "$BASE_REF" != "$RESOLVED" ]]; then
+            echo "base_ref '$BASE_REF' を full SHA '$RESOLVED' へ正規化しました。"
+          else
+            echo "base_ref '$RESOLVED' を確認しました。"
+          fi
+
   observe:
     name: 読み取りワーカー
     needs: validate
@@ -146,7 +205,7 @@ jobs:
       - name: リポジトリを取得
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.base_ref || inputs.base_branch || github.event.repository.default_branch }}
+          ref: ${{ needs.validate.outputs.checkout_ref }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -226,7 +285,7 @@ jobs:
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         env:
           # workflow_dispatchのrefではなく、実際に調査するrefをGitHub MCPへ渡す。
-          CLAUDE_BRANCH: ${{ inputs.base_ref || inputs.base_branch || github.event.repository.default_branch }}
+          CLAUDE_BRANCH: ${{ needs.validate.outputs.checkout_ref }}
           # setup_playwright時、e2e-webのテストがログイン系specを自動実行できるようにする
           # (TEST_USER_*未設定時はテスト側のskip条件で自動的にスキップされる)。
           TEST_USER_EMAIL: ${{ inputs.setup_playwright && secrets.TEST_USER_EMAIL || '' }}
@@ -299,9 +358,32 @@ jobs:
       # 見ない（投稿の要否はプロンプト次第で、ここで一律に強制すると調査だけを頼んだrunまで赤くなる）。
       # 空でなければ中身は job ログの `claude-result-begin:` 〜 `claude-result-end:` から回収できる。
       - name: 成果物が出力されたことを検証
-        if: always()
+        if: ${{ !cancelled() }}
         shell: bash
+        env:
+          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
         run: |
+          # ⚠️ 「Claudeが〜しなかった」と報告してよいのは、**Claudeが実際に走ったとき**だけ。
+          #
+          # 2026-08-26、run 32913852426 は step 2（checkout）が base_ref の短縮SHAで
+          # 落ち、Claudeの step は skipped だった。にもかかわらずこの step が
+          # 「成果物を1文字も出力せずに終了しました」と報告し、しかもそれが job の
+          # **最後のエラー**なので、リーダーには «Claudeが黙って終わった / 権限拒否» に見えた。
+          # 真因（checkoutの失敗）はログを先頭まで遡らないと分からない。
+          # 同じ罠は step 6（sharedのビルド）でも踏んでおり、そのときは «Claudeが出力せず
+          # 50秒で落ちる» と誤診したまま文書化だけして直していなかった（#1574）。
+          #
+          # 段取りの step が落ちた run は「段取りが落ちた」とだけ言う。Claudeの話をしない。
+          if [[ "$CLAUDE_OUTCOME" == "skipped" ]]; then
+            echo "::error::Claude Codeは実行されていません（前段のstepが失敗したためskipされました）。このjobの失敗原因はClaudeではなく、このjobで**最初に赤くなったstep**です（checkout / pnpm install / sharedのビルド / フォント導入 等）。ログを先頭から見てください。"
+            exit 1
+          fi
+
+          if [[ "$CLAUDE_OUTCOME" != "success" ]]; then
+            echo "::error::Claude Codeのstep自体が失敗しました（outcome=$CLAUDE_OUTCOME）。[subtype=${CLAUDE_SUBTYPE:-unknown} is_error=${CLAUDE_IS_ERROR:-unknown} turns=${CLAUDE_NUM_TURNS:-unknown} permission_denials=${CLAUDE_DENIALS:-unknown}]"
+            exit 1
+          fi
+
           if [[ "${CLAUDE_RESULT_CHARS:-0}" -eq 0 ]]; then
             echo "::error::読み取りワーカーが成果物を1文字も出力せずに終了しました。observeの成果物は commit ではなく «最後に書かれたテキスト» なので、これは成功ではありません。 [subtype=${CLAUDE_SUBTYPE:-unknown} is_error=${CLAUDE_IS_ERROR:-unknown} turns=${CLAUDE_NUM_TURNS:-unknown} permission_denials=${CLAUDE_DENIALS:-unknown}] 拒否されたツール名はjobログの 'claude-denial:' 行を見ること。"
             exit 1
@@ -340,7 +422,7 @@ jobs:
       - name: リポジトリを取得
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.base_ref || inputs.base_branch || github.event.repository.default_branch }}
+          ref: ${{ needs.validate.outputs.checkout_ref }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -521,13 +603,38 @@ jobs:
         # 何もcommit・pushしないまま終了した場合でもjobを明示的に失敗させる。
         # (SDKの実行自体は is_error:false で「成功」報告されることがあるため、
         # workflow runのconclusionだけでは成果物の有無を判断できない)
-        if: always()
+        if: ${{ !cancelled() }}
         shell: bash
         env:
           BRANCH_NAME: ${{ inputs.branch_name }}
           PRE_SHA: ${{ steps.pre_claude.outputs.sha }}
+          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
         run: |
           set -euo pipefail
+
+          # ⚠️ 「Claudeが〜しなかった」と報告してよいのは、**Claudeが実際に走ったとき**だけ。
+          #
+          # このstepは `always()` で動いていたため、段取りのstep（checkout / pnpm install /
+          # sharedのビルド / フォント導入）が落ちてClaudeがskipされたrunでも走っていた。
+          # そのとき下の `git rev-parse HEAD` は «作業ツリーが無い» まま実行され、
+          # set -e で git の生のエラーを吐いて終わる。リーダーに届く最後のエラーが
+          # 「commitが無い」でも git の内部エラーでもなく、**真因を1文字も含まない**。
+          # observe側は同じ形で «成果物を1文字も出力せずに終了しました» と誤って報告し、
+          # 実際に run 32913852426（base_refに短縮SHA）でリーダーを誤診させた。
+          # 同じ罠は step 6（sharedのビルド）でも踏んでおり、そのときは «Claudeが出力せず
+          # 50秒で落ちる» と誤診したまま文書化だけして直していなかった（#1574）。
+          #
+          # 段取りのstepが落ちたrunは「段取りが落ちた」とだけ言う。Claudeの話をしない。
+          if [[ "$CLAUDE_OUTCOME" == "skipped" ]]; then
+            echo "::error::Claude Codeは実行されていません（前段のstepが失敗したためskipされました）。このjobの失敗原因はClaudeではなく、このjobで**最初に赤くなったstep**です（checkout / pnpm install / sharedのビルド / フォント導入 等）。ログを先頭から見てください。"
+            exit 1
+          fi
+
+          if [[ "$CLAUDE_OUTCOME" != "success" ]]; then
+            echo "::error::Claude Codeのstep自体が失敗しました（outcome=$CLAUDE_OUTCOME）。[subtype=${CLAUDE_SUBTYPE:-unknown} is_error=${CLAUDE_IS_ERROR:-unknown} turns=${CLAUDE_NUM_TURNS:-unknown} permission_denials=${CLAUDE_DENIALS:-unknown}]"
+            exit 1
+          fi
+
           POST_SHA=$(git rev-parse HEAD)
           if [[ "$PRE_SHA" == "$POST_SHA" ]]; then
             # ⚠️ 原因の切り分けに要る値をこの1行へ必ず載せること。

--- a/.github/workflows/evidence-collect.yml
+++ b/.github/workflows/evidence-collect.yml
@@ -27,6 +27,11 @@ on:
         required: false
         default: false
         type: boolean
+      wait_timeout_minutes:
+        description: "元runがまだ走っているとき、完了を待つ上限（分）。0で待たずに即失敗する"
+        required: false
+        default: 25
+        type: number
 
 permissions:
   contents: read
@@ -36,7 +41,9 @@ jobs:
   collect:
     name: Publish ${{ inputs.artifact_name }} from run ${{ inputs.run_id }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    # 元runの完了待ち（wait_timeout_minutes、既定25分）＋ダウンロードと公開の実作業が
+    # 収まる長さにする。ここが待ち時間より短いと、待っている最中にjobごと打ち切られる。
+    timeout-minutes: 35
     env:
       GCS_BUCKET: nanitabeyo-public
       GCP_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -44,6 +51,7 @@ jobs:
       ARTIFACT_NAME: ${{ inputs.artifact_name }}
       SOURCE_SHA: ${{ inputs.source_sha }}
       ALLOW_FAILED_RUN: ${{ inputs.allow_failed_run }}
+      WAIT_TIMEOUT_MINUTES: ${{ inputs.wait_timeout_minutes }}
       # 元runが信頼できるWorkflowであることを .path で判定する（.name は run-name のため使えない）
       # - claude-worker.yml: テストエビデンス収集の本来の入力
       # - e2e-web-test.yml    : 手動実行で収集したUIカタログのスクリーンショット（Web）
@@ -71,6 +79,11 @@ jobs:
 
           if [[ ! "$SOURCE_SHA" =~ ^[0-9a-fA-F]{40,64}$ ]]; then
             echo "::error::source_shaは40〜64桁の16進commit SHAで指定してください。"
+            exit 1
+          fi
+
+          if [[ ! "$WAIT_TIMEOUT_MINUTES" =~ ^[0-9]+$ ]] || (( WAIT_TIMEOUT_MINUTES > 30 )); then
+            echo "::error::wait_timeout_minutesは0〜30で指定してください（jobのtimeout-minutesを超えられません）。"
             exit 1
           fi
 
@@ -110,6 +123,29 @@ jobs:
             exit 1
           fi
 
+          # ⚠️ 「まだ走っている」は失敗ではなく、**待てば解決する状態**である。
+          #
+          # 2026-08-25、run 32909994882 は元run（e2e-mobile）が in_progress のまま
+          # dispatchされ、8秒で赤くなった。実際にはオーナーが完了を目視してから
+          # 手で再dispatchし、26分後に同じ入力で成功している。
+          # つまり **待つべきところを失敗で返し、その待ちを人間にやらせていた**。
+          # エビデンス収集は元runの完了が前提なので、ここで待つのが正しい。
+          #
+          # 待ち上限は wait_timeout_minutes（既定25分。iOSのDetoxが約15分かかる）。
+          # 0を渡せば従来どおり即失敗する。
+          DEADLINE=$(( SECONDS + WAIT_TIMEOUT_MINUTES * 60 ))
+          while [[ "$STATUS" != "completed" ]]; do
+            if (( SECONDS >= DEADLINE )); then
+              echo "::error::元run（$SOURCE_URL）が完了しません（status=$STATUS）。${WAIT_TIMEOUT_MINUTES}分待って諦めました。元runが終わってから再実行するか、wait_timeout_minutesを延ばしてください。"
+              exit 1
+            fi
+            echo "元runは status=$STATUS です。30秒後に再確認します（残り $(( (DEADLINE - SECONDS) / 60 ))分）。"
+            sleep 30
+            RUN_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}")"
+            STATUS="$(jq -r '.status' <<<"$RUN_JSON")"
+            CONCLUSION="$(jq -r '.conclusion' <<<"$RUN_JSON")"
+          done
+
           # 【設計】既定では success の元runだけを通す。
           # 「緑の run から採ったエビデンス」であることが、このワークフローの出力の意味そのものだから。
           #
@@ -118,11 +154,6 @@ jobs:
           # 明示的にオプトインしたときだけ、完了済みの失敗runも許す。
           # ⚠️ このとき出力は «エビデンス» ではなく «調査用» である。ログに警告を残し、
           # PR へ貼るときは必ず「失敗runのスクリーンショット」と明記すること。
-          if [[ "$STATUS" != "completed" ]]; then
-            echo "::error::元runが完了していません（status=$STATUS）。"
-            exit 1
-          fi
-
           if [[ "$CONCLUSION" != "success" ]]; then
             if [[ "$ALLOW_FAILED_RUN" != "true" ]]; then
               echo "::error::元runが成功完了していません（status=$STATUS, conclusion=$CONCLUSION）。"


### PR DESCRIPTION
## 何を直したか

「claude-worker と evidence-collect が落ちている」の調査。原因は **3 つ**あり、いずれも直した。

### 1. claude-worker: `base_ref` の短縮 SHA で checkout が落ちていた

[run 32913852426](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/32913852426) は `base_ref` に短縮 SHA `f528bc69` を渡された。`actions/checkout` が ref として解決できるのは «実在するブランチ名 / タグ名» か «ちょうど 40 桁の commit SHA» だけなので、8 秒で落ちていた。

```
[command] git branch --list --remote origin/f528bc69
[command] git tag --list f528bc69
##[error] A branch or tag with the name 'f528bc69' could not be found
```

入力検証 job は `task_key` / `max_turns` / `base_branch` / `branch_name` を検査していたが、**`base_ref` だけは 1 文字も見ていなかった**ため素通りしていた。

→ validate job で commits API を使って解決し、**40 桁の full SHA へ正規化してから**両ワーカーへ渡す。これで短縮 SHA は «エラーにならず意図どおり動く» ようになる。解決できない ref は runner を 1 つも使わずに弾かれる。`base_branch` の存在確認も足した。

なお `f528bc69` は**実在する commit** (`f528bc69295b892656ab1ae92a1cd5a1a1fb883c`) だった。入力は正しく、checkout が受け取れなかっただけである。だから «早く失敗させる» ではなく «動くようにする» を選んだ。

副次的に、validate と checkout の間にブランチが動いても両ワーカーが同じ commit を見ることが保証される。

### 2. claude-worker: 段取りの失敗が «Claude が 1 文字も出力しなかった» と報告されていた

検証 step が `always()` だったため、checkout や shared ビルドが落ちて Claude の step が `skipped` になった run でも走り、

```
##[error] 読み取りワーカーが成果物を1文字も出力せずに終了しました。… [subtype=unknown
is_error=unknown turns=unknown permission_denials=unknown] 拒否されたツール名は
jobログの 'claude-denial:' 行を見ること。
```

を **job の最後のエラー**として出していた。真因（checkout の失敗）を 1 文字も含まないどころか、**Claude の権限・利用枠を見に行けと指示している**。同じ罠は step 6（shared のビルド）でも踏んでおり、#1574 で文書化だけして直していなかった。

→ 検証 step が `steps.claude.outcome` を見るようにした。`skipped` なら «このjobで最初に赤くなった step を見ろ» と言う。write 側も同様（そちらは作業ツリーが無いまま `git rev-parse HEAD` を叩き、git の生エラーで死んでいた）。あわせて `always()` → `!cancelled()`。

### 3. evidence-collect: 元 run がまだ走っているだけで即失敗していた

[run 32909994882](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/32909994882) は元 run（e2e-mobile）が `in_progress` のまま dispatch され 8 秒で赤くなった。その後**オーナーが完了を目視して手で再 dispatch し、26 分後に同じ入力で成功している**。待てば済むものを失敗で返し、その待ちを人間にやらせていた。

→ 完了までポーリングして待つ。上限は `wait_timeout_minutes`（既定 25 分 / `0` で従来どおり即失敗）。iOS の Detox が約 15 分かかるので既定を 25 分にし、job の `timeout-minutes` を 35 へ上げた。

## 検証

workflow から run ブロックを抜き出し `gh` をスタブ化して実測。**19 ケース全て緑**。

| 対象 | ケース | 結果 |
| --- | --- | --- |
| base_ref 解決 | 短縮SHA / full SHA / タグ / 未指定 | 全て解決して checkout_ref を出力 |
| base_ref 解決 | 存在しない ref / base_branch の誤り | exit 1 で拒否 |
| 検証 step | outcome=skipped | exit 1・«最初に赤くなった step を見ろ» |
| 検証 step | outcome=failure / success×0文字 | exit 1 |
| 検証 step | success×9546文字 | exit 0 |
| evidence-collect | in_progress×2 → 完了 | 待って通す |
| evidence-collect | 待ち上限切れ | 実時間 61 秒で 1 分の期限が発火し exit 1 |
| evidence-collect | failure 拒否 / allow_failed_run / 非許可workflow / push イベント | 既存挙動のまま（回帰なし） |

ブランチ名（スラッシュ入り `claude/probe-permission-mode`）・`refs/heads/main`・短縮 SHA が commits API で解決することは**実 API で確認済み**（＝既存の入力形式に回帰なし）。

## 残っている確認

GitHub Actions の式評価（`needs.validate.outputs.checkout_ref` / `steps.claude.outcome`）だけはスタブで再現できないため、マージ後の最初の実 dispatch が最終確認になる。

Related: #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqScoMXcjG2sk1p9gtbdoK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqScoMXcjG2sk1p9gtbdoK)_