### PR TITLE
fix(api): 再配送で dish_media の行が «何も変わっていないのに» 書き換わるのを止める (#1599)

### DIFF
--- a/api/src/internal/media-status-idempotent-write.spec.ts
+++ b/api/src/internal/media-status-idempotent-write.spec.ts
@@ -1,0 +1,254 @@
+// api/src/internal/media-status-idempotent-write.spec.ts
+//
+// #1599 **再配送で dish_media の行が «何も変わっていないのに» 書き換わる件。**
+//
+// Cloud Tasks も Pub/Sub Push も at-least-once 配送で、ハンドラが成功しても
+// 応答が届かなければ同じジョブ／通知がもう一度届く。
+// リサイズ完了もトランスコード完了も «同じ status を書く» 処理なので、
+// 再配送そのものは正しく無害に終わる。にもかかわらず以前は無条件 UPDATE で
+//
+//   - `lock_no` が 1 つ進む
+//   - `updated_at` が現在時刻へ動く（«最後に中身が変わった時刻» が読めなくなる）
+//   - 行の新しいバージョンが書かれる（WAL / VACUUM 対象が増える）
+//
+// が起きていた。
+//
+// **2 つのサービスに同じ形の欠陥があったので、両方をここで固定する。**
+// 片方だけ直すと、もう片方で同じことが残る。
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../prisma/prisma.service';
+import { StorageService } from '../core/storage/storage.service';
+import { AppLoggerService } from '../core/logger/logger.service';
+import { TranscoderService } from '../core/transcoder/transcoder.service';
+
+jest.mock('src/core/config/env', () => ({
+  env: {
+    API_COMMIT_ID: 'test',
+    API_NODE_ENV: 'test',
+    DB_SCHEMA: 'test',
+    GCS_BUCKET_NAME: 'test-bucket',
+    GCP_PROJECT: 'test-project',
+    TRANSCODER_LOCATION: 'us-central1',
+    TRANSCODER_PUBSUB_TOPIC: 'projects/test-project/topics/transcoder',
+  },
+}));
+
+// TranscoderServiceClient はコンストラクタで実際の GCP クライアントを作るのでモックする
+const mockGetJob = jest.fn();
+jest.mock('@google-cloud/video-transcoder', () => ({
+  TranscoderServiceClient: jest.fn().mockImplementation(() => ({
+    getJob: mockGetJob,
+  })),
+  protos: {},
+}));
+
+// `jest.mock` は import より前へ巻き上げられるので、素の import で問題ない
+import { ResizeImageService } from './resize-image/resize-image.service';
+import { TranscoderWebhookService } from './transcoder/transcoder-webhook.service';
+
+const RECORD_ID = '12345678-1234-1234-1234-123456789012';
+
+/** `dish_media.updateMany` だけを持つ最小の PrismaService モック */
+function makePrismaMock(updateManyCount: number) {
+  const updateMany = jest.fn().mockResolvedValue({ count: updateManyCount });
+  const update = jest.fn().mockResolvedValue({});
+  return {
+    mock: {
+      prisma: { dish_media: { updateMany, update } },
+      withTransaction: jest.fn(),
+    },
+    updateMany,
+    update,
+  };
+}
+
+const loggerMock = () => ({
+  debug: jest.fn(),
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('#1599 リサイズ完了の status 書き込み（ResizeImageService）', () => {
+  /**
+   * `resizeAndStoreImage` の «リサイズ済みが既にある» 経路が、再配送で通る道である。
+   * ここを通って `completed` を書きに行く。
+   */
+  async function buildService(updateManyCount: number) {
+    const prisma = makePrismaMock(updateManyCount);
+    const storage = {
+      fileExists: jest.fn().mockResolvedValue(true), // 既にリサイズ済み = 再配送された状態
+      generateSignedUrl: jest.fn().mockResolvedValue('https://example.com/x'),
+      uploadFileAtPath: jest.fn(),
+    };
+    const logger = loggerMock();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResizeImageService,
+        { provide: PrismaService, useValue: prisma.mock },
+        { provide: StorageService, useValue: storage },
+        { provide: AppLoggerService, useValue: logger },
+      ],
+    }).compile();
+
+    return {
+      service: module.get<ResizeImageService>(ResizeImageService),
+      prisma,
+      logger,
+    };
+  }
+
+  const dto = {
+    table: 'dish_media',
+    column: 'media_path',
+    recordId: RECORD_ID,
+    size: 512 as 64 | 256 | 512 | 1024,
+    originalPath: 'test/path/image.jpg',
+  };
+
+  it('既に同じ status なら 1 行も書かない（lock_no を進めない）', async () => {
+    // count: 0 = WHERE に一致しなかった = 既にその status だった
+    const { service, prisma, logger } = await buildService(0);
+
+    const result = await service.resizeAndStoreImage(dto as never);
+
+    expect(result.alreadyExisted).toBe(true);
+
+    // 無条件 UPDATE（update）を使っていないこと。使っていると必ず 1 行書く
+    expect(prisma.update).not.toHaveBeenCalled();
+
+    // 「今の値と違うときだけ書く」が SQL 側の条件になっていること。
+    // 読んでから比べて書く形にすると、その隙間に別のタスクが書き込める
+    expect(prisma.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: RECORD_ID,
+          NOT: { media_processing_status: 'completed' },
+        },
+      }),
+    );
+
+    expect(logger.log).toHaveBeenCalledWith(
+      'DishMediaProcessingStatusUnchanged',
+      'updateDishMediaProcessingStatus',
+      expect.objectContaining({ recordId: RECORD_ID, status: 'completed' }),
+    );
+  });
+
+  it('status が変わるときは従来どおり lock_no を進めて書く', async () => {
+    const { service, prisma, logger } = await buildService(1);
+
+    await service.resizeAndStoreImage(dto as never);
+
+    expect(prisma.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          media_processing_status: 'completed',
+          lock_no: { increment: 1 },
+        }),
+      }),
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      'DishMediaProcessingStatusUpdated',
+      'updateDishMediaProcessingStatus',
+      expect.objectContaining({ recordId: RECORD_ID }),
+    );
+  });
+
+  it('column が media_path 以外ならサムネイル側の列を見る', async () => {
+    const { service, prisma } = await buildService(0);
+
+    await service.resizeAndStoreImage({
+      ...dto,
+      column: 'thumbnail_path',
+    } as never);
+
+    expect(prisma.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: RECORD_ID,
+          NOT: { thumbnail_processing_status: 'completed' },
+        },
+      }),
+    );
+  });
+});
+
+describe('#1599 トランスコード完了の status 書き込み（TranscoderWebhookService）', () => {
+  async function buildService(updateManyCount: number) {
+    const prisma = makePrismaMock(updateManyCount);
+    const logger = loggerMock();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TranscoderWebhookService,
+        { provide: PrismaService, useValue: prisma.mock },
+        { provide: AppLoggerService, useValue: logger },
+        {
+          provide: TranscoderService,
+          useValue: { createTranscodeJob: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    return {
+      service: module.get<TranscoderWebhookService>(TranscoderWebhookService),
+      prisma,
+      logger,
+    };
+  }
+
+  const JOB_NAME = 'projects/p/locations/l/jobs/j';
+
+  beforeEach(() => {
+    mockGetJob.mockReset();
+    mockGetJob.mockResolvedValue([
+      {
+        name: JOB_NAME,
+        labels: {
+          table_name: 'dish_media',
+          column_name: 'media_path',
+          record_id: RECORD_ID,
+        },
+      },
+    ]);
+  });
+
+  it('既に completed なら 1 行も書かない（lock_no を進めない）', async () => {
+    const { service, prisma, logger } = await buildService(0);
+
+    await service.handleJobNotification(JOB_NAME, 'SUCCEEDED');
+
+    expect(prisma.update).not.toHaveBeenCalled();
+    expect(prisma.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: RECORD_ID,
+          NOT: { media_processing_status: 'completed' },
+        },
+      }),
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      'DishMediaProcessingStatusUnchanged',
+      'updateDishMediaProcessingStatus',
+      expect.objectContaining({ recordId: RECORD_ID, status: 'completed' }),
+    );
+  });
+
+  it('status が変わるときは従来どおり lock_no を進めて書く', async () => {
+    const { service, prisma } = await buildService(1);
+
+    await service.handleJobNotification(JOB_NAME, 'SUCCEEDED');
+
+    expect(prisma.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          media_processing_status: 'completed',
+          lock_no: { increment: 1 },
+        }),
+      }),
+    );
+  });
+});

--- a/api/src/internal/resize-image/resize-image.service.ts
+++ b/api/src/internal/resize-image/resize-image.service.ts
@@ -402,6 +402,29 @@ export class ResizeImageService {
 
   /**
    * #511 【設計】dish_media テーブルの processing_status を更新
+   *
+   * #1599 【バグ】**既にそのステータスなら 1 行も書かない。**
+   *
+   * Cloud Tasks は at-least-once 配送で、ハンドラが成功しても応答が届かなければ
+   * 再実行される。`resizeAndStoreImage` は再実行されると
+   * 「リサイズ済みが既にある」経路（`alreadyExisted`）へ入り、そこから
+   * **同じ status で**ここへ来る。以前は無条件 UPDATE だったので、再配送のたびに
+   *
+   *   - `lock_no` が 1 つ進む
+   *   - `updated_at` が «何も変わっていないのに» 現在時刻へ動く
+   *   - 行の新しいバージョンが書かれる（WAL・VACUUM 対象が増える）
+   *
+   * が起きていた。`updated_at` は «最後に中身が変わった時刻» として読める必要があり、
+   * 再配送の回数で動く値になっていると、後からログと突き合わせられない。
+   *
+   * 判定は `WHERE <statusColumn> <> :status` で **DB 側に 1 文で持たせる**。
+   * 「読んでから比べて書く」にすると、その隙間に別のタスクが書き込める。
+   *
+   * ⚠️ `update` ではなく `updateMany` なのは、条件に一致しないことを
+   * «例外» ではなく «0 行» で受け取るためである（`update` は P2025 を投げる）。
+   * そのぶん «行が無い» と «既にそのステータス» が区別できなくなるので、
+   * 0 行のときは両方を疑えるログを残す。
+   *
    * @param recordId dish_media レコードの ID
    * @param column 対象カラム（media_path / thumbnail_path）
    * @param status 更新後のステータス
@@ -417,14 +440,28 @@ export class ResizeImageService {
         : 'thumbnail_processing_status';
 
     try {
-      await this.prisma.prisma.dish_media.update({
-        where: { id: recordId },
+      const { count } = await this.prisma.prisma.dish_media.updateMany({
+        where: { id: recordId, NOT: { [statusColumn]: status } },
         data: {
           [statusColumn]: status,
           updated_at: new Date(),
           lock_no: { increment: 1 },
         },
       });
+
+      if (count === 0) {
+        this.logger.log(
+          'DishMediaProcessingStatusUnchanged',
+          'updateDishMediaProcessingStatus',
+          {
+            recordId,
+            statusColumn,
+            status,
+            reason: 'already_in_status_or_record_missing',
+          },
+        );
+        return;
+      }
 
       this.logger.log(
         'DishMediaProcessingStatusUpdated',

--- a/api/src/internal/resize-image/resize-image.unsupported-format.spec.ts
+++ b/api/src/internal/resize-image/resize-image.unsupported-format.spec.ts
@@ -67,7 +67,7 @@ describe('#1425 ResizeImageService - デコーダが無い形式は恒久失敗'
     log: jest.Mock;
     debug: jest.Mock;
   };
-  let prisma: { prisma: { dish_media: { update: jest.Mock } } };
+  let prisma: { prisma: { dish_media: { updateMany: jest.Mock } } };
 
   const dto = {
     table: 'dish_media',
@@ -89,7 +89,11 @@ describe('#1425 ResizeImageService - デコーダが無い形式は恒久失敗'
       debug: jest.fn(),
     };
     prisma = {
-      prisma: { dish_media: { update: jest.fn().mockResolvedValue({}) } },
+      prisma: {
+        dish_media: {
+          updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+        },
+      },
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -140,9 +144,14 @@ describe('#1425 ResizeImageService - デコーダが無い形式は恒久失敗'
   it('dish_media の processing_status を failed にする', async () => {
     await expect(service.resizeAndStoreImage(dto)).rejects.toThrow();
 
-    expect(prisma.prisma.dish_media.update).toHaveBeenCalledWith(
+    // #1599 「今の値と違うときだけ書く」形になったので where に NOT が付く。
+    // 再配送で同じ status を書き直して lock_no / updated_at を動かさないため
+    expect(prisma.prisma.dish_media.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: dto.recordId },
+        where: {
+          id: dto.recordId,
+          NOT: { media_processing_status: 'failed' },
+        },
         data: expect.objectContaining({ media_processing_status: 'failed' }),
       }),
     );

--- a/api/src/internal/transcoder/transcoder-webhook.service.ts
+++ b/api/src/internal/transcoder/transcoder-webhook.service.ts
@@ -64,20 +64,44 @@ export class TranscoderWebhookService {
 
   /**
    * #511 【設計】dish_media テーブルの processing_status を更新
+   *
+   * #1599 【バグ】**既にそのステータスなら 1 行も書かない。**
+   *
+   * Pub/Sub Push は at-least-once 配送で、ハンドラが成功しても応答が届かなければ
+   * 同じ通知がもう一度届く。以前は無条件 UPDATE だったので、再配送のたびに
+   * `lock_no` が進み、`updated_at` が «何も変わっていないのに» 現在時刻へ動いていた。
+   * `updated_at` は «最後に中身が変わった時刻» として読める必要がある。
+   *
+   * `resize-image.service.ts` の同名メソッドと同じ形にしてある（片方だけ直すと、
+   * もう片方で同じ «再配送のたびに行が書き換わる» が残る）。理由の詳細はあちらの
+   * doc comment にある。
    */
   private async updateDishMediaProcessingStatus(
     recordId: string,
     status: MediaProcessingStatus,
   ): Promise<void> {
     try {
-      await this.prisma.prisma.dish_media.update({
-        where: { id: recordId },
+      const { count } = await this.prisma.prisma.dish_media.updateMany({
+        where: { id: recordId, NOT: { media_processing_status: status } },
         data: {
           media_processing_status: status,
           updated_at: new Date(),
           lock_no: { increment: 1 },
         },
       });
+
+      if (count === 0) {
+        this.logger.log(
+          'DishMediaProcessingStatusUnchanged',
+          'updateDishMediaProcessingStatus',
+          {
+            recordId,
+            status,
+            reason: 'already_in_status_or_record_missing',
+          },
+        );
+        return;
+      }
 
       this.logger.log(
         'DishMediaProcessingStatusUpdated',


### PR DESCRIPTION
R12-A ②。

## 何が起きていたか

Cloud Tasks も Pub/Sub Push も **at-least-once** 配送で、ハンドラが成功しても応答が届かなければ
同じジョブ／通知がもう一度届く。リサイズ完了もトランスコード完了も «同じ status を書く» 処理なので
再実行自体は無害に終わる。にもかかわらず **無条件 UPDATE** だったため、再配送のたびに

- `lock_no` が 1 つ進む
- `updated_at` が «中身は同じなのに» 現在時刻へ動く
- 行の新しいバージョンが書かれる（WAL / VACUUM 対象が増える）

が起きていた。`updated_at` は «最後に中身が変わった時刻» として読める必要があり、
再配送の回数で動く値になっていると、後からログと突き合わせられない。

**`dish_media.lock_no` は楽観ロックの述語には使われていない**ことを確認済み
（`WHERE ... lock_no = ?` を持つのは `dish_reviews.repository.ts:97` だけ）。
つまり «409 が誤爆する» ような即時の実害は無く、影響は無駄な書き込みと `updated_at` の汚染に留まる。

## どう直したか

「今の値と違うときだけ書く」を **DB 側に 1 文で**持たせた。

```ts
await this.prisma.prisma.dish_media.updateMany({
  where: { id: recordId, NOT: { [statusColumn]: status } },
  data: { [statusColumn]: status, updated_at: new Date(), lock_no: { increment: 1 } },
});
```

- 読んでから比べて書く形にすると、その隙間に別のタスクが書き込める
- `update` ではなく `updateMany` なのは、条件不一致を **例外ではなく 0 行**で受け取るため
  （`update` は P2025 を投げる）。そのぶん «行が無い» と «既にその status» が区別できなくなるので、
  0 行のときは両方を疑えるログ（`DishMediaProcessingStatusUnchanged`）を残す
- `media_processing_status` / `thumbnail_processing_status` はどちらも `TEXT NOT NULL` なので、
  `NOT` の SQL 比較で NULL 行を取りこぼす心配は無い

**2 ファイルに同じ形の欠陥があったので両方直した**（`resize-image.service.ts` /
`transcoder-webhook.service.ts`）。片方だけだと、もう片方で同じことが残る。

## 検証

- 新規 `api/src/internal/media-status-idempotent-write.spec.ts`（5 件）で両サービスを固定
- **修正前のコードへ戻すと 5 件とも落ちる**ことを確認（revert-to-red）
- 既存 `resize-image.unsupported-format.spec.ts` の «failed にする» 検査は、同じ意図のまま
  `updateMany` + `NOT` 条件へ更新（検査は弱めていない。むしろ条件が 1 つ増えている）
- `pnpm --filter api typecheck` 0 エラー / `src/internal` 8 suites 65 tests green

## リンク

- 親: https://github.com/Ayato-kosaka/nanitabeyo/issues/1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_