### PR TITLE
fix(api): 通知ジョブの再配送で Push が二重に届くのを止める (#1599)

### DIFF
--- a/api/src/internal/media-status-idempotent-write.spec.ts
+++ b/api/src/internal/media-status-idempotent-write.spec.ts
@@ -190,6 +190,15 @@ describe('#1599 トランスコード完了の status 書き込み（TranscoderW
           provide: TranscoderService,
           useValue: { createTranscodeJob: jest.fn() },
         },
+        // #1599 ③ で TranscoderWebhookService が claim 用に StorageService を取るようになった。
+        // この suite は SUCCEEDED しか流さないので使われないが、DI は解決できる必要がある
+        {
+          provide: StorageService,
+          useValue: {
+            claimOnce: jest.fn(),
+            deleteFileIfExists: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/api/src/internal/notifications/notification-job.preferences.spec.ts
+++ b/api/src/internal/notifications/notification-job.preferences.spec.ts
@@ -50,6 +50,7 @@ describe('#1510 SET-02 通知カテゴリ別のプッシュ抑止', () => {
   let repo: {
     upsertNotification: jest.Mock;
     findNotificationPreference: jest.Mock;
+    claimPushDelivery: jest.Mock;
   };
   let notificationsService: {
     sendPushNotification: jest.Mock;
@@ -72,6 +73,8 @@ describe('#1510 SET-02 通知カテゴリ別のプッシュ抑止', () => {
         .fn()
         .mockResolvedValue({ notificationId: NOTIFICATION_ID, isNew: true }),
       findNotificationPreference: jest.fn().mockResolvedValue(null),
+      // #1599 既定は「まだ送っていない＝送ってよい」
+      claimPushDelivery: jest.fn().mockResolvedValue(true),
     };
 
     notificationsService = {

--- a/api/src/internal/notifications/notification-job.service.spec.ts
+++ b/api/src/internal/notifications/notification-job.service.spec.ts
@@ -54,9 +54,17 @@ describe('NotificationJobService GRP-04 投票完了通知', () => {
     { id: string; actorIds: string[]; recipientIds: Set<string> }
   >;
   let nextId: number;
+  /**
+   * #1599 «この受取人へ、この actor 分の Push を送る権利» の台帳。
+   * 実装（notification_recipients.last_pushed_actor_id への条件付き UPDATE）と
+   * 同じ判定をなぞる。ここを素通しの jest.fn() にすると、
+   * «再配送で二重に送る» 欠陥がテストからは見えなくなる
+   */
+  let pushedActorByRecipient: Map<string, string>;
 
   let repo: {
     upsertNotification: jest.Mock;
+    claimPushDelivery: jest.Mock;
   };
   let notificationsService: {
     sendPushNotification: jest.Mock;
@@ -84,6 +92,7 @@ describe('NotificationJobService GRP-04 投票完了通知', () => {
   beforeEach(async () => {
     notificationsByKey = new Map();
     nextId = 0;
+    pushedActorByRecipient = new Map();
 
     repo = {
       upsertNotification: jest.fn(
@@ -93,9 +102,7 @@ describe('NotificationJobService GRP-04 投票完了通知', () => {
           recipientIds: string[],
           actorId: string,
         ) => {
-          const existing = notificationsByKey.get(
-            notification.idempotency_key,
-          );
+          const existing = notificationsByKey.get(notification.idempotency_key);
           if (existing) {
             existing.actorIds = [
               actorId,
@@ -112,6 +119,19 @@ describe('NotificationJobService GRP-04 投票完了通知', () => {
           };
           notificationsByKey.set(notification.idempotency_key, created);
           return { notificationId: created.id, isNew: true };
+        },
+      ),
+      claimPushDelivery: jest.fn(
+        async (
+          notificationId: string,
+          recipientId: string,
+          actorId: string,
+        ) => {
+          const key = `${notificationId}:${recipientId}`;
+          // 実装の `last_pushed_actor_id IS DISTINCT FROM :actorId` と同じ
+          if (pushedActorByRecipient.get(key) === actorId) return false;
+          pushedActorByRecipient.set(key, actorId);
+          return true;
         },
       ),
     };
@@ -141,9 +161,7 @@ describe('NotificationJobService GRP-04 投票完了通知', () => {
     };
 
     usersService = {
-      getUserByIds: jest
-        .fn()
-        .mockResolvedValue([HOST_USER, VOTER_USER]),
+      getUserByIds: jest.fn().mockResolvedValue([HOST_USER, VOTER_USER]),
       // #1511 / #1557 «退会» と «users 行が無い（匿名）» を区別する取得。
       // 既定では getUserByIds と同じ集合を返す = 「誰も退会していない」。
       // 退会を模す test だけがこちらを個別に上書きする。
@@ -331,7 +349,11 @@ describe('NotificationJobService GRP-04 投票完了通知', () => {
     usersService.getUserByIds.mockResolvedValue([
       HOST_USER,
       VOTER_USER,
-      { id: OTHER_VOTER_ID, display_name: 'Other Voter', preferred_locale: 'en' },
+      {
+        id: OTHER_VOTER_ID,
+        display_name: 'Other Voter',
+        preferred_locale: 'en',
+      },
     ]);
 
     await service.processNotificationJob(votePayload(VOTER_ID));

--- a/api/src/internal/notifications/notification-job.service.ts
+++ b/api/src/internal/notifications/notification-job.service.ts
@@ -84,12 +84,16 @@ export class NotificationJobService {
       knownUsers.filter((u) => u.deleted_at != null).map((u) => u.id),
     );
     if (deletedUserIds.has(actorId) || deletedUserIds.has(recipientId)) {
-      this.logger.log('DeletedUserNotificationSkipped', 'processNotificationJob', {
-        actorId,
-        recipientId,
-        actorDeleted: deletedUserIds.has(actorId),
-        recipientDeleted: deletedUserIds.has(recipientId),
-      });
+      this.logger.log(
+        'DeletedUserNotificationSkipped',
+        'processNotificationJob',
+        {
+          actorId,
+          recipientId,
+          actorDeleted: deletedUserIds.has(actorId),
+          recipientDeleted: deletedUserIds.has(recipientId),
+        },
+      );
       return;
     }
 
@@ -151,6 +155,33 @@ export class NotificationJobService {
     });
     if (!message) return;
 
+    // 6. #1599 【バグ】**再配送で同じ Push が 2 回届くのを止める。**
+    //
+    // Cloud Tasks は at-least-once 配送で、**ハンドラが成功したのに応答が届かなかった
+    // 場合も再実行される**。手順 3 の upsert は idempotency_key で冪等なので «通知行» は
+    // 二重にならないが、ここは無条件に走っていたため配信だけが二重になっていた。
+    // 行の冪等性と配信の冪等性は別の話である。
+    //
+    // 【設計】`isNew` で分岐してはいけない。同じ投稿への 2 人目以降のいいねは
+    // isNew: false の経路に入るので、**通知そのものが届かなくなる**。
+    // 区別すべきは «再配送» と «正当な追加イベント» であって «新規» と «既存» ではない。
+    //
+    // 「送ってから記録する」ではなく **「記録できたら送る」**。逆順にすると、
+    // 記録の前に落ちた場合にもう一度送ってしまう（＝直っていない）。
+    const claimed = await this.repo.claimPushDelivery(
+      notificationId,
+      recipientId,
+      actorId,
+    );
+    if (!claimed) {
+      this.logger.log(
+        'NotificationPushAlreadyDelivered',
+        'processNotificationJob',
+        { notificationId, recipientId, actorId },
+      );
+      return;
+    }
+
     await this.service.sendPushNotification(recipientId, message);
   }
 
@@ -178,12 +209,10 @@ export class NotificationJobService {
     } else if (targetTable === 'dish_category_group_vote_sessions') {
       // #1506 GRP-04: recipient は投票セッションのホスト。
       const session =
-        await this.prisma.prisma.dish_category_group_vote_sessions.findUnique(
-          {
-            where: { id: targetId },
-            select: { host_user_id: true },
-          },
-        );
+        await this.prisma.prisma.dish_category_group_vote_sessions.findUnique({
+          where: { id: targetId },
+          select: { host_user_id: true },
+        });
       return session ? { user_id: session.host_user_id } : null;
     }
 

--- a/api/src/internal/notifications/notification-push-once.spec.ts
+++ b/api/src/internal/notifications/notification-push-once.spec.ts
@@ -1,0 +1,197 @@
+// api/src/internal/notifications/notification-push-once.spec.ts
+//
+// #1599 **通知ジョブが再配送されると Push が二重に届く件。**
+//
+// Cloud Tasks は at-least-once 配送で、**ハンドラが成功したのに応答が届かなかった
+// 場合も再実行される**。`processNotificationJob` は
+//   1. upsertNotification（idempotency_key で冪等。行は二重にならない）
+//   2. sendPushNotification（**無条件に実行**）
+// という順で動いていたため、再配送されると同じ Push がユーザーへ 2 回届いていた。
+// 行の冪等性と配信の冪等性は別の話である。
+//
+// ⚠️ ここで一番守りたいのは **「isNew で分岐してはいけない」** という点である。
+// 一見それで直るように見えるが、同じ投稿への 2 人目以降のいいねは isNew: false の
+// 経路に入るので、**通知そのものが届かなくなる**（症状が «二重» から «欠落» へ変わるだけ）。
+// 下の «2 人目» のテストがその退行を止める。
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationJobService } from './notification-job.service';
+import { NotificationsRepository } from '../../v1/notifications/notifications.repository';
+import { NotificationsService } from '../../v1/notifications/notifications.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { AppLoggerService } from '../../core/logger/logger.service';
+import { UsersService } from '../../v1/users/users.service';
+
+jest.mock('src/core/config/env', () => ({
+  env: { API_NODE_ENV: 'test', DB_SCHEMA: 'test' },
+}));
+
+const TARGET_ID = '11111111-1111-1111-1111-111111111111';
+const RECIPIENT_ID = '22222222-2222-2222-2222-222222222222';
+const ACTOR_A = '33333333-3333-3333-3333-333333333333';
+const ACTOR_B = '44444444-4444-4444-4444-444444444444';
+const NOTIFICATION_ID = '55555555-5555-5555-5555-555555555555';
+
+const payload = (actorId: string) => ({
+  actionType: 'like',
+  targetTable: 'dish_media',
+  targetId: TARGET_ID,
+  actorId,
+  idempotencyKey: `dish_media:like:${TARGET_ID}`,
+});
+
+describe('#1599 通知ジョブの再配送で Push を二重に送らない', () => {
+  let service: NotificationJobService;
+  let sendPushNotification: jest.Mock;
+  let claimPushDelivery: jest.Mock;
+  let logger: {
+    debug: jest.Mock;
+    log: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+  };
+  /** notification_recipients.last_pushed_actor_id の台帳（実装と同じ判定をなぞる） */
+  let pushedActorByRecipient: Map<string, string>;
+
+  beforeEach(async () => {
+    pushedActorByRecipient = new Map();
+
+    claimPushDelivery = jest.fn(
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async (notificationId: string, recipientId: string, actorId: string) => {
+        const key = `${notificationId}:${recipientId}`;
+        // `last_pushed_actor_id IS DISTINCT FROM :actorId` と同じ
+        if (pushedActorByRecipient.get(key) === actorId) return false;
+        pushedActorByRecipient.set(key, actorId);
+        return true;
+      },
+    );
+    sendPushNotification = jest.fn().mockResolvedValue(undefined);
+    logger = {
+      debug: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    /** 2 人目は isNew: false の経路に入る（idempotency_key を共有するため） */
+    let created = false;
+    const upsertNotification = jest.fn(() => {
+      const isNew = !created;
+      created = true;
+      return Promise.resolve({ notificationId: NOTIFICATION_ID, isNew });
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationJobService,
+        {
+          provide: NotificationsRepository,
+          useValue: { upsertNotification, claimPushDelivery },
+        },
+        {
+          provide: NotificationsService,
+          useValue: {
+            sendPushNotification,
+            isPushAllowedForKind: jest
+              .fn()
+              .mockResolvedValue({ allowed: true, category: 'likes' }),
+          },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            withTransaction: jest.fn((exec: (tx: unknown) => unknown) =>
+              exec({ __tx: true }),
+            ),
+            prisma: {
+              dish_media: {
+                findFirst: jest
+                  .fn()
+                  .mockResolvedValue({ user_id: RECIPIENT_ID }),
+              },
+            },
+          },
+        },
+        { provide: AppLoggerService, useValue: logger },
+        {
+          provide: UsersService,
+          useValue: {
+            getUsersByIdsIncludingDeleted: jest.fn().mockResolvedValue([]),
+            getUserByIds: jest.fn().mockResolvedValue([
+              { id: ACTOR_A, display_name: 'A', preferred_locale: 'ja' },
+              { id: ACTOR_B, display_name: 'B', preferred_locale: 'ja' },
+              {
+                id: RECIPIENT_ID,
+                display_name: '受取人',
+                preferred_locale: 'ja',
+              },
+            ]),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<NotificationJobService>(NotificationJobService);
+  });
+
+  it('1 回目は Push を送る', async () => {
+    await service.processNotificationJob(payload(ACTOR_A) as never);
+
+    expect(sendPushNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('同じジョブが再配送されても Push は 1 回だけ', async () => {
+    await service.processNotificationJob(payload(ACTOR_A) as never);
+    await service.processNotificationJob(payload(ACTOR_A) as never);
+
+    expect(sendPushNotification).toHaveBeenCalledTimes(1);
+    expect(logger.log).toHaveBeenCalledWith(
+      'NotificationPushAlreadyDelivered',
+      'processNotificationJob',
+      expect.objectContaining({ recipientId: RECIPIENT_ID, actorId: ACTOR_A }),
+    );
+  });
+
+  it('2 人目のいいねは «別の actor» なので、ちゃんと届く', async () => {
+    // ここが落ちるなら isNew で分岐している。症状が «二重» から «欠落» へ変わるだけで、
+    // 直っていない（idempotency_key を共有するので 2 人目は isNew: false に入る）
+    await service.processNotificationJob(payload(ACTOR_A) as never);
+    await service.processNotificationJob(payload(ACTOR_B) as never);
+
+    expect(sendPushNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('2 人目のジョブが再配送されても、その分は 1 回だけ', async () => {
+    await service.processNotificationJob(payload(ACTOR_A) as never);
+    await service.processNotificationJob(payload(ACTOR_B) as never);
+    await service.processNotificationJob(payload(ACTOR_B) as never);
+
+    expect(sendPushNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('「記録できたら送る」順であること（送ってから記録していないこと）', async () => {
+    // 逆順だと «送ったが記録の前に応答が落ちた» ケースで二重に送る
+    const order: string[] = [];
+    claimPushDelivery.mockImplementation(() => {
+      order.push('claim');
+      return Promise.resolve(true);
+    });
+    sendPushNotification.mockImplementation(() => {
+      order.push('push');
+      return Promise.resolve(undefined);
+    });
+
+    await service.processNotificationJob(payload(ACTOR_A) as never);
+
+    expect(order).toEqual(['claim', 'push']);
+  });
+
+  it('権利が取れなかったときは Push を呼ばない', async () => {
+    claimPushDelivery.mockResolvedValue(false);
+
+    await service.processNotificationJob(payload(ACTOR_A) as never);
+
+    expect(sendPushNotification).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/v1/notifications/notifications.repository.ts
+++ b/api/src/v1/notifications/notifications.repository.ts
@@ -322,6 +322,80 @@ export class NotificationsRepository {
     return { notificationId: createdNotification.id, isNew: true };
   }
 
+  /**
+   * #1599 **この受取人へ «この actor 分の Push» を送る権利を 1 回だけ取る。**
+   *
+   * Cloud Tasks は at-least-once 配送で、**ハンドラが成功したのに応答が届かなかった
+   * 場合も再実行される**。`upsertNotification` は `idempotency_key` で冪等なので
+   * «通知行» は二重にならないが、その後の `sendPushNotification` は無条件に走るため、
+   * **同じ Push がユーザーへ 2 回届く**。行の冪等性と配信の冪等性は別の話である。
+   *
+   * ## なぜ「新規作成のときだけ送る」では駄目なのか
+   * `upsertNotification` の戻り値 `isNew` で分岐すると、**同じ投稿への 2 人目以降の
+   * いいね通知が丸ごと消える**。`idempotency_key` は
+   * (action_type, target_table, target_id) 単位で共有され、2 人目は
+   * «既存通知の actor_ids を更新» する経路（isNew: false）に入るためである。
+   * 区別すべきは «再配送» と «正当な追加イベント» であって、«新規» と «既存» ではない。
+   *
+   * ## なぜ既存の列では判別できないのか
+   * - `actor_ids` … 先頭 3 件までの MRU リスト。同じ actor の再配送では中身が変わらず、
+   *   上限 3 に張り付くと 4 人目以降は件数も変わらない
+   * - `thread_updated_at` … 再配送でも毎回 `now()` で更新されるので時刻比較も使えない
+   *
+   * したがって «誰の分まで送ったか» を持つ列（`last_pushed_actor_id`）を足した
+   * （`20260826T0400_add_notification_recipients_last_pushed.sql`）。
+   *
+   * ## 「送ってから記録する」ではなく「記録できたら送る」
+   * 1 文の条件付き UPDATE なので、再配送が同時に 2 本届いても片方しか通らない。
+   * 逆順（送ってから記録）にすると、記録の前に落ちた場合にもう一度送ってしまう。
+   *
+   * ⚠️ Prisma の `updateMany` では書けない。`last_pushed_actor_id` は NULL 許容で、
+   * **まだ一度も送っていない行（NULL）も «この actor とは違う» として拾う**必要がある。
+   * SQL の `<>` は NULL を落とす（`NULL <> x` は NULL = 偽扱い）ので、
+   * それだと **1 回目の Push が誰にも届かない**。`IS DISTINCT FROM` でなければならない。
+   * PostgreSQL 16 で ①NULL→A=1 ②Aの再配送=0 ③B=1 ④Bの再配送=0、および
+   * `<>` では NULL 行が 0 件・`IS DISTINCT FROM` では 1 件になることを実測して確認した。
+   *
+   * ## 残る穴（承知のうえ）
+   * 持っているのは «最後の 1 件» なので、**A → B → A の再配送**という順に届くと
+   * A の分がもう一度送られる（最後が B になっているため）。守りたいのは
+   * «同じタスクの直後の再配送» であり、その間に別の actor のジョブが完了する必要がある
+   * この順序は稀である。ここを塞ぐには actor ごとに 1 行持つ（＝別テーブル）ことになり、
+   * 得られるものに対して重い。migration のヘッダにも同じ判断を書いてある。
+   *
+   * @returns true = 自分が取れた（送ってよい）/ false = 既にこの actor 分は送信済み
+   */
+  async claimPushDelivery(
+    notificationId: string,
+    recipientId: string,
+    actorId: string,
+  ): Promise<boolean> {
+    // withTransaction を通すのは search_path（DB_SCHEMA）を確実に効かせるため。
+    // 素の $executeRaw は接続既定のスキーマ解決に依存する
+    const updated = await this.prisma.withTransaction(
+      (tx) =>
+        tx.$executeRaw`
+        UPDATE notification_recipients
+           SET last_pushed_actor_id = ${actorId}::uuid,
+               last_pushed_at       = now()
+         WHERE notification_id = ${notificationId}::uuid
+           AND recipient_id    = ${recipientId}::uuid
+           AND last_pushed_actor_id IS DISTINCT FROM ${actorId}::uuid
+      `,
+    );
+
+    if (updated === 0) {
+      this.logger.log('PushDeliveryAlreadyClaimed', 'claimPushDelivery', {
+        notificationId,
+        recipientId,
+        actorId,
+      });
+      return false;
+    }
+
+    return true;
+  }
+
   /* ------------------------------------------------------------------ */
   /*        #1510 SET-02 通知カテゴリ別の受信設定                        */
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
R12-A ①。**ユーザーに直接見えていた唯一の件**（同じ通知が 2 回届く）。

`20260826T0400_add_notification_recipients_last_pushed.sql`（#1624）を dev へ適用済み
（[run 32969636028](https://github.com/Ayato-kosaka/nanitabeyo/actions/runs/32969636028) success）なので、列を使うコードを入れる。

## 何が起きていたか

Cloud Tasks は **at-least-once** 配送で、**ハンドラが成功したのに応答が届かなかった場合も再実行される**。
`processNotificationJob` は

1. `upsertNotification`（`idempotency_key` で冪等。**行**は二重にならない）
2. `sendPushNotification`（**無条件に実行**）

の順で動くため、再配送されると **同じ Push がユーザーへ 2 回届いていた**。
行の冪等性と配信の冪等性は別の話で、`notifications.service.ts` の doc comment にある
「idempotency_key があるので再実行しても通知が二重にならない」は行のことしか保証していない。

## `isNew` で分岐してはいけない

一見それで直るように見えるが、**同じ投稿への 2 人目以降のいいね通知が丸ごと消える**。
`idempotency_key` は (action_type, target_table, target_id) 単位で共有され、
2 人目は「既存通知の actor_ids を更新」する経路（`isNew: false`）に入るからである。
症状が «二重» から «欠落» へ変わるだけで、直っていない。

区別すべきは **«再配送» と «正当な追加イベント»** であって、«新規» と «既存» ではない。
`actor_ids`（上限 3 の MRU。同じ actor の再配送では中身が変わらない）も
`thread_updated_at`（再配送でも毎回 `now()`）もその区別に使えないため、
#1624 で足した `last_pushed_actor_id` を使う。

## どう直したか — claim-then-push

「送ってから記録する」ではなく **「記録できたら送る」**。

```sql
UPDATE notification_recipients
   SET last_pushed_actor_id = :actorId, last_pushed_at = now()
 WHERE notification_id = :id
   AND recipient_id    = :recipientId
   AND last_pushed_actor_id IS DISTINCT FROM :actorId
```

更新できた（count = 1）ときだけ Push する。1 文の条件付き UPDATE なので、
再配送が同時に 2 本届いても片方しか通らない。逆順（送ってから記録）にすると、
記録の前に落ちた場合にもう一度送ってしまう。

- **`<>` ではなく `IS DISTINCT FROM` でなければならない。** `last_pushed_actor_id` は
  NULL 許容で、まだ一度も送っていない行（NULL）も «この actor とは違う» として拾う必要がある。
  `NULL <> x` は NULL（偽扱い）なので、`<>` だと **1 回目の Push が誰にも届かない**。
  Prisma の `updateMany` では `IS DISTINCT FROM` を書けないため `$executeRaw` を使う
- `withTransaction` を通すのは `search_path`（`DB_SCHEMA`）を確実に効かせるため

### 残る穴（承知のうえ）

持っているのは «最後の 1 件» なので、**A → B → A の再配送** という順に届くと A の分が
もう一度送られる。守りたいのは «同じタスクの直後の再配送» であり、その間に別の actor の
ジョブが完了する必要があるこの順序は稀。塞ぐには actor ごとに 1 行持つ（＝別テーブル）ことになり、
得られるものに対して重い。migration のヘッダとコードコメントの両方に書いてある。

## 検証

- 新規 `notification-push-once.spec.ts`（6 件）
- **修正前のコードへ戻すと 4 件が落ちる**
- **«`isNew` のときだけ送る» という素朴な直し方だと 5 件が落ちる**
  （«2 人目のいいねが届く» が落ちるので、症状のすり替えを検出できる）
- 条件付き UPDATE の挙動を **PostgreSQL 16 で実測**:
  ① NULL→A = 1 / ② A の再配送 = 0 / ③ B = 1 / ④ B の再配送 = 0 /
  ⑤ 更新は 1 行だけ / ⑥ `<>` では NULL 行にマッチ 0 件・`IS DISTINCT FROM` では 1 件
- あわせて migration の事後アサーションが **素通りでない**ことも実測
  （列の無いスキーマで流すと `RAISE EXCEPTION` で落ちる）
- `pnpm --filter api typecheck` 0 エラー / `pnpm --filter api test` 72 suites 898 tests green

### 既存 spec のモックについて

`notification-job.service.spec.ts` の repo モックへ `claimPushDelivery` を足すとき、
素通しの `jest.fn()` **にはしなかった**。実装（`IS DISTINCT FROM`）と同じ判定を
インメモリで再現してある。素通しにすると «再配送で二重に送る» 欠陥がテストから見えなくなる
（この suite は過去に `isPushAllowedForKind` のモック追加漏れで 14 件が
«is not a function» のまま緑扱いになった前科がある）。

## リンク

- 親: https://github.com/Ayato-kosaka/nanitabeyo/issues/1599
- migration: https://github.com/Ayato-kosaka/nanitabeyo/pull/1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_