### PR TITLE
fix(api): #1625 と #1626 の同時マージで main のテストが落ちるのを直す (#1599)

### DIFF
--- a/api/src/internal/media-status-idempotent-write.spec.ts
+++ b/api/src/internal/media-status-idempotent-write.spec.ts
@@ -190,6 +190,15 @@ describe('#1599 トランスコード完了の status 書き込み（TranscoderW
           provide: TranscoderService,
           useValue: { createTranscodeJob: jest.fn() },
         },
+        // #1599 ③ で TranscoderWebhookService が claim 用に StorageService を取るようになった。
+        // この suite は SUCCEEDED しか流さないので使われないが、DI は解決できる必要がある
+        {
+          provide: StorageService,
+          useValue: {
+            claimOnce: jest.fn(),
+            deleteFileIfExists: jest.fn(),
+          },
+        },
       ],
     }).compile();
 


### PR DESCRIPTION
## 何が起きたか

- #1626 が `TranscoderWebhookService` の constructor へ `StorageService` を足した
- #1625 が同じサービスのテスト（`media-status-idempotent-write.spec.ts`）を追加した

**どちらも単独では緑**だが、両方 main に入ると #1625 側の `TestingModule` が
`StorageService` を解決できず `Nest can't resolve dependencies` で 2 件落ちる。

同じファイルの別の行を触っているため **git は衝突を報告せず、両方の CI が緑のまま
main だけが赤くなる**形の事故だった（意味的な衝突）。マージ後に main の HEAD で
`pnpm --filter api test` を回して気づいた。

## 直し方

この suite は `SUCCEEDED` しか流さないので claim は使われないが、DI は解決できる
必要があるのでモックを足す。

## 検証

main の HEAD（`b91bc08c` + この変更）で `pnpm --filter api typecheck` 0 エラー /
`pnpm --filter api test` **74 suites 916 tests green**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf2wtFr7Sctrcq1QxSY8cB)_