### PR TITLE
fix(api): 通知の再配送でトランスコードジョブを二重に作るのを止める (#1599)

### DIFF
--- a/api/src/core/storage/storage-claim-once.spec.ts
+++ b/api/src/core/storage/storage-claim-once.spec.ts
@@ -1,0 +1,164 @@
+// api/src/core/storage/storage-claim-once.spec.ts
+//
+// #1599 **at-least-once の配送で «課金される処理» を二度実行しないための claim。**
+//
+// Cloud Tasks / Pub/Sub Push はハンドラが成功しても応答が届かなければ再実行する。
+// 「やってから記録する」では守れない（記録の前に応答が落ちれば、次の配送でもう一度やる）。
+// 先に権利を取り、取れた側だけが実行する。
+//
+// ここで固定したいのは «取り方» である。`fileExists()` してから書く形にすると
+// その隙間に別の配送が入り込むので、**判定と書き込みが GCS 側で 1 つになっていること**
+// （`ifGenerationMatch: 0`）をテストで釘付けにする。
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { StorageService } from './storage.service';
+import { STORAGE_CLIENT } from './storage.constants';
+import { AppLoggerService } from '../logger/logger.service';
+import { CloudTasksService } from '../cloud-tasks/cloud-tasks.service';
+import { buildTranscodeRetryClaimPath } from './storage.utils';
+
+jest.mock('src/core/config/env', () => ({
+  env: {
+    API_NODE_ENV: 'test',
+    GCS_BUCKET_NAME: 'test-bucket',
+    GCS_BUCKET_PUBLIC_NAME: 'test-bucket-public',
+    CDN_HOST: 'cdn.example.com',
+    GCP_PROJECT: 'test-project',
+  },
+}));
+
+jest.mock('../config/env', () => ({
+  env: {
+    API_NODE_ENV: 'test',
+    GCS_BUCKET_NAME: 'test-bucket',
+    GCS_BUCKET_PUBLIC_NAME: 'test-bucket-public',
+    CDN_HOST: 'cdn.example.com',
+    GCP_PROJECT: 'test-project',
+  },
+}));
+
+describe('#1599 StorageService.claimOnce', () => {
+  let service: StorageService;
+  let save: jest.Mock;
+  let logger: {
+    log: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+    debug: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    save = jest.fn().mockResolvedValue(undefined);
+    logger = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StorageService,
+        {
+          provide: STORAGE_CLIENT,
+          useValue: { bucket: () => ({ file: () => ({ save }) }) },
+        },
+        { provide: AppLoggerService, useValue: logger },
+        { provide: CloudTasksService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<StorageService>(StorageService);
+  });
+
+  it('まだ誰も取っていなければ true を返す', async () => {
+    await expect(service.claimOnce('a/b/.retry-1.claim')).resolves.toBe(true);
+  });
+
+  it('「まだ無いときだけ書く」を GCS 側の前提条件として渡す', async () => {
+    // ここが緩むと «存在確認 → 書き込み» の隙間ができ、同時に来た 2 本が両方通る
+    await service.claimOnce('a/b/.retry-1.claim');
+
+    expect(save).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        preconditionOpts: { ifGenerationMatch: 0 },
+        resumable: false,
+      }),
+    );
+  });
+
+  it('既に取られている（412）なら false を返し、例外にしない', async () => {
+    save.mockRejectedValue(
+      Object.assign(new Error('precondition'), { code: 412 }),
+    );
+
+    await expect(service.claimOnce('a/b/.retry-1.claim')).resolves.toBe(false);
+  });
+
+  it('412 以外（権限・ネットワーク）は握り潰さず投げる', async () => {
+    // «取れなかった» と «取られていた» の区別が付かないまま false を返すと、
+    // 呼び出し側が «誰かが実行済み» と誤解して処理を落とす
+    save.mockRejectedValue(
+      Object.assign(new Error('forbidden'), { code: 403 }),
+    );
+
+    await expect(service.claimOnce('a/b/.retry-1.claim')).rejects.toThrow(
+      'forbidden',
+    );
+  });
+
+  it('誰が何のために取ったかを claim ファイルへ残す（調査用）', async () => {
+    await service.claimOnce('a/b/.retry-1.claim', {
+      reason: 'transcode_retry',
+    });
+
+    const [body] = save.mock.calls[0] as [string];
+    expect(JSON.parse(body)).toMatchObject({
+      reason: 'transcode_retry',
+      claimed_at: expect.any(String),
+    });
+  });
+});
+
+describe('#1599 buildTranscodeRetryClaimPath', () => {
+  const OUT =
+    'gs://test-bucket/test/transcoded-video/dish_media/media_path/rec-1/file/';
+
+  it('出力先の prefix 直下に世代付きの claim を置く', () => {
+    expect(buildTranscodeRetryClaimPath(OUT, 1)).toBe(
+      'test/transcoded-video/dish_media/media_path/rec-1/file/.retry-1.claim',
+    );
+  });
+
+  it('末尾に / が無くてもディレクトリとして扱う', () => {
+    expect(buildTranscodeRetryClaimPath(OUT.replace(/\/$/, ''), 1)).toBe(
+      'test/transcoded-video/dish_media/media_path/rec-1/file/.retry-1.claim',
+    );
+  });
+
+  it('レコードが違えば claim も違う（別の動画のリトライを巻き込まない）', () => {
+    const other = OUT.replace('rec-1', 'rec-2');
+    expect(buildTranscodeRetryClaimPath(other, 1)).not.toBe(
+      buildTranscodeRetryClaimPath(OUT, 1),
+    );
+  });
+
+  it('世代が違えば claim も違う', () => {
+    expect(buildTranscodeRetryClaimPath(OUT, 2)).not.toBe(
+      buildTranscodeRetryClaimPath(OUT, 1),
+    );
+  });
+
+  it('別バケットを指していたら落とす（取り違えは黙って二重ジョブになる）', () => {
+    expect(() =>
+      buildTranscodeRetryClaimPath('gs://someone-else/x/y/', 1),
+    ).toThrow(/another bucket/);
+  });
+
+  it('gs:// 形式でなければ落とす', () => {
+    expect(() =>
+      buildTranscodeRetryClaimPath('https://example.com/x', 1),
+    ).toThrow(/Invalid transcode outputUri/);
+  });
+});

--- a/api/src/core/storage/storage.service.ts
+++ b/api/src/core/storage/storage.service.ts
@@ -271,6 +271,67 @@ export class StorageService {
     }
   }
 
+  /* ---------------------------------------------------------------------- */
+  /*                   #1599 一度きりの権利取得（claim）                     */
+  /* ---------------------------------------------------------------------- */
+  /**
+   * #1599 **そのパスを «自分が最初に作れたか» で排他する。**
+   *
+   * 至れり尽くせりのロックではなく、«同じ副作用を二度起こさない» ための最小の仕掛け。
+   * Cloud Tasks / Pub/Sub Push は at-least-once なので、
+   * **課金や外部ジョブ作成を伴う処理は「やってから記録する」では守れない**
+   * （記録の前に応答が落ちれば、次の配送でもう一度やってしまう）。
+   * 先に権利を取り、取れた側だけが実行する。
+   *
+   * ⚠️ `fileExists()` してから書く形にしてはいけない。その隙間に別の配送が入り込む。
+   * ここでは GCS の **`ifGenerationMatch: 0`（オブジェクトがまだ存在しないときだけ書く）**
+   * という前提条件を使う。判定と書き込みが GCS 側で 1 つになるので、
+   * 同時に 2 本来ても片方だけが成功する。
+   *
+   * ⚠️ **claim は自動では失効しない。** 取ったあと実行前にプロセスが落ちると、
+   * その処理は二度と実行されない。呼び出し側は、実行に失敗したら
+   * `deleteFileIfExists()` で claim を明示的に返すこと。
+   *
+   * @param path 権利の識別子になる GCS パス（1 つの副作用に 1 つ）
+   * @param note claim ファイルへ残す補足（誰が・何のために取ったか。調査用）
+   * @returns true = 自分が取れた（実行してよい）/ false = 既に誰かが取っている
+   */
+  async claimOnce(
+    path: string,
+    note: Record<string, string> = {},
+  ): Promise<boolean> {
+    try {
+      await this.bucket
+        .file(path)
+        .save(
+          JSON.stringify({ claimed_at: new Date().toISOString(), ...note }),
+          {
+            resumable: false,
+            contentType: 'application/json',
+            // 「まだ無いときだけ書く」。存在すれば GCS が 412 を返す
+            preconditionOpts: { ifGenerationMatch: 0 },
+          },
+        );
+
+      this.logger.log('GcsClaimAcquired', 'claimOnce', { path, ...note });
+      return true;
+    } catch (err) {
+      // 412 = preconditionFailed = 既に誰かが作っている（＝正常系）
+      if ((err as { code?: number }).code === 412) {
+        this.logger.log('GcsClaimAlreadyHeld', 'claimOnce', { path, ...note });
+        return false;
+      }
+
+      // それ以外（権限・ネットワーク）は «取れなかった» と «取られていた» の区別が
+      // つかない。握り潰すと二重実行を許すので、呼び出し側へ投げてリトライさせる
+      this.logger.error('GcsClaimError', 'claimOnce', {
+        error_message: (err as Error).message,
+        path,
+      });
+      throw err;
+    }
+  }
+
   /**
    * ----------------------------------------------------------------------
    *                          CDN Signed URL Generation

--- a/api/src/core/storage/storage.utils.ts
+++ b/api/src/core/storage/storage.utils.ts
@@ -108,6 +108,47 @@ export function buildDerivedPrefix(params: {
   return `${env.API_NODE_ENV}/${params.kind}/${params.table}/${params.column}/${params.recordId}/`;
 }
 
+/**
+ * #1599 トランスコードの «再実行を 1 回だけにする» ための claim ファイルのパス。
+ *
+ * Transcoder の `CreateJobRequest` には **job 名を指定する欄が無い**
+ * （`ICreateJobRequest` は parent と job だけ。GCP が毎回ランダムな名前を採番する）。
+ * つまり «同じ id で作り直せば 2 本目にならない» という作り方ができない。
+ * 代わりに **作る前に GCS 上のマーカーを排他生成して権利を取る**（claim-then-create）。
+ *
+ * 置き場所は出力先の prefix の直下にする。守りたい単位が «この出力先へ書くジョブ» そのもの
+ * なので、キーは出力先から導けるのが正しい。加えて、アカウント削除の前方一致削除
+ * （`buildDerivedPrefix` 配下）に自然に巻き取られる。
+ *
+ * @param outputUri Transcoder Job の出力先（`gs://<bucket>/<prefix>/`）
+ * @param retryGeneration 何回目の再実行か（1 始まり）
+ * @example buildTranscodeRetryClaimPath('gs://b/development/transcoded-video/dish_media/media_path/x/y/', 1)
+ *   → 'development/transcoded-video/dish_media/media_path/x/y/.retry-1.claim'
+ */
+export function buildTranscodeRetryClaimPath(
+  outputUri: string,
+  retryGeneration: number,
+): string {
+  const matched = /^gs:\/\/([^/]+)\/(.+)$/.exec(outputUri);
+  if (!matched) {
+    throw new Error(`Invalid transcode outputUri: ${outputUri}`);
+  }
+  const [, bucket, objectPrefix] = matched;
+
+  // 出力先と claim が別バケットに分かれると «取ったつもりの権利» が別物になる。
+  // 取り違えは黙って二重ジョブになるので、ここで落とす
+  if (bucket !== env.GCS_BUCKET_NAME) {
+    throw new Error(
+      `Transcode outputUri points to another bucket: ${bucket} (expected ${env.GCS_BUCKET_NAME})`,
+    );
+  }
+
+  const normalized = objectPrefix.endsWith('/')
+    ? objectPrefix
+    : `${objectPrefix}/`;
+  return `${normalized}.retry-${retryGeneration}.claim`;
+}
+
 /* -------------------------------------------------------------------------- */
 /*                          ファイル名チェック                                */
 /* -------------------------------------------------------------------------- */

--- a/api/src/internal/transcoder/transcoder-retry-once.spec.ts
+++ b/api/src/internal/transcoder/transcoder-retry-once.spec.ts
@@ -1,0 +1,246 @@
+// api/src/internal/transcoder/transcoder-retry-once.spec.ts
+//
+// #1599 **AudioMissing のリトライが、再配送のたびに新しいジョブを作っていた件。**
+//
+// Pub/Sub Push は at-least-once 配送で、ハンドラが成功しても応答が届かなければ
+// 同じ FAILED 通知がもう一度届く。分岐の判定材料 `labels.retry` は
+// **失敗した «元のジョブ» の label** で、こちらがリトライを作っても変わらない。
+// よって再配送は毎回リトライ分岐へ入り、
+//
+//   - 課金されるトランスコードジョブが何本も走る
+//   - 同じ outputUri へ複数のジョブが同時に書く（出力が壊れうる）
+//
+// が起きていた。
+//
+// Transcoder の `CreateJobRequest` には **job 名を指定する欄が無い**
+// （`ICreateJobRequest` は parent と job だけ）ので «同じ id で作れば 1 本» にできない。
+// 作る前に GCS 上のマーカーを排他生成して権利を取る（claim-then-create）。
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../prisma/prisma.service';
+import { StorageService } from '../../core/storage/storage.service';
+import { AppLoggerService } from '../../core/logger/logger.service';
+import { TranscoderService } from '../../core/transcoder/transcoder.service';
+
+jest.mock('src/core/config/env', () => ({
+  env: {
+    API_NODE_ENV: 'test',
+    DB_SCHEMA: 'test',
+    GCS_BUCKET_NAME: 'test-bucket',
+    GCP_PROJECT: 'test-project',
+    TRANSCODER_LOCATION: 'us-central1',
+    TRANSCODER_PUBSUB_TOPIC: 'projects/test-project/topics/transcoder',
+  },
+}));
+
+jest.mock('../../core/config/env', () => ({
+  env: {
+    API_NODE_ENV: 'test',
+    DB_SCHEMA: 'test',
+    GCS_BUCKET_NAME: 'test-bucket',
+    GCP_PROJECT: 'test-project',
+    TRANSCODER_LOCATION: 'us-central1',
+    TRANSCODER_PUBSUB_TOPIC: 'projects/test-project/topics/transcoder',
+  },
+}));
+
+const mockGetJob = jest.fn();
+jest.mock('@google-cloud/video-transcoder', () => ({
+  TranscoderServiceClient: jest.fn().mockImplementation(() => ({
+    getJob: mockGetJob,
+  })),
+  protos: {},
+}));
+
+import { TranscoderWebhookService } from './transcoder-webhook.service';
+
+const RECORD_ID = '12345678-1234-1234-1234-123456789012';
+const JOB_NAME = 'projects/p/locations/l/jobs/failed-job';
+const OUTPUT_URI = `gs://test-bucket/test/transcoded-video/dish_media/media_path/${RECORD_ID}/video/`;
+const EXPECTED_CLAIM = `test/transcoded-video/dish_media/media_path/${RECORD_ID}/video/.retry-1.claim`;
+
+/** 音声トラックが無くて落ちた «元のジョブ» の getJob 応答 */
+function audioMissingJob() {
+  return [
+    {
+      name: JOB_NAME,
+      labels: {
+        table_name: 'dish_media',
+        column_name: 'media_path',
+        record_id: RECORD_ID,
+      },
+      error: { message: 'must be encoded with an audio track' },
+      config: {
+        inputs: [{ uri: 'gs://test-bucket/test/user-uploads/x/video.mp4' }],
+        output: { uri: OUTPUT_URI },
+      },
+    },
+  ];
+}
+
+describe('#1599 AudioMissing のリトライは 1 回だけ', () => {
+  let service: TranscoderWebhookService;
+  let claimOnce: jest.Mock;
+  let deleteFileIfExists: jest.Mock;
+  let createTranscodeJob: jest.Mock;
+  let update: jest.Mock;
+  let updateMany: jest.Mock;
+  /**
+   * status の書き込み方（update / updateMany）は #1599 の別 PR で入れ替わる。
+   * ここで見たいのは «書いたか / 書かなかったか» なので、両方を数える
+   */
+  const statusWrites = () =>
+    update.mock.calls.length + updateMany.mock.calls.length;
+  let logger: {
+    log: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+    debug: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    mockGetJob.mockReset();
+    mockGetJob.mockResolvedValue(audioMissingJob());
+
+    claimOnce = jest.fn().mockResolvedValue(true);
+    deleteFileIfExists = jest.fn().mockResolvedValue(true);
+    createTranscodeJob = jest.fn().mockResolvedValue('jobs/retry');
+    update = jest.fn().mockResolvedValue({});
+    updateMany = jest.fn().mockResolvedValue({ count: 1 });
+    logger = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TranscoderWebhookService,
+        { provide: AppLoggerService, useValue: logger },
+        { provide: TranscoderService, useValue: { createTranscodeJob } },
+        {
+          provide: PrismaService,
+          useValue: {
+            prisma: { dish_media: { update, updateMany } },
+          },
+        },
+        {
+          provide: StorageService,
+          useValue: { claimOnce, deleteFileIfExists },
+        },
+      ],
+    }).compile();
+
+    service = module.get<TranscoderWebhookService>(TranscoderWebhookService);
+  });
+
+  it('1 回目は権利を取ってからリトライジョブを作る', async () => {
+    await service.handleJobNotification(JOB_NAME, 'FAILED');
+
+    expect(claimOnce).toHaveBeenCalledWith(
+      EXPECTED_CLAIM,
+      expect.objectContaining({ record_id: RECORD_ID }),
+    );
+    expect(createTranscodeJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputUri: OUTPUT_URI,
+        labels: expect.objectContaining({ retry: '1', video_only: 'true' }),
+      }),
+    );
+  });
+
+  it('権利を «取ってから» 作る（作ってから記録する形になっていないこと）', async () => {
+    const order: string[] = [];
+    claimOnce.mockImplementation(() => {
+      order.push('claim');
+      return Promise.resolve(true);
+    });
+    createTranscodeJob.mockImplementation(() => {
+      order.push('create');
+      return Promise.resolve('jobs/retry');
+    });
+
+    await service.handleJobNotification(JOB_NAME, 'FAILED');
+
+    // 逆順だと «作ったが記録の前に応答が落ちた» ケースで二重に作る
+    expect(order).toEqual(['claim', 'create']);
+  });
+
+  it('再配送（権利が取れない）ならジョブを作らない', async () => {
+    claimOnce.mockResolvedValue(false);
+
+    await service.handleJobNotification(JOB_NAME, 'FAILED');
+
+    expect(createTranscodeJob).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(
+      'TranscoderJobRetryAlreadyClaimed',
+      'handleFailed',
+      expect.objectContaining({ claimPath: EXPECTED_CLAIM }),
+    );
+  });
+
+  it('再配送を «失敗» にせず終える（throw すると Pub/Sub が再配送し続ける）', async () => {
+    claimOnce.mockResolvedValue(false);
+
+    await expect(
+      service.handleJobNotification(JOB_NAME, 'FAILED'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('再配送で status を failed へ落とさない（リトライ中の動画を «失敗» にしない）', async () => {
+    claimOnce.mockResolvedValue(false);
+
+    await service.handleJobNotification(JOB_NAME, 'FAILED');
+
+    expect(statusWrites()).toBe(0);
+  });
+
+  it('ジョブ作成に失敗したら権利を返す（返さないと永久に processing のまま残る）', async () => {
+    createTranscodeJob.mockRejectedValue(new Error('quota exceeded'));
+
+    await expect(
+      service.handleJobNotification(JOB_NAME, 'FAILED'),
+    ).rejects.toThrow('quota exceeded');
+
+    expect(deleteFileIfExists).toHaveBeenCalledWith(EXPECTED_CLAIM);
+  });
+
+  it('AudioMissing でない失敗は権利を取りに行かない（従来どおり failed にする）', async () => {
+    mockGetJob.mockResolvedValue([
+      {
+        ...audioMissingJob()[0],
+        error: { message: 'something else went wrong' },
+      },
+    ]);
+
+    await service.handleJobNotification(JOB_NAME, 'FAILED');
+
+    expect(claimOnce).not.toHaveBeenCalled();
+    expect(createTranscodeJob).not.toHaveBeenCalled();
+    expect(statusWrites()).toBe(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'TranscoderJobFailedPermanent',
+      'handleFailed',
+      expect.anything(),
+    );
+  });
+
+  it('既に retry=1 のジョブが落ちたら、もう作らない', async () => {
+    mockGetJob.mockResolvedValue([
+      {
+        ...audioMissingJob()[0],
+        labels: {
+          ...audioMissingJob()[0].labels,
+          retry: '1',
+          video_only: 'true',
+        },
+      },
+    ]);
+
+    await service.handleJobNotification(JOB_NAME, 'FAILED');
+
+    expect(claimOnce).not.toHaveBeenCalled();
+    expect(createTranscodeJob).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/internal/transcoder/transcoder-webhook.service.ts
+++ b/api/src/internal/transcoder/transcoder-webhook.service.ts
@@ -13,6 +13,8 @@ import { AppLoggerService } from '../../core/logger/logger.service';
 import { TranscoderService } from '../../core/transcoder/transcoder.service';
 import { TranscoderJobLabels } from './transcoder-webhook.interface';
 import { PrismaService } from '../../prisma/prisma.service';
+import { StorageService } from '../../core/storage/storage.service';
+import { buildTranscodeRetryClaimPath } from '../../core/storage/storage.utils';
 import { MediaProcessingStatus } from '@shared/v1/res';
 
 @Injectable()
@@ -23,6 +25,7 @@ export class TranscoderWebhookService {
     private readonly logger: AppLoggerService,
     private readonly transcoderService: TranscoderService,
     private readonly prisma: PrismaService,
+    private readonly storage: StorageService,
   ) {
     this.client = new TranscoderServiceClient();
   }
@@ -155,20 +158,53 @@ export class TranscoderWebhookService {
     });
 
     // AudioMissing かつ retry=0 の場合のみリトライ
+    //
+    // #1599 【バグ】**再配送のたびにリトライジョブを作り直していた。**
+    //
+    // Pub/Sub Push は at-least-once 配送で、ハンドラが成功しても応答が届かなければ
+    // 同じ FAILED 通知がもう一度届く。判定材料の `labels.retry` は
+    // **失敗した «元のジョブ» の label** で、こちらがリトライを作っても変わらない
+    // （リトライ側の label に retry=1 が入るだけ）。よって再配送は毎回この分岐へ入り、
+    //   - 課金されるトランスコードジョブが何本も走る
+    //   - **同じ outputUri へ複数のジョブが同時に書く**（出力が壊れうる）
+    // が起きていた。
+    //
+    // Transcoder の `CreateJobRequest` には job 名を指定する欄が無い
+    // （`ICreateJobRequest` は parent と job だけ）ので «同じ id で作れば 1 本» に
+    // できない。代わりに **作る前に GCS 上のマーカーを排他生成して権利を取る**。
+    // 取れた配送だけがジョブを作る（claim-then-create）。
     const retryCount = parseInt(labels.retry ?? '0', 10);
     if (isAudioMissing && retryCount === 0) {
+      const inputUri = jobDetails.config?.inputs?.[0]?.uri;
+      const outputUri = jobDetails.config?.output?.uri;
+      if (!inputUri || !outputUri) {
+        this.logger.error('TranscoderJobRetryError', 'handleFailed', {
+          jobId,
+          labels,
+          jobDetails,
+          message: 'InputUri or OutputUri is missing in jobDetails.config',
+        });
+        throw new Error('InputUri or OutputUri is missing');
+      }
+
+      const claimPath = buildTranscodeRetryClaimPath(outputUri, retryCount + 1);
+      const claimed = await this.storage.claimOnce(claimPath, {
+        reason: 'transcode_retry_video_only',
+        record_id,
+        failed_job: jobId,
+      });
+      if (!claimed) {
+        // 既に別の配送がリトライを作っている。ここで «成功として» 抜けるのが正しい
+        // （throw すると Pub/Sub が再配送を続け、ログだけが増える）
+        this.logger.log('TranscoderJobRetryAlreadyClaimed', 'handleFailed', {
+          jobId,
+          labels,
+          claimPath,
+        });
+        return;
+      }
+
       try {
-        const inputUri = jobDetails.config?.inputs?.[0]?.uri;
-        const outputUri = jobDetails.config?.output?.uri;
-        if (!inputUri || !outputUri) {
-          this.logger.error('TranscoderJobRetryError', 'handleFailed', {
-            jobId,
-            labels,
-            jobDetails,
-            message: 'InputUri or OutputUri is missing in jobDetails.config',
-          });
-          throw new Error('InputUri or OutputUri is missing');
-        }
         await this.transcoderService.createTranscodeJob({
           inputUri,
           outputUri,
@@ -179,9 +215,14 @@ export class TranscoderWebhookService {
           },
         });
       } catch (error) {
+        // ジョブを作れなかったのに claim を握ったままだと、**再配送でも作り直せず**
+        // この動画が永久に processing のまま残る。権利を返してから投げ直す
+        await this.storage.deleteFileIfExists(claimPath);
+
         this.logger.error('TranscoderJobRetryError', 'handleFailed', {
           jobId,
           labels,
+          claimPath,
           error: error instanceof Error ? error.message : 'Unknown error',
         });
         throw error;


### PR DESCRIPTION
R12-A ③。**課金が絡む唯一の件**。

## 何が起きていたか

Pub/Sub Push は **at-least-once** 配送で、ハンドラが成功しても応答が届かなければ
同じ FAILED 通知がもう一度届く。AudioMissing のリトライ判定に使っている `labels.retry` は
**失敗した «元のジョブ» の label** で、こちらがリトライを作っても変わらない
（リトライ側の label に `retry=1` が入るだけ）。よって再配送は毎回リトライ分岐へ入り、

- **課金されるトランスコードジョブが何本も走る**
- **同じ `outputUri` へ複数のジョブが同時に書く**（HLS 出力が壊れうる）

が起きていた。

## 「決まった job 名で作り直す」はできない（確認済み）

最初に考えたのは «同じ job 名で作れば 2 本目にならない» だったが、**Transcoder の
`CreateJobRequest` には job 名を指定する欄が無い**。node クライアントの protos で確認した:

```
interface ICreateJobRequest {
    parent?: (string|null);
    job?: (google.cloud.video.transcoder.v1.IJob|null);
}
```

GCP が毎回ランダムな名前を採番するので、この方向は成立しない。

## どう直したか — claim-then-create

**作る前に GCS 上のマーカーを排他生成して権利を取り、取れた配送だけがジョブを作る。**

- `StorageService.claimOnce(path, note)` を追加。GCS の
  **`ifGenerationMatch: 0`（オブジェクトがまだ存在しないときだけ書く）** を使うので、
  判定と書き込みが GCS 側で 1 つになる。同時に 2 本届いても片方しか通らない
  - ⚠️ `fileExists()` してから書く形にしてはいけない（その隙間に別の配送が入り込む）。
    既存の `uploadFileAtPath(overwriteIfExists: false)` はこの «確認してから書く» 形なので、
    claim には使えない
  - 412 以外のエラーは握り潰さず投げる。«取れなかった» と «取られていた» を混同すると
    呼び出し側が «誰かが実行済み» と誤解して処理を落とす
  - ライブラリ側で本当に効くことも確認した（`resumable: false` → `startSimpleUpload_` →
    `Object.assign(reqOpts.qs, ..., options.preconditionOpts)` でクエリに載る）
- claim の置き場所は **出力先 prefix の直下**（`buildTranscodeRetryClaimPath`）。
  守りたい単位が «この出力先へ書くジョブ» そのものなので、キーは出力先から導けるのが正しい。
  加えてアカウント削除の前方一致削除（`buildDerivedPrefix` 配下）に自然に巻き取られる
- **ジョブ作成に失敗したら claim を返す**（`deleteFileIfExists`）。返さないとこの動画が
  再配送でも作り直されず、永久に `processing` のまま残る
- 再配送で claim が取れなかったときは **成功として抜ける**。throw すると Pub/Sub が
  再配送を続け、ログだけが増える

### 残る穴（意図して残したもの）

claim を取った直後・ジョブを作る前にプロセスが落ちると、その動画のリトライは二度と走らない
（claim は自動失効しない）。«二重に課金する» より «稀に 1 本取りこぼす» を選んだ。
コード内にも明記してある。

## 検証

- 新規 `storage-claim-once.spec.ts`（11 件）… `ifGenerationMatch: 0` を渡していること、
  412 は false・それ以外は throw、claim パスの導出（レコード違い / 世代違い / 別バケット拒否）
- 新規 `transcoder-retry-once.spec.ts`（8 件）… claim → create の**順序**、再配送でジョブを
  作らない、失敗時に claim を返す、AudioMissing 以外は従来どおり
- **修正前のコードへ戻すと中核 4 件が落ちる**ことを確認（revert-to-red）
- `pnpm --filter api typecheck` 0 エラー / `pnpm --filter api test` 73 suites 911 tests green

## 見つけたが、この PR では直していないもの

`getJobDetails` は job が NOT_FOUND（TTL 失効・削除済み）でも throw するため、
コントローラが 500 を返し **Pub/Sub がサブスクリプションの保持期間いっぱい再配送し続ける**。
この PR の主題（重複実行）とは別の失敗系で、GCP のエラー形状の判定が既にヒューリスティックな
場所なので、切り出して #1599 の未解決事項へ記録した。

## リンク

- 親: https://github.com/Ayato-kosaka/nanitabeyo/issues/1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_